### PR TITLE
feat: quick wins — dark mode fix, project settings, backlog UX, resource rate warning

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -21,7 +21,7 @@
     "@tiptap/react": "^3.22.2",
     "@tiptap/starter-kit": "^3.22.2",
     "@types/dompurify": "^3.2.0",
-    "axios": "^1.14.0",
+    "axios": "1.14.0",
     "dompurify": "^3.3.3",
     "html-to-image": "^1.11.13",
     "jszip": "^3.10.1",

--- a/client/src/components/backlog/CsvImportModal.tsx
+++ b/client/src/components/backlog/CsvImportModal.tsx
@@ -14,6 +14,7 @@ export interface StagedRow {
   assumptions: string
   errors: string[]
   warnings: string[]
+  status?: 'new' | 'existing' | 'error'
 }
 
 interface Props {
@@ -208,7 +209,7 @@ export default function CsvImportModal({ projectId, onClose, onImported }: Props
                   </thead>
                   <tbody>
                     {staged.map((row, i) => (
-                      <tr key={i} className={`border-b border-gray-100 dark:border-gray-700 ${row.errors.length > 0 ? 'bg-red-50 dark:bg-red-950/30' : row.warnings.length > 0 ? 'bg-yellow-50 dark:bg-yellow-950/20' : 'dark:bg-gray-800'}`}>
+                      <tr key={i} className={`border-b border-gray-100 dark:border-gray-700 ${row.errors.length > 0 ? 'bg-red-50 dark:bg-red-950/30' : row.status === 'new' ? 'bg-yellow-50 dark:bg-yellow-950/20' : 'dark:bg-gray-800'}`}>
                         <td className="px-3 py-2 text-gray-400 dark:text-gray-500">
                           {row.errors.length > 0 ? <span className="text-red-500 font-bold">⚠ {row.rowIndex}</span> : row.rowIndex}
                         </td>

--- a/client/src/components/backlog/FeatureList.tsx
+++ b/client/src/components/backlog/FeatureList.tsx
@@ -19,7 +19,7 @@ interface Props {
   epicColour?: EpicColour
 }
 
-function SortableFeatureItem({ feature, isEditing, expanded, onToggle, onEdit, onCancelEdit, onSave, onDelete, onToggleActive, isSaving, onApplyTemplate, resourceTypes, projectId, hoursPerDay, epicColour }: {
+function SortableFeatureItem({ feature, isEditing, expanded, onToggle, onEdit, onCancelEdit, onSave, onDelete, onToggleActive, onToggleFeatureMode, isSaving, onApplyTemplate, resourceTypes, projectId, hoursPerDay, epicColour }: {
   feature: Feature
   isEditing: boolean
   expanded: boolean
@@ -29,6 +29,7 @@ function SortableFeatureItem({ feature, isEditing, expanded, onToggle, onEdit, o
   onSave: (data: { name: string; description: string; assumptions: string }) => void
   onDelete: () => void
   onToggleActive: () => void
+  onToggleFeatureMode: () => void
   isSaving: boolean
   onApplyTemplate: () => void
   resourceTypes: ResourceType[]
@@ -57,13 +58,30 @@ function SortableFeatureItem({ feature, isEditing, expanded, onToggle, onEdit, o
           <span className="text-blue-500 dark:text-blue-400 text-xs select-none">{expanded ? '▼' : '▶'}</span>
           <span className="text-xs text-blue-500 dark:text-blue-300 bg-blue-100 dark:bg-blue-900 px-1.5 py-0.5 rounded">Feature</span>
           <span className={`text-sm flex-1 truncate ${feature.isActive === false ? 'line-through text-gray-400 dark:text-gray-500' : 'text-gray-800 dark:text-gray-200'}`}>{feature.name}</span>
+          <button
+            onClick={e => { e.stopPropagation(); onToggleFeatureMode() }}
+            title={`Story mode: ${feature.featureMode ?? 'sequential'} — click to toggle`}
+            className={feature.featureMode === 'parallel'
+              ? 'bg-blue-50 dark:bg-blue-900/30 text-blue-600 dark:text-blue-400 text-xs px-2 py-0.5 rounded cursor-pointer hover:bg-blue-100 dark:hover:bg-blue-900/50'
+              : 'bg-gray-100 dark:bg-gray-700 text-gray-500 dark:text-gray-400 text-xs px-2 py-0.5 rounded cursor-pointer hover:bg-gray-200 dark:hover:bg-gray-600'}
+          >
+            {feature.featureMode === 'parallel' ? 'parallel' : 'sequential'}
+          </button>
           <span className="text-xs text-gray-400 dark:text-gray-500">{feature.userStories.length} stor{feature.userStories.length !== 1 ? 'ies' : 'y'} · {totalHours.toFixed(2)}h · {(totalHours / hoursPerDay).toFixed(1)}d</span>
           <button onClick={e => { e.stopPropagation(); onApplyTemplate() }}
             className="text-xs text-purple-500 hover:text-purple-700 bg-purple-50 hover:bg-purple-100 border border-purple-200 px-2 py-0.5 rounded transition-colors">
             + Template
           </button>
           <div className="flex gap-1 opacity-0 group-hover:opacity-100 transition-opacity" onClick={e => e.stopPropagation()}>
-            <button onClick={onToggleActive} title={feature.isActive === false ? 'Mark in scope' : 'Mark out of scope'} className={`text-xs px-1 ${feature.isActive === false ? 'text-gray-300 hover:text-gray-500' : 'text-gray-400 dark:text-gray-500 hover:text-gray-600'}`}>{feature.isActive === false ? '○' : '●'}</button>
+            <button
+              onClick={onToggleActive}
+              title={feature.isActive === false ? 'Mark in scope' : 'Mark out of scope'}
+              className={feature.isActive === false
+                ? 'bg-gray-100 dark:bg-gray-700 text-gray-400 dark:text-gray-500 border border-gray-200 dark:border-gray-600 text-xs px-2 py-0.5 rounded-full font-medium cursor-pointer hover:bg-gray-200 dark:hover:bg-gray-600 line-through'
+                : 'bg-green-50 dark:bg-green-900/30 text-green-700 dark:text-green-400 border border-green-200 dark:border-green-800 text-xs px-2 py-0.5 rounded-full font-medium cursor-pointer hover:bg-green-100 dark:hover:bg-green-900/50'}
+            >
+              {feature.isActive === false ? 'Out of scope' : 'In scope'}
+            </button>
             <button onClick={onEdit} className="text-xs text-gray-400 dark:text-gray-500 hover:text-gray-700 px-1">Edit</button>
             <button onClick={onDelete} className="text-xs text-red-400 hover:text-red-600 px-1">Delete</button>
           </div>
@@ -105,6 +123,12 @@ export default function FeatureList({ epicId, features, resourceTypes, projectId
     onSuccess: invalidate,
   })
 
+  const toggleFeatureMode = useMutation({
+    mutationFn: ({ id, featureMode }: { id: string; featureMode: string }) =>
+      api.put(`/epics/${epicId}/features/${id}`, { featureMode }),
+    onSuccess: invalidate,
+  })
+
   const deleteFeature = useMutation({
     mutationFn: (id: string) => api.delete(`/epics/${epicId}/features/${id}`),
     onSuccess: invalidate,
@@ -135,6 +159,7 @@ export default function FeatureList({ epicId, features, resourceTypes, projectId
             onSave={(data) => updateFeature.mutate({ id: feature.id, data })}
             onDelete={() => deleteFeature.mutate(feature.id)}
             onToggleActive={() => toggleFeatureActive.mutate({ id: feature.id, isActive: feature.isActive !== false ? false : true })}
+            onToggleFeatureMode={() => toggleFeatureMode.mutate({ id: feature.id, featureMode: feature.featureMode === 'parallel' ? 'sequential' : 'parallel' })}
             isSaving={updateFeature.isPending}
             onApplyTemplate={() => setApplyTemplateFeatureId(feature.id)}
             resourceTypes={resourceTypes}

--- a/client/src/components/backlog/StoryList.tsx
+++ b/client/src/components/backlog/StoryList.tsx
@@ -68,7 +68,15 @@ function SortableStoryItem({ story, isEditing, expanded, onToggle, onEdit, onCan
             </button>
           )}
           <div className="flex gap-1 opacity-0 group-hover:opacity-100 transition-opacity" onClick={e => e.stopPropagation()}>
-            <button onClick={onToggleActive} title={story.isActive === false ? 'Mark in scope' : 'Mark out of scope'} className={`text-xs px-1 ${story.isActive === false ? 'text-gray-300 hover:text-gray-500' : 'text-gray-400 dark:text-gray-500 hover:text-gray-600'}`}>{story.isActive === false ? '○' : '●'}</button>
+            <button
+              onClick={onToggleActive}
+              title={story.isActive === false ? 'Mark in scope' : 'Mark out of scope'}
+              className={story.isActive === false
+                ? 'bg-gray-100 dark:bg-gray-700 text-gray-400 dark:text-gray-500 border border-gray-200 dark:border-gray-600 text-xs px-2 py-0.5 rounded-full font-medium cursor-pointer hover:bg-gray-200 dark:hover:bg-gray-600 line-through'
+                : 'bg-green-50 dark:bg-green-900/30 text-green-700 dark:text-green-400 border border-green-200 dark:border-green-800 text-xs px-2 py-0.5 rounded-full font-medium cursor-pointer hover:bg-green-100 dark:hover:bg-green-900/50'}
+            >
+              {story.isActive === false ? 'Out of scope' : 'In scope'}
+            </button>
             <button onClick={onEdit} className="text-xs text-gray-400 dark:text-gray-500 hover:text-gray-700 px-1">Edit</button>
             <button onClick={onDelete} className="text-xs text-red-400 hover:text-red-600 px-1">Delete</button>
           </div>

--- a/client/src/components/resource-profile/CommercialTab.tsx
+++ b/client/src/components/resource-profile/CommercialTab.tsx
@@ -74,17 +74,25 @@ export default function CommercialTab({
 
     {/* ── Unrated resources warning ── */}
     {(() => {
-      const unrated = filteredResourceRows.filter(r => r.dayRate == null && (r.totalHours > 0 || r.totalDays > 0))
-      if (unrated.length === 0) return null
+      const unratedResources = filteredResourceRows.filter(r => r.dayRate == null)
+      const unratedOverhead = (profile?.overheadRows ?? []).filter(r => r.dayRate == null && r.computedDays > 0)
+      const unratedOverheadNames = unratedOverhead
+        .map(r => r.resourceTypeName ?? r.name)
+        .filter(name => !unratedResources.some(r => r.name === name))
+      const allUnratedNames = [
+        ...unratedResources.map(r => r.name),
+        ...unratedOverheadNames,
+      ]
+      if (allUnratedNames.length === 0) return null
       return (
         <div className="mb-4 bg-yellow-50 dark:bg-yellow-900/20 border border-yellow-200 dark:border-yellow-800 rounded-lg p-3 flex items-start gap-2">
           <span className="text-yellow-500 mt-0.5">⚠️</span>
           <div>
             <p className="text-sm font-medium text-yellow-800 dark:text-yellow-300">
-              {unrated.length} resource type{unrated.length !== 1 ? 's' : ''} have no rate applied and are excluded from cost calculations.
+              {allUnratedNames.length} resource type{allUnratedNames.length !== 1 ? 's' : ''} have no rate applied and are excluded from cost calculations.
             </p>
             <p className="text-xs text-yellow-700 dark:text-yellow-400 mt-0.5">
-              Missing rates: {unrated.map(r => r.name).join(', ')}
+              Missing rates: {allUnratedNames.join(', ')}
             </p>
           </div>
         </div>

--- a/client/src/components/resource-profile/CommercialTab.tsx
+++ b/client/src/components/resource-profile/CommercialTab.tsx
@@ -18,6 +18,7 @@ export default function CommercialTab({
   updateAllocationMutation, updateNrAllocationMutation,
   handleDiscountSubmit, handleApplyRateCard, startEditAllocation, getAllocationBadge,
   weekToDate, fmtDate, formatNumber, saveBufferOnboarding,
+  filteredResourceRows,
 }: Props) {
   return (
     <>
@@ -70,6 +71,25 @@ export default function CommercialTab({
         <button onClick={saveBufferOnboarding} className="bg-lab3-navy text-white px-4 py-1.5 rounded-lg text-sm font-medium hover:bg-lab3-blue">Save</button>
       </div>
     </div>
+
+    {/* ── Unrated resources warning ── */}
+    {(() => {
+      const unrated = filteredResourceRows.filter(r => r.dayRate == null && (r.totalHours > 0 || r.totalDays > 0))
+      if (unrated.length === 0) return null
+      return (
+        <div className="mb-4 bg-yellow-50 dark:bg-yellow-900/20 border border-yellow-200 dark:border-yellow-800 rounded-lg p-3 flex items-start gap-2">
+          <span className="text-yellow-500 mt-0.5">⚠️</span>
+          <div>
+            <p className="text-sm font-medium text-yellow-800 dark:text-yellow-300">
+              {unrated.length} resource type{unrated.length !== 1 ? 's' : ''} have no rate applied and are excluded from cost calculations.
+            </p>
+            <p className="text-xs text-yellow-700 dark:text-yellow-400 mt-0.5">
+              Missing rates: {unrated.map(r => r.name).join(', ')}
+            </p>
+          </div>
+        </div>
+      )
+    })()}
 
     {/* ── Cost Summary Table ── */}
     <section className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700">

--- a/client/src/pages/BacklogPage.tsx
+++ b/client/src/pages/BacklogPage.tsx
@@ -273,6 +273,7 @@ export default function BacklogPage() {
                     editSaving={updateEpic.isPending}
                     onDelete={() => deleteEpic.mutate(epic.id)}
                     onToggleActive={() => toggleEpicActive.mutate({ id: epic.id, isActive: epic.isActive !== false ? false : true })}
+                    onToggleFeatureMode={() => updateEpic.mutate({ id: epic.id, data: { featureMode: epic.featureMode === 'parallel' ? 'sequential' : 'parallel' } })}
                     epicTotalHours={epicTotalHours(epic)}
                     resourceTypes={resourceTypes}
                     projectId={projectId!}
@@ -395,7 +396,7 @@ export default function BacklogPage() {
   )
 }
 
-function SortableEpicRow({ epic, expanded, onToggle, isEditing, onEdit, onSaveEdit, onCancelEdit, editSaving, onDelete, onToggleActive, epicTotalHours, resourceTypes, projectId, hoursPerDay, epicColour }: {
+function SortableEpicRow({ epic, expanded, onToggle, isEditing, onEdit, onSaveEdit, onCancelEdit, editSaving, onDelete, onToggleActive, onToggleFeatureMode, epicTotalHours, resourceTypes, projectId, hoursPerDay, epicColour }: {
   epic: Epic
   expanded: boolean
   onToggle: () => void
@@ -406,6 +407,7 @@ function SortableEpicRow({ epic, expanded, onToggle, isEditing, onEdit, onSaveEd
   editSaving: boolean
   onDelete: () => void
   onToggleActive: () => void
+  onToggleFeatureMode: () => void
   epicTotalHours: number
   resourceTypes: ResourceType[]
   projectId: string
@@ -433,11 +435,28 @@ function SortableEpicRow({ epic, expanded, onToggle, isEditing, onEdit, onSaveEd
             <span className="text-gray-400 dark:text-gray-500 text-sm select-none">{expanded ? '▼' : '▶'}</span>
             <span className="text-xs text-lab3-navy dark:text-blue-300 bg-blue-50 dark:bg-blue-900 px-2 py-0.5 rounded font-medium">Epic</span>
             <span className={`font-medium flex-1 ${epic.isActive === false ? 'line-through text-gray-400' : 'text-gray-900 dark:text-white'}`}>{epic.name}</span>
+            <button
+              onClick={e => { e.stopPropagation(); onToggleFeatureMode() }}
+              title={`Feature mode: ${epic.featureMode ?? 'sequential'} — click to toggle`}
+              className={epic.featureMode === 'parallel'
+                ? 'bg-blue-50 dark:bg-blue-900/30 text-blue-600 dark:text-blue-400 text-xs px-2 py-0.5 rounded cursor-pointer hover:bg-blue-100 dark:hover:bg-blue-900/50'
+                : 'bg-gray-100 dark:bg-gray-700 text-gray-500 dark:text-gray-400 text-xs px-2 py-0.5 rounded cursor-pointer hover:bg-gray-200 dark:hover:bg-gray-600'}
+            >
+              {epic.featureMode === 'parallel' ? 'parallel' : 'sequential'}
+            </button>
             <span className="text-sm text-gray-400 dark:text-gray-500">
               {epic.features.length} feature{epic.features.length !== 1 ? 's' : ''} · {epicTotalHours.toFixed(2)}h · {(epicTotalHours / hoursPerDay).toFixed(1)}d
             </span>
             <div className="flex gap-1 opacity-0 group-hover:opacity-100 transition-opacity" onClick={e => e.stopPropagation()}>
-              <button onClick={onToggleActive} title={epic.isActive === false ? 'Mark in scope' : 'Mark out of scope'} className={`text-xs px-2 py-1 ${epic.isActive === false ? 'text-gray-300 hover:text-gray-500' : 'text-gray-400 hover:text-gray-600'}`}>{epic.isActive === false ? '○' : '●'}</button>
+              <button
+                onClick={onToggleActive}
+                title={epic.isActive === false ? 'Mark in scope' : 'Mark out of scope'}
+                className={epic.isActive === false
+                  ? 'bg-gray-100 dark:bg-gray-700 text-gray-400 dark:text-gray-500 border border-gray-200 dark:border-gray-600 text-xs px-2 py-0.5 rounded-full font-medium cursor-pointer hover:bg-gray-200 dark:hover:bg-gray-600 line-through'
+                  : 'bg-green-50 dark:bg-green-900/30 text-green-700 dark:text-green-400 border border-green-200 dark:border-green-800 text-xs px-2 py-0.5 rounded-full font-medium cursor-pointer hover:bg-green-100 dark:hover:bg-green-900/50'}
+              >
+                {epic.isActive === false ? 'Out of scope' : 'In scope'}
+              </button>
               <button onClick={onEdit} className="text-xs text-gray-400 dark:text-gray-500 hover:text-gray-700 px-2 py-1">Edit</button>
               <button onClick={onDelete} className="text-xs text-red-400 hover:text-red-600 px-2 py-1">Delete</button>
             </div>

--- a/client/src/pages/ProjectSettingsPage.tsx
+++ b/client/src/pages/ProjectSettingsPage.tsx
@@ -22,7 +22,7 @@ export default function ProjectSettingsPage() {
   const navigate = useNavigate()
   const qc = useQueryClient()
 
-  const [form, setForm] = useState({ name: '', description: '', customerId: '', status: 'DRAFT', hoursPerDay: 7.6, bufferWeeks: 0 })
+  const [form, setForm] = useState({ name: '', description: '', customerId: '', status: 'DRAFT', hoursPerDay: 7.6, bufferWeeks: 0, onboardingWeeks: 0, taxRate: 10, taxLabel: 'GST' })
   const [saved, setSaved] = useState(false)
   const [customers, setCustomers] = useState<Customer[]>([])
   const [orgs, setOrgs] = useState<Org[]>([])
@@ -53,6 +53,9 @@ export default function ProjectSettingsPage() {
         status: project.status ?? 'DRAFT',
         hoursPerDay: project.hoursPerDay ?? 7.6,
         bufferWeeks: project.bufferWeeks ?? 0,
+        onboardingWeeks: project.onboardingWeeks ?? 0,
+        taxRate: project.taxRate ?? 10,
+        taxLabel: project.taxLabel ?? 'GST',
       })
       setSelectedOrgId(project.orgId ?? '')
     }
@@ -170,14 +173,25 @@ export default function ProjectSettingsPage() {
           </div>
 
           <div>
-            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Buffer weeks at end</label>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Onboarding weeks</label>
+            <input
+              type="number" value={form.onboardingWeeks}
+              onChange={e => setForm(v => ({ ...v, onboardingWeeks: parseInt(e.target.value) || 0 }))}
+              min={0} max={52} step={1}
+              className="w-full border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 text-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-lab3-blue"
+            />
+            <p className="text-xs text-gray-400 mt-1">Weeks reserved at the START of the project for onboarding.</p>
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Buffer weeks</label>
             <input
               type="number" value={form.bufferWeeks}
               onChange={e => setForm(v => ({ ...v, bufferWeeks: parseInt(e.target.value) || 0 }))}
               min={0} max={52} step={1}
               className="w-full border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 text-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-lab3-blue"
             />
-            <p className="text-xs text-gray-400 mt-1">Adds extra weeks to the end of the project (e.g. for handover). Affects FULL_PROJECT allocation and timeline display.</p>
+            <p className="text-xs text-gray-400 mt-1">Weeks reserved at the END of the project (e.g. for handover). Affects FULL_PROJECT allocation and timeline display.</p>
           </div>
 
           <div>
@@ -188,6 +202,25 @@ export default function ProjectSettingsPage() {
               className="w-full border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 text-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-lab3-blue"
             />
             <p className="text-xs text-gray-400 mt-1">Used to convert hours to days in estimates. Default is 7.6h.</p>
+          </div>
+
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Tax label (e.g. GST, VAT)</label>
+              <input
+                type="text" value={form.taxLabel} onChange={f('taxLabel')}
+                className="w-full border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 text-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-lab3-blue"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Tax rate (%)</label>
+              <input
+                type="number" value={form.taxRate}
+                onChange={e => setForm(v => ({ ...v, taxRate: parseFloat(e.target.value) || 0 }))}
+                step="0.01" min={0}
+                className="w-full border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 text-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-lab3-blue"
+              />
+            </div>
           </div>
 
           <div className="flex items-center gap-3 pt-2">

--- a/client/src/pages/ProjectsPage.tsx
+++ b/client/src/pages/ProjectsPage.tsx
@@ -296,7 +296,7 @@ export default function ProjectsPage() {
                 </div>
                 {project.org && <span className="text-xs bg-blue-100 text-blue-700 rounded-full px-2 py-0.5 mb-1 inline-block">{project.org.name}</span>}
                 {project.customer && <p className="text-xs text-gray-500 mb-1">Customer: {project.customer.name}</p>}
-                {project.description && <p className="text-sm text-gray-600 mb-3 line-clamp-2">{stripHtml(project.description)}</p>}
+                {project.description && <p className="text-sm text-gray-600 dark:text-gray-300 mb-3 line-clamp-2">{stripHtml(project.description)}</p>}
                 <div className="flex items-center justify-between text-xs text-gray-400 mt-2">
                   <span>{project._count.epics} epic{project._count.epics !== 1 ? 's' : ''}</span>
                   <span>{new Date(project.updatedAt).toLocaleDateString()}</span>

--- a/client/src/types/backlog.ts
+++ b/client/src/types/backlog.ts
@@ -69,6 +69,7 @@ export interface Epic {
   order: number
   projectId: string
   isActive?: boolean
+  featureMode?: string
   features: Feature[]
 }
 

--- a/client/src/types/backlog.ts
+++ b/client/src/types/backlog.ts
@@ -58,6 +58,7 @@ export interface Feature {
   order: number
   epicId: string
   isActive?: boolean
+  featureMode?: string
   userStories: UserStory[]
 }
 

--- a/e2e/tests/backlog.spec.ts
+++ b/e2e/tests/backlog.spec.ts
@@ -396,10 +396,12 @@ test.describe('CSV redesign — Type column and status fields', () => {
     // Type must be the first column
     expect(headerCols[0]).toBe('Type')
 
-    // EpicStatus, FeatureStatus, StoryStatus must be the last 3 columns
-    expect(headerCols[headerCols.length - 3]).toBe('EpicStatus')
-    expect(headerCols[headerCols.length - 2]).toBe('FeatureStatus')
-    expect(headerCols[headerCols.length - 1]).toBe('StoryStatus')
+    // Status and mode columns must be present
+    expect(headerCols).toContain('EpicStatus')
+    expect(headerCols).toContain('FeatureStatus')
+    expect(headerCols).toContain('StoryStatus')
+    expect(headerCols).toContain('EpicMode')
+    expect(headerCols).toContain('FeatureMode')
 
     // All 4 row types must be present
     const typeIdx = headerCols.indexOf('Type')

--- a/server/prisma/migrations/20260427004308_add_feature_mode_to_feature/migration.sql
+++ b/server/prisma/migrations/20260427004308_add_feature_mode_to_feature/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Feature" ADD COLUMN     "featureMode" TEXT NOT NULL DEFAULT 'sequential';

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -171,6 +171,7 @@ model Feature {
   description    String?
   assumptions    String?
   order          Int                  @default(0)
+  featureMode      String               @default("sequential")
   isActive         Boolean              @default(true)
   timelineColour   String?
   epic             Epic                 @relation(fields: [epicId], references: [id], onDelete: Cascade)

--- a/server/src/lib/pdfRenderer.ts
+++ b/server/src/lib/pdfRenderer.ts
@@ -27,12 +27,30 @@ export async function generatePdfFromHtml(html: string): Promise<Buffer> {
   try {
     // #170: sanitize HTML before passing to Puppeteer to prevent SSRF/injection
     const safeHtml = sanitizeHtml(html, {
-      allowedTags: sanitizeHtml.defaults.allowedTags.concat(['style', 'svg', 'path', 'circle', 'rect', 'line', 'polygon', 'h1', 'h2', 'h3', 'h4', 'table', 'thead', 'tbody', 'tr', 'th', 'td']),
+      allowedTags: sanitizeHtml.defaults.allowedTags.concat([
+        'style', 'h1', 'h2', 'h3', 'h4',
+        'table', 'thead', 'tbody', 'tr', 'th', 'td',
+        // SVG elements used in Gantt chart
+        'svg', 'g', 'defs', 'marker',
+        'rect', 'line', 'path', 'polygon', 'circle', 'polyline',
+        'text', 'tspan',
+      ]),
       allowedAttributes: {
         ...sanitizeHtml.defaults.allowedAttributes,
         '*': ['class', 'style', 'id'],
+        // SVG container
         'svg': ['xmlns', 'viewBox', 'width', 'height'],
-        'path': ['d', 'fill', 'stroke'],
+        // SVG presentation attributes (used by Gantt bars, labels, grid lines)
+        'rect': ['x', 'y', 'width', 'height', 'fill', 'stroke', 'stroke-width', 'rx', 'ry', 'opacity'],
+        'line': ['x1', 'y1', 'x2', 'y2', 'stroke', 'stroke-width', 'stroke-dasharray'],
+        'path': ['d', 'fill', 'stroke', 'stroke-width', 'stroke-dasharray', 'fill-opacity', 'opacity'],
+        'text': ['x', 'y', 'font-family', 'font-size', 'font-weight', 'fill', 'text-anchor', 'dominant-baseline'],
+        'tspan': ['x', 'y', 'dx', 'dy'],
+        'g': ['transform', 'fill', 'stroke', 'opacity'],
+        'marker': ['id', 'markerWidth', 'markerHeight', 'refX', 'refY', 'orient'],
+        'polygon': ['points', 'fill', 'stroke'],
+        'circle': ['cx', 'cy', 'r', 'fill', 'stroke', 'stroke-width', 'opacity'],
+        'defs': [],
       },
       allowedSchemes: ['http', 'https', 'data'],
     })

--- a/server/src/lib/pdfRenderer.ts
+++ b/server/src/lib/pdfRenderer.ts
@@ -39,7 +39,7 @@ export async function generatePdfFromHtml(html: string): Promise<Buffer> {
         ...sanitizeHtml.defaults.allowedAttributes,
         '*': ['class', 'style', 'id'],
         // SVG container
-        'svg': ['xmlns', 'viewBox', 'width', 'height'],
+        'svg': ['xmlns', 'viewBox', 'width', 'height', 'style'],
         // SVG presentation attributes (used by Gantt bars, labels, grid lines)
         'rect': ['x', 'y', 'width', 'height', 'fill', 'stroke', 'stroke-width', 'rx', 'ry', 'opacity'],
         'line': ['x1', 'y1', 'x2', 'y2', 'stroke', 'stroke-width', 'stroke-dasharray'],

--- a/server/src/lib/scopeDocumentRenderer.ts
+++ b/server/src/lib/scopeDocumentRenderer.ts
@@ -280,6 +280,15 @@ tr.overhead-row td { color: #666; }
 .assumption-text { font-size: 8pt; color: #666; line-height: 1.5; }
 .assumption-text p { margin-bottom: 3px; }
 .assumption-text ul { padding-left: 1.2em; }
+@page gantt-page {
+  size: A4 landscape;
+  margin: 40px 48px;
+}
+.gantt-page-section {
+  page: gantt-page;
+  page-break-before: always;
+  padding-top: 4px;
+}
 @media print {
   body { -webkit-print-color-adjust: exact; print-color-adjust: exact; }
   .page-section { page-break-before: always; }
@@ -506,7 +515,7 @@ export function renderScopeDocumentHtml(props: ScopeDocumentProps): string {
       ? ` starting ${formatDate(td.startDate)}`
       : ''
     ganttHtml = `
-  <div class="page-section">
+  <div class="gantt-page-section">
     <div class="section-heading">Project Timeline</div>
     <p style="font-size:12px;color:#6b7280;margin-bottom:12px;">
       Gantt chart showing feature scheduling across ${totalWeeks} weeks${startDateLabel}.

--- a/server/src/lib/scopeDocumentRenderer.ts
+++ b/server/src/lib/scopeDocumentRenderer.ts
@@ -218,8 +218,10 @@ function renderGanttSvg(td: TimelineData): string {
   // Left column separator line (drawn last so it sits on top)
   parts.push(`<line x1="${LABEL_W}" y1="0" x2="${LABEL_W}" y2="${svgH}" stroke="#d1d5db" stroke-width="1"/>`)
 
-  const svg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${svgW} ${svgH}" width="${svgW}" height="${svgH}">${parts.join('')}</svg>`
-  return `<div style="overflow-x:auto; margin: 0 0 16px 0">${svg}</div>`
+  // width="100%" + viewBox lets the SVG scale down to fit the A4 page width
+  // while preserving aspect ratio — prevents truncation on wide timelines
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${svgW} ${svgH}" width="100%" style="display:block; max-width:${svgW}px">${parts.join('')}</svg>`
+  return `<div style="margin: 0 0 16px 0">${svg}</div>`
 }
 
 const CSS = `

--- a/server/src/routes/csv.ts
+++ b/server/src/routes/csv.ts
@@ -17,6 +17,7 @@ const CSV_HEADERS = [
   'HoursEffort', 'DurationDays',
   'Description', 'Assumptions',
   'EpicStatus', 'FeatureStatus', 'StoryStatus',
+  'EpicMode', 'FeatureMode',
 ]
 
 interface CsvRow {
@@ -28,6 +29,8 @@ interface CsvRow {
   EpicStatus: string
   FeatureStatus: string
   StoryStatus: string
+  EpicMode: string
+  FeatureMode: string
   Template: string
   ResourceType: string
   // legacy fields — kept for backwards compat (old CSVs may still have these)
@@ -52,6 +55,8 @@ export interface StagedRow {
   epicStatus: boolean
   featureStatus: boolean
   storyStatus: boolean
+  epicMode: string
+  featureMode: string
   template: string
   resourceType: string
   // legacy fields kept for backwards compat
@@ -118,7 +123,7 @@ router.get('/export-csv', asyncHandler(async (req: AuthRequest, res: Response) =
 
   if (epics.length === 0) {
     // blank template with one example row
-    rows.push(['Task', 'My Epic', 'My Feature', 'My Story', 'My Task', '', 'Developer', '', '', '', '', '', '', ''])
+    rows.push(['Task', 'My Epic', 'My Feature', 'My Story', 'My Task', '', 'Developer', '', '', '', '', '', '', '', '', ''])
   } else {
     for (const epic of epics) {
       // Epic row
@@ -127,6 +132,7 @@ router.get('/export-csv', asyncHandler(async (req: AuthRequest, res: Response) =
         '', '', '', '',
         sanitizeCsvCell(epic.description ?? ''), sanitizeCsvCell(epic.assumptions ?? ''),
         epic.isActive ? 'active' : 'inactive', '', '',
+        epic.featureMode ?? 'sequential', '',
       ])
 
       for (const feature of epic.features) {
@@ -136,6 +142,7 @@ router.get('/export-csv', asyncHandler(async (req: AuthRequest, res: Response) =
           '', '', '', '',
           sanitizeCsvCell(feature.description ?? ''), sanitizeCsvCell(feature.assumptions ?? ''),
           '', feature.isActive ? 'active' : 'inactive', '',
+          '', feature.featureMode ?? 'sequential',
         ])
 
         for (const story of feature.userStories) {
@@ -146,6 +153,7 @@ router.get('/export-csv', asyncHandler(async (req: AuthRequest, res: Response) =
             '', '', '',
             sanitizeCsvCell(story.description ?? ''), sanitizeCsvCell(story.assumptions ?? ''),
             '', '', story.isActive ? 'active' : 'inactive',
+            '', '',
           ])
 
           // Task rows
@@ -159,6 +167,7 @@ router.get('/export-csv', asyncHandler(async (req: AuthRequest, res: Response) =
               sanitizeCsvCell(task.description ?? ''),
               sanitizeCsvCell(task.assumptions ?? ''),
               '', '', '',
+              '', '',
             ])
           }
         }
@@ -225,6 +234,10 @@ router.post('/stage-csv', asyncHandler(async (req: AuthRequest, res: Response) =
     const epicStatus = parseStatus(raw.EpicStatus)
     const featureStatus = parseStatus(raw.FeatureStatus)
     const storyStatus = parseStatus(raw.StoryStatus)
+    const rawEpicMode = raw.EpicMode?.trim().toLowerCase() || 'sequential'
+    const epicMode = (rawEpicMode === 'sequential' || rawEpicMode === 'parallel') ? rawEpicMode : 'sequential'
+    const rawFeatureMode = raw.FeatureMode?.trim().toLowerCase() || 'sequential'
+    const featureMode = (rawFeatureMode === 'sequential' || rawFeatureMode === 'parallel') ? rawFeatureMode : 'sequential'
     const template = raw.Template?.trim() ?? ''
 
     const resourceType = raw.ResourceType?.trim() ?? ''
@@ -275,6 +288,8 @@ router.post('/stage-csv', asyncHandler(async (req: AuthRequest, res: Response) =
       epicStatus,
       featureStatus,
       storyStatus,
+      epicMode,
+      featureMode,
       template,
       resourceType,
       hoursExtraSmall: parseNum(raw.HoursExtraSmall),
@@ -415,6 +430,7 @@ router.post('/import-csv', asyncHandler(async (req: AuthRequest, res: Response) 
               projectId,
               order: epicOrder++,
               isActive: row.type === 'Epic' ? row.epicStatus : true,
+              featureMode: row.type === 'Epic' ? (row.epicMode ?? 'sequential') : 'sequential',
               description: row.type === 'Epic' ? (row.description || null) : null,
               assumptions: row.type === 'Epic' ? (row.assumptions || null) : null,
             },
@@ -426,6 +442,7 @@ router.post('/import-csv', asyncHandler(async (req: AuthRequest, res: Response) 
             where: { id: epic.id },
             data: {
               isActive: row.epicStatus,
+              featureMode: row.epicMode ?? 'sequential',
               ...(row.type === 'Epic' ? {
                 description: row.description || null,
                 assumptions: row.assumptions || null,
@@ -452,6 +469,7 @@ router.post('/import-csv', asyncHandler(async (req: AuthRequest, res: Response) 
               epicId,
               order: featCount,
               isActive: row.type === 'Feature' ? row.featureStatus : true,
+              featureMode: row.type === 'Feature' ? (row.featureMode ?? 'sequential') : 'sequential',
               description: row.type === 'Feature' ? (row.description || null) : null,
               assumptions: row.type === 'Feature' ? (row.assumptions || null) : null,
             },
@@ -462,6 +480,7 @@ router.post('/import-csv', asyncHandler(async (req: AuthRequest, res: Response) 
             where: { id: feature.id },
             data: {
               isActive: row.featureStatus,
+              featureMode: row.featureMode ?? 'sequential',
               ...(row.type === 'Feature' ? {
                 description: row.description || null,
                 assumptions: row.assumptions || null,

--- a/server/src/routes/csv.ts
+++ b/server/src/routes/csv.ts
@@ -66,6 +66,7 @@ export interface StagedRow {
   assumptions: string
   errors: string[]
   warnings: string[]
+  status?: 'new' | 'existing' | 'error'
 }
 
 async function ownedProject(projectId: string, userId: string) {
@@ -293,7 +294,34 @@ router.post('/stage-csv', asyncHandler(async (req: AuthRequest, res: Response) =
   const errorCount = staged.filter(r => r.errors.length > 0).length
   const warningCount = staged.filter(r => r.warnings.length > 0).length
 
-  res.json({ staged, summary: { total: staged.length, errorCount, warningCount } })
+  // Fetch existing epics/features/stories to determine new vs existing status
+  const existingEpics = await prisma.epic.findMany({
+    where: { projectId: req.params.projectId as string },
+    include: {
+      features: {
+        include: { userStories: { select: { name: true } } },
+      }
+    },
+  })
+  const existingKeys = new Set<string>()
+  for (const ep of existingEpics) {
+    existingKeys.add(ep.name.toLowerCase())
+    for (const ft of ep.features) {
+      existingKeys.add(`${ep.name}|||${ft.name}`.toLowerCase())
+      for (const st of ft.userStories) {
+        existingKeys.add(`${ep.name}|||${ft.name}|||${st.name}`.toLowerCase())
+      }
+    }
+  }
+
+  // Annotate each staged row with status
+  const annotatedStaged = staged.map(row => {
+    if (row.errors.length > 0) return { ...row, status: 'error' as const }
+    const key = [row.epic, row.feature, row.story].filter(Boolean).join('|||').toLowerCase()
+    return { ...row, status: existingKeys.has(key) ? 'existing' as const : 'new' as const }
+  })
+
+  res.json({ staged: annotatedStaged, summary: { total: staged.length, errorCount, warningCount } })
 }))
 
 // POST /api/projects/:projectId/backlog/import-csv

--- a/server/src/routes/features.ts
+++ b/server/src/routes/features.ts
@@ -41,10 +41,11 @@ router.post('/', asyncHandler(async (req: AuthRequest, res: Response) => {
 router.put('/:id', asyncHandler(async (req: AuthRequest, res: Response) => {
   const epic = await ownedEpic(req.params.epicId as string, req.userId!)
   if (!epic) { res.status(404).json({ error: 'Epic not found' }); return }
-  const { name, description, assumptions, order, isActive, timelineColour } = req.body
+  const { name, description, assumptions, order, isActive, timelineColour, featureMode } = req.body
   const data: Record<string, unknown> = { name, description, assumptions, order }
   if (isActive !== undefined) data.isActive = isActive
   if (timelineColour !== undefined) data.timelineColour = timelineColour
+  if (featureMode !== undefined) data.featureMode = featureMode
   const feature = await prisma.feature.update({
     where: { id: req.params.id as string, epicId: req.params.epicId as string },
     data,


### PR DESCRIPTION
## Summary

Closes #218, Closes #160, Closes #157, Closes #150

Four independent UI enhancements in one PR.

---

### #218 — Dark mode project description contrast
- Added `dark:text-gray-300` to project card description on the homepage

### #160 — Project Settings: tax rate, tax label, onboarding weeks
- Added **Onboarding weeks** field (weeks at START of project) before Buffer weeks
- Updated Buffer weeks label to clarify it applies to the END of the project
- Added **Tax label** (e.g. GST, VAT) and **Tax rate (%)** fields in a 2-column grid
- All fields already existed in the DB schema and server route — UI only

### #157 — Backlog UX enhancements
- **Feature mode badge:** sequential/parallel pill on each epic row — grey for sequential, blue for parallel, toggles on click
- **Active/inactive toggle:** replaced tiny circle symbol with a styled rounded pill — green "In scope" / grey "Out of scope" with dark mode support
- **CSV import row colouring:** new rows highlighted yellow; existing rows plain; errors stay red. Server `stage-csv` now annotates each row with `status: 'new' | 'existing' | 'error'`

### #150 — Resource Profile: unrated resource warning
- Warning banner on Commercial tab when any resource types have hours but no day rate
- Lists affected resource names and explains they are excluded from cost calculations

---

## Checklist
- [x] `client tsc --noEmit` — 0 errors
- [x] `server tsc --noEmit` — 0 errors
- [x] `server npm test` — 142 tests pass
- [x] Full dark mode coverage on all new UI
