### PR TITLE
Resource type propagation and referential integrity

### DIFF
--- a/client/src/pages/GlobalResourceTypesPage.tsx
+++ b/client/src/pages/GlobalResourceTypesPage.tsx
@@ -136,6 +136,10 @@ export default function GlobalResourceTypesPage() {
   const deleteType = useMutation({
     mutationFn: (id: string) => api.delete(`/global-resource-types/${id}`),
     onSuccess: invalidate,
+    onError: (err: any) => {
+      const msg = err?.response?.data?.error ?? 'Failed to delete resource type'
+      alert(msg)
+    },
   })
 
   const handleDelete = (t: GlobalResourceType) => {

--- a/server/src/routes/globalResourceTypes.ts
+++ b/server/src/routes/globalResourceTypes.ts
@@ -11,29 +11,45 @@ router.get('/', async (_req: Request, res: Response) => {
 })
 
 // POST /api/global-resource-types — auth required
+// After creating, seeds a ResourceType instance into every existing project
 router.post('/', authenticate, async (req: AuthRequest, res: Response) => {
   const { name, category, description } = req.body
   if (!name || !category) { res.status(400).json({ error: 'name and category are required' }); return }
   const gt = await prisma.globalResourceType.create({ data: { name, category, description } })
+  const projects = await prisma.project.findMany({ select: { id: true } })
+  if (projects.length > 0) {
+    await prisma.resourceType.createMany({
+      data: projects.map(p => ({ name, category, projectId: p.id, globalTypeId: gt.id }))
+    })
+  }
   res.status(201).json(gt)
 })
 
 // PUT /api/global-resource-types/:id — auth required
+// Syncs name + category changes to all linked project-level ResourceType instances
 router.put('/:id', authenticate, async (req: AuthRequest, res: Response) => {
   const { name, category, description } = req.body
   if (!name || !category) { res.status(400).json({ error: 'name and category are required' }); return }
-  const existing = await prisma.globalResourceType.findFirst({ where: { id: req.params.id } })
+  const existing = await prisma.globalResourceType.findFirst({ where: { id: req.params.id as string } })
   if (!existing) { res.status(404).json({ error: 'Not found' }); return }
-  const gt = await prisma.globalResourceType.update({ where: { id: req.params.id }, data: { name, category, description } })
+  const gt = await prisma.globalResourceType.update({ where: { id: req.params.id as string }, data: { name, category, description } })
+  await prisma.resourceType.updateMany({ where: { globalTypeId: req.params.id as string }, data: { name, category } })
   res.json(gt)
 })
 
 // DELETE /api/global-resource-types/:id — auth required
+// Blocks deletion if any linked ResourceType has tasks assigned to it
 router.delete('/:id', authenticate, async (req: AuthRequest, res: Response) => {
-  const existing = await prisma.globalResourceType.findFirst({ where: { id: req.params.id } })
+  const existing = await prisma.globalResourceType.findFirst({ where: { id: req.params.id as string } })
   if (!existing) { res.status(404).json({ error: 'Not found' }); return }
   if (existing.isDefault) { res.status(403).json({ error: 'Default types cannot be deleted' }); return }
-  await prisma.globalResourceType.delete({ where: { id: req.params.id } })
+  const inUse = await prisma.task.findFirst({
+    where: { resourceType: { globalTypeId: req.params.id as string } }
+  })
+  if (inUse) { res.status(409).json({ error: 'This resource type is in use by one or more tasks and cannot be deleted' }); return }
+  // Nullify globalTypeId on linked ResourceTypes before deleting
+  await prisma.resourceType.updateMany({ where: { globalTypeId: req.params.id as string }, data: { globalTypeId: null } })
+  await prisma.globalResourceType.delete({ where: { id: req.params.id as string } })
   res.status(204).send()
 })
 

--- a/server/src/test/globalResourceTypes.test.ts
+++ b/server/src/test/globalResourceTypes.test.ts
@@ -25,14 +25,19 @@ describe('GET /api/global-resource-types', () => {
 })
 
 describe('POST /api/global-resource-types', () => {
-  it('creates a global resource type when authenticated', async () => {
+  it('creates a global resource type and seeds into existing projects', async () => {
     vi.mocked(prisma.globalResourceType.create).mockResolvedValue(mockGRT)
+    vi.mocked(prisma.project.findMany).mockResolvedValue([{ id: 'proj-1' }] as any)
+    vi.mocked(prisma.resourceType.createMany).mockResolvedValue({ count: 1 })
     const res = await request(app)
       .post('/api/global-resource-types')
       .set('Authorization', authHeader)
       .send({ name: 'Developer', category: 'ENGINEERING' })
     expect(res.status).toBe(201)
     expect(res.body.name).toBe('Developer')
+    expect(prisma.resourceType.createMany).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.arrayContaining([expect.objectContaining({ projectId: 'proj-1', globalTypeId: 'grt-1' })]) })
+    )
   })
 
   it('returns 401 without auth', async () => {
@@ -59,16 +64,20 @@ describe('PUT /api/global-resource-types/:id', () => {
     expect(res.status).toBe(401)
   })
 
-  it('updates a resource type successfully', async () => {
+  it('updates global type and syncs to all linked project resource types', async () => {
     const updated = { ...mockGRT, name: 'Senior Developer' }
     vi.mocked(prisma.globalResourceType.findFirst).mockResolvedValue(mockGRT)
     vi.mocked(prisma.globalResourceType.update).mockResolvedValue(updated)
+    vi.mocked(prisma.resourceType.updateMany).mockResolvedValue({ count: 2 })
     const res = await request(app)
       .put('/api/global-resource-types/grt-1')
       .set('Authorization', authHeader)
       .send({ name: 'Senior Developer', category: 'ENGINEERING' })
     expect(res.status).toBe(200)
     expect(res.body.name).toBe('Senior Developer')
+    expect(prisma.resourceType.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { globalTypeId: 'grt-1' }, data: { name: 'Senior Developer', category: 'ENGINEERING' } })
+    )
   })
 
   it('returns 400 if name is missing', async () => {
@@ -90,11 +99,23 @@ describe('DELETE /api/global-resource-types/:id', () => {
   it('removes a resource type and returns 204', async () => {
     const nonDefault = { ...mockGRT, id: 'grt-2', isDefault: false }
     vi.mocked(prisma.globalResourceType.findFirst).mockResolvedValue(nonDefault)
+    vi.mocked(prisma.task.findFirst).mockResolvedValue(null)
+    vi.mocked(prisma.resourceType.updateMany).mockResolvedValue({ count: 0 })
     vi.mocked(prisma.globalResourceType.delete).mockResolvedValue(nonDefault)
     const res = await request(app)
       .delete('/api/global-resource-types/grt-2')
       .set('Authorization', authHeader)
     expect(res.status).toBe(204)
+  })
+
+  it('returns 409 when resource type is in use by tasks', async () => {
+    const nonDefault = { ...mockGRT, id: 'grt-2', isDefault: false }
+    vi.mocked(prisma.globalResourceType.findFirst).mockResolvedValue(nonDefault)
+    vi.mocked(prisma.task.findFirst).mockResolvedValue({ id: 'task-1' } as any)
+    const res = await request(app)
+      .delete('/api/global-resource-types/grt-2')
+      .set('Authorization', authHeader)
+    expect(res.status).toBe(409)
   })
 
   it('returns 404 for non-existent resource type', async () => {

--- a/server/src/test/setup.ts
+++ b/server/src/test/setup.ts
@@ -9,7 +9,7 @@ vi.mock('../lib/prisma.js', () => ({
     feature: { findMany: vi.fn(), findFirst: vi.fn(), create: vi.fn(), update: vi.fn(), delete: vi.fn() },
     userStory: { findMany: vi.fn(), findFirst: vi.fn(), findUnique: vi.fn(), create: vi.fn(), update: vi.fn(), delete: vi.fn() },
     task: { findMany: vi.fn(), findFirst: vi.fn(), create: vi.fn(), update: vi.fn(), delete: vi.fn() },
-    resourceType: { findMany: vi.fn(), findFirst: vi.fn(), create: vi.fn(), update: vi.fn(), delete: vi.fn() },
+    resourceType: { findMany: vi.fn(), findFirst: vi.fn(), create: vi.fn(), createMany: vi.fn(), update: vi.fn(), updateMany: vi.fn(), delete: vi.fn() },
     globalResourceType: { findMany: vi.fn(), findFirst: vi.fn(), create: vi.fn(), update: vi.fn(), delete: vi.fn() },
     featureTemplate: { findMany: vi.fn(), findFirst: vi.fn(), findUnique: vi.fn(), create: vi.fn(), update: vi.fn(), delete: vi.fn() },
     templateTask: { findMany: vi.fn(), findFirst: vi.fn(), findUnique: vi.fn(), create: vi.fn(), update: vi.fn(), delete: vi.fn() },


### PR DESCRIPTION
## Changes
- **POST**: after creating a global resource type, seeds a `ResourceType` instance into every existing project automatically
- **PUT**: syncs `name` and `category` changes to all linked project-level `ResourceType` records
- **DELETE**: blocks deletion with 409 if the type is in use by any tasks; nullifies `globalTypeId` on unused instances before deleting
- **Client**: shows server error message (e.g. 'in use by tasks') on failed delete attempt
- 47 server tests passing (11 in globalResourceTypes suite)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>