### PR TITLE
feat: Performance Sprint 1 — indexes, transactions, code splitting, timeline optimisation

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,28 +1,36 @@
+import React, { lazy, Suspense } from 'react'
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { AuthProvider, useAuth } from './hooks/useAuth'
 import { useTheme } from './hooks/useTheme'
 import LoginPage from './pages/LoginPage'
 import RegisterPage from './pages/RegisterPage'
-import ForgotPasswordPage from './pages/ForgotPasswordPage'
-import ResetPasswordPage from './pages/ResetPasswordPage'
-import ProjectsPage from './pages/ProjectsPage'
-import ProjectDetailPage from './pages/ProjectDetailPage'
-import BacklogPage from './pages/BacklogPage'
-import TemplateLibraryPage from './pages/TemplateLibraryPage'
-import ProjectSettingsPage from './pages/ProjectSettingsPage'
-import EffortReviewPage from './pages/EffortReviewPage'
-import GlobalResourceTypesPage from './pages/GlobalResourceTypesPage'
-import RateCardsPage from './pages/RateCardsPage'
-import TimelinePage from './pages/TimelinePage'
-import ResourceProfilePage from './pages/ResourceProfilePage'
-import ProjectResourceTypesPage from './pages/ProjectResourceTypesPage'
-import DocumentsPage from './pages/DocumentsPage'
-import OrgsPage from './pages/OrgsPage'
-import AcceptInvitePage from './pages/AcceptInvitePage'
-import CustomersPage from './pages/CustomersPage'
+const ForgotPasswordPage = lazy(() => import('./pages/ForgotPasswordPage'))
+const ResetPasswordPage = lazy(() => import('./pages/ResetPasswordPage'))
+const ProjectsPage = lazy(() => import('./pages/ProjectsPage'))
+const ProjectDetailPage = lazy(() => import('./pages/ProjectDetailPage'))
+const BacklogPage = lazy(() => import('./pages/BacklogPage'))
+const TemplateLibraryPage = lazy(() => import('./pages/TemplateLibraryPage'))
+const ProjectSettingsPage = lazy(() => import('./pages/ProjectSettingsPage'))
+const EffortReviewPage = lazy(() => import('./pages/EffortReviewPage'))
+const GlobalResourceTypesPage = lazy(() => import('./pages/GlobalResourceTypesPage'))
+const RateCardsPage = lazy(() => import('./pages/RateCardsPage'))
+const TimelinePage = lazy(() => import('./pages/TimelinePage'))
+const ResourceProfilePage = lazy(() => import('./pages/ResourceProfilePage'))
+const ProjectResourceTypesPage = lazy(() => import('./pages/ProjectResourceTypesPage'))
+const DocumentsPage = lazy(() => import('./pages/DocumentsPage'))
+const OrgsPage = lazy(() => import('./pages/OrgsPage'))
+const AcceptInvitePage = lazy(() => import('./pages/AcceptInvitePage'))
+const CustomersPage = lazy(() => import('./pages/CustomersPage'))
 
-const queryClient = new QueryClient()
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 5 * 60 * 1000,  // 5 minutes
+      refetchOnWindowFocus: false,
+    },
+  },
+})
 
 function PrivateRoute({ children }: { children: React.ReactNode }) {
   const { user } = useAuth()
@@ -36,27 +44,29 @@ function PublicRoute({ children }: { children: React.ReactNode }) {
 
 function AppRoutes() {
   return (
-    <Routes>
-      <Route path="/login" element={<PublicRoute><LoginPage /></PublicRoute>} />
-      <Route path="/register" element={<PublicRoute><RegisterPage /></PublicRoute>} />
-      <Route path="/forgot-password" element={<ForgotPasswordPage />} />
-      <Route path="/reset-password" element={<ResetPasswordPage />} />
-      <Route path="/" element={<PrivateRoute><ProjectsPage /></PrivateRoute>} />
-      <Route path="/projects/:id" element={<PrivateRoute><ProjectDetailPage /></PrivateRoute>} />
-      <Route path="/projects/:id/backlog" element={<PrivateRoute><BacklogPage /></PrivateRoute>} />
-      <Route path="/projects/:id/effort" element={<PrivateRoute><EffortReviewPage /></PrivateRoute>} />
-      <Route path="/projects/:id/timeline" element={<PrivateRoute><TimelinePage /></PrivateRoute>} />
-      <Route path="/projects/:id/resource-profile" element={<PrivateRoute><ResourceProfilePage /></PrivateRoute>} />
-      <Route path="/projects/:id/resource-types" element={<PrivateRoute><ProjectResourceTypesPage /></PrivateRoute>} />
-      <Route path="/projects/:id/documents" element={<PrivateRoute><DocumentsPage /></PrivateRoute>} />
-      <Route path="/projects/:id/settings" element={<PrivateRoute><ProjectSettingsPage /></PrivateRoute>} />
-      <Route path="/templates" element={<PrivateRoute><TemplateLibraryPage /></PrivateRoute>} />
-      <Route path="/resource-types" element={<PrivateRoute><GlobalResourceTypesPage /></PrivateRoute>} />
-      <Route path="/rate-cards" element={<PrivateRoute><RateCardsPage /></PrivateRoute>} />
-      <Route path="/orgs" element={<PrivateRoute><OrgsPage /></PrivateRoute>} />
-      <Route path="/customers" element={<PrivateRoute><CustomersPage /></PrivateRoute>} />
-      <Route path="/accept-invite" element={<AcceptInvitePage />} />
-    </Routes>
+    <Suspense fallback={<div className="flex items-center justify-center h-screen text-gray-500">Loading...</div>}>
+      <Routes>
+        <Route path="/login" element={<PublicRoute><LoginPage /></PublicRoute>} />
+        <Route path="/register" element={<PublicRoute><RegisterPage /></PublicRoute>} />
+        <Route path="/forgot-password" element={<ForgotPasswordPage />} />
+        <Route path="/reset-password" element={<ResetPasswordPage />} />
+        <Route path="/" element={<PrivateRoute><ProjectsPage /></PrivateRoute>} />
+        <Route path="/projects/:id" element={<PrivateRoute><ProjectDetailPage /></PrivateRoute>} />
+        <Route path="/projects/:id/backlog" element={<PrivateRoute><BacklogPage /></PrivateRoute>} />
+        <Route path="/projects/:id/effort" element={<PrivateRoute><EffortReviewPage /></PrivateRoute>} />
+        <Route path="/projects/:id/timeline" element={<PrivateRoute><TimelinePage /></PrivateRoute>} />
+        <Route path="/projects/:id/resource-profile" element={<PrivateRoute><ResourceProfilePage /></PrivateRoute>} />
+        <Route path="/projects/:id/resource-types" element={<PrivateRoute><ProjectResourceTypesPage /></PrivateRoute>} />
+        <Route path="/projects/:id/documents" element={<PrivateRoute><DocumentsPage /></PrivateRoute>} />
+        <Route path="/projects/:id/settings" element={<PrivateRoute><ProjectSettingsPage /></PrivateRoute>} />
+        <Route path="/templates" element={<PrivateRoute><TemplateLibraryPage /></PrivateRoute>} />
+        <Route path="/resource-types" element={<PrivateRoute><GlobalResourceTypesPage /></PrivateRoute>} />
+        <Route path="/rate-cards" element={<PrivateRoute><RateCardsPage /></PrivateRoute>} />
+        <Route path="/orgs" element={<PrivateRoute><OrgsPage /></PrivateRoute>} />
+        <Route path="/customers" element={<PrivateRoute><CustomersPage /></PrivateRoute>} />
+        <Route path="/accept-invite" element={<AcceptInvitePage />} />
+      </Routes>
+    </Suspense>
   )
 }
 

--- a/server/prisma/migrations/20260407052237_add_fk_indexes/migration.sql
+++ b/server/prisma/migrations/20260407052237_add_fk_indexes/migration.sql
@@ -1,0 +1,35 @@
+-- CreateIndex
+CREATE INDEX "BacklogSnapshot_projectId_createdAt_idx" ON "BacklogSnapshot"("projectId", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "Epic_projectId_order_idx" ON "Epic"("projectId", "order");
+
+-- CreateIndex
+CREATE INDEX "Feature_epicId_order_idx" ON "Feature"("epicId", "order");
+
+-- CreateIndex
+CREATE INDEX "NamedResource_resourceTypeId_idx" ON "NamedResource"("resourceTypeId");
+
+-- CreateIndex
+CREATE INDEX "OrganisationMember_userId_idx" ON "OrganisationMember"("userId");
+
+-- CreateIndex
+CREATE INDEX "ProjectDiscount_projectId_idx" ON "ProjectDiscount"("projectId");
+
+-- CreateIndex
+CREATE INDEX "ProjectOverhead_projectId_idx" ON "ProjectOverhead"("projectId");
+
+-- CreateIndex
+CREATE INDEX "ResourceType_projectId_idx" ON "ResourceType"("projectId");
+
+-- CreateIndex
+CREATE INDEX "StoryTimelineEntry_projectId_idx" ON "StoryTimelineEntry"("projectId");
+
+-- CreateIndex
+CREATE INDEX "Task_userStoryId_idx" ON "Task"("userStoryId");
+
+-- CreateIndex
+CREATE INDEX "TimelineEntry_projectId_idx" ON "TimelineEntry"("projectId");
+
+-- CreateIndex
+CREATE INDEX "UserStory_featureId_order_idx" ON "UserStory"("featureId", "order");

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -108,6 +108,8 @@ model ResourceType {
   overheads     ProjectOverhead[]
   namedResources NamedResource[]
   discounts      ProjectDiscount[]
+
+  @@index([projectId])
 }
 
 model ProjectOverhead {
@@ -122,6 +124,8 @@ model ProjectOverhead {
   order          Int           @default(0)
   createdAt      DateTime      @default(now())
   updatedAt      DateTime      @updatedAt
+
+  @@index([projectId])
 }
 
 enum OverheadType {
@@ -157,6 +161,8 @@ model Epic {
   features          Feature[]
   createdAt         DateTime @default(now())
   updatedAt         DateTime @updatedAt
+
+  @@index([projectId, order])
 }
 
 model Feature {
@@ -175,6 +181,8 @@ model Feature {
   dependents       FeatureDependency[]  @relation("FeatureDepsOn")
   createdAt        DateTime             @default(now())
   updatedAt        DateTime             @updatedAt
+
+  @@index([epicId, order])
 }
 
 model FeatureDependency {
@@ -208,6 +216,8 @@ model StoryTimelineEntry {
   isManual      Boolean   @default(false)
   createdAt     DateTime  @default(now())
   updatedAt     DateTime  @updatedAt
+
+  @@index([projectId])
 }
 
 model UserStory {
@@ -227,6 +237,8 @@ model UserStory {
   timelineEntry     StoryTimelineEntry?
   createdAt         DateTime @default(now())
   updatedAt         DateTime @updatedAt
+
+  @@index([featureId, order])
 }
 
 model Task {
@@ -243,6 +255,8 @@ model Task {
   resourceTypeId String?
   createdAt      DateTime     @default(now())
   updatedAt      DateTime     @updatedAt
+
+  @@index([userStoryId])
 }
 
 // Global feature templates (shared across all projects)
@@ -286,6 +300,8 @@ model TimelineEntry {
   isManual      Boolean  @default(false)
   createdAt     DateTime @default(now())
   updatedAt     DateTime @updatedAt
+
+  @@index([projectId])
 }
 
 model BacklogSnapshot {
@@ -298,6 +314,8 @@ model BacklogSnapshot {
   createdAt   DateTime @default(now())
   createdBy   User     @relation(fields: [createdById], references: [id])
   createdById String
+
+  @@index([projectId, createdAt])
 }
 
 model TemplateSnapshot {
@@ -325,6 +343,8 @@ model NamedResource {
   pricingModel   String       @default("ACTUAL_DAYS")
   createdAt      DateTime     @default(now())
   updatedAt      DateTime     @updatedAt
+
+  @@index([resourceTypeId])
 }
 
 model RateCard {
@@ -357,6 +377,8 @@ model ProjectDiscount {
   label          String
   order          Int           @default(0)
   createdAt      DateTime      @default(now())
+
+  @@index([projectId])
 }
 
 enum DocumentTemplateType {
@@ -422,6 +444,7 @@ model OrganisationMember {
   role      OrgRole      @default(MEMBER)
   joinedAt  DateTime     @default(now())
   @@unique([orgId, userId])
+  @@index([userId])
 }
 
 model OrganisationInvite {

--- a/server/src/routes/applyTemplate.ts
+++ b/server/src/routes/applyTemplate.ts
@@ -1,5 +1,6 @@
 import { Router, Response } from 'express'
 import { prisma } from '../lib/prisma.js'
+import { asyncHandler } from '../lib/asyncHandler.js'
 import { authenticate, AuthRequest } from '../middleware/auth.js'
 import { calcDurationDays } from '../utils/round.js'
 
@@ -17,7 +18,7 @@ const HOURS_FIELD: Record<Complexity, 'hoursExtraSmall' | 'hoursSmall' | 'hoursM
 }
 
 // POST /api/features/:featureId/apply-template
-router.post('/:featureId/apply-template', async (req: AuthRequest, res: Response) => {
+router.post('/:featureId/apply-template', asyncHandler(async (req: AuthRequest, res: Response) => {
   const featureId = req.params.featureId as string
   const { templateId, complexity, storyName } = req.body as { templateId: string; complexity: Complexity; storyName?: string }
 
@@ -81,11 +82,11 @@ router.post('/:featureId/apply-template', async (req: AuthRequest, res: Response
   })
 
   res.status(201).json(result)
-})
+}))
 
 // POST /api/features/:featureId/refresh-template/:storyId
 // Additive refresh: adds any template tasks not already present in the story
-router.post('/:featureId/refresh-template/:storyId', async (req: AuthRequest, res: Response) => {
+router.post('/:featureId/refresh-template/:storyId', asyncHandler(async (req: AuthRequest, res: Response) => {
   const { featureId, storyId } = req.params as { featureId: string; storyId: string }
   const { complexity } = req.body as { complexity: Complexity }
 
@@ -162,6 +163,6 @@ router.post('/:featureId/refresh-template/:storyId', async (req: AuthRequest, re
     include: { tasks: { orderBy: { order: 'asc' }, include: { resourceType: true } } },
   })
   res.json({ added: newTasks.length, updated: existingTasks.length, story: result })
-})
+}))
 
 export default router

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -3,6 +3,7 @@ import bcrypt from 'bcryptjs'
 import jwt from 'jsonwebtoken'
 import crypto from 'crypto'
 import rateLimit from 'express-rate-limit'
+import { asyncHandler } from '../lib/asyncHandler.js'
 import { prisma } from '../lib/prisma.js'
 import { sendEmail } from '../lib/email.js'
 import { logger } from '../lib/logger.js'
@@ -38,7 +39,7 @@ const forgotPasswordLimiter = rateLimit({
   legacyHeaders: false,
 })
 
-router.post('/register', loginLimiter, validate(registerSchema), async (req: Request, res: Response) => {
+router.post('/register', loginLimiter, validate(registerSchema), asyncHandler(async (req: Request, res: Response) => {
   const { email, name, password } = req.body
 
   const existing = await prisma.user.findUnique({ where: { email } })
@@ -67,9 +68,9 @@ router.post('/register', loginLimiter, validate(registerSchema), async (req: Req
   logger.info({ userId: user.id }, 'New user registered')
   const token = jwt.sign({ userId: user.id, role: user.role }, process.env.JWT_SECRET!, { expiresIn: '7d' })
   res.status(201).json({ token, user: { id: user.id, email: user.email, name: user.name } })
-})
+}))
 
-router.post('/login', loginLimiter, validate(loginSchema), async (req: Request, res: Response) => {
+router.post('/login', loginLimiter, validate(loginSchema), asyncHandler(async (req: Request, res: Response) => {
   const { email, password } = req.body
   const user = await prisma.user.findUnique({ where: { email } })
   if (!user || !(await bcrypt.compare(password, user.password))) {
@@ -80,9 +81,9 @@ router.post('/login', loginLimiter, validate(loginSchema), async (req: Request, 
   logger.info({ userId: user.id }, 'User logged in')
   const token = jwt.sign({ userId: user.id, role: user.role }, process.env.JWT_SECRET!, { expiresIn: '7d' })
   res.json({ token, user: { id: user.id, email: user.email, name: user.name } })
-})
+}))
 
-router.post('/forgot-password', forgotPasswordLimiter, validate(forgotPasswordSchema), async (req: Request, res: Response) => {
+router.post('/forgot-password', forgotPasswordLimiter, validate(forgotPasswordSchema), asyncHandler(async (req: Request, res: Response) => {
   const { email } = req.body
   const successMessage = 'If that email is registered, a reset link has been sent.'
 
@@ -123,9 +124,9 @@ router.post('/forgot-password', forgotPasswordLimiter, validate(forgotPasswordSc
 
   logger.info({ userId: user.id }, 'Password reset email sent')
   res.json({ message: successMessage })
-})
+}))
 
-router.post('/reset-password', validate(resetPasswordSchema), async (req: Request, res: Response) => {
+router.post('/reset-password', validate(resetPasswordSchema), asyncHandler(async (req: Request, res: Response) => {
   const { token, password } = req.body
 
   const tokenHash = crypto.createHash('sha256').update(token).digest('hex')
@@ -150,6 +151,6 @@ router.post('/reset-password', validate(resetPasswordSchema), async (req: Reques
 
   logger.info({ userId: resetToken.userId }, 'Password reset successfully')
   res.json({ message: 'Password reset successfully' })
-})
+}))
 
 export default router

--- a/server/src/routes/csv.ts
+++ b/server/src/routes/csv.ts
@@ -1,5 +1,6 @@
 import { Router, Response } from 'express'
 import { prisma } from '../lib/prisma.js'
+import { asyncHandler } from '../lib/asyncHandler.js'
 import { authenticate, AuthRequest } from '../middleware/auth.js'
 import { parse } from 'csv-parse/sync'
 import { stringify } from 'csv-stringify/sync'
@@ -88,7 +89,7 @@ export function sanitizeCsvCell(value: string): string {
 }
 
 // GET /api/projects/:projectId/backlog/export-csv
-router.get('/export-csv', async (req: AuthRequest, res: Response) => {
+router.get('/export-csv', asyncHandler(async (req: AuthRequest, res: Response) => {
   const project = await ownedProject(req.params.projectId as string, req.userId!)
   if (!project) { res.status(404).json({ error: 'Project not found' }); return }
 
@@ -171,11 +172,11 @@ router.get('/export-csv', async (req: AuthRequest, res: Response) => {
   const filename = `${clientPart}${safeName(project.name)} - ${datestamp}.csv`
   res.setHeader('Content-Disposition', `attachment; filename="${filename}"`)
   res.send(csv)
-})
+}))
 
 // POST /api/projects/:projectId/backlog/stage-csv
 // Body: { csv: string }
-router.post('/stage-csv', async (req: AuthRequest, res: Response) => {
+router.post('/stage-csv', asyncHandler(async (req: AuthRequest, res: Response) => {
   const project = await ownedProject(req.params.projectId as string, req.userId!)
   if (!project) { res.status(404).json({ error: 'Project not found' }); return }
 
@@ -292,11 +293,11 @@ router.post('/stage-csv', async (req: AuthRequest, res: Response) => {
   const warningCount = staged.filter(r => r.warnings.length > 0).length
 
   res.json({ staged, summary: { total: staged.length, errorCount, warningCount } })
-})
+}))
 
 // POST /api/projects/:projectId/backlog/import-csv
 // Body: { rows: StagedRow[] }
-router.post('/import-csv', async (req: AuthRequest, res: Response) => {
+router.post('/import-csv', asyncHandler(async (req: AuthRequest, res: Response) => {
   const projectId = req.params.projectId as string
   const project = await ownedProject(projectId, req.userId!)
   if (!project) { res.status(404).json({ error: 'Project not found' }); return }
@@ -353,193 +354,191 @@ router.post('/import-csv', async (req: AuthRequest, res: Response) => {
     })
   }
 
-  // Build hierarchy maps to group rows (upsert by name within parent)
-  const epicMap = new Map<string, string>() // epic name → epic id
-  const featureMap = new Map<string, string>() // "epic||feature" → feature id
-  const storyMap = new Map<string, string>() // "epic||feature||story" → story id
+  // #176: wrap all DB writes in a transaction for atomicity
+  const result = await prisma.$transaction(async (tx) => {
+    // Build hierarchy maps to group rows (upsert by name within parent)
+    const epicMap = new Map<string, string>() // epic name → epic id
+    const featureMap = new Map<string, string>() // "epic||feature" → feature id
+    const storyMap = new Map<string, string>() // "epic||feature||story" → story id
 
-  let epicOrder = await prisma.epic.count({ where: { projectId } })
+    let epicOrder = await tx.epic.count({ where: { projectId } })
 
-  // Counters for response
-  let epicsCreated = 0, epicsUpdated = 0
-  let featuresCreated = 0, featuresUpdated = 0
-  let storiesCreated = 0, storiesUpdated = 0
-  let tasksCreated = 0, tasksUpdated = 0
+    // Counters for response
+    let epicsCreated = 0, epicsUpdated = 0
+    let featuresCreated = 0, featuresUpdated = 0
+    let storiesCreated = 0, storiesUpdated = 0
+    let tasksCreated = 0, tasksUpdated = 0
 
-  for (const row of rows) {
-    const epicKey = row.epic
-    const featureKey = `${row.epic}||${row.feature}`
-    const storyKey = `${row.epic}||${row.feature}||${row.story}`
+    for (const row of rows) {
+      const epicKey = row.epic
+      const featureKey = `${row.epic}||${row.feature}`
+      const storyKey = `${row.epic}||${row.feature}||${row.story}`
 
-    // ── Epic ───────────────────────────────────────────────────────────────
-    if (!epicMap.has(epicKey)) {
-      let epic = await prisma.epic.findFirst({ where: { projectId, name: row.epic } })
-      if (!epic) {
-        epic = await prisma.epic.create({
-          data: {
-            name: row.epic,
-            projectId,
-            order: epicOrder++,
-            isActive: row.type === 'Epic' ? row.epicStatus : true,
-            description: row.type === 'Epic' ? (row.description || null) : null,
-            assumptions: row.type === 'Epic' ? (row.assumptions || null) : null,
-          },
-        })
-        epicsCreated++
-      } else if (row.type === 'Epic') {
-        // Only update status when this is a canonical Epic row
-        await prisma.epic.update({
-          where: { id: epic.id },
-          data: {
-            isActive: row.epicStatus,
-            ...(row.type === 'Epic' ? {
-              description: row.description || null,
-              assumptions: row.assumptions || null,
-            } : {}),
-          },
-        })
-        epicsUpdated++
+      // ── Epic ───────────────────────────────────────────────────────────────
+      if (!epicMap.has(epicKey)) {
+        let epic = await tx.epic.findFirst({ where: { projectId, name: row.epic } })
+        if (!epic) {
+          epic = await tx.epic.create({
+            data: {
+              name: row.epic,
+              projectId,
+              order: epicOrder++,
+              isActive: row.type === 'Epic' ? row.epicStatus : true,
+              description: row.type === 'Epic' ? (row.description || null) : null,
+              assumptions: row.type === 'Epic' ? (row.assumptions || null) : null,
+            },
+          })
+          epicsCreated++
+        } else if (row.type === 'Epic') {
+          // Only update status when this is a canonical Epic row
+          await tx.epic.update({
+            where: { id: epic.id },
+            data: {
+              isActive: row.epicStatus,
+              ...(row.type === 'Epic' ? {
+                description: row.description || null,
+                assumptions: row.assumptions || null,
+              } : {}),
+            },
+          })
+          epicsUpdated++
+        }
+        epicMap.set(epicKey, epic.id)
       }
-      epicMap.set(epicKey, epic.id)
-    }
-    const epicId = epicMap.get(epicKey)!
+      const epicId = epicMap.get(epicKey)!
 
-    // Epic-only rows — stop here
-    if (row.type === 'Epic') continue
+      // Epic-only rows — stop here
+      if (row.type === 'Epic') continue
 
-    // ── Feature ────────────────────────────────────────────────────────────
-    if (!featureMap.has(featureKey)) {
-      let feature = await prisma.feature.findFirst({ where: { epicId, name: row.feature } })
-      if (!feature) {
-        const featCount = await prisma.feature.count({ where: { epicId } })
-        feature = await prisma.feature.create({
-          data: {
-            name: row.feature,
-            epicId,
-            order: featCount,
-            isActive: row.type === 'Feature' ? row.featureStatus : true,
-            description: row.type === 'Feature' ? (row.description || null) : null,
-            assumptions: row.type === 'Feature' ? (row.assumptions || null) : null,
-          },
-        })
-        featuresCreated++
-      } else if (row.type === 'Feature') {
-        await prisma.feature.update({
-          where: { id: feature.id },
-          data: {
-            isActive: row.featureStatus,
-            ...(row.type === 'Feature' ? {
-              description: row.description || null,
-              assumptions: row.assumptions || null,
-            } : {}),
-          },
-        })
-        featuresUpdated++
+      // ── Feature ────────────────────────────────────────────────────────────
+      if (!featureMap.has(featureKey)) {
+        let feature = await tx.feature.findFirst({ where: { epicId, name: row.feature } })
+        if (!feature) {
+          const featCount = await tx.feature.count({ where: { epicId } })
+          feature = await tx.feature.create({
+            data: {
+              name: row.feature,
+              epicId,
+              order: featCount,
+              isActive: row.type === 'Feature' ? row.featureStatus : true,
+              description: row.type === 'Feature' ? (row.description || null) : null,
+              assumptions: row.type === 'Feature' ? (row.assumptions || null) : null,
+            },
+          })
+          featuresCreated++
+        } else if (row.type === 'Feature') {
+          await tx.feature.update({
+            where: { id: feature.id },
+            data: {
+              isActive: row.featureStatus,
+              ...(row.type === 'Feature' ? {
+                description: row.description || null,
+                assumptions: row.assumptions || null,
+              } : {}),
+            },
+          })
+          featuresUpdated++
+        }
+        featureMap.set(featureKey, feature.id)
       }
-      featureMap.set(featureKey, feature.id)
-    }
-    const featureId = featureMap.get(featureKey)!
+      const featureId = featureMap.get(featureKey)!
 
-    // Feature-only rows — stop here
-    if (row.type === 'Feature') continue
+      // Feature-only rows — stop here
+      if (row.type === 'Feature') continue
 
-    // ── Story ──────────────────────────────────────────────────────────────
-    if (!storyMap.has(storyKey)) {
-      // Template and status are only applied from canonical Story rows
-      const isStoryRow = row.type === 'Story'
-      const templateRecord = isStoryRow && row.template
-        ? await prisma.featureTemplate.findUnique({ where: { name: row.template } })
-        : null
-      const appliedTemplateId = templateRecord?.id ?? null
+      // ── Story ──────────────────────────────────────────────────────────────
+      if (!storyMap.has(storyKey)) {
+        // Template and status are only applied from canonical Story rows
+        const isStoryRow = row.type === 'Story'
+        const templateRecord = isStoryRow && row.template
+          ? await tx.featureTemplate.findUnique({ where: { name: row.template } })
+          : null
+        const appliedTemplateId = templateRecord?.id ?? null
 
-      let story = await prisma.userStory.findFirst({ where: { featureId, name: row.story } })
-      if (!story) {
-        const storyCount = await prisma.userStory.count({ where: { featureId } })
-        story = await prisma.userStory.create({
-          data: {
-            name: row.story,
-            featureId,
-            order: storyCount,
-            isActive: isStoryRow ? row.storyStatus : true,
-            appliedTemplateId,
-            description: isStoryRow ? (row.description || null) : null,
-            assumptions: isStoryRow ? (row.assumptions || null) : null,
-          },
-        })
-        storiesCreated++
-      } else if (isStoryRow) {
-        // Only update story-level fields from a canonical Story row
-        await prisma.userStory.update({
-          where: { id: story.id },
-          data: {
-            isActive: row.storyStatus,
-            ...(appliedTemplateId !== null ? { appliedTemplateId } : {}),
-            ...(row.type === 'Story' ? {
-              description: row.description || null,
-              assumptions: row.assumptions || null,
-            } : {}),
-          },
-        })
-        storiesUpdated++
+        let story = await tx.userStory.findFirst({ where: { featureId, name: row.story } })
+        if (!story) {
+          const storyCount = await tx.userStory.count({ where: { featureId } })
+          story = await tx.userStory.create({
+            data: {
+              name: row.story,
+              featureId,
+              order: storyCount,
+              isActive: isStoryRow ? row.storyStatus : true,
+              appliedTemplateId,
+              description: isStoryRow ? (row.description || null) : null,
+              assumptions: isStoryRow ? (row.assumptions || null) : null,
+            },
+          })
+          storiesCreated++
+        } else if (isStoryRow) {
+          // Only update story-level fields from a canonical Story row
+          await tx.userStory.update({
+            where: { id: story.id },
+            data: {
+              isActive: row.storyStatus,
+              ...(appliedTemplateId !== null ? { appliedTemplateId } : {}),
+              ...(row.type === 'Story' ? {
+                description: row.description || null,
+                assumptions: row.assumptions || null,
+              } : {}),
+            },
+          })
+          storiesUpdated++
+        }
+        storyMap.set(storyKey, story.id)
       }
-      storyMap.set(storyKey, story.id)
+      const storyId = storyMap.get(storyKey)!
+
+      // Story-only rows — stop here
+      if (row.type === 'Story') continue
+
+      // ── Task ───────────────────────────────────────────────────────────────
+      if (!row.task) continue
+
+      const resourceType = row.resourceType
+        ? rtByName.get(row.resourceType.toLowerCase())
+        : undefined
+      const resourceTypeId = resourceType?.id ?? null
+      const hoursPerDay = resourceType?.hoursPerDay ?? fallbackHoursPerDay
+
+      const task = await tx.task.findFirst({ where: { userStoryId: storyId, name: row.task } })
+      if (!task) {
+        const taskCount = await tx.task.count({ where: { userStoryId: storyId } })
+        await tx.task.create({
+          data: {
+            name: row.task,
+            userStoryId: storyId,
+            order: taskCount,
+            resourceTypeId,
+            hoursEffort: row.hoursEffort,
+            durationDays: row.durationDays || calcDurationDays(row.hoursEffort, hoursPerDay),
+            description: row.description || null,
+            assumptions: row.assumptions || null,
+          },
+        })
+        tasksCreated++
+      } else {
+        await tx.task.update({
+          where: { id: task.id },
+          data: {
+            resourceTypeId,
+            hoursEffort: row.hoursEffort,
+            durationDays: row.durationDays || calcDurationDays(row.hoursEffort, hoursPerDay),
+            description: row.description || null,
+            assumptions: row.assumptions || null,
+          },
+        })
+        tasksUpdated++
+      }
     }
-    const storyId = storyMap.get(storyKey)!
 
-    // Story-only rows — stop here
-    if (row.type === 'Story') continue
-
-    // ── Task ───────────────────────────────────────────────────────────────
-    if (!row.task) continue
-
-    const resourceType = row.resourceType
-      ? rtByName.get(row.resourceType.toLowerCase())
-      : undefined
-    const resourceTypeId = resourceType?.id ?? null
-    const hoursPerDay = resourceType?.hoursPerDay ?? fallbackHoursPerDay
-
-    const task = await prisma.task.findFirst({ where: { userStoryId: storyId, name: row.task } })
-    if (!task) {
-      const taskCount = await prisma.task.count({ where: { userStoryId: storyId } })
-      await prisma.task.create({
-        data: {
-          name: row.task,
-          userStoryId: storyId,
-          order: taskCount,
-          resourceTypeId,
-          hoursEffort: row.hoursEffort,
-          durationDays: row.durationDays || calcDurationDays(row.hoursEffort, hoursPerDay),
-          description: row.description || null,
-          assumptions: row.assumptions || null,
-        },
-      })
-      tasksCreated++
-    } else {
-      await prisma.task.update({
-        where: { id: task.id },
-        data: {
-          resourceTypeId,
-          hoursEffort: row.hoursEffort,
-          durationDays: row.durationDays || calcDurationDays(row.hoursEffort, hoursPerDay),
-          description: row.description || null,
-          assumptions: row.assumptions || null,
-        },
-      })
-      tasksUpdated++
-    }
-  }
+    return { epicsCreated, epicsUpdated, featuresCreated, featuresUpdated, storiesCreated, storiesUpdated, tasksCreated, tasksUpdated }
+  }, { timeout: 60000 })
 
   res.json({
     message: 'Import successful',
-    epicsCreated,
-    epicsUpdated,
-    featuresCreated,
-    featuresUpdated,
-    storiesCreated,
-    storiesUpdated,
-    tasksCreated,
-    tasksUpdated,
+    ...result,
   })
-})
+}))
 
 export default router

--- a/server/src/routes/customers.ts
+++ b/server/src/routes/customers.ts
@@ -1,11 +1,12 @@
 import { Router, Response } from 'express'
+import { asyncHandler } from '../lib/asyncHandler.js'
 import { prisma } from '../lib/prisma.js'
 import { AuthRequest } from '../middleware/auth.js'
 
 const router = Router()
 
 // GET /api/customers
-router.get('/', async (req: AuthRequest, res: Response) => {
+router.get('/', asyncHandler(async (req: AuthRequest, res: Response) => {
   try {
     const userOrgIds = (await prisma.organisationMember.findMany({
       where: { userId: req.userId! },
@@ -27,10 +28,10 @@ router.get('/', async (req: AuthRequest, res: Response) => {
     console.error('GET /customers error:', err)
     res.status(500).json({ error: 'Failed to fetch customers' })
   }
-})
+}))
 
 // POST /api/customers
-router.post('/', async (req: AuthRequest, res: Response) => {
+router.post('/', asyncHandler(async (req: AuthRequest, res: Response) => {
   try {
     const { name, description, accountCode, crmLink, orgId } = req.body
     if (!name) { res.status(400).json({ error: 'name is required' }); return }
@@ -52,10 +53,10 @@ router.post('/', async (req: AuthRequest, res: Response) => {
     console.error('POST /customers error:', err)
     res.status(500).json({ error: 'Failed to create customer' })
   }
-})
+}))
 
 // PUT /api/customers/:id
-router.put('/:id', async (req: AuthRequest, res: Response) => {
+router.put('/:id', asyncHandler(async (req: AuthRequest, res: Response) => {
   try {
     const id = req.params.id as string
     const customer = await prisma.customer.findUnique({ where: { id } })
@@ -98,10 +99,10 @@ router.put('/:id', async (req: AuthRequest, res: Response) => {
     console.error('PUT /customers/:id error:', err)
     res.status(500).json({ error: 'Failed to update customer' })
   }
-})
+}))
 
 // DELETE /api/customers/:id
-router.delete('/:id', async (req: AuthRequest, res: Response) => {
+router.delete('/:id', asyncHandler(async (req: AuthRequest, res: Response) => {
   try {
     const id = req.params.id as string
     const customer = await prisma.customer.findUnique({ where: { id } })
@@ -120,6 +121,6 @@ router.delete('/:id', async (req: AuthRequest, res: Response) => {
     console.error('DELETE /customers/:id error:', err)
     res.status(500).json({ error: 'Failed to delete customer' })
   }
-})
+}))
 
 export default router

--- a/server/src/routes/discounts.ts
+++ b/server/src/routes/discounts.ts
@@ -1,5 +1,6 @@
 import { Router, Response } from 'express'
 import { prisma } from '../lib/prisma.js'
+import { asyncHandler } from '../lib/asyncHandler.js'
 import { authenticate, AuthRequest } from '../middleware/auth.js'
 
 const router = Router({ mergeParams: true })
@@ -13,7 +14,7 @@ async function ownedProject(projectId: string, userId: string) {
 const VALID_DISCOUNT_TYPES = ['PERCENTAGE', 'FIXED_AMOUNT']
 
 // GET /projects/:projectId/discounts
-router.get('/', async (req: AuthRequest, res: Response) => {
+router.get('/', asyncHandler(async (req: AuthRequest, res: Response) => {
   const project = await ownedProject(req.params.projectId as string, req.userId!)
   if (!project) { res.status(404).json({ error: 'Project not found' }); return }
   const discounts = await prisma.projectDiscount.findMany({
@@ -22,10 +23,10 @@ router.get('/', async (req: AuthRequest, res: Response) => {
     include: { resourceType: true },
   })
   res.json(discounts)
-})
+}))
 
 // POST /projects/:projectId/discounts
-router.post('/', async (req: AuthRequest, res: Response) => {
+router.post('/', asyncHandler(async (req: AuthRequest, res: Response) => {
   const project = await ownedProject(req.params.projectId as string, req.userId!)
   if (!project) { res.status(404).json({ error: 'Project not found' }); return }
 
@@ -58,10 +59,10 @@ router.post('/', async (req: AuthRequest, res: Response) => {
     include: { resourceType: true },
   })
   res.status(201).json(discount)
-})
+}))
 
 // PUT /projects/:projectId/discounts/:id
-router.put('/:id', async (req: AuthRequest, res: Response) => {
+router.put('/:id', asyncHandler(async (req: AuthRequest, res: Response) => {
   const project = await ownedProject(req.params.projectId as string, req.userId!)
   if (!project) { res.status(404).json({ error: 'Project not found' }); return }
 
@@ -100,10 +101,10 @@ router.put('/:id', async (req: AuthRequest, res: Response) => {
     include: { resourceType: true },
   })
   res.json(discount)
-})
+}))
 
 // DELETE /projects/:projectId/discounts/:id
-router.delete('/:id', async (req: AuthRequest, res: Response) => {
+router.delete('/:id', asyncHandler(async (req: AuthRequest, res: Response) => {
   const project = await ownedProject(req.params.projectId as string, req.userId!)
   if (!project) { res.status(404).json({ error: 'Project not found' }); return }
 
@@ -115,6 +116,6 @@ router.delete('/:id', async (req: AuthRequest, res: Response) => {
 
   await prisma.projectDiscount.delete({ where: { id: req.params.id as string } })
   res.status(204).send()
-})
+}))
 
 export default router

--- a/server/src/routes/documents.ts
+++ b/server/src/routes/documents.ts
@@ -1,4 +1,5 @@
 import { Router, Response } from 'express'
+import { asyncHandler } from '../lib/asyncHandler.js'
 import { authenticate, AuthRequest } from '../middleware/auth.js'
 import { prisma } from '../lib/prisma.js'
 import { renderScopeDocumentHtml } from '../lib/scopeDocumentRenderer.js'
@@ -35,7 +36,7 @@ function formatExportTimestamp(tz?: string): string {
 // POST /api/projects/:projectId/documents/generate
 // Body: { type: string, format: string, label: string, tz?: string, documentData: ScopeDocumentProps }
 // Server renders HTML via React renderToStaticMarkup, then generates PDF via Puppeteer.
-router.post('/generate', async (req: AuthRequest, res: Response) => {
+router.post('/generate', asyncHandler(async (req: AuthRequest, res: Response) => {
   const projectId = req.params.projectId as string
   const project = await ownedProject(projectId, req.userId!)
   if (!project) { res.status(404).json({ error: 'Project not found' }); return }
@@ -66,25 +67,37 @@ router.post('/generate', async (req: AuthRequest, res: Response) => {
   if (!path.resolve(filePath).startsWith(path.resolve(GENERATED_DIR))) {
     res.status(400).json({ error: 'Invalid file path' }); return
   }
-  fs.writeFileSync(filePath, buffer)
 
-  const doc = await prisma.generatedDocument.create({
-    data: {
-      projectId,
-      type,
-      format,
-      label,
-      filePath: filename, // store relative filename only
-      sections: documentData.sections ?? null,
-      generatedById: req.userId!,
-    },
-  })
+  // #176: wrap file write + DB insert so orphaned files are cleaned up on failure
+  let writtenFilePath: string | null = null
+  try {
+    fs.writeFileSync(filePath, buffer)
+    writtenFilePath = filePath
 
-  res.status(201).json(doc)
-})
+    const doc = await prisma.generatedDocument.create({
+      data: {
+        projectId,
+        type,
+        format,
+        label,
+        filePath: filename, // store relative filename only
+        sections: documentData.sections ?? null,
+        generatedById: req.userId!,
+      },
+    })
+
+    res.status(201).json(doc)
+  } catch (err) {
+    // Clean up orphaned file if DB insert failed after write
+    if (writtenFilePath && fs.existsSync(writtenFilePath)) {
+      fs.unlinkSync(writtenFilePath)
+    }
+    throw err  // re-throw so asyncHandler/errorHandler catches it
+  }
+}))
 
 // GET /api/projects/:projectId/documents
-router.get('/', async (req: AuthRequest, res: Response) => {
+router.get('/', asyncHandler(async (req: AuthRequest, res: Response) => {
   const projectId = req.params.projectId as string
   const project = await ownedProject(projectId, req.userId!)
   if (!project) { res.status(404).json({ error: 'Project not found' }); return }
@@ -95,10 +108,10 @@ router.get('/', async (req: AuthRequest, res: Response) => {
     include: { generatedBy: { select: { email: true } } },
   })
   res.json(docs)
-})
+}))
 
 // GET /api/projects/:projectId/documents/:docId/download
-router.get('/:docId/download', async (req: AuthRequest, res: Response) => {
+router.get('/:docId/download', asyncHandler(async (req: AuthRequest, res: Response) => {
   const projectId = req.params.projectId as string
   const project = await ownedProject(projectId, req.userId!)
   if (!project) { res.status(404).json({ error: 'Project not found' }); return }
@@ -128,10 +141,10 @@ router.get('/:docId/download', async (req: AuthRequest, res: Response) => {
   res.setHeader('Content-Type', contentTypes[doc.format] ?? 'application/octet-stream')
   res.setHeader('Content-Disposition', `attachment; filename="${downloadName}.${doc.format}"`)
   res.sendFile(filePath)
-})
+}))
 
 // DELETE /api/projects/:projectId/documents/:docId
-router.delete('/:docId', async (req: AuthRequest, res: Response) => {
+router.delete('/:docId', asyncHandler(async (req: AuthRequest, res: Response) => {
   const projectId = req.params.projectId as string
   const project = await ownedProject(projectId, req.userId!)
   if (!project) { res.status(404).json({ error: 'Project not found' }); return }
@@ -145,6 +158,6 @@ router.delete('/:docId', async (req: AuthRequest, res: Response) => {
 
   await prisma.generatedDocument.delete({ where: { id: doc.id } })
   res.json({ success: true })
-})
+}))
 
 export default router

--- a/server/src/routes/effort.ts
+++ b/server/src/routes/effort.ts
@@ -1,5 +1,6 @@
 import { Router, Response } from 'express'
 import { prisma } from '../lib/prisma.js'
+import { asyncHandler } from '../lib/asyncHandler.js'
 import { authenticate, AuthRequest } from '../middleware/auth.js'
 import { round2 } from '../utils/round.js'
 
@@ -9,7 +10,7 @@ router.use(authenticate)
 const CATEGORY_ORDER = ['ENGINEERING', 'GOVERNANCE', 'PROJECT_MANAGEMENT'] as const
 
 // GET /api/projects/:projectId/effort
-router.get('/', async (req: AuthRequest, res: Response) => {
+router.get('/', asyncHandler(async (req: AuthRequest, res: Response) => {
   const projectId = req.params.projectId as string
   const activeOnly = req.query.activeOnly === 'true'
 
@@ -181,6 +182,6 @@ router.get('/', async (req: AuthRequest, res: Response) => {
     : null
 
   res.json({ projectId, hoursPerDay: fallbackHoursPerDay, totalHours, totalDays, totalCost, hasCost, byCategory })
-})
+}))
 
 export default router

--- a/server/src/routes/epics.ts
+++ b/server/src/routes/epics.ts
@@ -1,5 +1,6 @@
 import { Router, Response } from 'express'
 import { prisma } from '../lib/prisma.js'
+import { asyncHandler } from '../lib/asyncHandler.js'
 import { authenticate, AuthRequest } from '../middleware/auth.js'
 import { ownedProject } from '../lib/ownership.js'
 
@@ -7,7 +8,7 @@ const router = Router({ mergeParams: true })
 router.use(authenticate)
 
 // GET /projects/:projectId/epics
-router.get('/', async (req: AuthRequest, res: Response) => {
+router.get('/', asyncHandler(async (req: AuthRequest, res: Response) => {
   const project = await ownedProject(req.params.projectId as string, req.userId!)
   if (!project) { res.status(404).json({ error: 'Project not found' }); return }
   const epics = await prisma.epic.findMany({
@@ -26,10 +27,10 @@ router.get('/', async (req: AuthRequest, res: Response) => {
     },
   })
   res.json(epics)
-})
+}))
 
 // POST /projects/:projectId/epics
-router.post('/', async (req: AuthRequest, res: Response) => {
+router.post('/', asyncHandler(async (req: AuthRequest, res: Response) => {
   const project = await ownedProject(req.params.projectId as string, req.userId!)
   if (!project) { res.status(404).json({ error: 'Project not found' }); return }
   const { name, description } = req.body
@@ -39,10 +40,10 @@ router.post('/', async (req: AuthRequest, res: Response) => {
     data: { name, description, projectId: req.params.projectId as string, order: count },
   })
   res.status(201).json(epic)
-})
+}))
 
 // PUT /projects/:projectId/epics/:id
-router.put('/:id', async (req: AuthRequest, res: Response) => {
+router.put('/:id', asyncHandler(async (req: AuthRequest, res: Response) => {
   const project = await ownedProject(req.params.projectId as string, req.userId!)
   if (!project) { res.status(404).json({ error: 'Project not found' }); return }
   const { name, description, assumptions, order, featureMode, scheduleMode, timelineStartWeek, isActive } = req.body
@@ -60,14 +61,14 @@ router.put('/:id', async (req: AuthRequest, res: Response) => {
     },
   })
   res.json(epic)
-})
+}))
 
 // DELETE /projects/:projectId/epics/:id
-router.delete('/:id', async (req: AuthRequest, res: Response) => {
+router.delete('/:id', asyncHandler(async (req: AuthRequest, res: Response) => {
   const project = await ownedProject(req.params.projectId as string, req.userId!)
   if (!project) { res.status(404).json({ error: 'Project not found' }); return }
   await prisma.epic.delete({ where: { id: req.params.id as string, projectId: project.id } })
   res.json({ message: 'Deleted' })
-})
+}))
 
 export default router

--- a/server/src/routes/featureDependencies.ts
+++ b/server/src/routes/featureDependencies.ts
@@ -1,5 +1,6 @@
 import { Router, Response } from 'express'
 import { prisma } from '../lib/prisma.js'
+import { asyncHandler } from '../lib/asyncHandler.js'
 import { authenticate, AuthRequest } from '../middleware/auth.js'
 
 const router = Router({ mergeParams: true })
@@ -10,7 +11,7 @@ async function ownedProject(projectId: string, userId: string) {
 }
 
 // GET /api/projects/:projectId/feature-dependencies
-router.get('/', async (req: AuthRequest, res: Response) => {
+router.get('/', asyncHandler(async (req: AuthRequest, res: Response) => {
   const project = await ownedProject(req.params.projectId as string, req.userId!)
   if (!project) { res.status(404).json({ error: 'Project not found' }); return }
 
@@ -24,10 +25,10 @@ router.get('/', async (req: AuthRequest, res: Response) => {
     },
   })
   res.json(deps)
-})
+}))
 
 // POST /api/projects/:projectId/feature-dependencies
-router.post('/', async (req: AuthRequest, res: Response) => {
+router.post('/', asyncHandler(async (req: AuthRequest, res: Response) => {
   const project = await ownedProject(req.params.projectId as string, req.userId!)
   if (!project) { res.status(404).json({ error: 'Project not found' }); return }
 
@@ -54,10 +55,10 @@ router.post('/', async (req: AuthRequest, res: Response) => {
     }
     throw e
   }
-})
+}))
 
 // DELETE /api/projects/:projectId/feature-dependencies/:featureId/:dependsOnId
-router.delete('/:featureId/:dependsOnId', async (req: AuthRequest, res: Response) => {
+router.delete('/:featureId/:dependsOnId', asyncHandler(async (req: AuthRequest, res: Response) => {
   const project = await ownedProject(req.params.projectId as string, req.userId!)
   if (!project) { res.status(404).json({ error: 'Project not found' }); return }
 
@@ -70,6 +71,6 @@ router.delete('/:featureId/:dependsOnId', async (req: AuthRequest, res: Response
     },
   })
   res.json({ message: 'Deleted' })
-})
+}))
 
 export default router

--- a/server/src/routes/features.ts
+++ b/server/src/routes/features.ts
@@ -1,5 +1,6 @@
 import { Router, Response } from 'express'
 import { prisma } from '../lib/prisma.js'
+import { asyncHandler } from '../lib/asyncHandler.js'
 import { authenticate, AuthRequest } from '../middleware/auth.js'
 import { ownedEpic } from '../lib/ownership.js'
 
@@ -7,7 +8,7 @@ const router = Router({ mergeParams: true })
 router.use(authenticate)
 
 // GET /epics/:epicId/features
-router.get('/', async (req: AuthRequest, res: Response) => {
+router.get('/', asyncHandler(async (req: AuthRequest, res: Response) => {
   const epic = await ownedEpic(req.params.epicId as string, req.userId!)
   if (!epic) { res.status(404).json({ error: 'Epic not found' }); return }
   const features = await prisma.feature.findMany({
@@ -21,10 +22,10 @@ router.get('/', async (req: AuthRequest, res: Response) => {
     },
   })
   res.json(features)
-})
+}))
 
 // POST /epics/:epicId/features
-router.post('/', async (req: AuthRequest, res: Response) => {
+router.post('/', asyncHandler(async (req: AuthRequest, res: Response) => {
   const epic = await ownedEpic(req.params.epicId as string, req.userId!)
   if (!epic) { res.status(404).json({ error: 'Epic not found' }); return }
   const { name, description, assumptions } = req.body
@@ -34,10 +35,10 @@ router.post('/', async (req: AuthRequest, res: Response) => {
     data: { name, description, assumptions, epicId: req.params.epicId as string, order: count },
   })
   res.status(201).json(feature)
-})
+}))
 
 // PUT /epics/:epicId/features/:id
-router.put('/:id', async (req: AuthRequest, res: Response) => {
+router.put('/:id', asyncHandler(async (req: AuthRequest, res: Response) => {
   const epic = await ownedEpic(req.params.epicId as string, req.userId!)
   if (!epic) { res.status(404).json({ error: 'Epic not found' }); return }
   const { name, description, assumptions, order, isActive, timelineColour } = req.body
@@ -49,14 +50,14 @@ router.put('/:id', async (req: AuthRequest, res: Response) => {
     data,
   })
   res.json(feature)
-})
+}))
 
 // DELETE /epics/:epicId/features/:id
-router.delete('/:id', async (req: AuthRequest, res: Response) => {
+router.delete('/:id', asyncHandler(async (req: AuthRequest, res: Response) => {
   const epic = await ownedEpic(req.params.epicId as string, req.userId!)
   if (!epic) { res.status(404).json({ error: 'Epic not found' }); return }
   await prisma.feature.delete({ where: { id: req.params.id as string, epicId: req.params.epicId as string } })
   res.json({ message: 'Deleted' })
-})
+}))
 
 export default router

--- a/server/src/routes/globalResourceTypes.ts
+++ b/server/src/routes/globalResourceTypes.ts
@@ -1,19 +1,20 @@
 import { Router, Response } from 'express'
 import { prisma } from '../lib/prisma.js'
+import { asyncHandler } from '../lib/asyncHandler.js'
 import { authenticate, AuthRequest } from '../middleware/auth.js'
 import { requireAdmin } from '../middleware/requireAdmin.js'
 
 const router = Router()
 
 // GET /api/global-resource-types — auth required
-router.get('/', authenticate, async (_req: AuthRequest, res: Response) => {
+router.get('/', authenticate, asyncHandler(async (_req: AuthRequest, res: Response) => {
   const types = await prisma.globalResourceType.findMany({ orderBy: { name: 'asc' } })
   res.json(types)
-})
+}))
 
 // POST /api/global-resource-types — auth required
 // After creating, seeds a ResourceType instance into every existing project
-router.post('/', authenticate, requireAdmin, async (req: AuthRequest, res: Response) => {
+router.post('/', authenticate, requireAdmin, asyncHandler(async (req: AuthRequest, res: Response) => {
   const { name, category, description, defaultHoursPerDay, defaultDayRate } = req.body
   if (!name || !category) { res.status(400).json({ error: 'name and category are required' }); return }
   const gt = await prisma.globalResourceType.create({
@@ -33,11 +34,11 @@ router.post('/', authenticate, requireAdmin, async (req: AuthRequest, res: Respo
     })
   }
   res.status(201).json(gt)
-})
+}))
 
 // PUT /api/global-resource-types/:id — auth required
 // Syncs name + category changes to all linked project-level ResourceType instances
-router.put('/:id', authenticate, requireAdmin, async (req: AuthRequest, res: Response) => {
+router.put('/:id', authenticate, requireAdmin, asyncHandler(async (req: AuthRequest, res: Response) => {
   const { name, category, description, defaultHoursPerDay, defaultDayRate } = req.body
   if (!name || !category) { res.status(400).json({ error: 'name and category are required' }); return }
   const existing = await prisma.globalResourceType.findFirst({ where: { id: req.params.id as string } })
@@ -48,11 +49,11 @@ router.put('/:id', authenticate, requireAdmin, async (req: AuthRequest, res: Res
   })
   await prisma.resourceType.updateMany({ where: { globalTypeId: req.params.id as string }, data: { name, category } })
   res.json(gt)
-})
+}))
 
 // DELETE /api/global-resource-types/:id — auth required
 // Blocks deletion if any linked ResourceType has tasks assigned to it
-router.delete('/:id', authenticate, requireAdmin, async (req: AuthRequest, res: Response) => {
+router.delete('/:id', authenticate, requireAdmin, asyncHandler(async (req: AuthRequest, res: Response) => {
   const existing = await prisma.globalResourceType.findFirst({ where: { id: req.params.id as string } })
   if (!existing) { res.status(404).json({ error: 'Not found' }); return }
   if (existing.isDefault) { res.status(403).json({ error: 'Default types cannot be deleted' }); return }
@@ -64,6 +65,6 @@ router.delete('/:id', authenticate, requireAdmin, async (req: AuthRequest, res: 
   await prisma.resourceType.updateMany({ where: { globalTypeId: req.params.id as string }, data: { globalTypeId: null } })
   await prisma.globalResourceType.delete({ where: { id: req.params.id as string } })
   res.status(204).send()
-})
+}))
 
 export default router

--- a/server/src/routes/namedResources.ts
+++ b/server/src/routes/namedResources.ts
@@ -1,6 +1,7 @@
 import { Router, Response } from 'express'
 import { AllocationMode } from '@prisma/client'
 import { prisma } from '../lib/prisma.js'
+import { asyncHandler } from '../lib/asyncHandler.js'
 import { authenticate, AuthRequest } from '../middleware/auth.js'
 
 const router = Router({ mergeParams: true })
@@ -18,7 +19,7 @@ async function verifyResourceType(rtId: string, projectId: string) {
 const VALID_PRICING_MODELS = ['ACTUAL_DAYS', 'PRO_RATA']
 
 // GET /projects/:projectId/resource-types/:rtId/named-resources
-router.get('/', async (req: AuthRequest, res: Response) => {
+router.get('/', asyncHandler(async (req: AuthRequest, res: Response) => {
   const { projectId, rtId } = req.params as { projectId: string; rtId: string }
   const project = await ownedProject(projectId, req.userId!)
   if (!project) { res.status(404).json({ error: 'Project not found' }); return }
@@ -32,10 +33,10 @@ router.get('/', async (req: AuthRequest, res: Response) => {
     orderBy: { name: 'asc' },
   })
   res.json(resources)
-})
+}))
 
 // POST /projects/:projectId/resource-types/:rtId/named-resources
-router.post('/', async (req: AuthRequest, res: Response) => {
+router.post('/', asyncHandler(async (req: AuthRequest, res: Response) => {
   const { projectId, rtId } = req.params as { projectId: string; rtId: string }
   const project = await ownedProject(projectId, req.userId!)
   if (!project) { res.status(404).json({ error: 'Project not found' }); return }
@@ -86,10 +87,10 @@ router.post('/', async (req: AuthRequest, res: Response) => {
   await prisma.resourceType.update({ where: { id: rtId }, data: { count: total } })
 
   res.status(201).json(resource)
-})
+}))
 
 // PUT /projects/:projectId/resource-types/:rtId/named-resources/:id
-router.put('/:id', async (req: AuthRequest, res: Response) => {
+router.put('/:id', asyncHandler(async (req: AuthRequest, res: Response) => {
   const { projectId, rtId, id } = req.params as { projectId: string; rtId: string; id: string }
   const project = await ownedProject(projectId, req.userId!)
   if (!project) { res.status(404).json({ error: 'Project not found' }); return }
@@ -121,10 +122,10 @@ router.put('/:id', async (req: AuthRequest, res: Response) => {
     data,
   })
   res.json(resource)
-})
+}))
 
 // PATCH /projects/:projectId/resource-types/:rtId/named-resources/:id
-router.patch('/:id', async (req: AuthRequest, res: Response) => {
+router.patch('/:id', asyncHandler(async (req: AuthRequest, res: Response) => {
   const { projectId, rtId, id } = req.params as { projectId: string; rtId: string; id: string }
   const project = await ownedProject(projectId, req.userId!)
   if (!project) { res.status(404).json({ error: 'Project not found' }); return }
@@ -147,10 +148,10 @@ router.patch('/:id', async (req: AuthRequest, res: Response) => {
     data,
   })
   res.json(resource)
-})
+}))
 
 // DELETE /projects/:projectId/resource-types/:rtId/named-resources/:id
-router.delete('/:id', async (req: AuthRequest, res: Response) => {
+router.delete('/:id', asyncHandler(async (req: AuthRequest, res: Response) => {
   const { projectId, rtId, id } = req.params as { projectId: string; rtId: string; id: string }
   const project = await ownedProject(projectId, req.userId!)
   if (!project) { res.status(404).json({ error: 'Project not found' }); return }
@@ -169,6 +170,6 @@ router.delete('/:id', async (req: AuthRequest, res: Response) => {
   await prisma.resourceType.update({ where: { id: rtId }, data: { count: total } })
 
   res.status(204).send()
-})
+}))
 
 export default router

--- a/server/src/routes/orgs.ts
+++ b/server/src/routes/orgs.ts
@@ -1,4 +1,5 @@
 import { Router, Response } from 'express'
+import { asyncHandler } from '../lib/asyncHandler.js'
 import { prisma } from '../lib/prisma.js'
 import { AuthRequest } from '../middleware/auth.js'
 import { createHash, randomBytes } from 'crypto'
@@ -10,7 +11,7 @@ const esc = (s: string) => s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replac
 const router = Router()
 
 // GET /api/orgs — list orgs for current user
-router.get('/', async (req: AuthRequest, res: Response) => {
+router.get('/', asyncHandler(async (req: AuthRequest, res: Response) => {
   const memberships = await prisma.organisationMember.findMany({
     where: { userId: req.userId! },
     include: {
@@ -22,10 +23,10 @@ router.get('/', async (req: AuthRequest, res: Response) => {
     },
   })
   res.json(memberships.map(m => ({ ...m.org, role: m.role })))
-})
+}))
 
 // POST /api/orgs — create org
-router.post('/', async (req: AuthRequest, res: Response) => {
+router.post('/', asyncHandler(async (req: AuthRequest, res: Response) => {
   const { name } = req.body
   if (!name) { res.status(400).json({ error: 'name is required' }); return }
   const org = await prisma.organisation.create({
@@ -36,11 +37,11 @@ router.post('/', async (req: AuthRequest, res: Response) => {
     include: { _count: { select: { members: true } } },
   })
   res.status(201).json({ ...org, role: 'OWNER' })
-})
+}))
 
 // POST /api/orgs/accept-invite — accept an invite (authenticated)
 // MUST be before /:id routes
-router.post('/accept-invite', async (req: AuthRequest, res: Response) => {
+router.post('/accept-invite', asyncHandler(async (req: AuthRequest, res: Response) => {
   const { token } = req.body
   if (!token) { res.status(400).json({ error: 'token is required' }); return }
 
@@ -63,10 +64,10 @@ router.post('/accept-invite', async (req: AuthRequest, res: Response) => {
   })
 
   res.json({ message: 'Joined organisation', orgId: invite.orgId })
-})
+}))
 
 // GET /api/orgs/:id/members — list members
-router.get('/:id/members', async (req: AuthRequest, res: Response) => {
+router.get('/:id/members', asyncHandler(async (req: AuthRequest, res: Response) => {
   const id = req.params.id as string
   const membership = await prisma.organisationMember.findUnique({
     where: { orgId_userId: { orgId: id, userId: req.userId! } },
@@ -77,10 +78,10 @@ router.get('/:id/members', async (req: AuthRequest, res: Response) => {
     include: { user: { select: { id: true, name: true, email: true } } },
   })
   res.json(members)
-})
+}))
 
 // DELETE /api/orgs/:id/members/:userId — remove member
-router.delete('/:id/members/:userId', async (req: AuthRequest, res: Response) => {
+router.delete('/:id/members/:userId', asyncHandler(async (req: AuthRequest, res: Response) => {
   const id = req.params.id as string
   const targetUserId = req.params.userId as string
   const requesterMembership = await prisma.organisationMember.findUnique({
@@ -104,10 +105,10 @@ router.delete('/:id/members/:userId', async (req: AuthRequest, res: Response) =>
     where: { orgId_userId: { orgId: id, userId: targetUserId } },
   })
   res.json({ message: 'Member removed' })
-})
+}))
 
 // POST /api/orgs/:id/invites/:inviteId/resend — resend a pending invite (BEFORE /:id/invites and /:id/invites/:inviteId)
-router.post('/:id/invites/:inviteId/resend', async (req: AuthRequest, res: Response) => {
+router.post('/:id/invites/:inviteId/resend', asyncHandler(async (req: AuthRequest, res: Response) => {
   try {
     const id = req.params.id as string
     const inviteId = req.params.inviteId as string
@@ -145,10 +146,10 @@ router.post('/:id/invites/:inviteId/resend', async (req: AuthRequest, res: Respo
   } catch {
     res.status(500).json({ error: 'Failed to resend invite' })
   }
-})
+}))
 
 // DELETE /api/orgs/:id/invites/:inviteId — cancel a pending invite
-router.delete('/:id/invites/:inviteId', async (req: AuthRequest, res: Response) => {
+router.delete('/:id/invites/:inviteId', asyncHandler(async (req: AuthRequest, res: Response) => {
   try {
     const id = req.params.id as string
     const inviteId = req.params.inviteId as string
@@ -167,10 +168,10 @@ router.delete('/:id/invites/:inviteId', async (req: AuthRequest, res: Response) 
   } catch {
     res.status(500).json({ error: 'Failed to cancel invite' })
   }
-})
+}))
 
 // GET /api/orgs/:id/invites — list pending invites
-router.get('/:id/invites', async (req: AuthRequest, res: Response) => {
+router.get('/:id/invites', asyncHandler(async (req: AuthRequest, res: Response) => {
   try {
     const id = req.params.id as string
     const membership = await prisma.organisationMember.findUnique({
@@ -186,10 +187,10 @@ router.get('/:id/invites', async (req: AuthRequest, res: Response) => {
   } catch {
     res.status(500).json({ error: 'Failed to fetch invites' })
   }
-})
+}))
 
 // POST /api/orgs/:id/invites — invite by email
-router.post('/:id/invites', async (req: AuthRequest, res: Response) => {
+router.post('/:id/invites', asyncHandler(async (req: AuthRequest, res: Response) => {
   const id = req.params.id as string
   const requesterMembership = await prisma.organisationMember.findUnique({
     where: { orgId_userId: { orgId: id, userId: req.userId! } },
@@ -219,10 +220,10 @@ router.post('/:id/invites', async (req: AuthRequest, res: Response) => {
   })
 
   res.status(201).json({ message: 'Invite sent' })
-})
+}))
 
 // PUT /api/orgs/:id/members/:userId — update member role
-router.put('/:id/members/:userId', async (req: AuthRequest, res: Response) => {
+router.put('/:id/members/:userId', asyncHandler(async (req: AuthRequest, res: Response) => {
   const id = req.params.id as string
   const targetUserId = req.params.userId as string
   const requesterMembership = await prisma.organisationMember.findUnique({
@@ -240,6 +241,6 @@ router.put('/:id/members/:userId', async (req: AuthRequest, res: Response) => {
     data: { role },
   })
   res.json(updated)
-})
+}))
 
 export default router

--- a/server/src/routes/overhead.ts
+++ b/server/src/routes/overhead.ts
@@ -1,6 +1,7 @@
 import { Router, Response } from 'express'
 import { OverheadType } from '@prisma/client'
 import { prisma } from '../lib/prisma.js'
+import { asyncHandler } from '../lib/asyncHandler.js'
 import { authenticate, AuthRequest } from '../middleware/auth.js'
 
 const router = Router({ mergeParams: true })
@@ -26,7 +27,7 @@ async function validateResourceType(resourceTypeId: string | null | undefined, p
 }
 
 // GET /api/projects/:projectId/overhead
-router.get('/', async (req: AuthRequest, res: Response) => {
+router.get('/', asyncHandler(async (req: AuthRequest, res: Response) => {
   const project = await ownedProject(req.params.projectId as string, req.userId!)
   if (!project) {
     res.status(404).json({ error: 'Project not found' })
@@ -39,10 +40,10 @@ router.get('/', async (req: AuthRequest, res: Response) => {
     include: { resourceType: true },
   })
   res.json(overheads)
-})
+}))
 
 // POST /api/projects/:projectId/overhead
-router.post('/', async (req: AuthRequest, res: Response) => {
+router.post('/', asyncHandler(async (req: AuthRequest, res: Response) => {
   const projectId = req.params.projectId as string
   const project = await ownedProject(projectId, req.userId!)
   if (!project) {
@@ -93,10 +94,10 @@ router.post('/', async (req: AuthRequest, res: Response) => {
     include: { resourceType: true },
   })
   res.status(201).json(overhead)
-})
+}))
 
 // PUT /api/projects/:projectId/overhead/:overheadId
-router.put('/:overheadId', async (req: AuthRequest, res: Response) => {
+router.put('/:overheadId', asyncHandler(async (req: AuthRequest, res: Response) => {
   const projectId = req.params.projectId as string
   const project = await ownedProject(projectId, req.userId!)
   if (!project) {
@@ -158,10 +159,10 @@ router.put('/:overheadId', async (req: AuthRequest, res: Response) => {
     include: { resourceType: true },
   })
   res.json(updated)
-})
+}))
 
 // DELETE /api/projects/:projectId/overhead/:overheadId
-router.delete('/:overheadId', async (req: AuthRequest, res: Response) => {
+router.delete('/:overheadId', asyncHandler(async (req: AuthRequest, res: Response) => {
   const projectId = req.params.projectId as string
   const project = await ownedProject(projectId, req.userId!)
   if (!project) {
@@ -178,6 +179,6 @@ router.delete('/:overheadId', async (req: AuthRequest, res: Response) => {
 
   await prisma.projectOverhead.delete({ where: { id: overheadId } })
   res.json({ message: 'Deleted' })
-})
+}))
 
 export default router

--- a/server/src/routes/projects.ts
+++ b/server/src/routes/projects.ts
@@ -1,5 +1,6 @@
 import { Router, Response } from 'express'
 import { prisma } from '../lib/prisma.js'
+import { asyncHandler } from '../lib/asyncHandler.js'
 import { authenticate, AuthRequest } from '../middleware/auth.js'
 
 const router = Router()
@@ -31,7 +32,7 @@ async function canAccessProject(projectId: string, userId: string) {
 
 // List projects for current user
 // ?archived=true → only deleted projects; default → only live projects
-router.get('/', async (req: AuthRequest, res: Response) => {
+router.get('/', asyncHandler(async (req: AuthRequest, res: Response) => {
   const archived = req.query.archived === 'true'
   const userOrgIds = (await prisma.organisationMember.findMany({
     where: { userId: req.userId! },
@@ -54,10 +55,10 @@ router.get('/', async (req: AuthRequest, res: Response) => {
     },
   })
   res.json(projects)
-})
+}))
 
 // Update project tax settings
-router.patch('/:id/tax', async (req: AuthRequest, res: Response) => {
+router.patch('/:id/tax', asyncHandler(async (req: AuthRequest, res: Response) => {
   const existing = await ownedProject(req.params.id as string, req.userId!)
   if (!existing) { res.status(404).json({ error: 'Not found' }); return }
 
@@ -74,10 +75,10 @@ router.patch('/:id/tax', async (req: AuthRequest, res: Response) => {
     },
   })
   res.json(project)
-})
+}))
 
 // Clone project — deep copy (specific route before /:id)
-router.post('/:id/clone', async (req: AuthRequest, res: Response) => {
+router.post('/:id/clone', asyncHandler(async (req: AuthRequest, res: Response) => {
   const source = await prisma.project.findFirst({
     where: { id: req.params.id as string, ownerId: req.userId },
     include: {
@@ -99,160 +100,164 @@ router.post('/:id/clone', async (req: AuthRequest, res: Response) => {
   })
   if (!source) { res.status(404).json({ error: 'Not found' }); return }
 
-  // Build resource type id map: old id → new id
-  const rtIdMap = new Map<string, string>()
+  // #176: wrap entire clone in a transaction so partial failures roll back cleanly
+  const clonedProject = await prisma.$transaction(async (tx) => {
+    // Build resource type id map: old id → new id
+    const rtIdMap = new Map<string, string>()
 
-  const newProject = await prisma.project.create({
-    data: {
-      name: `Copy of ${source.name}`,
-      description: source.description,
-      customerId: source.customerId,
-      orgId: source.orgId,
-      status: 'DRAFT',
-      hoursPerDay: source.hoursPerDay,
-      bufferWeeks: source.bufferWeeks,
-      startDate: source.startDate,
-      taxRate: source.taxRate,
-      taxLabel: source.taxLabel,
-      ownerId: req.userId!,
-    },
-  })
-
-  // Copy resource types
-  for (const rt of source.resourceTypes) {
-    const newRt = await prisma.resourceType.create({
+    const newProject = await tx.project.create({
       data: {
-        name: rt.name,
-        category: rt.category,
-        count: rt.count,
-        hoursPerDay: rt.hoursPerDay,
-        dayRate: rt.dayRate,
-        allocationMode: rt.allocationMode,
-        allocationPercent: rt.allocationPercent,
-        allocationStartWeek: rt.allocationStartWeek,
-        allocationEndWeek: rt.allocationEndWeek,
-        proposedName: rt.proposedName,
-        globalTypeId: rt.globalTypeId,
-        projectId: newProject.id,
+        name: `Copy of ${source.name}`,
+        description: source.description,
+        customerId: source.customerId,
+        orgId: source.orgId,
+        status: 'DRAFT',
+        hoursPerDay: source.hoursPerDay,
+        bufferWeeks: source.bufferWeeks,
+        startDate: source.startDate,
+        taxRate: source.taxRate,
+        taxLabel: source.taxLabel,
+        ownerId: req.userId!,
       },
     })
-    rtIdMap.set(rt.id, newRt.id)
 
-    // Copy named resources
-    for (const nr of rt.namedResources) {
-      await prisma.namedResource.create({
+    // Copy resource types
+    for (const rt of source.resourceTypes) {
+      const newRt = await tx.resourceType.create({
         data: {
-          name: nr.name,
-          startWeek: nr.startWeek,
-          endWeek: nr.endWeek,
-          allocationPct: nr.allocationPct,
-          allocationMode: nr.allocationMode,
-          allocationPercent: nr.allocationPercent,
-          allocationStartWeek: nr.allocationStartWeek,
-          allocationEndWeek: nr.allocationEndWeek,
-          pricingModel: nr.pricingModel,
-          resourceTypeId: newRt.id,
+          name: rt.name,
+          category: rt.category,
+          count: rt.count,
+          hoursPerDay: rt.hoursPerDay,
+          dayRate: rt.dayRate,
+          allocationMode: rt.allocationMode,
+          allocationPercent: rt.allocationPercent,
+          allocationStartWeek: rt.allocationStartWeek,
+          allocationEndWeek: rt.allocationEndWeek,
+          proposedName: rt.proposedName,
+          globalTypeId: rt.globalTypeId,
+          projectId: newProject.id,
+        },
+      })
+      rtIdMap.set(rt.id, newRt.id)
+
+      // Copy named resources
+      for (const nr of rt.namedResources) {
+        await tx.namedResource.create({
+          data: {
+            name: nr.name,
+            startWeek: nr.startWeek,
+            endWeek: nr.endWeek,
+            allocationPct: nr.allocationPct,
+            allocationMode: nr.allocationMode,
+            allocationPercent: nr.allocationPercent,
+            allocationStartWeek: nr.allocationStartWeek,
+            allocationEndWeek: nr.allocationEndWeek,
+            pricingModel: nr.pricingModel,
+            resourceTypeId: newRt.id,
+          },
+        })
+      }
+    }
+
+    // Copy overheads
+    for (const oh of source.overheads) {
+      await tx.projectOverhead.create({
+        data: {
+          projectId: newProject.id,
+          name: oh.name,
+          resourceTypeId: oh.resourceTypeId ? (rtIdMap.get(oh.resourceTypeId) ?? null) : null,
+          type: oh.type,
+          value: oh.value,
+          order: oh.order,
         },
       })
     }
-  }
 
-  // Copy overheads
-  for (const oh of source.overheads) {
-    await prisma.projectOverhead.create({
-      data: {
-        projectId: newProject.id,
-        name: oh.name,
-        resourceTypeId: oh.resourceTypeId ? (rtIdMap.get(oh.resourceTypeId) ?? null) : null,
-        type: oh.type,
-        value: oh.value,
-        order: oh.order,
-      },
-    })
-  }
-
-  // Copy discounts
-  for (const disc of source.discounts) {
-    await prisma.projectDiscount.create({
-      data: {
-        projectId: newProject.id,
-        resourceTypeId: disc.resourceTypeId ? (rtIdMap.get(disc.resourceTypeId) ?? null) : null,
-        type: disc.type,
-        value: disc.value,
-        label: disc.label,
-        order: disc.order,
-      },
-    })
-  }
-
-  // Copy epics → features → stories → tasks
-  for (const epic of source.epics) {
-    const newEpic = await prisma.epic.create({
-      data: {
-        name: epic.name,
-        description: epic.description,
-        assumptions: epic.assumptions,
-        order: epic.order,
-        featureMode: epic.featureMode,
-        scheduleMode: epic.scheduleMode,
-        timelineStartWeek: epic.timelineStartWeek,
-        isActive: epic.isActive,
-        projectId: newProject.id,
-      },
-    })
-
-    for (const feature of epic.features) {
-      const newFeature = await prisma.feature.create({
+    // Copy discounts
+    for (const disc of source.discounts) {
+      await tx.projectDiscount.create({
         data: {
-          name: feature.name,
-          description: feature.description,
-          assumptions: feature.assumptions,
-          order: feature.order,
-          isActive: feature.isActive,
-          epicId: newEpic.id,
+          projectId: newProject.id,
+          resourceTypeId: disc.resourceTypeId ? (rtIdMap.get(disc.resourceTypeId) ?? null) : null,
+          type: disc.type,
+          value: disc.value,
+          label: disc.label,
+          order: disc.order,
+        },
+      })
+    }
+
+    // Copy epics → features → stories → tasks
+    for (const epic of source.epics) {
+      const newEpic = await tx.epic.create({
+        data: {
+          name: epic.name,
+          description: epic.description,
+          assumptions: epic.assumptions,
+          order: epic.order,
+          featureMode: epic.featureMode,
+          scheduleMode: epic.scheduleMode,
+          timelineStartWeek: epic.timelineStartWeek,
+          isActive: epic.isActive,
+          projectId: newProject.id,
         },
       })
 
-      for (const story of feature.userStories) {
-        const newStory = await prisma.userStory.create({
+      for (const feature of epic.features) {
+        const newFeature = await tx.feature.create({
           data: {
-            name: story.name,
-            description: story.description,
-            assumptions: story.assumptions,
-            order: story.order,
-            isActive: story.isActive,
-            appliedTemplateId: story.appliedTemplateId,
-            featureId: newFeature.id,
+            name: feature.name,
+            description: feature.description,
+            assumptions: feature.assumptions,
+            order: feature.order,
+            isActive: feature.isActive,
+            epicId: newEpic.id,
           },
         })
 
-        for (const task of story.tasks) {
-          await prisma.task.create({
+        for (const story of feature.userStories) {
+          const newStory = await tx.userStory.create({
             data: {
-              name: task.name,
-              description: task.description,
-              assumptions: task.assumptions,
-              hoursEffort: task.hoursEffort,
-              durationDays: task.durationDays,
-              order: task.order,
-              userStoryId: newStory.id,
-              resourceTypeId: task.resourceTypeId ? (rtIdMap.get(task.resourceTypeId) ?? null) : null,
+              name: story.name,
+              description: story.description,
+              assumptions: story.assumptions,
+              order: story.order,
+              isActive: story.isActive,
+              appliedTemplateId: story.appliedTemplateId,
+              featureId: newFeature.id,
             },
           })
+
+          for (const task of story.tasks) {
+            await tx.task.create({
+              data: {
+                name: task.name,
+                description: task.description,
+                assumptions: task.assumptions,
+                hoursEffort: task.hoursEffort,
+                durationDays: task.durationDays,
+                order: task.order,
+                userStoryId: newStory.id,
+                resourceTypeId: task.resourceTypeId ? (rtIdMap.get(task.resourceTypeId) ?? null) : null,
+              },
+            })
+          }
         }
       }
     }
-  }
 
-  const result = await prisma.project.findFirst({
-    where: { id: newProject.id },
-    include: { resourceTypes: true, _count: { select: { epics: true } } },
-  })
-  res.status(201).json(result)
-})
+    return tx.project.findFirst({
+      where: { id: newProject.id },
+      include: { resourceTypes: true, _count: { select: { epics: true } } },
+    })
+  }, { timeout: 30000 })
+
+  res.status(201).json(clonedProject)
+}))
 
 // Restore soft-deleted project (specific route before /:id)
-router.post('/:id/restore', async (req: AuthRequest, res: Response) => {
+router.post('/:id/restore', asyncHandler(async (req: AuthRequest, res: Response) => {
   const existing = await prisma.project.findFirst({
     where: { id: req.params.id as string, ownerId: req.userId, deletedAt: { not: null } },
   })
@@ -262,25 +267,25 @@ router.post('/:id/restore', async (req: AuthRequest, res: Response) => {
     data: { deletedAt: null },
   })
   res.json(project)
-})
+}))
 
 // Permanent (hard) delete — for archived projects
-router.delete('/:id/permanent', async (req: AuthRequest, res: Response) => {
+router.delete('/:id/permanent', asyncHandler(async (req: AuthRequest, res: Response) => {
   const existing = await ownedProject(req.params.id as string, req.userId!)
   if (!existing) { res.status(404).json({ error: 'Not found' }); return }
   await prisma.project.delete({ where: { id: req.params.id as string } })
   res.json({ message: 'Project permanently deleted' })
-})
+}))
 
 // Get single project
-router.get('/:id', async (req: AuthRequest, res: Response) => {
+router.get('/:id', asyncHandler(async (req: AuthRequest, res: Response) => {
   const project = await canAccessProject(req.params.id as string, req.userId!)
   if (!project) { res.status(404).json({ error: 'Not found' }); return }
   res.json(project)
-})
+}))
 
 // Create project
-router.post('/', async (req: AuthRequest, res: Response) => {
+router.post('/', asyncHandler(async (req: AuthRequest, res: Response) => {
   const { name, description, status, hoursPerDay, bufferWeeks } = req.body
   const customerId = req.body.customerId || null
   const orgId = req.body.orgId || null
@@ -319,10 +324,10 @@ router.post('/', async (req: AuthRequest, res: Response) => {
     include: { resourceTypes: true, org: { select: { id: true, name: true } }, customer: { select: { id: true, name: true } } },
   })
   res.status(201).json(project)
-})
+}))
 
 // Partial update project (e.g. bufferWeeks, onboardingWeeks, hoursPerDay)
-router.patch('/:id', async (req: AuthRequest, res: Response) => {
+router.patch('/:id', asyncHandler(async (req: AuthRequest, res: Response) => {
   const existing = await ownedProject(req.params.id as string, req.userId!)
   if (!existing) { res.status(404).json({ error: 'Not found' }); return }
   const data: Record<string, unknown> = {}
@@ -333,10 +338,10 @@ router.patch('/:id', async (req: AuthRequest, res: Response) => {
   if (req.body.status !== undefined) data.status = req.body.status
   const project = await prisma.project.update({ where: { id: req.params.id as string }, data })
   res.json(project)
-})
+}))
 
 // Update project
-router.put('/:id', async (req: AuthRequest, res: Response) => {
+router.put('/:id', asyncHandler(async (req: AuthRequest, res: Response) => {
   const { name, description, status, hoursPerDay, taxRate, taxLabel } = req.body
   const customerId = req.body.customerId !== undefined ? (req.body.customerId || null) : undefined
   const bufferWeeks = req.body.bufferWeeks !== undefined ? (parseInt(req.body.bufferWeeks) || 0) : undefined
@@ -348,18 +353,18 @@ router.put('/:id', async (req: AuthRequest, res: Response) => {
     data: { name, description, ...(customerId !== undefined && { customerId }), status, hoursPerDay, taxRate, taxLabel, ...(bufferWeeks !== undefined && { bufferWeeks }), ...(onboardingWeeks !== undefined && { onboardingWeeks }) },
   })
   res.json(project)
-})
+}))
 
 // Soft-delete project (sets deletedAt)
-router.delete('/:id', async (req: AuthRequest, res: Response) => {
+router.delete('/:id', asyncHandler(async (req: AuthRequest, res: Response) => {
   const existing = await ownedProject(req.params.id as string, req.userId!)
   if (!existing) { res.status(404).json({ error: 'Not found' }); return }
   await prisma.project.update({ where: { id: req.params.id as string }, data: { deletedAt: new Date() } })
   res.json({ message: 'Project archived' })
-})
+}))
 
 // POST /api/projects/:id/move-to-org
-router.post('/:id/move-to-org', async (req: AuthRequest, res: Response) => {
+router.post('/:id/move-to-org', asyncHandler(async (req: AuthRequest, res: Response) => {
   try {
     const id = req.params.id as string
     const { orgId } = req.body
@@ -385,6 +390,6 @@ router.post('/:id/move-to-org', async (req: AuthRequest, res: Response) => {
     console.error('POST /projects/:id/move-to-org error:', err)
     res.status(500).json({ error: 'Failed to update project org' })
   }
-})
+}))
 
 export default router

--- a/server/src/routes/rateCards.ts
+++ b/server/src/routes/rateCards.ts
@@ -1,5 +1,6 @@
 import { Router, Response } from 'express'
 import { prisma } from '../lib/prisma.js'
+import { asyncHandler } from '../lib/asyncHandler.js'
 import { authenticate, AuthRequest } from '../middleware/auth.js'
 import { requireAdmin } from '../middleware/requireAdmin.js'
 
@@ -7,7 +8,7 @@ const router = Router()
 router.use(authenticate)
 
 // GET /api/rate-cards
-router.get('/', async (_req: AuthRequest, res: Response) => {
+router.get('/', asyncHandler(async (_req: AuthRequest, res: Response) => {
   const rateCards = await prisma.rateCard.findMany({
     orderBy: { name: 'asc' },
     include: {
@@ -17,10 +18,10 @@ router.get('/', async (_req: AuthRequest, res: Response) => {
     },
   })
   res.json(rateCards)
-})
+}))
 
 // GET /api/rate-cards/:id
-router.get('/:id', async (req: AuthRequest, res: Response) => {
+router.get('/:id', asyncHandler(async (req: AuthRequest, res: Response) => {
   const rateCard = await prisma.rateCard.findUnique({
     where: { id: req.params.id as string },
     include: {
@@ -31,10 +32,10 @@ router.get('/:id', async (req: AuthRequest, res: Response) => {
   })
   if (!rateCard) { res.status(404).json({ error: 'Rate card not found' }); return }
   res.json(rateCard)
-})
+}))
 
 // POST /api/rate-cards
-router.post('/', requireAdmin, async (req: AuthRequest, res: Response) => {
+router.post('/', requireAdmin, asyncHandler(async (req: AuthRequest, res: Response) => {
   const { name, isDefault, entries } = req.body
   if (!name) { res.status(400).json({ error: 'name is required' }); return }
   if (!Array.isArray(entries) || entries.length === 0) {
@@ -65,10 +66,10 @@ router.post('/', requireAdmin, async (req: AuthRequest, res: Response) => {
   })
 
   res.status(201).json(rateCard)
-})
+}))
 
 // PUT /api/rate-cards/:id
-router.put('/:id', requireAdmin, async (req: AuthRequest, res: Response) => {
+router.put('/:id', requireAdmin, asyncHandler(async (req: AuthRequest, res: Response) => {
   const { name, isDefault, entries } = req.body
 
   const existing = await prisma.rateCard.findUnique({ where: { id: req.params.id as string } })
@@ -106,15 +107,15 @@ router.put('/:id', requireAdmin, async (req: AuthRequest, res: Response) => {
   })
 
   res.json(rateCard)
-})
+}))
 
 // DELETE /api/rate-cards/:id
-router.delete('/:id', requireAdmin, async (req: AuthRequest, res: Response) => {
+router.delete('/:id', requireAdmin, asyncHandler(async (req: AuthRequest, res: Response) => {
   const existing = await prisma.rateCard.findUnique({ where: { id: req.params.id as string } })
   if (!existing) { res.status(404).json({ error: 'Rate card not found' }); return }
   await prisma.rateCard.delete({ where: { id: req.params.id as string } })
   res.status(204).send()
-})
+}))
 
 export default router
 

--- a/server/src/routes/reorder.ts
+++ b/server/src/routes/reorder.ts
@@ -1,5 +1,6 @@
 import { Router, Response } from 'express'
 import { prisma } from '../lib/prisma.js'
+import { asyncHandler } from '../lib/asyncHandler.js'
 import { authenticate, AuthRequest } from '../middleware/auth.js'
 
 const router = Router({ mergeParams: true })
@@ -11,7 +12,7 @@ async function ownedProject(projectId: string, userId: string) {
 
 // PATCH /projects/:projectId/reorder/epics
 // Body: { items: [{ id, order }] }
-router.patch('/epics', async (req: AuthRequest, res: Response) => {
+router.patch('/epics', asyncHandler(async (req: AuthRequest, res: Response) => {
   const { projectId } = req.params as { projectId: string }
   const project = await ownedProject(projectId, req.userId!)
   if (!project) { res.status(404).json({ error: 'Project not found' }); return }
@@ -28,11 +29,11 @@ router.patch('/epics', async (req: AuthRequest, res: Response) => {
     prisma.epic.update({ where: { id }, data: { order } })
   ))
   res.json({ ok: true })
-})
+}))
 
 // PATCH /projects/:projectId/reorder/features
 // Body: { items: [{ id, order, epicId }] }
-router.patch('/features', async (req: AuthRequest, res: Response) => {
+router.patch('/features', asyncHandler(async (req: AuthRequest, res: Response) => {
   const { projectId } = req.params as { projectId: string }
   const project = await ownedProject(projectId, req.userId!)
   if (!project) { res.status(404).json({ error: 'Project not found' }); return }
@@ -49,11 +50,11 @@ router.patch('/features', async (req: AuthRequest, res: Response) => {
     prisma.feature.update({ where: { id }, data: { order, epicId } })
   ))
   res.json({ ok: true })
-})
+}))
 
 // PATCH /projects/:projectId/reorder/stories
 // Body: { items: [{ id, order, featureId }] }
-router.patch('/stories', async (req: AuthRequest, res: Response) => {
+router.patch('/stories', asyncHandler(async (req: AuthRequest, res: Response) => {
   const { projectId } = req.params as { projectId: string }
   const project = await ownedProject(projectId, req.userId!)
   if (!project) { res.status(404).json({ error: 'Project not found' }); return }
@@ -70,11 +71,11 @@ router.patch('/stories', async (req: AuthRequest, res: Response) => {
     prisma.userStory.update({ where: { id }, data: { order, featureId } })
   ))
   res.json({ ok: true })
-})
+}))
 
 // PATCH /projects/:projectId/reorder/tasks
 // Body: { items: [{ id, order, storyId }] }
-router.patch('/tasks', async (req: AuthRequest, res: Response) => {
+router.patch('/tasks', asyncHandler(async (req: AuthRequest, res: Response) => {
   const { projectId } = req.params as { projectId: string }
   const project = await ownedProject(projectId, req.userId!)
   if (!project) { res.status(404).json({ error: 'Project not found' }); return }
@@ -91,6 +92,6 @@ router.patch('/tasks', async (req: AuthRequest, res: Response) => {
     prisma.task.update({ where: { id }, data: { order, userStoryId: storyId } })
   ))
   res.json({ ok: true })
-})
+}))
 
 export default router

--- a/server/src/routes/resourceProfile.ts
+++ b/server/src/routes/resourceProfile.ts
@@ -1,6 +1,7 @@
 import { Router, Response } from 'express'
 import { ResourceCategory } from '@prisma/client'
 import { prisma } from '../lib/prisma.js'
+import { asyncHandler } from '../lib/asyncHandler.js'
 import { authenticate, AuthRequest } from '../middleware/auth.js'
 
 type AllocationMode = 'EFFORT' | 'TIMELINE' | 'FULL_PROJECT'
@@ -11,7 +12,7 @@ router.use(authenticate)
 const CATEGORY_ORDER: ResourceCategory[] = ['ENGINEERING', 'GOVERNANCE', 'PROJECT_MANAGEMENT']
 const round2 = (value: number) => Math.round(value * 100) / 100
 
-router.get('/', async (req: AuthRequest, res: Response) => {
+router.get('/', asyncHandler(async (req: AuthRequest, res: Response) => {
   const projectId = req.params.projectId as string
   const project = await prisma.project.findFirst({
     where: { id: projectId, ownerId: req.userId },
@@ -383,6 +384,6 @@ router.get('/', async (req: AuthRequest, res: Response) => {
       hasCost,
     },
   })
-})
+}))
 
 export default router

--- a/server/src/routes/resourceTypes.ts
+++ b/server/src/routes/resourceTypes.ts
@@ -1,5 +1,6 @@
 import { Router, Response } from 'express'
 import { prisma } from '../lib/prisma.js'
+import { asyncHandler } from '../lib/asyncHandler.js'
 import { authenticate, AuthRequest } from '../middleware/auth.js'
 import { ownedProject } from '../lib/ownership.js'
 
@@ -7,7 +8,7 @@ const router = Router({ mergeParams: true })
 router.use(authenticate)
 
 // GET /projects/:projectId/resource-types
-router.get('/', async (req: AuthRequest, res: Response) => {
+router.get('/', asyncHandler(async (req: AuthRequest, res: Response) => {
   const project = await ownedProject(req.params.projectId as string, req.userId!)
   if (!project) { res.status(404).json({ error: 'Project not found' }); return }
   const types = await prisma.resourceType.findMany({
@@ -21,10 +22,10 @@ router.get('/', async (req: AuthRequest, res: Response) => {
     },
   })
   res.json(types)
-})
+}))
 
 // POST /projects/:projectId/resource-types
-router.post('/', async (req: AuthRequest, res: Response) => {
+router.post('/', asyncHandler(async (req: AuthRequest, res: Response) => {
   const project = await ownedProject(req.params.projectId as string, req.userId!)
   if (!project) { res.status(404).json({ error: 'Project not found' }); return }
   const { name, category, count, proposedName, hoursPerDay, dayRate } = req.body
@@ -46,10 +47,10 @@ router.post('/', async (req: AuthRequest, res: Response) => {
   })
   await prisma.resourceType.update({ where: { id: rt.id }, data: { count: 1 } })
   res.status(201).json(rt)
-})
+}))
 
 // PUT /projects/:projectId/resource-types/:id
-router.put('/:id', async (req: AuthRequest, res: Response) => {
+router.put('/:id', asyncHandler(async (req: AuthRequest, res: Response) => {
   const project = await ownedProject(req.params.projectId as string, req.userId!)
   if (!project) { res.status(404).json({ error: 'Project not found' }); return }
   const { name, category, count, proposedName, hoursPerDay, dayRate, allocationMode, allocationPercent, allocationStartWeek, allocationEndWeek } = req.body
@@ -77,10 +78,10 @@ router.put('/:id', async (req: AuthRequest, res: Response) => {
     data,
   })
   res.json(rt)
-})
+}))
 
 // PATCH /projects/:projectId/resource-types/:id — update count and sync named resources
-router.patch('/:id', async (req: AuthRequest, res: Response) => {
+router.patch('/:id', asyncHandler(async (req: AuthRequest, res: Response) => {
   const project = await ownedProject(req.params.projectId as string, req.userId!)
   if (!project) { res.status(404).json({ error: 'Project not found' }); return }
 
@@ -128,14 +129,14 @@ router.patch('/:id', async (req: AuthRequest, res: Response) => {
 
   const updated = await prisma.resourceType.update({ where: { id: rt.id }, data: { count } })
   res.json({ ...updated, warnings: warnings.length > 0 ? warnings : undefined })
-})
+}))
 
 // DELETE /projects/:projectId/resource-types/:id
-router.delete('/:id', async (req: AuthRequest, res: Response) => {
+router.delete('/:id', asyncHandler(async (req: AuthRequest, res: Response) => {
   const project = await ownedProject(req.params.projectId as string, req.userId!)
   if (!project) { res.status(404).json({ error: 'Project not found' }); return }
   await prisma.resourceType.delete({ where: { id: req.params.id as string } })
   res.json({ message: 'Deleted' })
-})
+}))
 
 export default router

--- a/server/src/routes/snapshots.ts
+++ b/server/src/routes/snapshots.ts
@@ -1,5 +1,6 @@
 import { Router, Response } from 'express'
 import { prisma } from '../lib/prisma.js'
+import { asyncHandler } from '../lib/asyncHandler.js'
 import { authenticate, AuthRequest } from '../middleware/auth.js'
 import { ownedProject } from '../lib/ownership.js'
 
@@ -31,7 +32,7 @@ async function buildSnapshot(projectId: string) {
 }
 
 // GET /api/projects/:projectId/snapshots
-router.get('/', async (req: AuthRequest, res: Response) => {
+router.get('/', asyncHandler(async (req: AuthRequest, res: Response) => {
   const projectId = req.params.projectId as string
   const project = await ownedProject(projectId, req.userId!)
   if (!project) { res.status(404).json({ error: 'Project not found' }); return }
@@ -42,10 +43,10 @@ router.get('/', async (req: AuthRequest, res: Response) => {
     select: { id: true, label: true, trigger: true, createdAt: true, createdById: true },
   })
   res.json(snapshots)
-})
+}))
 
 // POST /api/projects/:projectId/snapshots — manual snapshot
-router.post('/', async (req: AuthRequest, res: Response) => {
+router.post('/', asyncHandler(async (req: AuthRequest, res: Response) => {
   const projectId = req.params.projectId as string
   const project = await ownedProject(projectId, req.userId!)
   if (!project) { res.status(404).json({ error: 'Project not found' }); return }
@@ -63,10 +64,10 @@ router.post('/', async (req: AuthRequest, res: Response) => {
     select: { id: true, label: true, trigger: true, createdAt: true },
   })
   res.status(201).json(snap)
-})
+}))
 
 // GET /api/projects/:projectId/snapshots/:snapshotId
-router.get('/:snapshotId', async (req: AuthRequest, res: Response) => {
+router.get('/:snapshotId', asyncHandler(async (req: AuthRequest, res: Response) => {
   const { projectId, snapshotId } = req.params as { projectId: string; snapshotId: string }
   const project = await ownedProject(projectId, req.userId!)
   if (!project) { res.status(404).json({ error: 'Project not found' }); return }
@@ -74,10 +75,10 @@ router.get('/:snapshotId', async (req: AuthRequest, res: Response) => {
   const snap = await prisma.backlogSnapshot.findFirst({ where: { id: snapshotId, projectId } })
   if (!snap) { res.status(404).json({ error: 'Snapshot not found' }); return }
   res.json(snap)
-})
+}))
 
 // GET /api/projects/:projectId/snapshots/:snapshotId/diff
-router.get('/:snapshotId/diff', async (req: AuthRequest, res: Response) => {
+router.get('/:snapshotId/diff', asyncHandler(async (req: AuthRequest, res: Response) => {
   const { projectId, snapshotId } = req.params as { projectId: string; snapshotId: string }
   const project = await ownedProject(projectId, req.userId!)
   if (!project) { res.status(404).json({ error: 'Project not found' }); return }
@@ -115,10 +116,10 @@ router.get('/:snapshotId/diff', async (req: AuthRequest, res: Response) => {
     removed: snapItems.filter(i => !currentSet.has(i)),
     snapshotAt: snap.createdAt,
   })
-})
+}))
 
 // POST /api/projects/:projectId/snapshots/:snapshotId/rollback
-router.post('/:snapshotId/rollback', async (req: AuthRequest, res: Response) => {
+router.post('/:snapshotId/rollback', asyncHandler(async (req: AuthRequest, res: Response) => {
   const { projectId, snapshotId } = req.params as { projectId: string; snapshotId: string }
   const project = await ownedProject(projectId, req.userId!)
   if (!project) { res.status(404).json({ error: 'Project not found' }); return }
@@ -185,7 +186,7 @@ router.post('/:snapshotId/rollback', async (req: AuthRequest, res: Response) => 
   })
 
   res.json({ message: 'Rollback complete' })
-})
+}))
 
 export default router
 

--- a/server/src/routes/stories.ts
+++ b/server/src/routes/stories.ts
@@ -1,5 +1,6 @@
 import { Router, Response } from 'express'
 import { prisma } from '../lib/prisma.js'
+import { asyncHandler } from '../lib/asyncHandler.js'
 import { authenticate, AuthRequest } from '../middleware/auth.js'
 import { ownedProject, ownedFeature } from '../lib/ownership.js'
 
@@ -7,7 +8,7 @@ const router = Router({ mergeParams: true })
 router.use(authenticate)
 
 // POST /api/projects/:projectId/stories/:storyId/dependencies
-router.post('/:storyId/dependencies', async (req: AuthRequest, res: Response) => {
+router.post('/:storyId/dependencies', asyncHandler(async (req: AuthRequest, res: Response) => {
   const project = await ownedProject(req.params.projectId as string, req.userId!)
   if (!project) { res.status(404).json({ error: 'Project not found' }); return }
 
@@ -32,10 +33,10 @@ router.post('/:storyId/dependencies', async (req: AuthRequest, res: Response) =>
     update: {},
   })
   res.status(201).json(dep)
-})
+}))
 
 // DELETE /api/projects/:projectId/stories/:storyId/dependencies/:dependsOnId
-router.delete('/:storyId/dependencies/:dependsOnId', async (req: AuthRequest, res: Response) => {
+router.delete('/:storyId/dependencies/:dependsOnId', asyncHandler(async (req: AuthRequest, res: Response) => {
   const project = await ownedProject(req.params.projectId as string, req.userId!)
   if (!project) { res.status(404).json({ error: 'Project not found' }); return }
 
@@ -45,10 +46,10 @@ router.delete('/:storyId/dependencies/:dependsOnId', async (req: AuthRequest, re
     where: { storyId, dependsOnId },
   })
   res.status(204).end()
-})
+}))
 
 // GET /features/:featureId/stories
-router.get('/', async (req: AuthRequest, res: Response) => {
+router.get('/', asyncHandler(async (req: AuthRequest, res: Response) => {
   const feature = await ownedFeature(req.params.featureId as string, req.userId!)
   if (!feature) { res.status(404).json({ error: 'Feature not found' }); return }
   const stories = await prisma.userStory.findMany({
@@ -57,10 +58,10 @@ router.get('/', async (req: AuthRequest, res: Response) => {
     include: { tasks: { orderBy: { order: 'asc' }, include: { resourceType: true } } },
   })
   res.json(stories)
-})
+}))
 
 // POST /features/:featureId/stories
-router.post('/', async (req: AuthRequest, res: Response) => {
+router.post('/', asyncHandler(async (req: AuthRequest, res: Response) => {
   const feature = await ownedFeature(req.params.featureId as string, req.userId!)
   if (!feature) { res.status(404).json({ error: 'Feature not found' }); return }
   const { name, description, assumptions } = req.body
@@ -70,10 +71,10 @@ router.post('/', async (req: AuthRequest, res: Response) => {
     data: { name, description, assumptions, featureId: req.params.featureId as string, order: count },
   })
   res.status(201).json(story)
-})
+}))
 
 // PUT /features/:featureId/stories/:id
-router.put('/:id', async (req: AuthRequest, res: Response) => {
+router.put('/:id', asyncHandler(async (req: AuthRequest, res: Response) => {
   const feature = await ownedFeature(req.params.featureId as string, req.userId!)
   if (!feature) { res.status(404).json({ error: 'Feature not found' }); return }
   const { name, description, assumptions, order, isActive } = req.body
@@ -82,14 +83,14 @@ router.put('/:id', async (req: AuthRequest, res: Response) => {
     data: { name, description, assumptions, order, ...(isActive !== undefined && { isActive }) },
   })
   res.json(story)
-})
+}))
 
 // DELETE /features/:featureId/stories/:id
-router.delete('/:id', async (req: AuthRequest, res: Response) => {
+router.delete('/:id', asyncHandler(async (req: AuthRequest, res: Response) => {
   const feature = await ownedFeature(req.params.featureId as string, req.userId!)
   if (!feature) { res.status(404).json({ error: 'Feature not found' }); return }
   await prisma.userStory.delete({ where: { id: req.params.id as string, featureId: req.params.featureId as string } })
   res.json({ message: 'Deleted' })
-})
+}))
 
 export default router

--- a/server/src/routes/tasks.ts
+++ b/server/src/routes/tasks.ts
@@ -1,5 +1,6 @@
 import { Router, Response } from 'express'
 import { prisma } from '../lib/prisma.js'
+import { asyncHandler } from '../lib/asyncHandler.js'
 import { authenticate, AuthRequest } from '../middleware/auth.js'
 import { calcDurationDays } from '../utils/round.js'
 import { ownedStory } from '../lib/ownership.js'
@@ -8,7 +9,7 @@ const router = Router({ mergeParams: true })
 router.use(authenticate)
 
 // GET /stories/:storyId/tasks
-router.get('/', async (req: AuthRequest, res: Response) => {
+router.get('/', asyncHandler(async (req: AuthRequest, res: Response) => {
   const story = await ownedStory(req.params.storyId as string, req.userId!)
   if (!story) { res.status(404).json({ error: 'Story not found' }); return }
   const tasks = await prisma.task.findMany({
@@ -17,10 +18,10 @@ router.get('/', async (req: AuthRequest, res: Response) => {
     include: { resourceType: true },
   })
   res.json(tasks)
-})
+}))
 
 // POST /stories/:storyId/tasks
-router.post('/', async (req: AuthRequest, res: Response) => {
+router.post('/', asyncHandler(async (req: AuthRequest, res: Response) => {
   const story = await ownedStory(req.params.storyId as string, req.userId!)
   if (!story) { res.status(404).json({ error: 'Story not found' }); return }
   const { name, description, assumptions, hoursEffort, resourceTypeId } = req.body
@@ -40,10 +41,10 @@ router.post('/', async (req: AuthRequest, res: Response) => {
     include: { resourceType: true },
   })
   res.status(201).json(task)
-})
+}))
 
 // PUT /stories/:storyId/tasks/:id
-router.put('/:id', async (req: AuthRequest, res: Response) => {
+router.put('/:id', asyncHandler(async (req: AuthRequest, res: Response) => {
   const story = await ownedStory(req.params.storyId as string, req.userId!)
   if (!story) { res.status(404).json({ error: 'Story not found' }); return }
   const { name, description, assumptions, hoursEffort, resourceTypeId, order, durationDays } = req.body
@@ -57,14 +58,14 @@ router.put('/:id', async (req: AuthRequest, res: Response) => {
     include: { resourceType: true },
   })
   res.json(task)
-})
+}))
 
 // DELETE /stories/:storyId/tasks/:id
-router.delete('/:id', async (req: AuthRequest, res: Response) => {
+router.delete('/:id', asyncHandler(async (req: AuthRequest, res: Response) => {
   const story = await ownedStory(req.params.storyId as string, req.userId!)
   if (!story) { res.status(404).json({ error: 'Story not found' }); return }
   await prisma.task.delete({ where: { id: req.params.id as string, userStoryId: req.params.storyId as string } })
   res.json({ message: 'Deleted' })
-})
+}))
 
 export default router

--- a/server/src/routes/templates.ts
+++ b/server/src/routes/templates.ts
@@ -1,5 +1,6 @@
 import { Router, Response } from 'express'
 import { prisma } from '../lib/prisma.js'
+import { asyncHandler } from '../lib/asyncHandler.js'
 import { authenticate, AuthRequest } from '../middleware/auth.js'
 import { parse } from 'csv-parse/sync'
 import { stringify } from 'csv-stringify/sync'
@@ -39,7 +40,7 @@ async function captureSnapshot(templateId: string, label: string | null, trigger
 
 // GET /api/templates — auth required
 // ?archived=true → only soft-deleted templates; default → only live templates
-router.get('/', authenticate, async (req: AuthRequest, res: Response) => {
+router.get('/', authenticate, asyncHandler(async (req: AuthRequest, res: Response) => {
   const archived = req.query.archived === 'true'
   const templates = await prisma.featureTemplate.findMany({
     where: { deletedAt: archived ? { not: null } : null },
@@ -47,10 +48,10 @@ router.get('/', authenticate, async (req: AuthRequest, res: Response) => {
     include: templateInclude,
   })
   res.json(templates)
-})
+}))
 
 // POST /api/templates — auth required
-router.post('/', authenticate, async (req: AuthRequest, res: Response) => {
+router.post('/', authenticate, asyncHandler(async (req: AuthRequest, res: Response) => {
   const { name, category, description } = req.body
   if (!name) { res.status(400).json({ error: 'name is required' }); return }
   const existing = await prisma.featureTemplate.findUnique({ where: { name } })
@@ -60,10 +61,10 @@ router.post('/', authenticate, async (req: AuthRequest, res: Response) => {
     include: templateInclude,
   })
   res.status(201).json(template)
-})
+}))
 
 // GET /api/templates/export-csv — auth required (before /:id to avoid conflict)
-router.get('/export-csv', authenticate, async (_req: AuthRequest, res: Response) => {
+router.get('/export-csv', authenticate, asyncHandler(async (_req: AuthRequest, res: Response) => {
   const templates = await prisma.featureTemplate.findMany({
     orderBy: { name: 'asc' },
     include: { tasks: { orderBy: { order: 'asc' } } },
@@ -91,10 +92,10 @@ router.get('/export-csv', authenticate, async (_req: AuthRequest, res: Response)
   res.setHeader('Content-Type', 'text/csv')
   res.setHeader('Content-Disposition', 'attachment; filename="templates.csv"')
   res.send(csv)
-})
+}))
 
 // POST /api/templates/import-csv/preview — auth required, returns diff without writing
-router.post('/import-csv/preview', authenticate, async (req: AuthRequest, res: Response) => {
+router.post('/import-csv/preview', authenticate, asyncHandler(async (req: AuthRequest, res: Response) => {
   const csvText: string = req.body.csv
   if (!csvText) { res.status(400).json({ error: 'csv field is required' }); return }
 
@@ -142,10 +143,10 @@ router.post('/import-csv/preview', authenticate, async (req: AuthRequest, res: R
   }
 
   res.json({ newTemplates, updatedTemplates, errors: rowErrors })
-})
+}))
 
 // POST /api/templates/import-csv — auth required, commits the import
-router.post('/import-csv', authenticate, async (req: AuthRequest, res: Response) => {
+router.post('/import-csv', authenticate, asyncHandler(async (req: AuthRequest, res: Response) => {
   const csvText: string = req.body.csv
   if (!csvText) { res.status(400).json({ error: 'csv field is required' }); return }
 
@@ -218,10 +219,10 @@ router.post('/import-csv', authenticate, async (req: AuthRequest, res: Response)
   }
 
   res.status(201).json({ message: 'Import successful', templatesCreated: created, templatesUpdated: updated, tasksCreated })
-})
+}))
 
 // POST /api/templates/:id/restore — auth required (clears soft delete)
-router.post('/:id/restore', authenticate, async (req: AuthRequest, res: Response) => {
+router.post('/:id/restore', authenticate, asyncHandler(async (req: AuthRequest, res: Response) => {
   const template = await prisma.featureTemplate.findUnique({ where: { id: req.params.id as string } })
   if (!template || !template.deletedAt) { res.status(404).json({ error: 'Template not found or not archived' }); return }
   const restored = await prisma.featureTemplate.update({
@@ -230,10 +231,10 @@ router.post('/:id/restore', authenticate, async (req: AuthRequest, res: Response
     include: templateInclude,
   })
   res.json(restored)
-})
+}))
 
 // GET /api/templates/:id/export-csv — auth required (before /:id to avoid conflict)
-router.get('/:id/export-csv', authenticate, async (req: AuthRequest, res: Response) => {
+router.get('/:id/export-csv', authenticate, asyncHandler(async (req: AuthRequest, res: Response) => {
   const template = await prisma.featureTemplate.findUnique({
     where: { id: req.params.id as string },
     include: { tasks: { orderBy: { order: 'asc' } } },
@@ -258,20 +259,20 @@ router.get('/:id/export-csv', authenticate, async (req: AuthRequest, res: Respon
   res.setHeader('Content-Type', 'text/csv')
   res.setHeader('Content-Disposition', `attachment; filename="${slug}.csv"`)
   res.send(csv)
-})
+}))
 
 // GET /api/templates/:id
-router.get('/:id', authenticate, async (req: AuthRequest, res: Response) => {
+router.get('/:id', authenticate, asyncHandler(async (req: AuthRequest, res: Response) => {
   const template = await prisma.featureTemplate.findUnique({
     where: { id: req.params.id as string },
     include: templateInclude,
   })
   if (!template) { res.status(404).json({ error: 'Template not found' }); return }
   res.json(template)
-})
+}))
 
 // PUT /api/templates/:id — auth required (auto-snapshots before save)
-router.put('/:id', authenticate, async (req: AuthRequest, res: Response) => {
+router.put('/:id', authenticate, asyncHandler(async (req: AuthRequest, res: Response) => {
   const { name, category, description, snapshot: takeSnapshot, snapshotLabel } = req.body
   if (takeSnapshot !== false) {
     await captureSnapshot(req.params.id as string, snapshotLabel ?? null, 'manual_edit')
@@ -282,16 +283,16 @@ router.put('/:id', authenticate, async (req: AuthRequest, res: Response) => {
     include: templateInclude,
   })
   res.json(template)
-})
+}))
 
 // DELETE /api/templates/:id — auth required (soft delete)
-router.delete('/:id', authenticate, async (req: AuthRequest, res: Response) => {
+router.delete('/:id', authenticate, asyncHandler(async (req: AuthRequest, res: Response) => {
   await prisma.featureTemplate.update({ where: { id: req.params.id as string }, data: { deletedAt: new Date() } })
   res.json({ message: 'Archived' })
-})
+}))
 
 // POST /api/templates/:id/tasks — auth required
-router.post('/:id/tasks', authenticate, async (req: AuthRequest, res: Response) => {
+router.post('/:id/tasks', authenticate, asyncHandler(async (req: AuthRequest, res: Response) => {
   const { name, hoursExtraSmall, hoursSmall, hoursMedium, hoursLarge, hoursExtraLarge, resourceTypeName } = req.body
   if (!name || !resourceTypeName) { res.status(400).json({ error: 'name and resourceTypeName are required' }); return }
   const count = await prisma.templateTask.count({ where: { templateId: req.params.id as string } })
@@ -305,10 +306,10 @@ router.post('/:id/tasks', authenticate, async (req: AuthRequest, res: Response) 
     },
   })
   res.status(201).json(task)
-})
+}))
 
 // PUT /api/templates/:id/tasks/reorder — auth required
-router.put('/:id/tasks/reorder', authenticate, async (req: AuthRequest, res: Response) => {
+router.put('/:id/tasks/reorder', authenticate, asyncHandler(async (req: AuthRequest, res: Response) => {
   const items = req.body as { id: string; order: number }[]
   if (!Array.isArray(items)) { res.status(400).json({ error: 'Expected array of { id, order }' }); return }
   await Promise.all(items.map(({ id, order }) =>
@@ -319,35 +320,35 @@ router.put('/:id/tasks/reorder', authenticate, async (req: AuthRequest, res: Res
     include: templateInclude,
   })
   res.json(template)
-})
+}))
 
 // PUT /api/templates/:id/tasks/:taskId — auth required
-router.put('/:id/tasks/:taskId', authenticate, async (req: AuthRequest, res: Response) => {
+router.put('/:id/tasks/:taskId', authenticate, asyncHandler(async (req: AuthRequest, res: Response) => {
   const { name, hoursExtraSmall, hoursSmall, hoursMedium, hoursLarge, hoursExtraLarge, resourceTypeName } = req.body
   const task = await prisma.templateTask.update({
     where: { id: req.params.taskId as string },
     data: { name, hoursExtraSmall, hoursSmall, hoursMedium, hoursLarge, hoursExtraLarge, resourceTypeName },
   })
   res.json(task)
-})
+}))
 
 // DELETE /api/templates/:id/tasks/:taskId — auth required
-router.delete('/:id/tasks/:taskId', authenticate, async (req: AuthRequest, res: Response) => {
+router.delete('/:id/tasks/:taskId', authenticate, asyncHandler(async (req: AuthRequest, res: Response) => {
   await prisma.templateTask.delete({ where: { id: req.params.taskId as string } })
   res.json({ message: 'Deleted' })
-})
+}))
 
 // GET /api/templates/:id/snapshots — auth required
-router.get('/:id/snapshots', authenticate, async (req: AuthRequest, res: Response) => {
+router.get('/:id/snapshots', authenticate, asyncHandler(async (req: AuthRequest, res: Response) => {
   const snapshots = await prisma.templateSnapshot.findMany({
     where: { templateId: req.params.id as string },
     orderBy: { createdAt: 'desc' },
   })
   res.json(snapshots)
-})
+}))
 
 // POST /api/templates/:id/snapshots — auth required (manual snapshot)
-router.post('/:id/snapshots', authenticate, async (req: AuthRequest, res: Response) => {
+router.post('/:id/snapshots', authenticate, asyncHandler(async (req: AuthRequest, res: Response) => {
   const { label } = req.body
   await captureSnapshot(req.params.id as string, label ?? null, 'manual')
   const snapshots = await prisma.templateSnapshot.findMany({
@@ -355,10 +356,10 @@ router.post('/:id/snapshots', authenticate, async (req: AuthRequest, res: Respon
     orderBy: { createdAt: 'desc' },
   })
   res.status(201).json(snapshots[0])
-})
+}))
 
 // POST /api/templates/:id/snapshots/:snapshotId/restore — auth required
-router.post('/:id/snapshots/:snapshotId/restore', authenticate, async (req: AuthRequest, res: Response) => {
+router.post('/:id/snapshots/:snapshotId/restore', authenticate, asyncHandler(async (req: AuthRequest, res: Response) => {
   const snap = await prisma.templateSnapshot.findUnique({ where: { id: req.params.snapshotId as string } })
   if (!snap) { res.status(404).json({ error: 'Snapshot not found' }); return }
 
@@ -382,7 +383,7 @@ router.post('/:id/snapshots/:snapshotId/restore', authenticate, async (req: Auth
     include: templateInclude,
   })
   res.json(template)
-})
+}))
 
 
 export default router

--- a/server/src/routes/timeline.ts
+++ b/server/src/routes/timeline.ts
@@ -1,5 +1,6 @@
 import { Router, Response } from 'express'
 import { prisma } from '../lib/prisma.js'
+import { asyncHandler } from '../lib/asyncHandler.js'
 import { authenticate, AuthRequest } from '../middleware/auth.js'
 
 const router = Router({ mergeParams: true })
@@ -395,7 +396,7 @@ async function computeParallelWarnings(
 }
 
 // GET /api/projects/:projectId/timeline
-router.get('/', async (req: AuthRequest, res: Response) => {
+router.get('/', asyncHandler(async (req: AuthRequest, res: Response) => {
   const project = await ownedProject(req.params.projectId as string, req.userId!)
   if (!project) { res.status(404).json({ error: 'Project not found' }); return }
 
@@ -452,10 +453,10 @@ router.get('/', async (req: AuthRequest, res: Response) => {
     ? new Map<string, number>(Object.entries(project.weeklyDemandCache as Record<string, number>))
     : undefined
   res.json(buildResponse(project, activeEntries, parallelWarnings, mappedStoryEntries, featureDependencies, storyDependencies, resourceTypes, simulatedDemand))
-})
+}))
 
 // POST /api/projects/:projectId/timeline/schedule
-router.post('/schedule', async (req: AuthRequest, res: Response) => {
+router.post('/schedule', asyncHandler(async (req: AuthRequest, res: Response) => {
   let project = await ownedProject(req.params.projectId as string, req.userId!)
   if (!project) { res.status(404).json({ error: 'Project not found' }); return }
 
@@ -698,6 +699,12 @@ router.post('/schedule', async (req: AuthRequest, res: Response) => {
       return result
     }
 
+    // #178: pre-compute featureResourceHours for all features to avoid re-computing in the simulation loop
+    const featureResourceHoursCache = new Map<string, Map<string, number>>()
+    for (const fId of processed) {
+      featureResourceHoursCache.set(fId, featureResourceHours(featureMap.get(fId)!))
+    }
+
     // Variable weekly capacity: build lookup by resource type ID
     const rtById = new Map(resourceTypes.map(rt => [rt.id, rt as ResourceTypeWithNamed]))
     const allRtIds = [...resourceTypes.map(rt => rt.id), '_unassigned']
@@ -706,7 +713,7 @@ router.post('/schedule', async (req: AuthRequest, res: Response) => {
     const remainingHours = new Map<string, Map<string, number>>()
     for (const fId of processed) {
       if (manualStartWeeks.has(fId)) continue
-      remainingHours.set(fId, featureResourceHours(featureMap.get(fId)!))
+      remainingHours.set(fId, featureResourceHoursCache.get(fId)!)
     }
 
     // Simulation state
@@ -771,7 +778,7 @@ router.post('/schedule', async (req: AuthRequest, res: Response) => {
           const fDone = simDone.get(fId)
           if (fStart === undefined || fDone === undefined || fDone <= fStart) continue
           if (t >= fStart && t < fDone) {
-            const rtHours = featureResourceHours(featureMap.get(fId)!).get(rtId) ?? 0
+            const rtHours = featureResourceHoursCache.get(fId)!.get(rtId) ?? 0
             if (rtHours > 0) {
               const perStep = (rtHours / (fDone - fStart)) * STEP
               const consumptionKey = `${rtName}|${currentWeek}`
@@ -811,7 +818,7 @@ router.post('/schedule', async (req: AuthRequest, res: Response) => {
           const fDone = simDone.get(fId)
           if (fStart === undefined || fDone === undefined || fDone <= fStart) continue
           if (t >= fStart && t < fDone) {
-            const rtHours = featureResourceHours(featureMap.get(fId)!).get(rtId) ?? 0
+            const rtHours = featureResourceHoursCache.get(fId)!.get(rtId) ?? 0
             if (rtHours > 0) {
               const perStep = (rtHours / (fDone - fStart)) * STEP
               capPerStep = Math.max(0, capPerStep - perStep)
@@ -953,17 +960,18 @@ router.post('/schedule', async (req: AuthRequest, res: Response) => {
   await Promise.all(storyUpserts)
   // ── End story-level scheduling ─────────────────────────────────────────────
 
-  for (const fId of processed) {
+  // #178: run feature timeline upserts in parallel instead of sequentially
+  await Promise.all([...processed].map(fId => {
     const sw = startWeeks.get(fId)!
     const f = featureMap.get(fId)!
     const dur = (finishWeeks.get(fId) ?? (sw + featureDurationWeeks(f))) - sw
     const isManual = manualStartWeeks.has(fId)
-    await prisma.timelineEntry.upsert({
+    return prisma.timelineEntry.upsert({
       where: { featureId: fId },
       create: { projectId: project.id, featureId: fId, startWeek: sw, durationWeeks: dur, isManual },
       update: isManual ? {} : { startWeek: sw, durationWeeks: dur, isManual: false },
     })
-  }
+  }))
 
   const entries = await prisma.timelineEntry.findMany({
     where: { projectId: project.id },
@@ -1015,10 +1023,10 @@ router.post('/schedule', async (req: AuthRequest, res: Response) => {
   })
 
   res.json(buildResponse(project, entries, parallelWarnings, mappedStoryEntries, featureDependencies, storyDependencies, resourceTypes, weeklyConsumptionMap))
-})
+}))
 
 // PUT /api/projects/:projectId/timeline/stories/:storyId — manual story timeline override
-router.put('/stories/:storyId', async (req: AuthRequest, res: Response) => {
+router.put('/stories/:storyId', asyncHandler(async (req: AuthRequest, res: Response) => {
   const project = await ownedProject(req.params.projectId as string, req.userId!)
   if (!project) { res.status(404).json({ error: 'Project not found' }); return }
 
@@ -1051,10 +1059,10 @@ router.put('/stories/:storyId', async (req: AuthRequest, res: Response) => {
     durationWeeks: entry.durationWeeks,
     isManual: entry.isManual,
   })
-})
+}))
 
 // DELETE /api/projects/:projectId/timeline — clear ALL manual overrides (features + stories)
-router.delete('/', async (req: AuthRequest, res: Response) => {
+router.delete('/', asyncHandler(async (req: AuthRequest, res: Response) => {
   const project = await ownedProject(req.params.projectId as string, req.userId!)
   if (!project) { res.status(404).json({ error: 'Project not found' }); return }
 
@@ -1063,10 +1071,10 @@ router.delete('/', async (req: AuthRequest, res: Response) => {
     prisma.storyTimelineEntry.deleteMany({ where: { projectId: project.id, isManual: true } }),
   ])
   res.status(204).end()
-})
+}))
 
 // DELETE /api/projects/:projectId/timeline/stories/:storyId — clear manual story override
-router.delete('/stories/:storyId', async (req: AuthRequest, res: Response) => {
+router.delete('/stories/:storyId', asyncHandler(async (req: AuthRequest, res: Response) => {
   const project = await ownedProject(req.params.projectId as string, req.userId!)
   if (!project) { res.status(404).json({ error: 'Project not found' }); return }
 
@@ -1074,10 +1082,10 @@ router.delete('/stories/:storyId', async (req: AuthRequest, res: Response) => {
     where: { storyId: req.params.storyId as string, projectId: project.id },
   })
   res.status(204).end()
-})
+}))
 
 // GET /api/projects/:projectId/timeline/export/csv
-router.get('/export/csv', async (req: AuthRequest, res: Response) => {
+router.get('/export/csv', asyncHandler(async (req: AuthRequest, res: Response) => {
   const project = await prisma.project.findFirst({
     where: { id: req.params.projectId as string, ownerId: req.userId },
     include: {
@@ -1226,10 +1234,10 @@ router.get('/export/csv', async (req: AuthRequest, res: Response) => {
   res.setHeader('Content-Type', 'text/csv; charset=utf-8')
   res.setHeader('Content-Disposition', `attachment; filename="${filename}"`)
   res.send(csv)
-})
+}))
 
 // PUT /api/projects/:projectId/timeline/:featureId
-router.put('/:featureId', async (req: AuthRequest, res: Response) => {
+router.put('/:featureId', asyncHandler(async (req: AuthRequest, res: Response) => {
   const project = await ownedProject(req.params.projectId as string, req.userId!)
   if (!project) { res.status(404).json({ error: 'Project not found' }); return }
 
@@ -1259,10 +1267,10 @@ router.put('/:featureId', async (req: AuthRequest, res: Response) => {
     isManual: entry.isManual,
     ...computeDates(project.startDate, entry.startWeek, entry.durationWeeks),
   })
-})
+}))
 
 // DELETE /api/projects/:projectId/timeline/:featureId — clear manual override
-router.delete('/:featureId', async (req: AuthRequest, res: Response) => {
+router.delete('/:featureId', asyncHandler(async (req: AuthRequest, res: Response) => {
   const project = await ownedProject(req.params.projectId as string, req.userId!)
   if (!project) { res.status(404).json({ error: 'Project not found' }); return }
 
@@ -1270,10 +1278,10 @@ router.delete('/:featureId', async (req: AuthRequest, res: Response) => {
     where: { featureId: req.params.featureId as string, projectId: project.id },
   })
   res.status(204).end()
-})
+}))
 
 // PATCH /api/projects/:projectId/timeline/start-date
-router.patch('/start-date', async (req: AuthRequest, res: Response) => {
+router.patch('/start-date', asyncHandler(async (req: AuthRequest, res: Response) => {
   const project = await ownedProject(req.params.projectId as string, req.userId!)
   if (!project) { res.status(404).json({ error: 'Project not found' }); return }
 
@@ -1286,6 +1294,6 @@ router.patch('/start-date', async (req: AuthRequest, res: Response) => {
   })
 
   res.json({ startDate: updated.startDate?.toISOString() ?? null })
-})
+}))
 
 export default router


### PR DESCRIPTION
## Summary

Partially closes #175, #176, #177, #178.

---

## #175 — Database Indexes

Added `@@index` to 12 models — all FK columns that were doing full sequential table scans:

`Epic[projectId,order]`, `Feature[epicId,order]`, `UserStory[featureId,order]`, `Task[userStoryId]`, `BacklogSnapshot[projectId,createdAt]`, `TimelineEntry[projectId]`, `StoryTimelineEntry[projectId]`, `ResourceType[projectId]`, `NamedResource[resourceTypeId]`, `ProjectOverhead[projectId]`, `ProjectDiscount[projectId]`, `OrganisationMember[userId]`

Migration: `20260407052237_add_fk_indexes`

---

## #176 — Reliability: Error Handling & Transactions

- **asyncHandler** applied to all route handlers across 24 route files — unhandled async rejections now flow to the global `errorHandler` instead of crashing the process
- **documents.ts**: try/catch around Puppeteer + disk write + DB insert; orphaned files cleaned up if DB insert fails after write
- **projects.ts clone**: entire clone wrapped in `prisma.$transaction({ timeout: 30000 })` — partial clones auto-rollback on failure
- **csv.ts import**: all DB writes wrapped in `prisma.$transaction({ timeout: 60000 })`; validation stays outside the transaction

---

## #177 — Performance: Code Splitting + Query staleTime

**Bundle size before → after:**
| | Before | After |
|---|---|---|
| Main chunk (minified) | 2,106 KB | 307 KB |
| Main chunk (gzip) | 538 KB | 99 KB |
| Reduction | — | **7× smaller** |

- All 17 page components (except LoginPage/RegisterPage) converted to `React.lazy()`
- `<Routes>` wrapped in `<Suspense>` with full-screen loading fallback
- `QueryClient` default `staleTime: 5min`, `refetchOnWindowFocus: false` — eliminates refetch-on-focus flicker

Remaining: `ResourceProfilePage` (520KB) still triggers the 500KB warning — it bundles recharts + jszip. Tracked in #177 for follow-up.

---

## #178 — Performance: Timeline Algorithm

- **Parallel upserts**: Feature `TimelineEntry` upserts changed from sequential `for-await` loop to `Promise.all([...].map(...))` — matches existing pattern for story upserts
- **Pre-computed cache**: `featureResourceHours()` results cached in a `Map` before the resource-levelling simulation loop — eliminates up to 200,000 redundant O(stories×tasks) calls

Remaining from #178: Kahn's topological sort heap optimisation — deferred to a follow-up sprint.

---

## Tests

- `server npx tsc --noEmit` ✅
- `client npx tsc --noEmit` ✅
- `server npm test`: **121 passing**