### PR TITLE
feat: per-resource hoursPerDay + dayRate, snapshot rollback perf (#52, #50)

### DIFF
--- a/client/src/pages/GlobalResourceTypesPage.tsx
+++ b/client/src/pages/GlobalResourceTypesPage.tsx
@@ -9,6 +9,8 @@ interface GlobalResourceType {
   name: string
   category: 'ENGINEERING' | 'GOVERNANCE' | 'PROJECT_MANAGEMENT'
   description?: string | null
+  defaultHoursPerDay?: number | null
+  defaultDayRate?: number | null
   isDefault: boolean
 }
 
@@ -38,6 +40,24 @@ interface RowFormState {
   name: string
   category: GlobalResourceType['category']
   description: string
+  defaultHoursPerDay: string
+  defaultDayRate: string
+}
+
+function parseNullableNumber(value: string) {
+  if (!value || !value.trim()) return null
+  const parsed = parseFloat(value)
+  return Number.isFinite(parsed) ? parsed : null
+}
+
+function toPayload(data: RowFormState) {
+  return {
+    name: data.name,
+    category: data.category,
+    description: data.description || null,
+    defaultHoursPerDay: parseNullableNumber(data.defaultHoursPerDay),
+    defaultDayRate: parseNullableNumber(data.defaultDayRate),
+  }
 }
 
 interface EditRowProps {
@@ -80,6 +100,26 @@ function EditRow({ initial, onSave, onCancel, saving }: EditRowProps) {
           placeholder="Description"
         />
       </td>
+      <td className="px-4 py-2">
+        <input
+          type="number"
+          step="0.1"
+          value={form.defaultHoursPerDay}
+          onChange={e => setForm(f => ({ ...f, defaultHoursPerDay: e.target.value }))}
+          className="w-full border border-gray-300 rounded px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-red-500"
+          placeholder="7.6"
+        />
+      </td>
+      <td className="px-4 py-2">
+        <input
+          type="number"
+          step="50"
+          value={form.defaultDayRate}
+          onChange={e => setForm(f => ({ ...f, defaultDayRate: e.target.value }))}
+          className="w-full border border-gray-300 rounded px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-red-500"
+          placeholder="1200"
+        />
+      </td>
       <td className="px-4 py-2" />
       <td className="px-4 py-2">
         <div className="flex gap-2">
@@ -109,7 +149,13 @@ export default function GlobalResourceTypesPage() {
 
   const [editingId, setEditingId] = useState<string | null>(null)
   const [showAddForm, setShowAddForm] = useState(false)
-  const [addForm, setAddForm] = useState({ name: '', category: 'ENGINEERING' as GlobalResourceType['category'], description: '' })
+  const [addForm, setAddForm] = useState<RowFormState>({
+    name: '',
+    category: 'ENGINEERING' as GlobalResourceType['category'],
+    description: '',
+    defaultHoursPerDay: '',
+    defaultDayRate: '',
+  })
 
   const { data: types = [], isLoading } = useQuery<GlobalResourceType[]>({
     queryKey: ['global-resource-types'],
@@ -120,16 +166,16 @@ export default function GlobalResourceTypesPage() {
 
   const updateType = useMutation({
     mutationFn: ({ id, data }: { id: string; data: RowFormState }) =>
-      api.put(`/global-resource-types/${id}`, data),
+      api.put(`/global-resource-types/${id}`, toPayload(data)),
     onSuccess: () => { invalidate(); setEditingId(null) },
   })
 
   const createType = useMutation({
-    mutationFn: (data: typeof addForm) => api.post('/global-resource-types', data),
+    mutationFn: (data: typeof addForm) => api.post('/global-resource-types', toPayload(data)),
     onSuccess: () => {
       invalidate()
       setShowAddForm(false)
-      setAddForm({ name: '', category: 'ENGINEERING', description: '' })
+      setAddForm({ name: '', category: 'ENGINEERING', description: '', defaultHoursPerDay: '', defaultDayRate: '' })
     },
   })
 
@@ -190,6 +236,8 @@ export default function GlobalResourceTypesPage() {
                   <th className="px-4 py-3 text-left font-medium text-gray-600">Name</th>
                   <th className="px-4 py-3 text-left font-medium text-gray-600">Category</th>
                   <th className="px-4 py-3 text-left font-medium text-gray-600">Description</th>
+                  <th className="px-4 py-3 text-left font-medium text-gray-600">Default hrs/day</th>
+                  <th className="px-4 py-3 text-left font-medium text-gray-600">Default day rate</th>
                   <th className="px-4 py-3 text-left font-medium text-gray-600">Default</th>
                   <th className="px-4 py-3 text-left font-medium text-gray-600">Actions</th>
                 </tr>
@@ -199,7 +247,13 @@ export default function GlobalResourceTypesPage() {
                   editingId === t.id ? (
                     <EditRow
                       key={t.id}
-                      initial={{ name: t.name, category: t.category, description: t.description ?? '' }}
+                      initial={{
+                        name: t.name,
+                        category: t.category,
+                        description: t.description ?? '',
+                        defaultHoursPerDay: t.defaultHoursPerDay?.toString() ?? '',
+                        defaultDayRate: t.defaultDayRate?.toString() ?? '',
+                      }}
                       onSave={data => updateType.mutate({ id: t.id, data })}
                       onCancel={() => setEditingId(null)}
                       saving={updateType.isPending}
@@ -213,6 +267,10 @@ export default function GlobalResourceTypesPage() {
                         </span>
                       </td>
                       <td className="px-4 py-3 text-gray-500">{t.description ?? ''}</td>
+                      <td className="px-4 py-3 text-gray-700">{t.defaultHoursPerDay ?? '—'}</td>
+                      <td className="px-4 py-3 text-gray-700">
+                        {t.defaultDayRate != null ? t.defaultDayRate.toLocaleString() : '—'}
+                      </td>
                       <td className="px-4 py-3">
                         {t.isDefault && (
                           <span className="text-xs px-2 py-0.5 rounded-full font-medium bg-gray-100 text-gray-600">Default</span>
@@ -249,7 +307,7 @@ export default function GlobalResourceTypesPage() {
 
                 {sorted.length === 0 && (
                   <tr>
-                    <td colSpan={5} className="px-4 py-12 text-center text-gray-400">No resource types yet</td>
+                    <td colSpan={7} className="px-4 py-12 text-center text-gray-400">No resource types yet</td>
                   </tr>
                 )}
               </tbody>
@@ -290,6 +348,28 @@ export default function GlobalResourceTypesPage() {
                   value={addForm.description}
                   onChange={e => setAddForm(f => ({ ...f, description: e.target.value }))}
                   className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-red-500"
+                />
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">Default hrs/day</label>
+                <input
+                  type="number"
+                  step="0.1"
+                  value={addForm.defaultHoursPerDay}
+                  onChange={e => setAddForm(f => ({ ...f, defaultHoursPerDay: e.target.value }))}
+                  className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-red-500"
+                  placeholder="7.6"
+                />
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">Default day rate</label>
+                <input
+                  type="number"
+                  step="50"
+                  value={addForm.defaultDayRate}
+                  onChange={e => setAddForm(f => ({ ...f, defaultDayRate: e.target.value }))}
+                  className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-red-500"
+                  placeholder="1200"
                 />
               </div>
             </div>

--- a/client/src/pages/TemplateLibraryPage.tsx
+++ b/client/src/pages/TemplateLibraryPage.tsx
@@ -16,6 +16,8 @@ interface GlobalResourceType {
   id: string
   name: string
   category: string
+  defaultHoursPerDay?: number | null
+  defaultDayRate?: number | null
 }
 
 interface TemplateTask {

--- a/client/src/pages/TimelinePage.tsx
+++ b/client/src/pages/TimelinePage.tsx
@@ -96,8 +96,13 @@ export default function TimelinePage() {
   })
 
   const updateResourceType = useMutation({
-    mutationFn: ({ id, count }: { id: string; count: number }) =>
-      api.put(`/projects/${projectId}/resource-types/${id}`, { count }).then(r => r.data),
+    mutationFn: ({ id, ...data }: { id: string; count?: number; hoursPerDay?: number | null; dayRate?: number | null }) => {
+      const payload: Record<string, number | null> = {}
+      if (data.count !== undefined) payload.count = data.count
+      if (data.hoursPerDay !== undefined) payload.hoursPerDay = data.hoursPerDay
+      if (data.dayRate !== undefined) payload.dayRate = data.dayRate
+      return api.put(`/projects/${projectId}/resource-types/${id}`, payload).then(r => r.data)
+    },
     onSuccess: () => qc.invalidateQueries({ queryKey: ['resource-types', projectId] }),
   })
 
@@ -231,7 +236,9 @@ export default function TimelinePage() {
                     <thead>
                       <tr className="text-xs text-gray-400">
                         <th className="text-left pb-1 font-normal">Resource Type</th>
-                        <th className="text-right pb-1 font-normal w-24">Count</th>
+                        <th className="text-right pb-1 font-normal w-20">Count</th>
+                        <th className="text-right pb-1 font-normal w-24">Hrs/day</th>
+                        <th className="text-right pb-1 font-normal w-28">Day rate</th>
                       </tr>
                     </thead>
                     <tbody>
@@ -240,16 +247,52 @@ export default function TimelinePage() {
                           <td className="py-1.5 text-gray-700">{rt.name}</td>
                           <td className="py-1.5 text-right">
                             <input
+                              key={`count-${rt.id}-${rt.count}`}
                               type="number"
                               min="1"
                               defaultValue={rt.count}
                               onBlur={e => {
-                                const v = parseInt(e.target.value)
-                                if (!isNaN(v) && v > 0 && v !== rt.count) {
-                                  updateResourceType.mutate({ id: rt.id, count: v })
-                                }
+                                const v = parseInt(e.target.value, 10)
+                                if (!Number.isFinite(v) || v <= 0 || v === rt.count) return
+                                updateResourceType.mutate({ id: rt.id, count: v })
                               }}
                               className="w-16 border border-gray-200 rounded px-2 py-0.5 text-sm text-right focus:outline-none focus:ring-1 focus:ring-blue-400"
+                            />
+                          </td>
+                          <td className="py-1.5 text-right">
+                            <input
+                              key={`hours-${rt.id}-${rt.hoursPerDay ?? 'null'}`}
+                              type="number"
+                              step="0.1"
+                              defaultValue={rt.hoursPerDay ?? ''}
+                              placeholder={project?.hoursPerDay ? String(project.hoursPerDay) : ''}
+                              onBlur={e => {
+                                const value = e.target.value.trim()
+                                const parsed = value === '' ? null : parseFloat(value)
+                                if (parsed !== null && !Number.isFinite(parsed)) return
+                                const current = rt.hoursPerDay ?? null
+                                if (parsed === current) return
+                                updateResourceType.mutate({ id: rt.id, hoursPerDay: parsed })
+                              }}
+                              className="w-20 border border-gray-200 rounded px-2 py-0.5 text-sm text-right focus:outline-none focus:ring-1 focus:ring-blue-400"
+                            />
+                          </td>
+                          <td className="py-1.5 text-right">
+                            <input
+                              key={`rate-${rt.id}-${rt.dayRate ?? 'null'}`}
+                              type="number"
+                              step="50"
+                              defaultValue={rt.dayRate ?? ''}
+                              placeholder={rt.globalType?.defaultDayRate != null ? String(rt.globalType.defaultDayRate) : '—'}
+                              onBlur={e => {
+                                const value = e.target.value.trim()
+                                const parsed = value === '' ? null : parseFloat(value)
+                                if (parsed !== null && !Number.isFinite(parsed)) return
+                                const current = rt.dayRate ?? null
+                                if (parsed === current) return
+                                updateResourceType.mutate({ id: rt.id, dayRate: parsed })
+                              }}
+                              className="w-24 border border-gray-200 rounded px-2 py-0.5 text-sm text-right focus:outline-none focus:ring-1 focus:ring-blue-400"
                             />
                           </td>
                         </tr>

--- a/client/src/types/backlog.ts
+++ b/client/src/types/backlog.ts
@@ -3,6 +3,8 @@ export interface GlobalResourceType {
   name: string
   category: string
   description?: string
+  defaultHoursPerDay?: number | null
+  defaultDayRate?: number | null
   isDefault: boolean
 }
 
@@ -11,6 +13,8 @@ export interface ResourceType {
   name: string
   category: 'ENGINEERING' | 'GOVERNANCE' | 'PROJECT_MANAGEMENT'
   count: number
+  hoursPerDay?: number | null
+  dayRate?: number | null
   proposedName?: string
   globalTypeId?: string
   globalType?: GlobalResourceType

--- a/server/prisma/migrations/20260303042534_add_resource_type_rates/migration.sql
+++ b/server/prisma/migrations/20260303042534_add_resource_type_rates/migration.sql
@@ -1,0 +1,7 @@
+-- AlterTable
+ALTER TABLE "GlobalResourceType" ADD COLUMN     "defaultDayRate" DOUBLE PRECISION,
+ADD COLUMN     "defaultHoursPerDay" DOUBLE PRECISION;
+
+-- AlterTable
+ALTER TABLE "ResourceType" ADD COLUMN     "dayRate" DOUBLE PRECISION,
+ADD COLUMN     "hoursPerDay" DOUBLE PRECISION;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -19,14 +19,16 @@ model User {
 }
 
 model GlobalResourceType {
-  id            String           @id @default(cuid())
-  name          String           @unique
-  category      ResourceCategory
-  description   String?
-  isDefault     Boolean          @default(false)
-  resourceTypes ResourceType[]
-  createdAt     DateTime         @default(now())
-  updatedAt     DateTime         @updatedAt
+  id                 String           @id @default(cuid())
+  name               String           @unique
+  category           ResourceCategory
+  description        String?
+  defaultHoursPerDay Float?
+  defaultDayRate     Float?
+  isDefault          Boolean          @default(false)
+  resourceTypes      ResourceType[]
+  createdAt          DateTime         @default(now())
+  updatedAt          DateTime         @updatedAt
 }
 
 model Project {
@@ -56,16 +58,18 @@ enum ProjectStatus {
 }
 
 model ResourceType {
-  id           String              @id @default(cuid())
-  name         String
-  category     ResourceCategory
-  count        Int                 @default(1)
-  proposedName String?
-  globalType   GlobalResourceType? @relation(fields: [globalTypeId], references: [id])
-  globalTypeId String?
-  project      Project             @relation(fields: [projectId], references: [id], onDelete: Cascade)
-  projectId    String
-  tasks        Task[]
+  id            String              @id @default(cuid())
+  name          String
+  category      ResourceCategory
+  count         Int                 @default(1)
+  hoursPerDay   Float?
+  dayRate       Float?
+  proposedName  String?
+  globalType    GlobalResourceType? @relation(fields: [globalTypeId], references: [id])
+  globalTypeId  String?
+  project       Project             @relation(fields: [projectId], references: [id], onDelete: Cascade)
+  projectId     String
+  tasks         Task[]
   templateTasks TemplateTask[]
 }
 

--- a/server/src/routes/csv.ts
+++ b/server/src/routes/csv.ts
@@ -218,9 +218,12 @@ router.post('/import-csv', async (req: AuthRequest, res: Response) => {
   }
 
   // Fetch resource types for matching
-  const hoursPerDay = project.hoursPerDay ?? 7.6
-  const resourceTypes = await prisma.resourceType.findMany({ where: { projectId } })
-  const rtByName = new Map(resourceTypes.map(r => [r.name.toLowerCase(), r.id]))
+  const fallbackHoursPerDay = project.hoursPerDay ?? 7.6
+  const resourceTypes = await prisma.resourceType.findMany({
+    where: { projectId },
+    select: { id: true, name: true, hoursPerDay: true },
+  })
+  const rtByName = new Map(resourceTypes.map(r => [r.name.toLowerCase(), r]))
 
   // Auto-snapshot before import
   const existingEpics = await prisma.epic.findMany({
@@ -291,9 +294,11 @@ router.post('/import-csv', async (req: AuthRequest, res: Response) => {
     if (!row.task) continue
 
     // Create Task
-    const resourceTypeId = row.resourceType
-      ? (rtByName.get(row.resourceType.toLowerCase()) ?? null)
-      : null
+    const resourceType = row.resourceType
+      ? rtByName.get(row.resourceType.toLowerCase())
+      : undefined
+    const resourceTypeId = resourceType?.id ?? null
+    const hoursPerDay = resourceType?.hoursPerDay ?? fallbackHoursPerDay
 
     const taskCount = await prisma.task.count({ where: { userStoryId: storyId } })
     await prisma.task.create({

--- a/server/src/routes/effort.ts
+++ b/server/src/routes/effort.ts
@@ -38,7 +38,7 @@ router.get('/', async (req: AuthRequest, res: Response) => {
     return
   }
 
-  const hoursPerDay = project.hoursPerDay
+  const fallbackHoursPerDay = project.hoursPerDay
 
   // Collect all tasks with context
   type TaskEntry = {
@@ -57,6 +57,7 @@ router.get('/', async (req: AuthRequest, res: Response) => {
     for (const feature of epic.features) {
       for (const story of feature.userStories) {
         for (const task of story.tasks) {
+          const taskHoursPerDay = task.resourceType?.hoursPerDay ?? fallbackHoursPerDay
           allTasks.push({
             taskId: task.id,
             taskName: task.name,
@@ -64,7 +65,7 @@ router.get('/', async (req: AuthRequest, res: Response) => {
             featureName: feature.name,
             epicName: epic.name,
             hoursEffort: task.hoursEffort,
-            daysEffort: Math.round((task.hoursEffort / hoursPerDay) * 100) / 100,
+            daysEffort: Math.round((task.hoursEffort / taskHoursPerDay) * 100) / 100,
             resourceTypeId: task.resourceTypeId,
           })
         }
@@ -99,6 +100,7 @@ router.get('/', async (req: AuthRequest, res: Response) => {
       const resourceTypes = rts.map(rt => {
         const tasks = tasksByRt.get(rt.id) ?? []
         const totalHours = tasks.reduce((s, t) => s + t.hoursEffort, 0)
+        const hoursPerDay = rt.hoursPerDay ?? fallbackHoursPerDay
         const totalDays = Math.round((totalHours / hoursPerDay) * 100) / 100
         return {
           resourceTypeId: rt.id,
@@ -115,15 +117,15 @@ router.get('/', async (req: AuthRequest, res: Response) => {
       })
 
       const totalHours = resourceTypes.reduce((s, rt) => s + rt.totalHours, 0)
-      const totalDays = Math.round((totalHours / hoursPerDay) * 100) / 100
+      const totalDays = Math.round((resourceTypes.reduce((s, rt) => s + rt.totalDays, 0)) * 100) / 100
 
       return { category: cat, totalHours, totalDays, resourceTypes }
     })
 
   const totalHours = byCategory.reduce((s, c) => s + c.totalHours, 0)
-  const totalDays = Math.round((totalHours / hoursPerDay) * 100) / 100
+  const totalDays = Math.round((byCategory.reduce((s, c) => s + c.totalDays, 0)) * 100) / 100
 
-  res.json({ projectId, hoursPerDay, totalHours, totalDays, byCategory })
+  res.json({ projectId, hoursPerDay: fallbackHoursPerDay, totalHours, totalDays, byCategory })
 })
 
 export default router

--- a/server/src/routes/globalResourceTypes.ts
+++ b/server/src/routes/globalResourceTypes.ts
@@ -13,13 +13,22 @@ router.get('/', async (_req: Request, res: Response) => {
 // POST /api/global-resource-types — auth required
 // After creating, seeds a ResourceType instance into every existing project
 router.post('/', authenticate, async (req: AuthRequest, res: Response) => {
-  const { name, category, description } = req.body
+  const { name, category, description, defaultHoursPerDay, defaultDayRate } = req.body
   if (!name || !category) { res.status(400).json({ error: 'name and category are required' }); return }
-  const gt = await prisma.globalResourceType.create({ data: { name, category, description } })
+  const gt = await prisma.globalResourceType.create({
+    data: { name, category, description, defaultHoursPerDay, defaultDayRate },
+  })
   const projects = await prisma.project.findMany({ select: { id: true } })
   if (projects.length > 0) {
     await prisma.resourceType.createMany({
-      data: projects.map(p => ({ name, category, projectId: p.id, globalTypeId: gt.id }))
+      data: projects.map(p => ({
+        name,
+        category,
+        projectId: p.id,
+        globalTypeId: gt.id,
+        hoursPerDay: gt.defaultHoursPerDay ?? null,
+        dayRate: gt.defaultDayRate ?? null,
+      }))
     })
   }
   res.status(201).json(gt)
@@ -28,11 +37,14 @@ router.post('/', authenticate, async (req: AuthRequest, res: Response) => {
 // PUT /api/global-resource-types/:id — auth required
 // Syncs name + category changes to all linked project-level ResourceType instances
 router.put('/:id', authenticate, async (req: AuthRequest, res: Response) => {
-  const { name, category, description } = req.body
+  const { name, category, description, defaultHoursPerDay, defaultDayRate } = req.body
   if (!name || !category) { res.status(400).json({ error: 'name and category are required' }); return }
   const existing = await prisma.globalResourceType.findFirst({ where: { id: req.params.id as string } })
   if (!existing) { res.status(404).json({ error: 'Not found' }); return }
-  const gt = await prisma.globalResourceType.update({ where: { id: req.params.id as string }, data: { name, category, description } })
+  const gt = await prisma.globalResourceType.update({
+    where: { id: req.params.id as string },
+    data: { name, category, description, defaultHoursPerDay, defaultDayRate },
+  })
   await prisma.resourceType.updateMany({ where: { globalTypeId: req.params.id as string }, data: { name, category } })
   res.json(gt)
 })

--- a/server/src/routes/projects.ts
+++ b/server/src/routes/projects.ts
@@ -1,4 +1,5 @@
 import { Router, Response } from 'express'
+import { ResourceCategory } from '@prisma/client'
 import { prisma } from '../lib/prisma.js'
 import { authenticate, AuthRequest } from '../middleware/auth.js'
 
@@ -32,7 +33,24 @@ router.post('/', async (req: AuthRequest, res: Response) => {
 
   // Fetch global types to link by name
   const globalTypes = await prisma.globalResourceType.findMany()
-  const nameToGlobalId = new Map(globalTypes.map(gt => [gt.name, gt.id]))
+  const globalTypeByName = new Map(globalTypes.map(gt => [gt.name, gt]))
+  const baseTypes: Array<{ name: string; category: ResourceCategory }> = [
+    { name: 'Business Analyst', category: 'ENGINEERING' },
+    { name: 'Developer', category: 'ENGINEERING' },
+    { name: 'Tech Lead', category: 'ENGINEERING' },
+    { name: 'QA Engineer', category: 'ENGINEERING' },
+    { name: 'Tech Governance', category: 'GOVERNANCE' },
+    { name: 'Project Manager', category: 'PROJECT_MANAGEMENT' },
+  ]
+  const seedTypes = baseTypes.map(type => {
+    const globalType = globalTypeByName.get(type.name)
+    return {
+      ...type,
+      globalTypeId: globalType?.id,
+      hoursPerDay: globalType?.defaultHoursPerDay ?? null,
+      dayRate: globalType?.defaultDayRate ?? null,
+    }
+  })
 
   const project = await prisma.project.create({
     data: {
@@ -41,16 +59,7 @@ router.post('/', async (req: AuthRequest, res: Response) => {
       customer,
       ownerId: req.userId!,
       // Seed default resource types
-      resourceTypes: {
-        create: [
-          { name: 'Business Analyst', category: 'ENGINEERING', globalTypeId: nameToGlobalId.get('Business Analyst') },
-          { name: 'Developer', category: 'ENGINEERING', globalTypeId: nameToGlobalId.get('Developer') },
-          { name: 'Tech Lead', category: 'ENGINEERING', globalTypeId: nameToGlobalId.get('Tech Lead') },
-          { name: 'QA Engineer', category: 'ENGINEERING', globalTypeId: nameToGlobalId.get('QA Engineer') },
-          { name: 'Tech Governance', category: 'GOVERNANCE', globalTypeId: nameToGlobalId.get('Tech Governance') },
-          { name: 'Project Manager', category: 'PROJECT_MANAGEMENT', globalTypeId: nameToGlobalId.get('Project Manager') },
-        ],
-      },
+      resourceTypes: { create: seedTypes },
     },
     include: { resourceTypes: true },
   })

--- a/server/src/routes/resourceTypes.ts
+++ b/server/src/routes/resourceTypes.ts
@@ -16,7 +16,11 @@ router.get('/', async (req: AuthRequest, res: Response) => {
   const types = await prisma.resourceType.findMany({
     where: { projectId: req.params.projectId as string },
     orderBy: { name: 'asc' },
-    include: { globalType: { select: { id: true, name: true, category: true } } },
+    include: {
+      globalType: {
+        select: { id: true, name: true, category: true, defaultHoursPerDay: true, defaultDayRate: true },
+      },
+    },
   })
   res.json(types)
 })
@@ -25,10 +29,18 @@ router.get('/', async (req: AuthRequest, res: Response) => {
 router.post('/', async (req: AuthRequest, res: Response) => {
   const project = await ownedProject(req.params.projectId as string, req.userId!)
   if (!project) { res.status(404).json({ error: 'Project not found' }); return }
-  const { name, category } = req.body
+  const { name, category, count, proposedName, hoursPerDay, dayRate } = req.body
   if (!name || !category) { res.status(400).json({ error: 'name and category are required' }); return }
   const rt = await prisma.resourceType.create({
-    data: { name, category, projectId: req.params.projectId as string },
+    data: {
+      name,
+      category,
+      count,
+      proposedName,
+      hoursPerDay,
+      dayRate,
+      projectId: req.params.projectId as string,
+    },
   })
   res.status(201).json(rt)
 })
@@ -37,10 +49,14 @@ router.post('/', async (req: AuthRequest, res: Response) => {
 router.put('/:id', async (req: AuthRequest, res: Response) => {
   const project = await ownedProject(req.params.projectId as string, req.userId!)
   if (!project) { res.status(404).json({ error: 'Project not found' }); return }
-  const { name, category, count, proposedName } = req.body
+  const { name, category, count, proposedName, hoursPerDay, dayRate } = req.body
+  const data: Record<string, unknown> = { name, category, count, proposedName, hoursPerDay, dayRate }
+  Object.keys(data).forEach(key => {
+    if (data[key] === undefined) delete data[key]
+  })
   const rt = await prisma.resourceType.update({
     where: { id: req.params.id as string },
-    data: { name, category, count, proposedName },
+    data,
   })
   res.json(rt)
 })

--- a/server/src/routes/snapshots.ts
+++ b/server/src/routes/snapshots.ts
@@ -142,36 +142,51 @@ router.post('/:snapshotId/rollback', async (req: AuthRequest, res: Response) => 
     },
   })
 
-  // Delete current backlog (cascades to features/stories/tasks)
-  await prisma.epic.deleteMany({ where: { projectId } })
+  const resourceTypes = await prisma.resourceType.findMany({
+    where: { projectId },
+    select: { id: true, name: true },
+  })
+  const rtMap = new Map(
+    resourceTypes.map(rt => [rt.name.toLowerCase(), rt.id]),
+  )
 
-  // Recreate from snapshot
   const epics = snap.snapshot as unknown as typeof currentData
-  for (const epic of epics) {
-    const newEpic = await prisma.epic.create({
-      data: { name: epic.name, description: epic.description, order: epic.order, projectId },
-    })
-    for (const feature of epic.features) {
-      const newFeature = await prisma.feature.create({
-        data: { name: feature.name, description: feature.description, assumptions: feature.assumptions, order: feature.order, epicId: newEpic.id },
+  await prisma.$transaction(async tx => {
+    await tx.epic.deleteMany({ where: { projectId } })
+
+    for (const epic of epics) {
+      const newEpic = await tx.epic.create({
+        data: { name: epic.name, description: epic.description, order: epic.order, projectId },
       })
-      for (const story of feature.userStories) {
-        const newStory = await prisma.userStory.create({
-          data: { name: story.name, description: story.description, assumptions: story.assumptions, order: story.order, featureId: newFeature.id, appliedTemplateId: story.appliedTemplateId },
+      for (const feature of epic.features) {
+        const newFeature = await tx.feature.create({
+          data: { name: feature.name, description: feature.description, assumptions: feature.assumptions, order: feature.order, epicId: newEpic.id },
         })
-        for (const task of story.tasks) {
-          // Re-match resource type by name in the project
-          const rt = await prisma.resourceType.findFirst({
-            where: { projectId, name: task.resourceType?.name },
+        for (const story of feature.userStories) {
+          const newStory = await tx.userStory.create({
+            data: { name: story.name, description: story.description, assumptions: story.assumptions, order: story.order, featureId: newFeature.id, appliedTemplateId: story.appliedTemplateId },
           })
-          if (!rt) continue
-          await prisma.task.create({
-            data: { name: task.name, description: task.description, assumptions: task.assumptions, hoursEffort: task.hoursEffort, durationDays: task.durationDays, order: task.order, userStoryId: newStory.id, resourceTypeId: rt.id },
-          })
+          for (const task of story.tasks) {
+            const resourceTypeId = task.resourceType?.name
+              ? (rtMap.get(task.resourceType.name.toLowerCase()) ?? null)
+              : null
+            await tx.task.create({
+              data: {
+                name: task.name,
+                description: task.description,
+                assumptions: task.assumptions,
+                hoursEffort: task.hoursEffort,
+                durationDays: task.durationDays,
+                order: task.order,
+                userStoryId: newStory.id,
+                resourceTypeId,
+              },
+            })
+          }
         }
       }
     }
-  }
+  })
 
   res.json({ message: 'Rollback complete' })
 })

--- a/server/src/routes/timeline.ts
+++ b/server/src/routes/timeline.ts
@@ -69,7 +69,7 @@ router.post('/schedule', async (req: AuthRequest, res: Response) => {
     })
   }
 
-  const hoursPerDay = project.hoursPerDay
+  const fallbackHoursPerDay = project.hoursPerDay
 
   // Load full hierarchy
   const epics = await prisma.epic.findMany({
@@ -118,7 +118,11 @@ router.post('/schedule', async (req: AuthRequest, res: Response) => {
 
       let maxDays = 0
       for (const [rtId, tasks] of byRt) {
-        const personDays = tasks.reduce((sum, t) => sum + (t.durationDays ?? t.hoursEffort / hoursPerDay), 0)
+        const personDays = tasks.reduce((sum, t) => {
+          const taskHoursPerDay = t.resourceType?.hoursPerDay ?? fallbackHoursPerDay
+          const taskDays = t.durationDays ?? (t.hoursEffort / taskHoursPerDay)
+          return sum + taskDays
+        }, 0)
         const count = rtId ? (rtCountMap.get(rtId) ?? 1) : 1
         const parallelDays = personDays / count
         if (parallelDays > maxDays) maxDays = parallelDays

--- a/server/src/test/globalResourceTypes.test.ts
+++ b/server/src/test/globalResourceTypes.test.ts
@@ -10,7 +10,17 @@ const userId = 'user-1'
 const token = jwt.sign({ userId }, 'test-secret')
 const authHeader = `Bearer ${token}`
 
-const mockGRT = { id: 'grt-1', name: 'Developer', category: 'ENGINEERING' as const, description: null, isDefault: true, createdAt: new Date(), updatedAt: new Date() }
+const mockGRT = {
+  id: 'grt-1',
+  name: 'Developer',
+  category: 'ENGINEERING' as const,
+  description: null,
+  defaultHoursPerDay: null,
+  defaultDayRate: null,
+  isDefault: true,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+}
 
 beforeEach(() => vi.clearAllMocks())
 


### PR DESCRIPTION
## Summary

Schema changes and performance improvement for Phase 6 groundwork.

### #52 — Per-resource hoursPerDay + dayRate

**Schema (migration):**
- `ResourceType`: added `hoursPerDay Float?` and `dayRate Float?` (nullable overrides)
- `GlobalResourceType`: added `defaultHoursPerDay Float?` and `defaultDayRate Float?` (seeds project instances)

**Duration calc updated everywhere:**
- `effort.ts`, `csv.ts`, `timeline.ts` — all now use `task.resourceType?.hoursPerDay ?? project.hoursPerDay`
- Enables AU (7.6h) and NZ (8.0h) resource type variants on the same project

**Seeding:**
- Project create seeds `hoursPerDay` + `dayRate` from global type defaults
- Global type POST also seeds new fields into existing projects

**UI:**
- Project resource type settings: editable `Hrs/day` and `Day rate` fields per row
- Global resource types admin: editable `defaultHoursPerDay` and `defaultDayRate` fields

### #50 — Snapshot rollback perf

- Pre-resolve all resource types in one `findMany` call before the rollback loop (eliminates O(N_tasks) DB round trips)
- Entire rollback wrapped in `prisma.$transaction` for atomicity

## Quality
- `npx tsc --noEmit` clean on server and client

Closes #52
Closes #50