### PR TITLE
fix(#103): remove HoursXS/S/M/L/XL columns from backlog CSV export

### DIFF
--- a/server/src/routes/csv.ts
+++ b/server/src/routes/csv.ts
@@ -10,7 +10,6 @@ router.use(authenticate)
 const CSV_HEADERS = [
   'Epic', 'Feature', 'Story', 'Task',
   'ResourceType',
-  'HoursExtraSmall', 'HoursSmall', 'HoursMedium', 'HoursLarge', 'HoursExtraLarge',
   'HoursEffort', 'DurationDays',
   'Description', 'Assumptions',
 ]
@@ -87,7 +86,7 @@ router.get('/export-csv', async (req: AuthRequest, res: Response) => {
 
   if (epics.length === 0) {
     // blank template with one example row
-    rows.push(['My Epic', 'My Feature', 'My Story', 'My Task', 'Developer', '1', '2', '4', '8', '16', '', '', '', ''])
+    rows.push(['My Epic', 'My Feature', 'My Story', 'My Task', 'Developer', '', '', '', ''])
   } else {
     for (const epic of epics) {
       for (const feature of epic.features) {
@@ -99,11 +98,6 @@ router.get('/export-csv', async (req: AuthRequest, res: Response) => {
               story.name,
               task.name,
               task.resourceType?.name ?? '',
-              '', // HoursExtraSmall (template field, not applicable to exported tasks)
-              '', // HoursSmall
-              '', // HoursMedium
-              '', // HoursLarge
-              '', // HoursExtraLarge
               String(task.hoursEffort),
               String(task.durationDays ?? ''),
               task.description ?? '',
@@ -111,7 +105,7 @@ router.get('/export-csv', async (req: AuthRequest, res: Response) => {
             ])
           }
           if (story.tasks.length === 0) {
-            rows.push([epic.name, feature.name, story.name, '', '', '', '', '', '', '', '', '', story.description ?? '', story.assumptions ?? ''])
+            rows.push([epic.name, feature.name, story.name, '', '', '', '', story.description ?? '', story.assumptions ?? ''])
           }
         }
       }


### PR DESCRIPTION
## Summary

Removes the five complexity-tier hour columns (`HoursExtraSmall`, `HoursSmall`, `HoursMedium`, `HoursLarge`, `HoursExtraLarge`) from the backlog CSV export. These are template fields — the exported backlog only has `HoursEffort` and `DurationDays` on tasks, so they were always empty and just added noise.

## Related issue

Closes #103

## Changes

- `CSV_HEADERS`: removed the 5 complexity columns
- Blank template row (empty backlog export): removed the 5 placeholder values
- Task data rows: removed the 5 empty string columns
- Story-level fallback row: removed the 5 empty string columns
- `CsvRow` interface and import parsing (`stage-csv`): **unchanged** — still reads those columns for backwards compatibility with older exports

## Testing

- [x] `npx tsc --noEmit` passes in `/server`
- [x] No behaviour change on import — `stage-csv` still maps all legacy columns