### PR TITLE
Global Resource Type Management

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -9,6 +9,7 @@ import BacklogPage from './pages/BacklogPage'
 import TemplateLibraryPage from './pages/TemplateLibraryPage'
 import ProjectSettingsPage from './pages/ProjectSettingsPage'
 import EffortReviewPage from './pages/EffortReviewPage'
+import GlobalResourceTypesPage from './pages/GlobalResourceTypesPage'
 
 const queryClient = new QueryClient()
 
@@ -33,6 +34,7 @@ function AppRoutes() {
       <Route path="/projects/:id/effort" element={<PrivateRoute><EffortReviewPage /></PrivateRoute>} />
       <Route path="/projects/:id/settings" element={<PrivateRoute><ProjectSettingsPage /></PrivateRoute>} />
       <Route path="/templates" element={<PrivateRoute><TemplateLibraryPage /></PrivateRoute>} />
+      <Route path="/resource-types" element={<PrivateRoute><GlobalResourceTypesPage /></PrivateRoute>} />
     </Routes>
   )
 }

--- a/client/src/pages/GlobalResourceTypesPage.tsx
+++ b/client/src/pages/GlobalResourceTypesPage.tsx
@@ -1,0 +1,312 @@
+import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { api } from '../lib/api'
+import { useAuth } from '../hooks/useAuth'
+
+interface GlobalResourceType {
+  id: string
+  name: string
+  category: 'ENGINEERING' | 'GOVERNANCE' | 'PROJECT_MANAGEMENT'
+  description?: string | null
+  isDefault: boolean
+}
+
+const CATEGORY_LABELS: Record<GlobalResourceType['category'], string> = {
+  ENGINEERING: 'Engineering',
+  GOVERNANCE: 'Governance',
+  PROJECT_MANAGEMENT: 'Project Management',
+}
+
+const CATEGORY_COLOURS: Record<GlobalResourceType['category'], string> = {
+  ENGINEERING: 'bg-blue-100 text-blue-700',
+  GOVERNANCE: 'bg-amber-100 text-amber-700',
+  PROJECT_MANAGEMENT: 'bg-green-100 text-green-700',
+}
+
+const CATEGORIES: GlobalResourceType['category'][] = ['ENGINEERING', 'GOVERNANCE', 'PROJECT_MANAGEMENT']
+
+function sortTypes(types: GlobalResourceType[]) {
+  return [...types].sort((a, b) => {
+    if (a.category < b.category) return -1
+    if (a.category > b.category) return 1
+    return a.name.localeCompare(b.name)
+  })
+}
+
+interface RowFormState {
+  name: string
+  category: GlobalResourceType['category']
+  description: string
+}
+
+interface EditRowProps {
+  initial: RowFormState
+  onSave: (data: RowFormState) => void
+  onCancel: () => void
+  saving: boolean
+}
+
+function EditRow({ initial, onSave, onCancel, saving }: EditRowProps) {
+  const [form, setForm] = useState(initial)
+  return (
+    <tr className="bg-blue-50">
+      <td className="px-4 py-2">
+        <input
+          type="text"
+          value={form.name}
+          onChange={e => setForm(f => ({ ...f, name: e.target.value }))}
+          className="w-full border border-gray-300 rounded px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-red-500"
+          placeholder="Name *"
+        />
+      </td>
+      <td className="px-4 py-2">
+        <select
+          value={form.category}
+          onChange={e => setForm(f => ({ ...f, category: e.target.value as GlobalResourceType['category'] }))}
+          className="w-full border border-gray-300 rounded px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-red-500"
+        >
+          {CATEGORIES.map(c => (
+            <option key={c} value={c}>{CATEGORY_LABELS[c]}</option>
+          ))}
+        </select>
+      </td>
+      <td className="px-4 py-2">
+        <input
+          type="text"
+          value={form.description}
+          onChange={e => setForm(f => ({ ...f, description: e.target.value }))}
+          className="w-full border border-gray-300 rounded px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-red-500"
+          placeholder="Description"
+        />
+      </td>
+      <td className="px-4 py-2" />
+      <td className="px-4 py-2">
+        <div className="flex gap-2">
+          <button
+            onClick={() => onSave(form)}
+            disabled={!form.name || saving}
+            className="text-xs bg-red-600 text-white px-3 py-1 rounded hover:bg-red-700 disabled:opacity-50 transition-colors"
+          >
+            {saving ? 'Saving…' : 'Save'}
+          </button>
+          <button
+            onClick={onCancel}
+            className="text-xs text-gray-600 px-3 py-1 rounded hover:bg-gray-100 transition-colors"
+          >
+            Cancel
+          </button>
+        </div>
+      </td>
+    </tr>
+  )
+}
+
+export default function GlobalResourceTypesPage() {
+  const { user, logout } = useAuth()
+  const navigate = useNavigate()
+  const qc = useQueryClient()
+
+  const [editingId, setEditingId] = useState<string | null>(null)
+  const [showAddForm, setShowAddForm] = useState(false)
+  const [addForm, setAddForm] = useState({ name: '', category: 'ENGINEERING' as GlobalResourceType['category'], description: '' })
+
+  const { data: types = [], isLoading } = useQuery<GlobalResourceType[]>({
+    queryKey: ['global-resource-types'],
+    queryFn: () => api.get('/global-resource-types').then(r => r.data),
+  })
+
+  const invalidate = () => qc.invalidateQueries({ queryKey: ['global-resource-types'] })
+
+  const updateType = useMutation({
+    mutationFn: ({ id, data }: { id: string; data: RowFormState }) =>
+      api.put(`/global-resource-types/${id}`, data),
+    onSuccess: () => { invalidate(); setEditingId(null) },
+  })
+
+  const createType = useMutation({
+    mutationFn: (data: typeof addForm) => api.post('/global-resource-types', data),
+    onSuccess: () => {
+      invalidate()
+      setShowAddForm(false)
+      setAddForm({ name: '', category: 'ENGINEERING', description: '' })
+    },
+  })
+
+  const deleteType = useMutation({
+    mutationFn: (id: string) => api.delete(`/global-resource-types/${id}`),
+    onSuccess: invalidate,
+  })
+
+  const handleDelete = (t: GlobalResourceType) => {
+    if (window.confirm(`Delete "${t.name}"? This cannot be undone.`)) {
+      deleteType.mutate(t.id)
+    }
+  }
+
+  const sorted = sortTypes(types)
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <header className="bg-white border-b border-gray-200">
+        <div className="max-w-6xl mx-auto px-6 py-4 flex items-center justify-between">
+          <div className="flex items-center gap-2 text-sm text-gray-500">
+            <button onClick={() => navigate('/')} className="hover:text-red-600 transition-colors font-semibold text-gray-900">Monrad Estimator</button>
+            <span>/</span>
+            <span className="text-gray-700">Resource Types</span>
+          </div>
+          <div className="flex items-center gap-3">
+            <span className="text-sm text-gray-500">{user?.name}</span>
+            <button onClick={logout} className="text-sm text-gray-500 hover:text-gray-700">Sign out</button>
+          </div>
+        </div>
+      </header>
+
+      <main className="max-w-6xl mx-auto px-6 py-8">
+        <div className="flex items-center justify-between mb-6">
+          <div>
+            <h1 className="text-xl font-semibold text-gray-900">Resource Types</h1>
+            <p className="text-sm text-gray-500 mt-0.5">Manage the standard resource types available across all projects</p>
+          </div>
+          <button
+            onClick={() => setShowAddForm(true)}
+            className="bg-red-600 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-red-700 transition-colors"
+          >
+            + Add resource type
+          </button>
+        </div>
+
+        <div className="bg-white rounded-xl border border-gray-200 overflow-hidden">
+          {isLoading ? (
+            <div className="text-center py-12 text-gray-400">Loading…</div>
+          ) : (
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-gray-200 bg-gray-50">
+                  <th className="px-4 py-3 text-left font-medium text-gray-600">Name</th>
+                  <th className="px-4 py-3 text-left font-medium text-gray-600">Category</th>
+                  <th className="px-4 py-3 text-left font-medium text-gray-600">Description</th>
+                  <th className="px-4 py-3 text-left font-medium text-gray-600">Default</th>
+                  <th className="px-4 py-3 text-left font-medium text-gray-600">Actions</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-100">
+                {sorted.map(t =>
+                  editingId === t.id ? (
+                    <EditRow
+                      key={t.id}
+                      initial={{ name: t.name, category: t.category, description: t.description ?? '' }}
+                      onSave={data => updateType.mutate({ id: t.id, data })}
+                      onCancel={() => setEditingId(null)}
+                      saving={updateType.isPending}
+                    />
+                  ) : (
+                    <tr key={t.id} className="hover:bg-gray-50 transition-colors">
+                      <td className="px-4 py-3 font-medium text-gray-900">{t.name}</td>
+                      <td className="px-4 py-3">
+                        <span className={`text-xs px-2 py-0.5 rounded-full font-medium ${CATEGORY_COLOURS[t.category]}`}>
+                          {CATEGORY_LABELS[t.category]}
+                        </span>
+                      </td>
+                      <td className="px-4 py-3 text-gray-500">{t.description ?? ''}</td>
+                      <td className="px-4 py-3">
+                        {t.isDefault && (
+                          <span className="text-xs px-2 py-0.5 rounded-full font-medium bg-gray-100 text-gray-600">Default</span>
+                        )}
+                      </td>
+                      <td className="px-4 py-3">
+                        <div className="flex items-center gap-2">
+                          <button
+                            onClick={() => setEditingId(t.id)}
+                            className="text-gray-400 hover:text-gray-700 transition-colors p-1 rounded"
+                            title="Edit"
+                          >
+                            {/* Pencil icon */}
+                            <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
+                              <path d="M13.586 3.586a2 2 0 112.828 2.828l-.793.793-2.828-2.828.793-.793zM11.379 5.793L3 14.172V17h2.828l8.38-8.379-2.83-2.828z" />
+                            </svg>
+                          </button>
+                          <button
+                            onClick={() => handleDelete(t)}
+                            disabled={t.isDefault}
+                            title={t.isDefault ? 'Default types cannot be deleted' : 'Delete'}
+                            className={`p-1 rounded transition-colors ${t.isDefault ? 'text-gray-200 cursor-not-allowed' : 'text-gray-400 hover:text-red-600'}`}
+                          >
+                            {/* Trash icon */}
+                            <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
+                              <path fillRule="evenodd" d="M9 2a1 1 0 00-.894.553L7.382 4H4a1 1 0 000 2v10a2 2 0 002 2h8a2 2 0 002-2V6a1 1 0 100-2h-3.382l-.724-1.447A1 1 0 0011 2H9zM7 8a1 1 0 012 0v6a1 1 0 11-2 0V8zm5-1a1 1 0 00-1 1v6a1 1 0 102 0V8a1 1 0 00-1-1z" clipRule="evenodd" />
+                            </svg>
+                          </button>
+                        </div>
+                      </td>
+                    </tr>
+                  )
+                )}
+
+                {sorted.length === 0 && (
+                  <tr>
+                    <td colSpan={5} className="px-4 py-12 text-center text-gray-400">No resource types yet</td>
+                  </tr>
+                )}
+              </tbody>
+            </table>
+          )}
+        </div>
+
+        {/* Add form */}
+        {showAddForm && (
+          <div className="bg-white rounded-xl border border-blue-200 p-6 mt-4">
+            <h2 className="font-medium text-gray-900 mb-4">New resource type</h2>
+            <div className="grid grid-cols-2 gap-4 mb-4">
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">Name *</label>
+                <input
+                  type="text"
+                  value={addForm.name}
+                  onChange={e => setAddForm(f => ({ ...f, name: e.target.value }))}
+                  className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-red-500"
+                />
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">Category *</label>
+                <select
+                  value={addForm.category}
+                  onChange={e => setAddForm(f => ({ ...f, category: e.target.value as GlobalResourceType['category'] }))}
+                  className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-red-500"
+                >
+                  {CATEGORIES.map(c => (
+                    <option key={c} value={c}>{CATEGORY_LABELS[c]}</option>
+                  ))}
+                </select>
+              </div>
+              <div className="col-span-2">
+                <label className="block text-sm font-medium text-gray-700 mb-1">Description</label>
+                <input
+                  type="text"
+                  value={addForm.description}
+                  onChange={e => setAddForm(f => ({ ...f, description: e.target.value }))}
+                  className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-red-500"
+                />
+              </div>
+            </div>
+            <div className="flex gap-2">
+              <button
+                onClick={() => createType.mutate(addForm)}
+                disabled={!addForm.name || createType.isPending}
+                className="bg-red-600 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-red-700 disabled:opacity-50 transition-colors"
+              >
+                {createType.isPending ? 'Saving…' : 'Save'}
+              </button>
+              <button
+                onClick={() => setShowAddForm(false)}
+                className="px-4 py-2 rounded-lg text-sm font-medium text-gray-600 hover:bg-gray-100 transition-colors"
+              >
+                Cancel
+              </button>
+            </div>
+          </div>
+        )}
+      </main>
+    </div>
+  )
+}

--- a/client/src/pages/ProjectsPage.tsx
+++ b/client/src/pages/ProjectsPage.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { useNavigate } from 'react-router-dom'
+import { useNavigate, Link } from 'react-router-dom'
 import { api } from '../lib/api'
 import { useAuth } from '../hooks/useAuth'
 
@@ -55,6 +55,7 @@ export default function ProjectsPage() {
               <span className="text-white text-xs font-bold">M</span>
             </div>
             <span className="font-semibold text-gray-900">Monrad Estimator</span>
+            <Link to="/resource-types" className="text-sm text-gray-500 hover:text-red-600 transition-colors ml-2">Resource Types</Link>
           </div>
           <div className="flex items-center gap-3">
             <span className="text-sm text-gray-500">{user?.name}</span>

--- a/server/src/routes/globalResourceTypes.ts
+++ b/server/src/routes/globalResourceTypes.ts
@@ -18,4 +18,23 @@ router.post('/', authenticate, async (req: AuthRequest, res: Response) => {
   res.status(201).json(gt)
 })
 
+// PUT /api/global-resource-types/:id — auth required
+router.put('/:id', authenticate, async (req: AuthRequest, res: Response) => {
+  const { name, category, description } = req.body
+  if (!name || !category) { res.status(400).json({ error: 'name and category are required' }); return }
+  const existing = await prisma.globalResourceType.findFirst({ where: { id: req.params.id } })
+  if (!existing) { res.status(404).json({ error: 'Not found' }); return }
+  const gt = await prisma.globalResourceType.update({ where: { id: req.params.id }, data: { name, category, description } })
+  res.json(gt)
+})
+
+// DELETE /api/global-resource-types/:id — auth required
+router.delete('/:id', authenticate, async (req: AuthRequest, res: Response) => {
+  const existing = await prisma.globalResourceType.findFirst({ where: { id: req.params.id } })
+  if (!existing) { res.status(404).json({ error: 'Not found' }); return }
+  if (existing.isDefault) { res.status(403).json({ error: 'Default types cannot be deleted' }); return }
+  await prisma.globalResourceType.delete({ where: { id: req.params.id } })
+  res.status(204).send()
+})
+
 export default router

--- a/server/src/test/globalResourceTypes.test.ts
+++ b/server/src/test/globalResourceTypes.test.ts
@@ -50,3 +50,58 @@ describe('POST /api/global-resource-types', () => {
     expect(res.status).toBe(400)
   })
 })
+
+describe('PUT /api/global-resource-types/:id', () => {
+  it('returns 401 without auth', async () => {
+    const res = await request(app)
+      .put('/api/global-resource-types/grt-1')
+      .send({ name: 'Dev', category: 'ENGINEERING' })
+    expect(res.status).toBe(401)
+  })
+
+  it('updates a resource type successfully', async () => {
+    const updated = { ...mockGRT, name: 'Senior Developer' }
+    vi.mocked(prisma.globalResourceType.findFirst).mockResolvedValue(mockGRT)
+    vi.mocked(prisma.globalResourceType.update).mockResolvedValue(updated)
+    const res = await request(app)
+      .put('/api/global-resource-types/grt-1')
+      .set('Authorization', authHeader)
+      .send({ name: 'Senior Developer', category: 'ENGINEERING' })
+    expect(res.status).toBe(200)
+    expect(res.body.name).toBe('Senior Developer')
+  })
+
+  it('returns 400 if name is missing', async () => {
+    const res = await request(app)
+      .put('/api/global-resource-types/grt-1')
+      .set('Authorization', authHeader)
+      .send({ category: 'ENGINEERING' })
+    expect(res.status).toBe(400)
+  })
+})
+
+describe('DELETE /api/global-resource-types/:id', () => {
+  it('returns 401 without auth', async () => {
+    const res = await request(app)
+      .delete('/api/global-resource-types/grt-1')
+    expect(res.status).toBe(401)
+  })
+
+  it('removes a resource type and returns 204', async () => {
+    const nonDefault = { ...mockGRT, id: 'grt-2', isDefault: false }
+    vi.mocked(prisma.globalResourceType.findFirst).mockResolvedValue(nonDefault)
+    vi.mocked(prisma.globalResourceType.delete).mockResolvedValue(nonDefault)
+    const res = await request(app)
+      .delete('/api/global-resource-types/grt-2')
+      .set('Authorization', authHeader)
+    expect(res.status).toBe(204)
+  })
+
+  it('returns 404 for non-existent resource type', async () => {
+    vi.mocked(prisma.globalResourceType.findFirst).mockResolvedValue(null)
+    const res = await request(app)
+      .delete('/api/global-resource-types/nonexistent')
+      .set('Authorization', authHeader)
+    expect(res.status).toBe(404)
+  })
+})


### PR DESCRIPTION
## Changes
- **API**: Added `PUT /:id` and `DELETE /:id` to `/api/global-resource-types` — default types protected from deletion (403)
- **GlobalResourceTypesPage** at `/resource-types`: table with coloured category badges, inline row editing, add form, delete with confirm dialog; default types non-deletable
- **ProjectsPage header**: "Resource Types" top-level nav link added
- 10 server tests (6 new for PUT/DELETE)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>