### PR TITLE
Phase 4: Effort Review

### DIFF
--- a/client/.vite/deps/_metadata.json
+++ b/client/.vite/deps/_metadata.json
@@ -1,0 +1,8 @@
+{
+  "hash": "2464fa3f",
+  "configHash": "58532f46",
+  "lockfileHash": "c9dacaaa",
+  "browserHash": "2ea0029d",
+  "optimized": {},
+  "chunks": {}
+}

--- a/client/.vite/deps/package.json
+++ b/client/.vite/deps/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -8,6 +8,7 @@ import ProjectDetailPage from './pages/ProjectDetailPage'
 import BacklogPage from './pages/BacklogPage'
 import TemplateLibraryPage from './pages/TemplateLibraryPage'
 import ProjectSettingsPage from './pages/ProjectSettingsPage'
+import EffortReviewPage from './pages/EffortReviewPage'
 
 const queryClient = new QueryClient()
 
@@ -29,6 +30,7 @@ function AppRoutes() {
       <Route path="/" element={<PrivateRoute><ProjectsPage /></PrivateRoute>} />
       <Route path="/projects/:id" element={<PrivateRoute><ProjectDetailPage /></PrivateRoute>} />
       <Route path="/projects/:id/backlog" element={<PrivateRoute><BacklogPage /></PrivateRoute>} />
+      <Route path="/projects/:id/effort" element={<PrivateRoute><EffortReviewPage /></PrivateRoute>} />
       <Route path="/projects/:id/settings" element={<PrivateRoute><ProjectSettingsPage /></PrivateRoute>} />
       <Route path="/templates" element={<PrivateRoute><TemplateLibraryPage /></PrivateRoute>} />
     </Routes>

--- a/client/src/pages/EffortReviewPage.tsx
+++ b/client/src/pages/EffortReviewPage.tsx
@@ -1,0 +1,349 @@
+import { useState } from 'react'
+import { useParams, useNavigate } from 'react-router-dom'
+import { useQuery } from '@tanstack/react-query'
+import { api } from '../lib/api'
+import { useAuth } from '../hooks/useAuth'
+import type { Project } from '../types/backlog'
+
+type ResourceCategory = 'ENGINEERING' | 'GOVERNANCE' | 'PROJECT_MANAGEMENT'
+
+interface TaskSummary {
+  taskId: string
+  taskName: string
+  storyName: string
+  featureName: string
+  epicName: string
+  hoursEffort: number
+  daysEffort: number
+}
+
+interface ResourceTypeSummary {
+  resourceTypeId: string
+  name: string
+  category: ResourceCategory
+  count: number
+  proposedName: string | null
+  totalHours: number
+  totalDays: number
+  tasks: TaskSummary[]
+}
+
+interface CategorySummary {
+  category: ResourceCategory
+  totalHours: number
+  totalDays: number
+  resourceTypes: ResourceTypeSummary[]
+}
+
+interface EffortSummary {
+  projectId: string
+  hoursPerDay: number
+  totalHours: number
+  totalDays: number
+  byCategory: CategorySummary[]
+}
+
+const CATEGORY_LABELS: Record<ResourceCategory, string> = {
+  ENGINEERING: 'Engineering',
+  GOVERNANCE: 'Governance',
+  PROJECT_MANAGEMENT: 'Project Management',
+}
+
+const CATEGORY_ROW_BG: Record<ResourceCategory, string> = {
+  ENGINEERING: 'bg-blue-50',
+  GOVERNANCE: 'bg-amber-50',
+  PROJECT_MANAGEMENT: 'bg-green-50',
+}
+
+const CATEGORY_HEADER_BG: Record<ResourceCategory, string> = {
+  ENGINEERING: 'bg-blue-100',
+  GOVERNANCE: 'bg-amber-100',
+  PROJECT_MANAGEMENT: 'bg-green-100',
+}
+
+const CATEGORY_BAR_BG: Record<ResourceCategory, string> = {
+  ENGINEERING: 'bg-blue-400',
+  GOVERNANCE: 'bg-amber-400',
+  PROJECT_MANAGEMENT: 'bg-green-400',
+}
+
+export default function EffortReviewPage() {
+  const { id: projectId } = useParams<{ id: string }>()
+  const navigate = useNavigate()
+  const { user, logout } = useAuth()
+  const [view, setView] = useState<'summary' | 'detail'>('summary')
+  const [expandedRts, setExpandedRts] = useState<Set<string>>(new Set())
+  const [collapsedCategories, setCollapsedCategories] = useState<Set<string>>(new Set())
+
+  const { data: project } = useQuery<Project>({
+    queryKey: ['project', projectId],
+    queryFn: () => api.get(`/projects/${projectId}`).then(r => r.data),
+  })
+
+  const { data: effort, isLoading } = useQuery<EffortSummary>({
+    queryKey: ['effort', projectId],
+    queryFn: () => api.get(`/projects/${projectId}/effort`).then(r => r.data),
+  })
+
+  const toggleRt = (id: string) =>
+    setExpandedRts(s => { const n = new Set(s); n.has(id) ? n.delete(id) : n.add(id); return n })
+
+  const toggleCategory = (cat: string) =>
+    setCollapsedCategories(s => { const n = new Set(s); n.has(cat) ? n.delete(cat) : n.add(cat); return n })
+
+  const totalResourceTypes = effort?.byCategory.reduce((s, c) => s + c.resourceTypes.length, 0) ?? 0
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <header className="bg-white border-b border-gray-200">
+        <div className="max-w-6xl mx-auto px-6 py-4 flex items-center justify-between">
+          <div className="flex items-center gap-2 text-sm text-gray-500">
+            <button onClick={() => navigate('/')} className="hover:text-red-600 transition-colors font-semibold text-gray-900">Monrad Estimator</button>
+            <span>/</span>
+            <button onClick={() => navigate(`/projects/${projectId}`)} className="hover:text-red-600 transition-colors">{project?.name ?? '…'}</button>
+            <span>/</span>
+            <span className="text-gray-700">Effort Review</span>
+          </div>
+          <div className="flex items-center gap-3">
+            <span className="text-sm text-gray-500">{user?.name}</span>
+            <button onClick={logout} className="text-sm text-gray-500 hover:text-gray-700">Sign out</button>
+          </div>
+        </div>
+      </header>
+
+      <main className="max-w-6xl mx-auto px-6 py-8">
+        <div className="flex items-center justify-between mb-6">
+          <h1 className="text-xl font-semibold text-gray-900">Effort Review</h1>
+          {/* View toggle */}
+          <div className="flex rounded-lg border border-gray-200 overflow-hidden text-sm">
+            <button
+              onClick={() => setView('summary')}
+              className={`px-4 py-2 font-medium transition-colors ${view === 'summary' ? 'bg-red-600 text-white' : 'bg-white text-gray-600 hover:bg-gray-50'}`}
+            >
+              Summary
+            </button>
+            <button
+              onClick={() => setView('detail')}
+              className={`px-4 py-2 font-medium transition-colors ${view === 'detail' ? 'bg-red-600 text-white' : 'bg-white text-gray-600 hover:bg-gray-50'}`}
+            >
+              Detail
+            </button>
+          </div>
+        </div>
+
+        {/* Summary bar */}
+        {effort && (
+          <div className="grid grid-cols-3 gap-4 mb-6">
+            <div className="bg-white rounded-xl border border-gray-200 p-4 text-center">
+              <p className="text-2xl font-bold text-gray-900">{effort.totalHours.toFixed(0)}h</p>
+              <p className="text-sm text-gray-500 mt-1">Total hours</p>
+            </div>
+            <div className="bg-white rounded-xl border border-gray-200 p-4 text-center">
+              <p className="text-2xl font-bold text-gray-900">{effort.totalDays.toFixed(1)}</p>
+              <p className="text-sm text-gray-500 mt-1">Total days</p>
+            </div>
+            <div className="bg-white rounded-xl border border-gray-200 p-4 text-center">
+              <p className="text-2xl font-bold text-gray-900">{totalResourceTypes}</p>
+              <p className="text-sm text-gray-500 mt-1">Resource types</p>
+            </div>
+          </div>
+        )}
+
+        {isLoading && <div className="text-center py-12 text-gray-400">Loading…</div>}
+
+        {effort && effort.byCategory.length === 0 && (
+          <div className="text-center py-16 text-gray-400">
+            <p className="text-lg mb-1">No effort data yet</p>
+            <p className="text-sm">Add tasks with hours to the backlog to see effort here</p>
+          </div>
+        )}
+
+        {effort && effort.byCategory.length > 0 && view === 'summary' && (
+          <SummaryView
+            effort={effort}
+            collapsedCategories={collapsedCategories}
+            onToggleCategory={toggleCategory}
+          />
+        )}
+
+        {effort && effort.byCategory.length > 0 && view === 'detail' && (
+          <DetailView
+            effort={effort}
+            expandedRts={expandedRts}
+            onToggleRt={toggleRt}
+          />
+        )}
+      </main>
+    </div>
+  )
+}
+
+function SummaryView({
+  effort,
+  collapsedCategories,
+  onToggleCategory,
+}: {
+  effort: EffortSummary
+  collapsedCategories: Set<string>
+  onToggleCategory: (cat: string) => void
+}) {
+  const totalHours = effort.totalHours
+
+  return (
+    <div className="bg-white rounded-xl border border-gray-200 overflow-hidden">
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="border-b border-gray-200 bg-gray-50">
+            <th className="text-left px-4 py-3 font-medium text-gray-600">Resource Type</th>
+            <th className="text-center px-4 py-3 font-medium text-gray-600">Count</th>
+            <th className="text-left px-4 py-3 font-medium text-gray-600">Proposed Name</th>
+            <th className="text-right px-4 py-3 font-medium text-gray-600">Hours</th>
+            <th className="text-right px-4 py-3 font-medium text-gray-600">Days</th>
+            <th className="text-right px-4 py-3 font-medium text-gray-600">% of Total</th>
+            <th className="px-4 py-3"></th>
+          </tr>
+        </thead>
+        <tbody>
+          {effort.byCategory.map(cat => (
+            <>
+              {/* Category header row */}
+              <tr
+                key={`cat-${cat.category}`}
+                className={`${CATEGORY_HEADER_BG[cat.category]} cursor-pointer`}
+                onClick={() => onToggleCategory(cat.category)}
+              >
+                <td colSpan={5} className="px-4 py-2.5 font-bold text-gray-800">
+                  <span className="mr-2 text-xs">{collapsedCategories.has(cat.category) ? '▶' : '▼'}</span>
+                  {CATEGORY_LABELS[cat.category]}
+                </td>
+                <td className="px-4 py-2.5 text-right font-bold text-gray-800">
+                  {totalHours > 0 ? ((cat.totalHours / totalHours) * 100).toFixed(1) : '0.0'}%
+                </td>
+                <td className="px-4 py-2.5 text-right font-medium text-gray-700">
+                  {cat.totalHours}h / {cat.totalDays}d
+                </td>
+              </tr>
+
+              {/* Resource type rows */}
+              {!collapsedCategories.has(cat.category) && cat.resourceTypes.map(rt => {
+                const pct = totalHours > 0 ? (rt.totalHours / totalHours) * 100 : 0
+                return (
+                  <tr key={rt.resourceTypeId} className={`${CATEGORY_ROW_BG[rt.category]} border-t border-gray-100`}>
+                    <td className="px-4 py-2.5 text-gray-800 pl-8">{rt.name}</td>
+                    <td className="px-4 py-2.5 text-center text-gray-600">{rt.count}</td>
+                    <td className="px-4 py-2.5 text-gray-500">{rt.proposedName ?? '—'}</td>
+                    <td className="px-4 py-2.5 text-right text-gray-800">{rt.totalHours}</td>
+                    <td className="px-4 py-2.5 text-right text-gray-800">{rt.totalDays}</td>
+                    <td className="px-4 py-2.5 text-right text-gray-600">{pct.toFixed(1)}%</td>
+                    <td className="px-4 py-2.5 w-32">
+                      <div className="h-2 bg-gray-200 rounded-full overflow-hidden">
+                        <div
+                          className={`h-full rounded-full ${CATEGORY_BAR_BG[rt.category]}`}
+                          style={{ width: `${pct}%` }}
+                        />
+                      </div>
+                    </td>
+                  </tr>
+                )
+              })}
+
+              {/* Category subtotal row */}
+              {!collapsedCategories.has(cat.category) && (
+                <tr key={`subtotal-${cat.category}`} className={`${CATEGORY_HEADER_BG[cat.category]} border-t border-gray-200`}>
+                  <td colSpan={3} className="px-4 py-2 pl-8 font-semibold text-gray-700 text-xs uppercase tracking-wide">
+                    {CATEGORY_LABELS[cat.category]} subtotal
+                  </td>
+                  <td className="px-4 py-2 text-right font-semibold text-gray-800">{cat.totalHours}</td>
+                  <td className="px-4 py-2 text-right font-semibold text-gray-800">{cat.totalDays}</td>
+                  <td colSpan={2} />
+                </tr>
+              )}
+            </>
+          ))}
+
+          {/* Grand total row */}
+          <tr className="bg-gray-100 border-t-2 border-gray-300">
+            <td colSpan={3} className="px-4 py-3 font-bold text-gray-900">Grand Total</td>
+            <td className="px-4 py-3 text-right font-bold text-gray-900">{effort.totalHours}</td>
+            <td className="px-4 py-3 text-right font-bold text-gray-900">{effort.totalDays}</td>
+            <td className="px-4 py-3 text-right font-bold text-gray-900">100%</td>
+            <td />
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+function DetailView({
+  effort,
+  expandedRts,
+  onToggleRt,
+}: {
+  effort: EffortSummary
+  expandedRts: Set<string>
+  onToggleRt: (id: string) => void
+}) {
+  return (
+    <div className="space-y-4">
+      {effort.byCategory.map(cat => (
+        <div key={cat.category} className="bg-white rounded-xl border border-gray-200 overflow-hidden">
+          <div className={`${CATEGORY_HEADER_BG[cat.category]} px-4 py-3`}>
+            <span className="font-bold text-gray-800">{CATEGORY_LABELS[cat.category]}</span>
+            <span className="ml-3 text-sm text-gray-600">{cat.totalHours}h · {cat.totalDays} days</span>
+          </div>
+
+          {cat.resourceTypes.map(rt => (
+            <div key={rt.resourceTypeId} className="border-t border-gray-100">
+              <button
+                className={`w-full text-left ${CATEGORY_ROW_BG[rt.category]} px-4 py-3 flex items-center justify-between hover:brightness-95 transition-all`}
+                onClick={() => onToggleRt(rt.resourceTypeId)}
+              >
+                <div className="flex items-center gap-3">
+                  <span className="text-xs text-gray-400">{expandedRts.has(rt.resourceTypeId) ? '▼' : '▶'}</span>
+                  <span className="font-medium text-gray-900">{rt.name}</span>
+                  {rt.proposedName && <span className="text-xs text-gray-500">({rt.proposedName})</span>}
+                  <span className="text-xs text-gray-500 bg-white px-2 py-0.5 rounded-full border border-gray-200">×{rt.count}</span>
+                </div>
+                <span className="text-sm text-gray-600">{rt.totalHours}h · {rt.totalDays}d · {rt.tasks.length} task{rt.tasks.length !== 1 ? 's' : ''}</span>
+              </button>
+
+              {expandedRts.has(rt.resourceTypeId) && rt.tasks.length > 0 && (
+                <div className="border-t border-gray-100">
+                  <table className="w-full text-sm">
+                    <thead>
+                      <tr className="bg-gray-50 text-gray-500">
+                        <th className="text-left px-4 py-2 font-medium pl-10">Epic</th>
+                        <th className="text-left px-4 py-2 font-medium">Feature</th>
+                        <th className="text-left px-4 py-2 font-medium">Story</th>
+                        <th className="text-left px-4 py-2 font-medium">Task</th>
+                        <th className="text-right px-4 py-2 font-medium">Hours</th>
+                        <th className="text-right px-4 py-2 font-medium">Days</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {rt.tasks.map(task => (
+                        <tr key={task.taskId} className="border-t border-gray-100 hover:bg-gray-50">
+                          <td className="px-4 py-2 text-gray-600 pl-10">{task.epicName}</td>
+                          <td className="px-4 py-2 text-gray-600">{task.featureName}</td>
+                          <td className="px-4 py-2 text-gray-600">{task.storyName}</td>
+                          <td className="px-4 py-2 text-gray-900">{task.taskName}</td>
+                          <td className="px-4 py-2 text-right text-gray-800">{task.hoursEffort}</td>
+                          <td className="px-4 py-2 text-right text-gray-800">{task.daysEffort}</td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              )}
+
+              {expandedRts.has(rt.resourceTypeId) && rt.tasks.length === 0 && (
+                <div className="px-10 py-4 text-sm text-gray-400">No tasks assigned to this resource type.</div>
+              )}
+            </div>
+          ))}
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -11,6 +11,7 @@ import resourceTypeRoutes from './routes/resourceTypes.js'
 import templateRoutes from './routes/templates.js'
 import applyTemplateRoutes from './routes/applyTemplate.js'
 import globalResourceTypeRoutes from './routes/globalResourceTypes.js'
+import effortRoutes from './routes/effort.js'
 
 const app = express()
 const PORT = process.env.PORT ?? 3001
@@ -29,6 +30,7 @@ app.use('/api/stories/:storyId/tasks', taskRoutes)
 app.use('/api/templates', templateRoutes)
 app.use('/api/features', applyTemplateRoutes)
 app.use('/api/global-resource-types', globalResourceTypeRoutes)
+app.use('/api/projects/:projectId/effort', effortRoutes)
 
 export { app }
 app.listen(PORT, () => console.log(`Server running on http://localhost:${PORT}`))

--- a/server/src/routes/effort.ts
+++ b/server/src/routes/effort.ts
@@ -1,0 +1,129 @@
+import { Router, Response } from 'express'
+import { prisma } from '../lib/prisma.js'
+import { authenticate, AuthRequest } from '../middleware/auth.js'
+
+const router = Router({ mergeParams: true })
+router.use(authenticate)
+
+const CATEGORY_ORDER = ['ENGINEERING', 'GOVERNANCE', 'PROJECT_MANAGEMENT'] as const
+
+// GET /api/projects/:projectId/effort
+router.get('/', async (req: AuthRequest, res: Response) => {
+  const projectId = req.params.projectId as string
+
+  const project = await prisma.project.findFirst({
+    where: { id: projectId, ownerId: req.userId },
+    include: {
+      epics: {
+        include: {
+          features: {
+            include: {
+              userStories: {
+                include: {
+                  tasks: {
+                    include: { resourceType: true },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      resourceTypes: true,
+    },
+  })
+
+  if (!project) {
+    res.status(404).json({ error: 'Project not found' })
+    return
+  }
+
+  const hoursPerDay = project.hoursPerDay
+
+  // Collect all tasks with context
+  type TaskEntry = {
+    taskId: string
+    taskName: string
+    storyName: string
+    featureName: string
+    epicName: string
+    hoursEffort: number
+    daysEffort: number
+    resourceTypeId: string
+  }
+
+  const allTasks: TaskEntry[] = []
+  for (const epic of project.epics) {
+    for (const feature of epic.features) {
+      for (const story of feature.userStories) {
+        for (const task of story.tasks) {
+          allTasks.push({
+            taskId: task.id,
+            taskName: task.name,
+            storyName: story.name,
+            featureName: feature.name,
+            epicName: epic.name,
+            hoursEffort: task.hoursEffort,
+            daysEffort: Math.round((task.hoursEffort / hoursPerDay) * 100) / 100,
+            resourceTypeId: task.resourceTypeId,
+          })
+        }
+      }
+    }
+  }
+
+  // Group tasks by resourceTypeId
+  const tasksByRt = new Map<string, TaskEntry[]>()
+  for (const t of allTasks) {
+    const arr = tasksByRt.get(t.resourceTypeId) ?? []
+    arr.push(t)
+    tasksByRt.set(t.resourceTypeId, arr)
+  }
+
+  // Group resourceTypes by category
+  const rtsByCategory = new Map<string, typeof project.resourceTypes>()
+  for (const rt of project.resourceTypes) {
+    const arr = rtsByCategory.get(rt.category) ?? []
+    arr.push(rt)
+    rtsByCategory.set(rt.category, arr)
+  }
+
+  // Build byCategory
+  const byCategory = CATEGORY_ORDER
+    .filter(cat => rtsByCategory.has(cat))
+    .map(cat => {
+      const rts = (rtsByCategory.get(cat) ?? [])
+        .slice()
+        .sort((a, b) => a.name.localeCompare(b.name))
+
+      const resourceTypes = rts.map(rt => {
+        const tasks = tasksByRt.get(rt.id) ?? []
+        const totalHours = tasks.reduce((s, t) => s + t.hoursEffort, 0)
+        const totalDays = Math.round((totalHours / hoursPerDay) * 100) / 100
+        return {
+          resourceTypeId: rt.id,
+          name: rt.name,
+          category: rt.category,
+          count: rt.count,
+          proposedName: rt.proposedName ?? null,
+          totalHours,
+          totalDays,
+          tasks: tasks.map(({ taskId, taskName, storyName, featureName, epicName, hoursEffort, daysEffort }) => ({
+            taskId, taskName, storyName, featureName, epicName, hoursEffort, daysEffort,
+          })),
+        }
+      })
+
+      const totalHours = resourceTypes.reduce((s, rt) => s + rt.totalHours, 0)
+      const totalDays = Math.round((totalHours / hoursPerDay) * 100) / 100
+
+      return { category: cat, totalHours, totalDays, resourceTypes }
+    })
+
+  const totalHours = byCategory.reduce((s, c) => s + c.totalHours, 0)
+  const totalDays = Math.round((totalHours / hoursPerDay) * 100) / 100
+
+  res.json({ projectId, hoursPerDay, totalHours, totalDays, byCategory })
+})
+
+export default router

--- a/server/src/test/effort.test.ts
+++ b/server/src/test/effort.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import request from 'supertest'
+import jwt from 'jsonwebtoken'
+import { app } from '../index.js'
+import { prisma } from '../lib/prisma.js'
+
+process.env.JWT_SECRET = 'test-secret'
+
+const userId = 'user-1'
+const token = jwt.sign({ userId }, 'test-secret')
+const authHeader = `Bearer ${token}`
+
+const mockProject = {
+  id: 'proj-1',
+  ownerId: userId,
+  hoursPerDay: 8,
+  epics: [
+    {
+      id: 'epic-1',
+      name: 'Authentication',
+      features: [
+        {
+          id: 'feat-1',
+          name: 'Login Feature',
+          userStories: [
+            {
+              id: 'story-1',
+              name: 'As a user I can log in',
+              tasks: [
+                {
+                  id: 'task-1',
+                  name: 'Build login form',
+                  hoursEffort: 16,
+                  resourceTypeId: 'rt-1',
+                  resourceType: { id: 'rt-1', name: 'Developer', category: 'ENGINEERING', count: 2, proposedName: null },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+  resourceTypes: [
+    { id: 'rt-1', name: 'Developer', category: 'ENGINEERING', count: 2, proposedName: null },
+    { id: 'rt-2', name: 'Project Manager', category: 'PROJECT_MANAGEMENT', count: 1, proposedName: 'PM Lead' },
+  ],
+}
+
+beforeEach(() => vi.clearAllMocks())
+
+describe('GET /api/projects/:projectId/effort', () => {
+  it('returns 401 without auth', async () => {
+    const res = await request(app).get('/api/projects/proj-1/effort')
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 404 when project not found', async () => {
+    vi.mocked(prisma.project.findFirst).mockResolvedValue(null)
+    const res = await request(app)
+      .get('/api/projects/proj-1/effort')
+      .set('Authorization', authHeader)
+    expect(res.status).toBe(404)
+  })
+
+  it('returns effort summary with correct structure', async () => {
+    vi.mocked(prisma.project.findFirst).mockResolvedValue(mockProject as any)
+
+    const res = await request(app)
+      .get('/api/projects/proj-1/effort')
+      .set('Authorization', authHeader)
+
+    expect(res.status).toBe(200)
+    expect(res.body.projectId).toBe('proj-1')
+    expect(res.body.hoursPerDay).toBe(8)
+    expect(res.body.totalHours).toBe(16)
+    expect(res.body.totalDays).toBe(2)
+    expect(res.body.byCategory).toHaveLength(2)
+  })
+
+  it('calculates totals correctly using hoursPerDay', async () => {
+    vi.mocked(prisma.project.findFirst).mockResolvedValue(mockProject as any)
+
+    const res = await request(app)
+      .get('/api/projects/proj-1/effort')
+      .set('Authorization', authHeader)
+
+    const engCategory = res.body.byCategory.find((c: any) => c.category === 'ENGINEERING')
+    expect(engCategory).toBeDefined()
+    expect(engCategory.totalHours).toBe(16)
+    expect(engCategory.totalDays).toBe(2) // 16 / 8
+
+    const devRt = engCategory.resourceTypes[0]
+    expect(devRt.name).toBe('Developer')
+    expect(devRt.count).toBe(2)
+    expect(devRt.totalHours).toBe(16)
+    expect(devRt.totalDays).toBe(2)
+
+    expect(devRt.tasks).toHaveLength(1)
+    expect(devRt.tasks[0].taskName).toBe('Build login form')
+    expect(devRt.tasks[0].epicName).toBe('Authentication')
+    expect(devRt.tasks[0].featureName).toBe('Login Feature')
+    expect(devRt.tasks[0].storyName).toBe('As a user I can log in')
+    expect(devRt.tasks[0].hoursEffort).toBe(16)
+    expect(devRt.tasks[0].daysEffort).toBe(2)
+  })
+
+  it('sorts categories ENGINEERING first, then PROJECT_MANAGEMENT', async () => {
+    vi.mocked(prisma.project.findFirst).mockResolvedValue(mockProject as any)
+
+    const res = await request(app)
+      .get('/api/projects/proj-1/effort')
+      .set('Authorization', authHeader)
+
+    expect(res.body.byCategory[0].category).toBe('ENGINEERING')
+    expect(res.body.byCategory[1].category).toBe('PROJECT_MANAGEMENT')
+  })
+
+  it('returns empty byCategory when project has no tasks', async () => {
+    const emptyProject = {
+      ...mockProject,
+      epics: [],
+      resourceTypes: [],
+    }
+    vi.mocked(prisma.project.findFirst).mockResolvedValue(emptyProject as any)
+
+    const res = await request(app)
+      .get('/api/projects/proj-1/effort')
+      .set('Authorization', authHeader)
+
+    expect(res.status).toBe(200)
+    expect(res.body.totalHours).toBe(0)
+    expect(res.body.totalDays).toBe(0)
+    expect(res.body.byCategory).toHaveLength(0)
+  })
+
+  it('includes proposedName when set', async () => {
+    const projectWithTasks = {
+      ...mockProject,
+      epics: [
+        {
+          id: 'epic-2',
+          name: 'Planning',
+          features: [
+            {
+              id: 'feat-2',
+              name: 'Project Setup',
+              userStories: [
+                {
+                  id: 'story-2',
+                  name: 'As PM I can track progress',
+                  tasks: [
+                    {
+                      id: 'task-2',
+                      name: 'Create project plan',
+                      hoursEffort: 8,
+                      resourceTypeId: 'rt-2',
+                      resourceType: { id: 'rt-2', name: 'Project Manager', category: 'PROJECT_MANAGEMENT', count: 1, proposedName: 'PM Lead' },
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    }
+    vi.mocked(prisma.project.findFirst).mockResolvedValue(projectWithTasks as any)
+
+    const res = await request(app)
+      .get('/api/projects/proj-1/effort')
+      .set('Authorization', authHeader)
+
+    const pmCategory = res.body.byCategory.find((c: any) => c.category === 'PROJECT_MANAGEMENT')
+    expect(pmCategory).toBeDefined()
+    expect(pmCategory.resourceTypes[0].proposedName).toBe('PM Lead')
+  })
+})


### PR DESCRIPTION
## Changes
- Effort summary API: `GET /api/projects/:projectId/effort` — aggregates hours/days by resource type, grouped by category
- EffortReviewPage: summary + detail tabs, category groupings (ENGINEERING/GOVERNANCE/PROJECT_MANAGEMENT), CSS bar chart, collapsible detail view
- 7 new server tests (28 total passing)

Closes #4

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>