### PR TITLE
Resource abstraction, project hoursPerDay, project settings

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -7,6 +7,7 @@ import ProjectsPage from './pages/ProjectsPage'
 import ProjectDetailPage from './pages/ProjectDetailPage'
 import BacklogPage from './pages/BacklogPage'
 import TemplateLibraryPage from './pages/TemplateLibraryPage'
+import ProjectSettingsPage from './pages/ProjectSettingsPage'
 
 const queryClient = new QueryClient()
 
@@ -28,6 +29,7 @@ function AppRoutes() {
       <Route path="/" element={<PrivateRoute><ProjectsPage /></PrivateRoute>} />
       <Route path="/projects/:id" element={<PrivateRoute><ProjectDetailPage /></PrivateRoute>} />
       <Route path="/projects/:id/backlog" element={<PrivateRoute><BacklogPage /></PrivateRoute>} />
+      <Route path="/projects/:id/settings" element={<PrivateRoute><ProjectSettingsPage /></PrivateRoute>} />
       <Route path="/templates" element={<PrivateRoute><TemplateLibraryPage /></PrivateRoute>} />
     </Routes>
   )

--- a/client/src/components/backlog/FeatureList.tsx
+++ b/client/src/components/backlog/FeatureList.tsx
@@ -10,9 +10,10 @@ interface Props {
   features: Feature[]
   resourceTypes: ResourceType[]
   projectId: string
+  hoursPerDay: number
 }
 
-export default function FeatureList({ epicId, features, resourceTypes, projectId }: Props) {
+export default function FeatureList({ epicId, features, resourceTypes, projectId, hoursPerDay }: Props) {
   const qc = useQueryClient()
   const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set())
   const [adding, setAdding] = useState(false)
@@ -78,7 +79,7 @@ export default function FeatureList({ epicId, features, resourceTypes, projectId
             </div>
           )}
           {expandedIds.has(feature.id) && (
-            <StoryList featureId={feature.id} stories={feature.userStories} resourceTypes={resourceTypes} projectId={projectId} />
+            <StoryList featureId={feature.id} stories={feature.userStories} resourceTypes={resourceTypes} projectId={projectId} hoursPerDay={hoursPerDay} />
           )}
         </div>
       ))}

--- a/client/src/components/backlog/StoryList.tsx
+++ b/client/src/components/backlog/StoryList.tsx
@@ -9,9 +9,10 @@ interface Props {
   stories: UserStory[]
   resourceTypes: ResourceType[]
   projectId: string
+  hoursPerDay: number
 }
 
-export default function StoryList({ featureId, stories, resourceTypes, projectId }: Props) {
+export default function StoryList({ featureId, stories, resourceTypes, projectId, hoursPerDay }: Props) {
   const qc = useQueryClient()
   const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set())
   const [adding, setAdding] = useState(false)
@@ -67,7 +68,7 @@ export default function StoryList({ featureId, stories, resourceTypes, projectId
             </div>
           )}
           {expandedIds.has(story.id) && (
-            <TaskList storyId={story.id} tasks={story.tasks} resourceTypes={resourceTypes} projectId={projectId} />
+            <TaskList storyId={story.id} tasks={story.tasks} resourceTypes={resourceTypes} projectId={projectId} hoursPerDay={hoursPerDay} />
           )}
         </div>
       ))}

--- a/client/src/components/backlog/TaskList.tsx
+++ b/client/src/components/backlog/TaskList.tsx
@@ -8,11 +8,10 @@ interface Props {
   tasks: Task[]
   resourceTypes: ResourceType[]
   projectId: string
+  hoursPerDay: number
 }
 
-const HOURS_PER_DAY = 7.6
-
-export default function TaskList({ storyId, tasks, resourceTypes, projectId }: Props) {
+export default function TaskList({ storyId, tasks, resourceTypes, projectId, hoursPerDay }: Props) {
   const qc = useQueryClient()
   const [adding, setAdding] = useState(false)
   const [editingId, setEditingId] = useState<string | null>(null)
@@ -45,6 +44,7 @@ export default function TaskList({ storyId, tasks, resourceTypes, projectId }: P
             <TaskForm
               initial={{ name: task.name, description: task.description ?? '', assumptions: task.assumptions ?? '', hoursEffort: String(task.hoursEffort), resourceTypeId: task.resourceTypeId }}
               resourceTypes={resourceTypes}
+              hoursPerDay={hoursPerDay}
               onSave={(data) => updateTask.mutate({ id: task.id, data })}
               onCancel={() => setEditingId(null)}
               saving={updateTask.isPending}
@@ -57,7 +57,7 @@ export default function TaskList({ storyId, tasks, resourceTypes, projectId }: P
                   <span className="text-sm text-gray-800">{task.name}</span>
                   <span className="text-xs text-blue-600 bg-blue-50 px-1.5 py-0.5 rounded">{task.resourceType.name}</span>
                   <span className="text-xs font-medium text-gray-700 ml-auto">
-                    {task.hoursEffort}h / {(task.hoursEffort / HOURS_PER_DAY).toFixed(1)}d
+                    {task.hoursEffort}h / {(task.hoursEffort / hoursPerDay).toFixed(1)}d
                   </span>
                 </div>
                 {task.description && <p className="text-xs text-gray-500 mt-0.5 ml-0 truncate">{task.description}</p>}
@@ -76,6 +76,7 @@ export default function TaskList({ storyId, tasks, resourceTypes, projectId }: P
           <TaskForm
             initial={form}
             resourceTypes={resourceTypes}
+            hoursPerDay={hoursPerDay}
             onSave={(data) => createTask.mutate(data)}
             onCancel={() => setAdding(false)}
             saving={createTask.isPending}
@@ -90,9 +91,10 @@ export default function TaskList({ storyId, tasks, resourceTypes, projectId }: P
   )
 }
 
-function TaskForm({ initial, resourceTypes, onSave, onCancel, saving }: {
+function TaskForm({ initial, resourceTypes, hoursPerDay, onSave, onCancel, saving }: {
   initial: { name: string; description: string; assumptions: string; hoursEffort: string; resourceTypeId: string }
   resourceTypes: ResourceType[]
+  hoursPerDay: number
   onSave: (data: typeof initial) => void
   onCancel: () => void
   saving: boolean
@@ -100,7 +102,7 @@ function TaskForm({ initial, resourceTypes, onSave, onCancel, saving }: {
   const [form, setForm] = useState(initial)
   const [days, setDays] = useState(
     initial.hoursEffort && parseFloat(initial.hoursEffort) > 0
-      ? String(parseFloat((parseFloat(initial.hoursEffort) / HOURS_PER_DAY).toFixed(2)))
+      ? String(parseFloat((parseFloat(initial.hoursEffort) / hoursPerDay).toFixed(2)))
       : ''
   )
 
@@ -111,14 +113,14 @@ function TaskForm({ initial, resourceTypes, onSave, onCancel, saving }: {
     const h = e.target.value
     setForm(v => ({ ...v, hoursEffort: h }))
     const parsed = parseFloat(h)
-    setDays(!isNaN(parsed) && parsed > 0 ? String(parseFloat((parsed / HOURS_PER_DAY).toFixed(2))) : '')
+    setDays(!isNaN(parsed) && parsed > 0 ? String(parseFloat((parsed / hoursPerDay).toFixed(2))) : '')
   }
 
   const onDaysChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const d = e.target.value
     setDays(d)
     const parsed = parseFloat(d)
-    setForm(v => ({ ...v, hoursEffort: !isNaN(parsed) && parsed > 0 ? String(parseFloat((parsed * HOURS_PER_DAY).toFixed(2))) : '' }))
+    setForm(v => ({ ...v, hoursEffort: !isNaN(parsed) && parsed > 0 ? String(parseFloat((parsed * hoursPerDay).toFixed(2))) : '' }))
   }
 
   return (
@@ -134,7 +136,7 @@ function TaskForm({ initial, resourceTypes, onSave, onCancel, saving }: {
           <input type="number" placeholder="0" min="0" step="0.5" value={form.hoursEffort} onChange={onHoursChange} className="w-full border border-gray-200 rounded px-2 py-1 text-sm focus:outline-none focus:ring-1 focus:ring-blue-400" />
         </div>
         <div>
-          <label className="block text-xs text-gray-500 mb-0.5">Days (@ {HOURS_PER_DAY}h)</label>
+          <label className="block text-xs text-gray-500 mb-0.5">Days (@ {hoursPerDay}h)</label>
           <input type="number" placeholder="0" min="0" step="0.1" value={days} onChange={onDaysChange} className="w-full border border-gray-200 rounded px-2 py-1 text-sm focus:outline-none focus:ring-1 focus:ring-blue-400" />
         </div>
         <textarea placeholder="Description" value={form.description} onChange={f('description')} rows={1} className="col-span-2 border border-gray-200 rounded px-2 py-1 text-sm focus:outline-none focus:ring-1 focus:ring-blue-400" />

--- a/client/src/pages/BacklogPage.tsx
+++ b/client/src/pages/BacklogPage.tsx
@@ -3,7 +3,7 @@ import { useParams, useNavigate } from 'react-router-dom'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { api } from '../lib/api'
 import { useAuth } from '../hooks/useAuth'
-import type { Epic, ResourceType } from '../types/backlog'
+import type { Epic, ResourceType, Project } from '../types/backlog'
 import FeatureList from '../components/backlog/FeatureList'
 
 export default function BacklogPage() {
@@ -17,7 +17,7 @@ export default function BacklogPage() {
   const [editingEpicId, setEditingEpicId] = useState<string | null>(null)
   const [epicForm, setEpicForm] = useState({ name: '', description: '' })
 
-  const { data: project } = useQuery({
+  const { data: project } = useQuery<Project>({
     queryKey: ['project', projectId],
     queryFn: () => api.get(`/projects/${projectId}`).then(r => r.data),
   })
@@ -32,7 +32,7 @@ export default function BacklogPage() {
     queryFn: () => api.get(`/projects/${projectId}/resource-types`).then(r => r.data),
   })
 
-  const invalidate = () => qc.invalidateQueries({ queryKey: ['backlog', projectId] })
+  const hoursPerDay = project?.hoursPerDay ?? 7.6
 
   const createEpic = useMutation({
     mutationFn: (data: typeof epicForm) => api.post(`/projects/${projectId}/epics`, data),
@@ -84,7 +84,7 @@ export default function BacklogPage() {
             <h1 className="text-xl font-semibold text-gray-900">Backlog</h1>
             {epics.length > 0 && (
               <p className="text-sm text-gray-500 mt-0.5">
-                {epics.length} epic{epics.length !== 1 ? 's' : ''} · {grandTotal}h total ({(grandTotal / 8).toFixed(1)} days)
+                {epics.length} epic{epics.length !== 1 ? 's' : ''} · {grandTotal}h total ({(grandTotal / hoursPerDay).toFixed(1)} days)
               </p>
             )}
           </div>
@@ -126,7 +126,7 @@ export default function BacklogPage() {
                 )}
                 {expandedEpics.has(epic.id) && (
                   <div className="border-t border-gray-100 px-3 pb-3 pt-2">
-                    <FeatureList epicId={epic.id} features={epic.features} resourceTypes={resourceTypes} projectId={projectId!} />
+                    <FeatureList epicId={epic.id} features={epic.features} resourceTypes={resourceTypes} projectId={projectId!} hoursPerDay={hoursPerDay} />
                   </div>
                 )}
               </div>

--- a/client/src/pages/ProjectDetailPage.tsx
+++ b/client/src/pages/ProjectDetailPage.tsx
@@ -31,6 +31,7 @@ export default function ProjectDetailPage() {
     { label: 'Resource Profile', href: `/projects/${id}/resources`, icon: '👥', desc: 'Engineering and overlay profile' },
     { label: 'Documents', href: `/projects/${id}/documents`, icon: '📄', desc: 'Generate scope doc and SOW' },
     { label: 'Template Library', href: `/templates`, icon: '🧩', desc: 'Browse and manage feature templates' },
+    { label: 'Settings', href: `/projects/${id}/settings`, icon: '⚙️', desc: 'Edit project name, customer, hours per day' },
   ]
 
   return (
@@ -61,6 +62,7 @@ export default function ProjectDetailPage() {
             <span className={`text-xs px-2 py-0.5 rounded-full font-medium ${STATUS_COLOURS[project.status]}`}>
               {project.status}
             </span>
+            <button onClick={() => navigate(`/projects/${id}/settings`)} title="Edit project settings" className="text-gray-400 hover:text-red-600 transition-colors">✏️</button>
           </div>
           {project.customer && <p className="text-sm text-gray-500">Customer: {project.customer}</p>}
           {project.description && <p className="text-sm text-gray-600 mt-1">{project.description}</p>}

--- a/client/src/pages/ProjectSettingsPage.tsx
+++ b/client/src/pages/ProjectSettingsPage.tsx
@@ -1,0 +1,139 @@
+import { useState, useEffect } from 'react'
+import { useParams, useNavigate } from 'react-router-dom'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { api } from '../lib/api'
+import { useAuth } from '../hooks/useAuth'
+
+const STATUS_OPTIONS = ['DRAFT', 'ACTIVE', 'REVIEW', 'COMPLETE', 'ARCHIVED']
+
+export default function ProjectSettingsPage() {
+  const { id } = useParams<{ id: string }>()
+  const navigate = useNavigate()
+  const { user, logout } = useAuth()
+  const qc = useQueryClient()
+
+  const [form, setForm] = useState({ name: '', description: '', customer: '', status: 'DRAFT', hoursPerDay: 7.6 })
+  const [saved, setSaved] = useState(false)
+
+  const { data: project, isLoading } = useQuery({
+    queryKey: ['project', id],
+    queryFn: () => api.get(`/projects/${id}`).then(r => r.data),
+  })
+
+  useEffect(() => {
+    if (project) {
+      setForm({
+        name: project.name ?? '',
+        description: project.description ?? '',
+        customer: project.customer ?? '',
+        status: project.status ?? 'DRAFT',
+        hoursPerDay: project.hoursPerDay ?? 7.6,
+      })
+    }
+  }, [project])
+
+  const updateProject = useMutation({
+    mutationFn: (data: typeof form) => api.put(`/projects/${id}`, data),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['project', id] })
+      qc.invalidateQueries({ queryKey: ['projects'] })
+      setSaved(true)
+      setTimeout(() => setSaved(false), 3000)
+    },
+  })
+
+  const f = (field: keyof typeof form) => (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) => {
+    const value = field === 'hoursPerDay' ? parseFloat(e.target.value) || 7.6 : e.target.value
+    setForm(v => ({ ...v, [field]: value }))
+  }
+
+  if (isLoading) return <div className="min-h-screen flex items-center justify-center text-gray-400">Loading…</div>
+  if (!project) return <div className="min-h-screen flex items-center justify-center text-gray-400">Project not found</div>
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <header className="bg-white border-b border-gray-200">
+        <div className="max-w-6xl mx-auto px-6 py-4 flex items-center justify-between">
+          <div className="flex items-center gap-2 text-sm text-gray-500">
+            <button onClick={() => navigate('/')} className="hover:text-red-600 transition-colors font-semibold text-gray-900">Monrad Estimator</button>
+            <span>/</span>
+            <button onClick={() => navigate(`/projects/${id}`)} className="hover:text-red-600 transition-colors">{project.name}</button>
+            <span>/</span>
+            <span className="text-gray-700">Settings</span>
+          </div>
+          <div className="flex items-center gap-3">
+            <span className="text-sm text-gray-500">{user?.name}</span>
+            <button onClick={logout} className="text-sm text-gray-500 hover:text-gray-700">Sign out</button>
+          </div>
+        </div>
+      </header>
+
+      <main className="max-w-2xl mx-auto px-6 py-8">
+        <h1 className="text-xl font-semibold text-gray-900 mb-6">Project Settings</h1>
+
+        <div className="bg-white rounded-xl border border-gray-200 p-6 space-y-4">
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Project name *</label>
+            <input
+              type="text" value={form.name} onChange={f('name')}
+              className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-red-500"
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Customer</label>
+            <input
+              type="text" value={form.customer} onChange={f('customer')}
+              className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-red-500"
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Description</label>
+            <textarea
+              value={form.description} onChange={f('description')} rows={3}
+              className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-red-500"
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Status</label>
+            <select
+              value={form.status} onChange={f('status')}
+              className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-red-500"
+            >
+              {STATUS_OPTIONS.map(s => <option key={s} value={s}>{s}</option>)}
+            </select>
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Hours per day</label>
+            <input
+              type="number" value={form.hoursPerDay} onChange={f('hoursPerDay')}
+              min={1} max={24} step={0.1}
+              className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-red-500"
+            />
+            <p className="text-xs text-gray-400 mt-1">Used to convert hours to days in estimates. Default is 7.6h.</p>
+          </div>
+
+          <div className="flex items-center gap-3 pt-2">
+            <button
+              onClick={() => updateProject.mutate(form)}
+              disabled={!form.name || updateProject.isPending}
+              className="bg-red-600 text-white px-5 py-2 rounded-lg text-sm font-medium hover:bg-red-700 disabled:opacity-50 transition-colors"
+            >
+              {updateProject.isPending ? 'Saving…' : 'Save settings'}
+            </button>
+            <button
+              onClick={() => navigate(`/projects/${id}`)}
+              className="px-5 py-2 rounded-lg text-sm text-gray-600 hover:bg-gray-100 transition-colors"
+            >
+              Cancel
+            </button>
+            {saved && <span className="text-sm text-green-600">✓ Settings saved</span>}
+          </div>
+        </div>
+      </main>
+    </div>
+  )
+}

--- a/client/src/pages/ProjectsPage.tsx
+++ b/client/src/pages/ProjectsPage.tsx
@@ -10,6 +10,7 @@ interface Project {
   description?: string
   customer?: string
   status: string
+  hoursPerDay: number
   updatedAt: string
   _count: { epics: number }
 }

--- a/client/src/pages/TemplateLibraryPage.tsx
+++ b/client/src/pages/TemplateLibraryPage.tsx
@@ -6,6 +6,12 @@ import { useAuth } from '../hooks/useAuth'
 
 const HOURS_PER_DAY = 7.6
 
+interface GlobalResourceType {
+  id: string
+  name: string
+  category: string
+}
+
 interface TemplateTask {
   id: string
   templateId: string
@@ -41,6 +47,11 @@ export default function TemplateLibraryPage() {
   const { data: templates = [], isLoading } = useQuery<FeatureTemplate[]>({
     queryKey: ['templates'],
     queryFn: () => api.get('/templates').then(r => r.data),
+  })
+
+  const { data: globalResourceTypes = [] } = useQuery<GlobalResourceType[]>({
+    queryKey: ['global-resource-types'],
+    queryFn: () => api.get('/global-resource-types').then(r => r.data),
   })
 
   const invalidate = () => qc.invalidateQueries({ queryKey: ['templates'] })
@@ -182,6 +193,7 @@ export default function TemplateLibraryPage() {
                                 <td colSpan={7} className="py-2">
                                   <TaskForm
                                     initial={{ name: task.name, hoursSmall: task.hoursSmall, hoursMedium: task.hoursMedium, hoursLarge: task.hoursLarge, hoursExtraLarge: task.hoursExtraLarge, resourceTypeName: task.resourceTypeName }}
+                                    globalResourceTypes={globalResourceTypes}
                                     onSave={(data) => updateTask.mutate({ templateId: tpl.id, taskId: task.id, data })}
                                     onCancel={() => setEditingTaskId(null)}
                                     saving={updateTask.isPending}
@@ -212,6 +224,7 @@ export default function TemplateLibraryPage() {
                     {addingTaskForId === tpl.id ? (
                       <TaskForm
                         initial={taskForm}
+                        globalResourceTypes={globalResourceTypes}
                         onSave={(data) => createTask.mutate({ templateId: tpl.id, data })}
                         onCancel={() => setAddingTaskForId(null)}
                         saving={createTask.isPending}
@@ -271,14 +284,15 @@ function TemplateForm({ initial, onSave, onCancel, saving }: {
   )
 }
 
-function TaskForm({ initial, onSave, onCancel, saving }: {
+function TaskForm({ initial, globalResourceTypes, onSave, onCancel, saving }: {
   initial: { name: string; hoursSmall: number; hoursMedium: number; hoursLarge: number; hoursExtraLarge: number; resourceTypeName: string }
+  globalResourceTypes: GlobalResourceType[]
   onSave: (data: typeof initial) => void
   onCancel: () => void
   saving: boolean
 }) {
   const [form, setForm] = useState(initial)
-  const fText = (field: 'name' | 'resourceTypeName') => (e: React.ChangeEvent<HTMLInputElement>) =>
+  const fText = (field: 'name') => (e: React.ChangeEvent<HTMLInputElement>) =>
     setForm(v => ({ ...v, [field]: e.target.value }))
   const fNum = (field: 'hoursSmall' | 'hoursMedium' | 'hoursLarge' | 'hoursExtraLarge') => (e: React.ChangeEvent<HTMLInputElement>) =>
     setForm(v => ({ ...v, [field]: parseFloat(e.target.value) || 0 }))
@@ -288,8 +302,16 @@ function TaskForm({ initial, onSave, onCancel, saving }: {
       <div className="grid grid-cols-2 gap-2">
         <input placeholder="Task name *" value={form.name} onChange={fText('name')}
           className="border border-gray-200 rounded px-2 py-1 text-sm focus:outline-none focus:ring-1 focus:ring-blue-400" />
-        <input placeholder="Resource type name *" value={form.resourceTypeName} onChange={fText('resourceTypeName')}
-          className="border border-gray-200 rounded px-2 py-1 text-sm focus:outline-none focus:ring-1 focus:ring-blue-400" />
+        {globalResourceTypes.length > 0 ? (
+          <select value={form.resourceTypeName} onChange={e => setForm(v => ({ ...v, resourceTypeName: e.target.value }))}
+            className="border border-gray-200 rounded px-2 py-1 text-sm focus:outline-none focus:ring-1 focus:ring-blue-400">
+            <option value="">Resource type *</option>
+            {globalResourceTypes.map(gt => <option key={gt.id} value={gt.name}>{gt.name}</option>)}
+          </select>
+        ) : (
+          <input placeholder="Resource type name *" value={form.resourceTypeName} onChange={e => setForm(v => ({ ...v, resourceTypeName: e.target.value }))}
+            className="border border-gray-200 rounded px-2 py-1 text-sm focus:outline-none focus:ring-1 focus:ring-blue-400" />
+        )}
       </div>
       <div className="grid grid-cols-4 gap-2">
         {(['hoursSmall', 'hoursMedium', 'hoursLarge', 'hoursExtraLarge'] as const).map((field, i) => (

--- a/client/src/test/TaskList.test.tsx
+++ b/client/src/test/TaskList.test.tsx
@@ -13,7 +13,7 @@ vi.mock('../../lib/api', () => ({
 }))
 
 const resourceTypes: ResourceType[] = [
-  { id: 'rt-1', name: 'Developer', category: 'ENGINEERING', projectId: 'proj-1' },
+  { id: 'rt-1', name: 'Developer', category: 'ENGINEERING', count: 1, projectId: 'proj-1' },
 ]
 
 const tasks: Task[] = [
@@ -26,25 +26,25 @@ function wrapper({ children }: { children: React.ReactNode }) {
 
 describe('TaskList', () => {
   it('renders task name and hours', () => {
-    render(<TaskList storyId="s-1" tasks={tasks} resourceTypes={resourceTypes} projectId="proj-1" />, { wrapper })
+    render(<TaskList storyId="s-1" tasks={tasks} resourceTypes={resourceTypes} projectId="proj-1" hoursPerDay={7.6} />, { wrapper })
     expect(screen.getByText('Implement login')).toBeInTheDocument()
     expect(screen.getByText(/4h/)).toBeInTheDocument()
     expect(screen.getByText('Developer')).toBeInTheDocument()
   })
 
   it('shows add task button', () => {
-    render(<TaskList storyId="s-1" tasks={[]} resourceTypes={resourceTypes} projectId="proj-1" />, { wrapper })
+    render(<TaskList storyId="s-1" tasks={[]} resourceTypes={resourceTypes} projectId="proj-1" hoursPerDay={7.6} />, { wrapper })
     expect(screen.getByText('+ Add task')).toBeInTheDocument()
   })
 
   it('shows task form when add task clicked', () => {
-    render(<TaskList storyId="s-1" tasks={[]} resourceTypes={resourceTypes} projectId="proj-1" />, { wrapper })
+    render(<TaskList storyId="s-1" tasks={[]} resourceTypes={resourceTypes} projectId="proj-1" hoursPerDay={7.6} />, { wrapper })
     fireEvent.click(screen.getByText('+ Add task'))
     expect(screen.getByPlaceholderText('Task name *')).toBeInTheDocument()
   })
 
   it('shows hours in days too', () => {
-    render(<TaskList storyId="s-1" tasks={tasks} resourceTypes={resourceTypes} projectId="proj-1" />, { wrapper })
+    render(<TaskList storyId="s-1" tasks={tasks} resourceTypes={resourceTypes} projectId="proj-1" hoursPerDay={7.6} />, { wrapper })
     expect(screen.getByText(/0\.5d/)).toBeInTheDocument()
   })
 })

--- a/client/src/types/backlog.ts
+++ b/client/src/types/backlog.ts
@@ -1,7 +1,19 @@
+export interface GlobalResourceType {
+  id: string
+  name: string
+  category: string
+  description?: string
+  isDefault: boolean
+}
+
 export interface ResourceType {
   id: string
   name: string
   category: 'ENGINEERING' | 'GOVERNANCE' | 'PROJECT_MANAGEMENT'
+  count: number
+  proposedName?: string
+  globalTypeId?: string
+  globalType?: GlobalResourceType
   projectId: string
 }
 
@@ -44,4 +56,14 @@ export interface Epic {
   order: number
   projectId: string
   features: Feature[]
+}
+
+export interface Project {
+  id: string
+  name: string
+  description?: string
+  customer?: string
+  status: string
+  hoursPerDay: number
+  updatedAt: string
 }

--- a/server/package.json
+++ b/server/package.json
@@ -10,6 +10,9 @@
     "start": "node dist/index.js",
     "test:watch": "vitest"
   },
+  "prisma": {
+    "seed": "tsx prisma/seed.ts"
+  },
   "keywords": [],
   "author": "",
   "license": "ISC",

--- a/server/prisma.config.ts
+++ b/server/prisma.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
   schema: "prisma/schema.prisma",
   migrations: {
     path: "prisma/migrations",
+    seed: "tsx prisma/seed.ts",
   },
   datasource: {
     url: process.env["DATABASE_URL"],

--- a/server/prisma/migrations/20260228044334_resource_abstraction/migration.sql
+++ b/server/prisma/migrations/20260228044334_resource_abstraction/migration.sql
@@ -1,0 +1,26 @@
+-- AlterTable
+ALTER TABLE "Project" ADD COLUMN     "hoursPerDay" DOUBLE PRECISION NOT NULL DEFAULT 7.6;
+
+-- AlterTable
+ALTER TABLE "ResourceType" ADD COLUMN     "count" INTEGER NOT NULL DEFAULT 1,
+ADD COLUMN     "globalTypeId" TEXT,
+ADD COLUMN     "proposedName" TEXT;
+
+-- CreateTable
+CREATE TABLE "GlobalResourceType" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "category" "ResourceCategory" NOT NULL,
+    "description" TEXT,
+    "isDefault" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "GlobalResourceType_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "GlobalResourceType_name_key" ON "GlobalResourceType"("name");
+
+-- AddForeignKey
+ALTER TABLE "ResourceType" ADD CONSTRAINT "ResourceType_globalTypeId_fkey" FOREIGN KEY ("globalTypeId") REFERENCES "GlobalResourceType"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -17,12 +17,24 @@ model User {
   projects  Project[]
 }
 
+model GlobalResourceType {
+  id            String           @id @default(cuid())
+  name          String           @unique
+  category      ResourceCategory
+  description   String?
+  isDefault     Boolean          @default(false)
+  resourceTypes ResourceType[]
+  createdAt     DateTime         @default(now())
+  updatedAt     DateTime         @updatedAt
+}
+
 model Project {
   id          String        @id @default(cuid())
   name        String
   description String?
   customer    String?
   status      ProjectStatus @default(DRAFT)
+  hoursPerDay Float         @default(7.6)
   createdAt   DateTime      @default(now())
   updatedAt   DateTime      @updatedAt
   owner       User          @relation(fields: [ownerId], references: [id])
@@ -40,12 +52,16 @@ enum ProjectStatus {
 }
 
 model ResourceType {
-  id        String           @id @default(cuid())
-  name      String
-  category  ResourceCategory
-  project   Project          @relation(fields: [projectId], references: [id], onDelete: Cascade)
-  projectId String
-  tasks     Task[]
+  id           String              @id @default(cuid())
+  name         String
+  category     ResourceCategory
+  count        Int                 @default(1)
+  proposedName String?
+  globalType   GlobalResourceType? @relation(fields: [globalTypeId], references: [id])
+  globalTypeId String?
+  project      Project             @relation(fields: [projectId], references: [id], onDelete: Cascade)
+  projectId    String
+  tasks        Task[]
   templateTasks TemplateTask[]
 }
 

--- a/server/prisma/seed.ts
+++ b/server/prisma/seed.ts
@@ -1,0 +1,43 @@
+import { PrismaPg } from '@prisma/adapter-pg'
+import { PrismaClient } from '@prisma/client'
+import 'dotenv/config'
+
+const adapter = new PrismaPg({ connectionString: process.env.DATABASE_URL })
+const prisma = new PrismaClient({ adapter })
+
+const DEFAULT_GLOBAL_TYPES = [
+  { name: 'Business Analyst', category: 'ENGINEERING' as const },
+  { name: 'Developer', category: 'ENGINEERING' as const },
+  { name: 'Tech Lead', category: 'ENGINEERING' as const },
+  { name: 'QA Engineer', category: 'ENGINEERING' as const },
+  { name: 'Tech Governance', category: 'GOVERNANCE' as const },
+  { name: 'Project Manager', category: 'PROJECT_MANAGEMENT' as const },
+]
+
+async function main() {
+  // Upsert global resource types
+  for (const gt of DEFAULT_GLOBAL_TYPES) {
+    await prisma.globalResourceType.upsert({
+      where: { name: gt.name },
+      create: { ...gt, isDefault: true },
+      update: {},
+    })
+  }
+
+  // Build name -> id map
+  const globalTypes = await prisma.globalResourceType.findMany()
+  const nameToId = new Map(globalTypes.map(gt => [gt.name, gt.id]))
+
+  // Link existing resource types to global types by name
+  const resourceTypes = await prisma.resourceType.findMany({ where: { globalTypeId: null } })
+  for (const rt of resourceTypes) {
+    const globalTypeId = nameToId.get(rt.name)
+    if (globalTypeId) {
+      await prisma.resourceType.update({ where: { id: rt.id }, data: { globalTypeId } })
+    }
+  }
+
+  console.log('Seed complete.')
+}
+
+main().catch(e => { console.error(e); process.exit(1) }).finally(() => prisma.$disconnect())

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -10,6 +10,7 @@ import taskRoutes from './routes/tasks.js'
 import resourceTypeRoutes from './routes/resourceTypes.js'
 import templateRoutes from './routes/templates.js'
 import applyTemplateRoutes from './routes/applyTemplate.js'
+import globalResourceTypeRoutes from './routes/globalResourceTypes.js'
 
 const app = express()
 const PORT = process.env.PORT ?? 3001
@@ -27,6 +28,7 @@ app.use('/api/features/:featureId/stories', storyRoutes)
 app.use('/api/stories/:storyId/tasks', taskRoutes)
 app.use('/api/templates', templateRoutes)
 app.use('/api/features', applyTemplateRoutes)
+app.use('/api/global-resource-types', globalResourceTypeRoutes)
 
 export { app }
 app.listen(PORT, () => console.log(`Server running on http://localhost:${PORT}`))

--- a/server/src/routes/globalResourceTypes.ts
+++ b/server/src/routes/globalResourceTypes.ts
@@ -1,0 +1,21 @@
+import { Router, Request, Response } from 'express'
+import { prisma } from '../lib/prisma.js'
+import { authenticate, AuthRequest } from '../middleware/auth.js'
+
+const router = Router()
+
+// GET /api/global-resource-types — no auth required
+router.get('/', async (_req: Request, res: Response) => {
+  const types = await prisma.globalResourceType.findMany({ orderBy: { name: 'asc' } })
+  res.json(types)
+})
+
+// POST /api/global-resource-types — auth required
+router.post('/', authenticate, async (req: AuthRequest, res: Response) => {
+  const { name, category, description } = req.body
+  if (!name || !category) { res.status(400).json({ error: 'name and category are required' }); return }
+  const gt = await prisma.globalResourceType.create({ data: { name, category, description } })
+  res.status(201).json(gt)
+})
+
+export default router

--- a/server/src/routes/projects.ts
+++ b/server/src/routes/projects.ts
@@ -30,6 +30,10 @@ router.post('/', async (req: AuthRequest, res: Response) => {
   const { name, description, customer } = req.body
   if (!name) { res.status(400).json({ error: 'name is required' }); return }
 
+  // Fetch global types to link by name
+  const globalTypes = await prisma.globalResourceType.findMany()
+  const nameToGlobalId = new Map(globalTypes.map(gt => [gt.name, gt.id]))
+
   const project = await prisma.project.create({
     data: {
       name,
@@ -39,12 +43,12 @@ router.post('/', async (req: AuthRequest, res: Response) => {
       // Seed default resource types
       resourceTypes: {
         create: [
-          { name: 'Business Analyst', category: 'ENGINEERING' },
-          { name: 'Developer', category: 'ENGINEERING' },
-          { name: 'Tech Lead', category: 'ENGINEERING' },
-          { name: 'QA Engineer', category: 'ENGINEERING' },
-          { name: 'Tech Governance', category: 'GOVERNANCE' },
-          { name: 'Project Manager', category: 'PROJECT_MANAGEMENT' },
+          { name: 'Business Analyst', category: 'ENGINEERING', globalTypeId: nameToGlobalId.get('Business Analyst') },
+          { name: 'Developer', category: 'ENGINEERING', globalTypeId: nameToGlobalId.get('Developer') },
+          { name: 'Tech Lead', category: 'ENGINEERING', globalTypeId: nameToGlobalId.get('Tech Lead') },
+          { name: 'QA Engineer', category: 'ENGINEERING', globalTypeId: nameToGlobalId.get('QA Engineer') },
+          { name: 'Tech Governance', category: 'GOVERNANCE', globalTypeId: nameToGlobalId.get('Tech Governance') },
+          { name: 'Project Manager', category: 'PROJECT_MANAGEMENT', globalTypeId: nameToGlobalId.get('Project Manager') },
         ],
       },
     },
@@ -55,12 +59,12 @@ router.post('/', async (req: AuthRequest, res: Response) => {
 
 // Update project
 router.put('/:id', async (req: AuthRequest, res: Response) => {
-  const { name, description, customer, status } = req.body
+  const { name, description, customer, status, hoursPerDay } = req.body
   const existing = await prisma.project.findFirst({ where: { id: req.params.id as string, ownerId: req.userId } })
   if (!existing) { res.status(404).json({ error: 'Not found' }); return }
   const project = await prisma.project.update({
     where: { id: req.params.id as string },
-    data: { name, description, customer, status },
+    data: { name, description, customer, status, hoursPerDay },
   })
   res.json(project)
 })

--- a/server/src/routes/resourceTypes.ts
+++ b/server/src/routes/resourceTypes.ts
@@ -16,6 +16,7 @@ router.get('/', async (req: AuthRequest, res: Response) => {
   const types = await prisma.resourceType.findMany({
     where: { projectId: req.params.projectId as string },
     orderBy: { name: 'asc' },
+    include: { globalType: { select: { id: true, name: true, category: true } } },
   })
   res.json(types)
 })
@@ -36,10 +37,10 @@ router.post('/', async (req: AuthRequest, res: Response) => {
 router.put('/:id', async (req: AuthRequest, res: Response) => {
   const project = await ownedProject(req.params.projectId as string, req.userId!)
   if (!project) { res.status(404).json({ error: 'Project not found' }); return }
-  const { name, category } = req.body
+  const { name, category, count, proposedName } = req.body
   const rt = await prisma.resourceType.update({
     where: { id: req.params.id as string },
-    data: { name, category },
+    data: { name, category, count, proposedName },
   })
   res.json(rt)
 })

--- a/server/src/test/globalResourceTypes.test.ts
+++ b/server/src/test/globalResourceTypes.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import request from 'supertest'
+import jwt from 'jsonwebtoken'
+import { app } from '../index.js'
+import { prisma } from '../lib/prisma.js'
+
+process.env.JWT_SECRET = 'test-secret'
+
+const userId = 'user-1'
+const token = jwt.sign({ userId }, 'test-secret')
+const authHeader = `Bearer ${token}`
+
+const mockGRT = { id: 'grt-1', name: 'Developer', category: 'ENGINEERING' as const, description: null, isDefault: true, createdAt: new Date(), updatedAt: new Date() }
+
+beforeEach(() => vi.clearAllMocks())
+
+describe('GET /api/global-resource-types', () => {
+  it('returns array without auth', async () => {
+    vi.mocked(prisma.globalResourceType.findMany).mockResolvedValue([mockGRT])
+    const res = await request(app).get('/api/global-resource-types')
+    expect(res.status).toBe(200)
+    expect(res.body).toHaveLength(1)
+    expect(res.body[0].name).toBe('Developer')
+  })
+})
+
+describe('POST /api/global-resource-types', () => {
+  it('creates a global resource type when authenticated', async () => {
+    vi.mocked(prisma.globalResourceType.create).mockResolvedValue(mockGRT)
+    const res = await request(app)
+      .post('/api/global-resource-types')
+      .set('Authorization', authHeader)
+      .send({ name: 'Developer', category: 'ENGINEERING' })
+    expect(res.status).toBe(201)
+    expect(res.body.name).toBe('Developer')
+  })
+
+  it('returns 401 without auth', async () => {
+    const res = await request(app)
+      .post('/api/global-resource-types')
+      .send({ name: 'Developer', category: 'ENGINEERING' })
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 400 when name is missing', async () => {
+    const res = await request(app)
+      .post('/api/global-resource-types')
+      .set('Authorization', authHeader)
+      .send({ category: 'ENGINEERING' })
+    expect(res.status).toBe(400)
+  })
+})

--- a/server/src/test/projectSettings.test.ts
+++ b/server/src/test/projectSettings.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import request from 'supertest'
+import jwt from 'jsonwebtoken'
+import { app } from '../index.js'
+import { prisma } from '../lib/prisma.js'
+
+process.env.JWT_SECRET = 'test-secret'
+
+const userId = 'user-1'
+const token = jwt.sign({ userId }, 'test-secret')
+const authHeader = `Bearer ${token}`
+
+const mockProject = {
+  id: 'proj-1', name: 'Test Project', description: null, customer: null,
+  status: 'DRAFT', hoursPerDay: 7.6, ownerId: userId, createdAt: new Date(), updatedAt: new Date(),
+}
+
+beforeEach(() => vi.clearAllMocks())
+
+describe('PUT /api/projects/:id', () => {
+  it('updates project name and hoursPerDay', async () => {
+    vi.mocked(prisma.project.findFirst).mockResolvedValue(mockProject as any)
+    vi.mocked(prisma.project.update).mockResolvedValue({ ...mockProject, name: 'Updated', hoursPerDay: 8 } as any)
+
+    const res = await request(app)
+      .put('/api/projects/proj-1')
+      .set('Authorization', authHeader)
+      .send({ name: 'Updated', hoursPerDay: 8 })
+
+    expect(res.status).toBe(200)
+    expect(res.body.name).toBe('Updated')
+    expect(res.body.hoursPerDay).toBe(8)
+  })
+
+  it('updates project status', async () => {
+    vi.mocked(prisma.project.findFirst).mockResolvedValue(mockProject as any)
+    vi.mocked(prisma.project.update).mockResolvedValue({ ...mockProject, status: 'ACTIVE' } as any)
+
+    const res = await request(app)
+      .put('/api/projects/proj-1')
+      .set('Authorization', authHeader)
+      .send({ status: 'ACTIVE' })
+
+    expect(res.status).toBe(200)
+    expect(res.body.status).toBe('ACTIVE')
+  })
+
+  it('returns 404 for non-owned project', async () => {
+    vi.mocked(prisma.project.findFirst).mockResolvedValue(null)
+
+    const res = await request(app)
+      .put('/api/projects/proj-1')
+      .set('Authorization', authHeader)
+      .send({ name: 'X' })
+
+    expect(res.status).toBe(404)
+  })
+})

--- a/server/src/test/setup.ts
+++ b/server/src/test/setup.ts
@@ -10,6 +10,7 @@ vi.mock('../lib/prisma.js', () => ({
     userStory: { findMany: vi.fn(), findFirst: vi.fn(), findUnique: vi.fn(), create: vi.fn(), update: vi.fn(), delete: vi.fn() },
     task: { findMany: vi.fn(), findFirst: vi.fn(), create: vi.fn(), update: vi.fn(), delete: vi.fn() },
     resourceType: { findMany: vi.fn(), findFirst: vi.fn(), create: vi.fn(), update: vi.fn(), delete: vi.fn() },
+    globalResourceType: { findMany: vi.fn(), findFirst: vi.fn(), create: vi.fn(), update: vi.fn(), delete: vi.fn() },
     featureTemplate: { findMany: vi.fn(), findFirst: vi.fn(), findUnique: vi.fn(), create: vi.fn(), update: vi.fn(), delete: vi.fn() },
     templateTask: { findMany: vi.fn(), findFirst: vi.fn(), findUnique: vi.fn(), create: vi.fn(), update: vi.fn(), delete: vi.fn() },
   },


### PR DESCRIPTION
## Resource abstraction, project hoursPerDay, project settings

Closes #15
Closes #16
Closes #17

## Summary

### What's included

**Schema & DB**
- New `GlobalResourceType` model — shared catalog of resource types
- `ResourceType` gains `globalTypeId`, `count`, `proposedName`
- `Project` gains `hoursPerDay` (default 7.6)
- Migration applied; seed script populates 6 default global resource types

**Server**
- `GET/POST /api/global-resource-types` — global catalog endpoints
- `PUT /api/projects/:id` — now accepts `hoursPerDay`
- `PUT /api/projects/:projectId/resource-types/:id` — accepts `count`, `proposedName`
- Project creation links seeded resource types to global catalog by name

**Client**
- `hoursPerDay` threaded from project data through BacklogPage → FeatureList → StoryList → TaskList (no more hardcoded 7.6)
- New `ProjectSettingsPage` at `/projects/:id/settings`
- Settings nav card + ✏️ edit icon on ProjectDetailPage
- Template task form uses global resource type dropdown (not free text)

## Testing
- [ ] `npm test` passes in `/server`
- [x] `npm test` passes in `/server` — 21 tests passing (5 files)
- [x] `npx tsc --noEmit` passes in `/server`
- [x] `npx tsc --noEmit` passes in `/client`