### PR TITLE
feat(#226): backlog dependency tracking — epic & feature deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,8 @@ Day rates per resource type (global defaults + project overrides) and cost colum
 | Timeline & Resource Profile enhancements — person-first model, over-allocation indicators, custom feature colours, onboarding/buffer zones, PNG/CSV export, allocation mode-aware named resources | #164 |
 | Doc Generator v2 — Puppeteer server-side PDF, TipTap rich text editor (all description/assumptions fields), Overview section in scope doc, timezone-aware timestamps on document label and filename | #166 |
 | Doc Generator v2 (continued) — redesigned Documents page (generation panel + document grid), Gantt chart section (server-side SVG), sections metadata on document cards, project name in label/filename, HTML preserved in CSV export for round-trip fidelity | #166 |
+| Quick wins — dark mode description contrast, project settings tax/onboarding fields, backlog feature mode (sequential/parallel) badges, scope toggle pill redesign, CSV import row colouring, unrated resource warning improvements; Gantt PDF sanitize-html fix + landscape page; pin axios to 1.14.0 (supply chain safety) | #220 |
+| Backlog dependency tracking — EpicDependency schema + API (circular dep detection), epic dep hard constraints in timeline scheduler, epic dep arrows on Timeline Gantt, dep selector UI on backlog epic/feature rows, EpicDependsOn/FeatureDependsOn columns in CSV import/export | #228 |
 
 ---
 
@@ -230,7 +232,6 @@ Day rates per resource type (global defaults + project overrides) and cost colum
 ### 🔧 Near-term enhancements
 | # | Title |
 |---|---|
-| [#150](https://github.com/NickMonrad/monrad-estimator/issues/150) | Resource Profile: warn when project resources have no rates applied |
 | [#108](https://github.com/NickMonrad/monrad-estimator/issues/108) | docs: comprehensive functional specification (`docs/FUNCTIONAL_SPEC.md`) |
 | [#109](https://github.com/NickMonrad/monrad-estimator/issues/109) | Global Customer entity (name, description, account code, CRM link) + link to projects |
 | [#57](https://github.com/NickMonrad/monrad-estimator/issues/57) | Template tasks: assumptions + description fields |

--- a/README.md
+++ b/README.md
@@ -243,6 +243,7 @@ Day rates per resource type (global defaults + project overrides) and cost colum
 | [#62](https://github.com/NickMonrad/monrad-estimator/issues/62) | Refactor: flatMap in effort.ts + snapshots.ts |
 | [#19](https://github.com/NickMonrad/monrad-estimator/issues/19) | Apply template button — improve discoverability |
 | [#69](https://github.com/NickMonrad/monrad-estimator/issues/69) | GST configurable rate per project via Project Settings (ex-GST/inc-GST totals already ship in Resource Profile; rate UI missing) |
+| [#229](https://github.com/NickMonrad/monrad-estimator/issues/229) | CSV import: auto-expand template tasks and backfill estimates from template sizing (requires new TemplateSize column) |
 
 ### 🚀 Feature ideas
 | # | Title |

--- a/client/src/components/backlog/FeatureList.tsx
+++ b/client/src/components/backlog/FeatureList.tsx
@@ -9,7 +9,6 @@ import type { EpicColour } from '../../lib/epicColours'
 import StoryList from './StoryList'
 import ApplyTemplateModal from './ApplyTemplateModal'
 import RichTextEditor from '../shared/RichTextEditor'
-
 interface Props {
   epicId: string
   features: Feature[]
@@ -17,9 +16,14 @@ interface Props {
   projectId: string
   hoursPerDay: number
   epicColour?: EpicColour
+  allFeatures?: Array<{ id: string; name: string; epicName: string }>
+  featureDeps?: Array<{ featureId: string; dependsOnId: string }>
+  onAddFeatureDep?: (featureId: string, dependsOnId: string) => void
+  onRemoveFeatureDep?: (featureId: string, dependsOnId: string) => void
+  featureDepError?: string | null
 }
 
-function SortableFeatureItem({ feature, isEditing, expanded, onToggle, onEdit, onCancelEdit, onSave, onDelete, onToggleActive, onToggleFeatureMode, isSaving, onApplyTemplate, resourceTypes, projectId, hoursPerDay, epicColour }: {
+function SortableFeatureItem({ feature, isEditing, expanded, onToggle, onEdit, onCancelEdit, onSave, onDelete, onToggleActive, onToggleFeatureMode, isSaving, onApplyTemplate, resourceTypes, projectId, hoursPerDay, epicColour, allFeatures, featureDeps, onAddFeatureDep, onRemoveFeatureDep, featureDepError }: {
   feature: Feature
   isEditing: boolean
   expanded: boolean
@@ -36,10 +40,16 @@ function SortableFeatureItem({ feature, isEditing, expanded, onToggle, onEdit, o
   projectId: string
   hoursPerDay: number
   epicColour?: EpicColour
+  allFeatures?: Array<{ id: string; name: string; epicName: string }>
+  featureDeps?: Array<{ featureId: string; dependsOnId: string }>
+  onAddFeatureDep?: (featureId: string, dependsOnId: string) => void
+  onRemoveFeatureDep?: (featureId: string, dependsOnId: string) => void
+  featureDepError?: string | null
 }) {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id: 'feature-' + feature.id })
   const style = { transform: CSS.Transform.toString(transform), transition, opacity: isDragging ? 0.4 : undefined }
   const totalHours = feature.userStories.reduce((s, st) => s + st.tasks.reduce((a, t) => a + t.hoursEffort, 0), 0)
+  const [featureDepPickerOpen, setFeatureDepPickerOpen] = useState(false)
 
   return (
     <div ref={setNodeRef} style={style} {...attributes}>
@@ -90,11 +100,56 @@ function SortableFeatureItem({ feature, isEditing, expanded, onToggle, onEdit, o
       {expanded && (
         <StoryList featureId={feature.id} stories={feature.userStories} resourceTypes={resourceTypes} projectId={projectId} hoursPerDay={hoursPerDay} epicColour={epicColour} />
       )}
+      {/* Feature dependency row */}
+      {(featureDeps !== undefined || onAddFeatureDep) && (
+        <div className="flex flex-wrap items-center gap-1 mt-0.5 ml-6" onClick={e => e.stopPropagation()}>
+          {(featureDeps ?? [])
+            .filter(d => d.featureId === feature.id)
+            .map(d => {
+              const depFeature = (allFeatures ?? []).find(f => f.id === d.dependsOnId)
+              const depLabel = depFeature ? `${depFeature.epicName} / ${depFeature.name}` : d.dependsOnId
+              return (
+                <span key={d.dependsOnId} className="inline-flex items-center gap-0.5 text-xs bg-blue-50 dark:bg-blue-900/30 text-blue-600 dark:text-blue-400 px-1.5 py-0.5 rounded">
+                  → {depLabel}
+                  <button onClick={() => onRemoveFeatureDep?.(feature.id, d.dependsOnId)} className="ml-0.5 text-blue-400 hover:text-red-500">×</button>
+                </span>
+              )
+            })}
+          {onAddFeatureDep && (
+            <div className="relative">
+              <button
+                onClick={() => setFeatureDepPickerOpen(v => !v)}
+                className="text-xs text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 border border-dashed border-gray-300 dark:border-gray-600 px-1.5 py-0.5 rounded"
+                title="Add feature dependency"
+              >＋ dep</button>
+              {featureDepPickerOpen && (
+                <div className="absolute top-full left-0 z-50 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-600 rounded shadow-lg py-1 min-w-[200px]">
+                  {(allFeatures ?? [])
+                    .filter(f => f.id !== feature.id && !(featureDeps ?? []).some(d => d.featureId === feature.id && d.dependsOnId === f.id))
+                    .map(f => (
+                      <button
+                        key={f.id}
+                        className="w-full text-left text-xs px-3 py-1.5 hover:bg-gray-50 dark:hover:bg-gray-700 text-gray-700 dark:text-gray-300"
+                        onClick={() => { onAddFeatureDep(feature.id, f.id); setFeatureDepPickerOpen(false) }}
+                      >
+                        <span className="text-gray-400 dark:text-gray-500">{f.epicName} / </span>{f.name}
+                      </button>
+                    ))}
+                  {(allFeatures ?? []).filter(f => f.id !== feature.id && !(featureDeps ?? []).some(d => d.featureId === feature.id && d.dependsOnId === f.id)).length === 0 && (
+                    <span className="text-xs px-3 py-1.5 text-gray-400 block">No features available</span>
+                  )}
+                </div>
+              )}
+            </div>
+          )}
+          {featureDepError && <span className="text-xs text-red-500">{featureDepError}</span>}
+        </div>
+      )}
     </div>
   )
 }
 
-export default function FeatureList({ epicId, features, resourceTypes, projectId, hoursPerDay, epicColour }: Props) {
+export default function FeatureList({ epicId, features, resourceTypes, projectId, hoursPerDay, epicColour, allFeatures, featureDeps, onAddFeatureDep, onRemoveFeatureDep, featureDepError }: Props) {
   const qc = useQueryClient()
   const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set())
   const [adding, setAdding] = useState(false)
@@ -166,6 +221,11 @@ export default function FeatureList({ epicId, features, resourceTypes, projectId
             projectId={projectId}
             hoursPerDay={hoursPerDay}
             epicColour={epicColour}
+            allFeatures={allFeatures}
+            featureDeps={featureDeps}
+            onAddFeatureDep={onAddFeatureDep}
+            onRemoveFeatureDep={onRemoveFeatureDep}
+            featureDepError={featureDepError}
           />
         ))}
       </SortableContext>

--- a/client/src/components/timeline/GanttChart.tsx
+++ b/client/src/components/timeline/GanttChart.tsx
@@ -10,6 +10,7 @@ import type {
   StoryTimelineEntry,
   FeatureDependency,
   StoryDependency,
+  EpicDependency,
   GanttDraggingState,
 } from '../../hooks/useGanttLayout'
 import GanttBar from './GanttBar'
@@ -38,6 +39,7 @@ interface GanttChartProps {
   storyEntries?: StoryTimelineEntry[]
   featureDependencies?: FeatureDependency[]
   storyDependencies?: StoryDependency[]
+  epicDependencies?: EpicDependency[]
   totalWeeks: number
   projectStartDate: Date | null
   onDragFeature: (featureId: string, newStartWeek: number) => void
@@ -46,6 +48,8 @@ interface GanttChartProps {
   onAddStoryDep: (storyId: string, dependsOnId: string) => void
   onRemoveFeatureDep: (featureId: string, dependsOnId: string) => void
   onRemoveStoryDep: (storyId: string, dependsOnId: string) => void
+  onAddEpicDep?: (epicId: string, dependsOnId: string) => void
+  onRemoveEpicDep?: (epicId: string, dependsOnId: string) => void
   editingFeatureId: string | null
   setEditingFeatureId: (id: string | null) => void
   editingStoryId: string | null
@@ -69,6 +73,7 @@ export default function GanttChart({
   storyEntries = [],
   featureDependencies = [],
   storyDependencies = [],
+  epicDependencies = [],
   totalWeeks,
   projectStartDate,
   onDragFeature,
@@ -77,6 +82,8 @@ export default function GanttChart({
   onMoveFeature,
   onUpdateEpicMode,
   onUpdateEpicScheduleMode,
+  onAddEpicDep,
+  onRemoveEpicDep,
   editingFeatureId: _editingFeatureId,
   setEditingFeatureId,
   editingStoryId: _editingStoryId,
@@ -102,7 +109,7 @@ export default function GanttChart({
   // -----------------------------------------------------------------------
   // Layout (rows, positions)
   // -----------------------------------------------------------------------
-  const { rows, rowY, totalHeight } = useGanttLayout(
+  const { rows, rowY, totalHeight, epicGroups } = useGanttLayout(
     entries, storyEntries, totalWeeks, expandedEpics, expandedFeatures,
   )
 
@@ -118,6 +125,19 @@ export default function GanttChart({
     for (const s of storyEntries) m.set(s.storyId, s)
     return m
   }, [storyEntries])
+
+  // epicById: maps epicId → { epicId, startWeek, durationWeeks }
+  const epicById = useMemo(() => {
+    const m = new Map<string, { epicId: string; startWeek: number; durationWeeks: number }>()
+    for (const eg of epicGroups) {
+      const allWeeks = eg.features.flatMap(f => [f.startWeek, f.startWeek + f.durationWeeks])
+      if (allWeeks.length === 0) continue
+      const minWeek = Math.min(...allWeeks)
+      const maxWeek = Math.max(...allWeeks)
+      m.set(eg.epicId, { epicId: eg.epicId, startWeek: minWeek, durationWeeks: maxWeek - minWeek })
+    }
+    return m
+  }, [epicGroups])
 
   // Set of featureIds that have at least one story entry
   const featuresWithStories = useMemo(() => new Set(storyEntries.map(s => s.featureId)), [storyEntries])
@@ -187,6 +207,9 @@ export default function GanttChart({
         onMoveFeature={onMoveFeature}
         onUpdateEpicMode={onUpdateEpicMode}
         onUpdateEpicScheduleMode={onUpdateEpicScheduleMode}
+        epicDependencies={epicDependencies}
+        onAddEpicDep={onAddEpicDep}
+        onRemoveEpicDep={onRemoveEpicDep}
       />
 
       {/* Right SVG area — horizontally scrollable */}
@@ -195,8 +218,10 @@ export default function GanttChart({
           <GanttDependencyArrows
             featureDependencies={featureDependencies}
             storyDependencies={storyDependencies}
+            epicDependencies={epicDependencies}
             featureById={featureById}
             storyById={storyById}
+            epicById={epicById}
             rowY={rowY}
             weekOffset={weekOffset}
             dragging={dragging}

--- a/client/src/components/timeline/GanttDependencyArrows.tsx
+++ b/client/src/components/timeline/GanttDependencyArrows.tsx
@@ -3,9 +3,10 @@ import type {
   StoryTimelineEntry,
   FeatureDependency,
   StoryDependency,
+  EpicDependency,
   GanttDraggingState,
 } from '../../hooks/useGanttLayout'
-import { COL_W, FEAT_ROW_H, STORY_ROW_H, DEP_ARROW_COLOR } from '../../hooks/useGanttLayout'
+import { COL_W, FEAT_ROW_H, STORY_ROW_H, EPIC_ROW_H, DEP_ARROW_COLOR } from '../../hooks/useGanttLayout'
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -22,8 +23,10 @@ function bezierArrow(x1: number, y1: number, x2: number, y2: number): string {
 interface GanttDependencyArrowsProps {
   featureDependencies: FeatureDependency[]
   storyDependencies: StoryDependency[]
+  epicDependencies: EpicDependency[]
   featureById: Map<string, TimelineEntry>
   storyById: Map<string, StoryTimelineEntry>
+  epicById: Map<string, { epicId: string; startWeek: number; durationWeeks: number }>
   rowY: Map<string, number>
   weekOffset: number
   dragging: GanttDraggingState | null
@@ -35,8 +38,10 @@ interface GanttDependencyArrowsProps {
 export default function GanttDependencyArrows({
   featureDependencies,
   storyDependencies,
+  epicDependencies,
   featureById,
   storyById,
+  epicById,
   rowY,
   weekOffset,
   dragging,
@@ -111,6 +116,34 @@ export default function GanttDependencyArrows({
             fill="none"
             markerEnd="url(#arrow)"
             opacity={0.7}
+          />
+        )
+      })}
+
+      {/* Epic dependency arrows */}
+      {epicDependencies.map(dep => {
+        const predEpic = epicById.get(dep.dependsOnId)
+        const succEpic = epicById.get(dep.epicId)
+        if (!predEpic || !succEpic) return null
+
+        const predY = rowY.get(`epic-${dep.dependsOnId}`)
+        const succY = rowY.get(`epic-${dep.epicId}`)
+        if (predY === undefined || succY === undefined) return null
+
+        const x1 = (predEpic.startWeek + weekOffset + predEpic.durationWeeks) * COL_W
+        const y1 = predY + EPIC_ROW_H / 2
+        const x2 = (succEpic.startWeek + weekOffset) * COL_W
+        const y2 = succY + EPIC_ROW_H / 2
+
+        return (
+          <path
+            key={`edep-${dep.dependsOnId}-${dep.epicId}`}
+            d={bezierArrow(x1, y1, x2, y2)}
+            stroke={DEP_ARROW_COLOR}
+            strokeWidth={2}
+            fill="none"
+            markerEnd="url(#arrow)"
+            opacity={0.8}
           />
         )
       })}

--- a/client/src/components/timeline/GanttLabelPanel.tsx
+++ b/client/src/components/timeline/GanttLabelPanel.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react'
 import type { GanttRow } from '../../hooks/useGanttLayout'
 import { EPIC_ROW_H, FEAT_ROW_H, STORY_ROW_H, HEADER_H, LABEL_W } from '../../hooks/useGanttLayout'
 import { getEpicColour } from '../../lib/epicColours'
@@ -17,6 +18,9 @@ interface GanttLabelPanelProps {
   onMoveFeature?: (epicId: string, featureIdx: number, direction: 'up' | 'down') => void
   onUpdateEpicMode?: (epicId: string, featureMode: 'sequential' | 'parallel') => void
   onUpdateEpicScheduleMode?: (epicId: string, scheduleMode: 'sequential' | 'parallel') => void
+  epicDependencies?: Array<{ epicId: string; dependsOnId: string }>
+  onAddEpicDep?: (epicId: string, dependsOnId: string) => void
+  onRemoveEpicDep?: (epicId: string, dependsOnId: string) => void
 }
 
 // ---------------------------------------------------------------------------
@@ -34,7 +38,15 @@ export default function GanttLabelPanel({
   onMoveFeature,
   onUpdateEpicMode,
   onUpdateEpicScheduleMode,
+  epicDependencies = [],
+  onAddEpicDep,
+  onRemoveEpicDep,
 }: GanttLabelPanelProps) {
+  // track which epic row has its dep-picker dropdown open
+  const [depPickerEpicId, setDepPickerEpicId] = useState<string | null>(null)
+
+  // derive the full list of epic rows for the dep dropdown
+  const allEpicRows = rows.filter((r): r is Extract<GanttRow, { type: 'epic' }> => r.type === 'epic')
   return (
     <div
       style={{ width: LABEL_W, flexShrink: 0 }}
@@ -140,6 +152,61 @@ export default function GanttLabelPanel({
                 >
                   {row.epicScheduleMode === 'parallel' ? '⬛' : '⏭'}
                 </button>
+              )}
+              {/* Epic dependency chips + picker */}
+              {onAddEpicDep && (
+                <div
+                  className="flex items-center gap-1 flex-shrink-0 relative"
+                  onClick={e => e.stopPropagation()}
+                >
+                  {/* existing dep chips */}
+                  {epicDependencies
+                    .filter(d => d.epicId === row.epicId)
+                    .map(d => {
+                      const depName = allEpicRows.find(r => r.epicId === d.dependsOnId)?.epicName ?? d.dependsOnId
+                      return (
+                        <span
+                          key={d.dependsOnId}
+                          className="inline-flex items-center gap-0.5 text-xs bg-gray-100 dark:bg-gray-700 text-gray-500 dark:text-gray-400 px-1 py-0.5 rounded"
+                          title={`Depends on: ${depName}`}
+                        >
+                          →{depName.slice(0, 6)}
+                          <button
+                            onClick={() => onRemoveEpicDep?.(row.epicId, d.dependsOnId)}
+                            className="ml-0.5 text-gray-400 hover:text-red-500 leading-none"
+                          >×</button>
+                        </span>
+                      )
+                    })}
+                  {/* add dep button */}
+                  <button
+                    onClick={() => setDepPickerEpicId(prev => prev === row.epicId ? null : row.epicId)}
+                    className="text-xs text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 px-1 leading-none"
+                    title="Add dependency"
+                  >＋</button>
+                  {/* dropdown picker */}
+                  {depPickerEpicId === row.epicId && (
+                    <div className="absolute top-full left-0 z-50 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-600 rounded shadow-lg py-1 min-w-[140px]">
+                      {allEpicRows
+                        .filter(r => r.epicId !== row.epicId && !epicDependencies.some(d => d.epicId === row.epicId && d.dependsOnId === r.epicId))
+                        .map(r => (
+                          <button
+                            key={r.epicId}
+                            className="w-full text-left text-xs px-3 py-1.5 hover:bg-gray-50 dark:hover:bg-gray-700 text-gray-700 dark:text-gray-300"
+                            onClick={() => {
+                              onAddEpicDep(row.epicId, r.epicId)
+                              setDepPickerEpicId(null)
+                            }}
+                          >
+                            {r.epicName}
+                          </button>
+                        ))}
+                      {allEpicRows.filter(r => r.epicId !== row.epicId && !epicDependencies.some(d => d.epicId === row.epicId && d.dependsOnId === r.epicId)).length === 0 && (
+                        <span className="text-xs px-3 py-1.5 text-gray-400 block">No epics available</span>
+                      )}
+                    </div>
+                  )}
+                </div>
               )}
             </div>
           )

--- a/client/src/hooks/useGanttLayout.ts
+++ b/client/src/hooks/useGanttLayout.ts
@@ -23,6 +23,11 @@ export interface StoryDependency {
   dependsOnId: string
 }
 
+export interface EpicDependency {
+  epicId: string
+  dependsOnId: string
+}
+
 export type GanttRow =
   | {
       type: 'epic'

--- a/client/src/pages/BacklogPage.tsx
+++ b/client/src/pages/BacklogPage.tsx
@@ -101,6 +101,60 @@ export default function BacklogPage() {
     onSuccess: invalidate,
   })
 
+  const { data: epicDepsData = [] } = useQuery<Array<{ epicId: string; dependsOnId: string }>>({
+    queryKey: ['epicDeps', projectId],
+    queryFn: () => api.get(`/projects/${projectId}/epic-dependencies`).then(r => r.data),
+    enabled: !!projectId,
+  })
+
+  const [epicDepError, setEpicDepError] = useState<string | null>(null)
+
+  const addEpicDep = useMutation({
+    mutationFn: ({ epicId, dependsOnId }: { epicId: string; dependsOnId: string }) =>
+      api.post(`/projects/${projectId}/epic-dependencies`, { epicId, dependsOnId }).then(r => r.data),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['epicDeps', projectId] })
+      setEpicDepError(null)
+    },
+    onError: (err: unknown) => {
+      const msg = (err as { response?: { data?: { error?: string } } })?.response?.data?.error ?? 'Failed to add dependency'
+      setEpicDepError(msg)
+    },
+  })
+
+  const removeEpicDep = useMutation({
+    mutationFn: ({ epicId, dependsOnId }: { epicId: string; dependsOnId: string }) =>
+      api.delete(`/projects/${projectId}/epic-dependencies/${epicId}/${dependsOnId}`),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['epicDeps', projectId] }),
+  })
+
+  const { data: featureDepsData = [] } = useQuery<Array<{ featureId: string; dependsOnId: string }>>({
+    queryKey: ['feature-deps', projectId],
+    queryFn: () => api.get(`/projects/${projectId}/feature-dependencies`).then(r => r.data),
+    enabled: !!projectId,
+  })
+
+  const [featureDepError, setFeatureDepError] = useState<string | null>(null)
+
+  const addFeatureDepBacklog = useMutation({
+    mutationFn: ({ featureId, dependsOnId }: { featureId: string; dependsOnId: string }) =>
+      api.post(`/projects/${projectId}/feature-dependencies`, { featureId, dependsOnId }).then(r => r.data),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['feature-deps', projectId] })
+      setFeatureDepError(null)
+    },
+    onError: (err: unknown) => {
+      const msg = (err as { response?: { data?: { error?: string } } })?.response?.data?.error ?? 'Failed to add dependency'
+      setFeatureDepError(msg)
+    },
+  })
+
+  const removeFeatureDepBacklog = useMutation({
+    mutationFn: ({ featureId, dependsOnId }: { featureId: string; dependsOnId: string }) =>
+      api.delete(`/projects/${projectId}/feature-dependencies/${featureId}/${dependsOnId}`),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['feature-deps', projectId] }),
+  })
+
   interface Snapshot { id: string; label: string | null; trigger: string; createdAt: string }
   interface Diff { added: string[]; removed: string[]; snapshotAt: string }
 
@@ -279,6 +333,16 @@ export default function BacklogPage() {
                     projectId={projectId!}
                     hoursPerDay={hoursPerDay}
                     epicColour={getEpicColour(index)}
+                    allEpics={tree.map(e => ({ id: e.id, name: e.name }))}
+                    epicDeps={epicDepsData}
+                    onAddEpicDep={(epicId, dependsOnId) => addEpicDep.mutate({ epicId, dependsOnId })}
+                    onRemoveEpicDep={(epicId, dependsOnId) => removeEpicDep.mutate({ epicId, dependsOnId })}
+                    epicDepError={epicDepError}
+                    allFeatures={tree.flatMap(e => e.features.map(f => ({ id: f.id, name: f.name, epicName: e.name })))}
+                    featureDeps={featureDepsData}
+                    onAddFeatureDep={(featureId, dependsOnId) => addFeatureDepBacklog.mutate({ featureId, dependsOnId })}
+                    onRemoveFeatureDep={(featureId, dependsOnId) => removeFeatureDepBacklog.mutate({ featureId, dependsOnId })}
+                    featureDepError={featureDepError}
                   />
                 ))}
 
@@ -396,7 +460,7 @@ export default function BacklogPage() {
   )
 }
 
-function SortableEpicRow({ epic, expanded, onToggle, isEditing, onEdit, onSaveEdit, onCancelEdit, editSaving, onDelete, onToggleActive, onToggleFeatureMode, epicTotalHours, resourceTypes, projectId, hoursPerDay, epicColour }: {
+function SortableEpicRow({ epic, expanded, onToggle, isEditing, onEdit, onSaveEdit, onCancelEdit, editSaving, onDelete, onToggleActive, onToggleFeatureMode, epicTotalHours, resourceTypes, projectId, hoursPerDay, epicColour, allEpics, epicDeps, onAddEpicDep, onRemoveEpicDep, epicDepError, allFeatures, featureDeps, onAddFeatureDep, onRemoveFeatureDep, featureDepError }: {
   epic: Epic
   expanded: boolean
   onToggle: () => void
@@ -413,9 +477,20 @@ function SortableEpicRow({ epic, expanded, onToggle, isEditing, onEdit, onSaveEd
   projectId: string
   hoursPerDay: number
   epicColour: EpicColour
+  allEpics: Array<{ id: string; name: string }>
+  epicDeps: Array<{ epicId: string; dependsOnId: string }>
+  onAddEpicDep: (epicId: string, dependsOnId: string) => void
+  onRemoveEpicDep: (epicId: string, dependsOnId: string) => void
+  epicDepError: string | null
+  allFeatures: Array<{ id: string; name: string; epicName: string }>
+  featureDeps: Array<{ featureId: string; dependsOnId: string }>
+  onAddFeatureDep: (featureId: string, dependsOnId: string) => void
+  onRemoveFeatureDep: (featureId: string, dependsOnId: string) => void
+  featureDepError: string | null
 }) {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id: 'epic-' + epic.id })
   const style = { transform: CSS.Transform.toString(transform), transition, opacity: isDragging ? 0.4 : undefined }
+  const [epicDepPickerOpen, setEpicDepPickerOpen] = useState(false)
 
   return (
     <div ref={setNodeRef} style={style} {...attributes} className={`bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 overflow-hidden border-l-4 ${epicColour.border}`}>
@@ -476,11 +551,63 @@ function SortableEpicRow({ epic, expanded, onToggle, isEditing, onEdit, onSaveEd
               />
             </div>
           )}
+          {/* Epic dependencies row */}
+          <div className="flex flex-wrap items-center gap-1 mt-1 ml-7" onClick={e => e.stopPropagation()}>
+            {epicDeps
+              .filter(d => d.epicId === epic.id)
+              .map(d => {
+                const depName = allEpics.find(e => e.id === d.dependsOnId)?.name ?? d.dependsOnId
+                return (
+                  <span key={d.dependsOnId} className="inline-flex items-center gap-0.5 text-xs bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300 px-1.5 py-0.5 rounded">
+                    → {depName}
+                    <button onClick={() => onRemoveEpicDep(epic.id, d.dependsOnId)} className="ml-0.5 text-gray-400 hover:text-red-500">×</button>
+                  </span>
+                )
+              })}
+            <div className="relative">
+              <button
+                onClick={() => setEpicDepPickerOpen(v => !v)}
+                className="text-xs text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 border border-dashed border-gray-300 dark:border-gray-600 px-1.5 py-0.5 rounded"
+                title="Add epic dependency"
+              >＋ dep</button>
+              {epicDepPickerOpen && (
+                <div className="absolute top-full left-0 z-50 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-600 rounded shadow-lg py-1 min-w-[160px]">
+                  {allEpics
+                    .filter(e => e.id !== epic.id && !epicDeps.some(d => d.epicId === epic.id && d.dependsOnId === e.id))
+                    .map(e => (
+                      <button
+                        key={e.id}
+                        className="w-full text-left text-xs px-3 py-1.5 hover:bg-gray-50 dark:hover:bg-gray-700 text-gray-700 dark:text-gray-300"
+                        onClick={() => { onAddEpicDep(epic.id, e.id); setEpicDepPickerOpen(false) }}
+                      >
+                        {e.name}
+                      </button>
+                    ))}
+                  {allEpics.filter(e => e.id !== epic.id && !epicDeps.some(d => d.epicId === epic.id && d.dependsOnId === e.id)).length === 0 && (
+                    <span className="text-xs px-3 py-1.5 text-gray-400 block">No epics available</span>
+                  )}
+                </div>
+              )}
+            </div>
+            {epicDepError && <span className="text-xs text-red-500">{epicDepError}</span>}
+          </div>
         </div>
       )}
       {expanded && (
         <div className="border-t border-gray-100 dark:border-gray-700 px-3 pb-3 pt-2">
-          <FeatureList epicId={epic.id} features={epic.features} resourceTypes={resourceTypes} projectId={projectId} hoursPerDay={hoursPerDay} epicColour={epicColour} />
+          <FeatureList
+            epicId={epic.id}
+            features={epic.features}
+            resourceTypes={resourceTypes}
+            projectId={projectId}
+            hoursPerDay={hoursPerDay}
+            epicColour={epicColour}
+            allFeatures={allFeatures}
+            featureDeps={featureDeps}
+            onAddFeatureDep={onAddFeatureDep}
+            onRemoveFeatureDep={onRemoveFeatureDep}
+            featureDepError={featureDepError}
+          />
         </div>
       )}
     </div>

--- a/client/src/pages/BacklogPage.tsx
+++ b/client/src/pages/BacklogPage.tsx
@@ -493,7 +493,7 @@ function SortableEpicRow({ epic, expanded, onToggle, isEditing, onEdit, onSaveEd
   const [epicDepPickerOpen, setEpicDepPickerOpen] = useState(false)
 
   return (
-    <div ref={setNodeRef} style={style} {...attributes} className={`bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 overflow-hidden border-l-4 ${epicColour.border}`}>
+    <div ref={setNodeRef} style={style} {...attributes} className={`bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 border-l-4 ${epicColour.border}`}>
       {isEditing ? (
         <div className="p-3">
           <EpicForm

--- a/client/src/pages/TimelinePage.tsx
+++ b/client/src/pages/TimelinePage.tsx
@@ -452,6 +452,32 @@ export default function TimelinePage() {
     },
   })
 
+  const { data: epicDeps = [] } = useQuery<Array<{ epicId: string; dependsOnId: string; epic: { name: string }; dependsOn: { name: string } }>>({
+    queryKey: ['epicDeps', projectId],
+    queryFn: () => api.get(`/projects/${projectId}/epic-dependencies`).then(r => r.data),
+    enabled: !!projectId,
+  })
+
+  const addEpicDep = useMutation({
+    mutationFn: ({ epicId, dependsOnId }: { epicId: string; dependsOnId: string }) =>
+      api.post(`/projects/${projectId}/epic-dependencies`, { epicId, dependsOnId }).then(r => r.data),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['epicDeps', projectId] })
+      qc.invalidateQueries({ queryKey: ['timeline', projectId] })
+      setScheduleStale(true)
+    },
+  })
+
+  const removeEpicDep = useMutation({
+    mutationFn: ({ epicId, dependsOnId }: { epicId: string; dependsOnId: string }) =>
+      api.delete(`/projects/${projectId}/epic-dependencies/${epicId}/${dependsOnId}`),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['epicDeps', projectId] })
+      qc.invalidateQueries({ queryKey: ['timeline', projectId] })
+      setScheduleStale(true)
+    },
+  })
+
   const updateStoryTimeline = useMutation({
     mutationFn: ({ storyId, startWeek, durationWeeks }: { storyId: string; startWeek: number; durationWeeks: number }) =>
       api.put(`/projects/${projectId}/timeline/stories/${storyId}`, { startWeek, durationWeeks }).then(r => r.data),
@@ -902,6 +928,9 @@ export default function TimelinePage() {
                 onRemoveFeatureDep={(featureId, dependsOnId) => removeFeatureDep.mutate({ featureId, dependsOnId })}
                 onAddStoryDep={(storyId, dependsOnId) => addStoryDep.mutate({ storyId, dependsOnId })}
                 onRemoveStoryDep={(storyId, dependsOnId) => removeStoryDep.mutate({ storyId, dependsOnId })}
+                epicDependencies={epicDeps}
+                onAddEpicDep={(epicId, dependsOnId) => addEpicDep.mutate({ epicId, dependsOnId })}
+                onRemoveEpicDep={(epicId, dependsOnId) => removeEpicDep.mutate({ epicId, dependsOnId })}
                 editingFeatureId={editingFeatureId}
                 setEditingFeatureId={setEditingFeatureId}
                 editingStoryId={editingStoryId}

--- a/e2e/TESTS.md
+++ b/e2e/TESTS.md
@@ -74,7 +74,7 @@ API-level tests using the `request` fixture. No browser UI involved.
 
 ---
 
-### `backlog.spec.ts` — Backlog (11 tests)
+### `backlog.spec.ts` — Backlog (13 tests)
 
 #### `Backlog` describe block (8 tests)
 
@@ -96,6 +96,13 @@ API-level tests using the `request` fixture. No browser UI involved.
 | export includes Type column and status columns at end | Seeds data via old-format CSV import, then exports and verifies: `Type` is column 0; `EpicStatus`, `FeatureStatus`, `StoryStatus` are the last 3 columns; all 4 row types (Epic/Feature/Story/Task) are present; the Epic row has `active` in `EpicStatus` and empty `FeatureStatus`/`StoryStatus` |
 | import with status columns — inactive epic/feature visible after import | Imports a new-format CSV with `EpicStatus=inactive`, `FeatureStatus=inactive`, `StoryStatus=active`, and a plain Task row; asserts the backlog renders the imported epic (inactive items shown with strikethrough but still visible) |
 | staging warns when EpicStatus is set on a Task row (wrong type) | Uploads a CSV with a Task row that has `EpicStatus=inactive`; after automatic staging, verifies the yellow warning panel appears with text "Warnings (import will still proceed):" and the message "EpicStatus is only applied on Epic rows" |
+
+#### `Dependencies` describe block (2 tests — PR #228 / issue #226)
+
+| Test | Description |
+|------|-------------|
+| CSV export includes EpicDependsOn and FeatureDependsOn columns | Seeds a project with one epic + feature via CSV import, exports the backlog CSV, and asserts that both `EpicDependsOn` and `FeatureDependsOn` column headers are present in the exported file |
+| epic rows on backlog page show Add dep button | Creates a project, adds one epic via the UI, and asserts the `＋ dep` button (`title="Add epic dependency"`) is visible on the epic row — confirming the dependency UI is rendered on the Backlog page |
 
 ---
 

--- a/e2e/tests/backlog.spec.ts
+++ b/e2e/tests/backlog.spec.ts
@@ -501,3 +501,62 @@ test.describe('CSV redesign — Type column and status fields', () => {
   // is already covered by the existing test in the 'Backlog' describe block above:
   //   "durationDays is auto-calculated from hoursEffort on CSV import"
 })
+
+// ─── Dependencies (PR #228 / issue #226) ────────────────────────────────────
+test.describe('Dependencies', () => {
+  test('CSV export includes EpicDependsOn and FeatureDependsOn columns', async ({ page }) => {
+    const PROJ = `E2E Dep CSV Export ${Date.now()}`
+    await login(page)
+    await createProject(page, PROJ)
+    await page.getByRole('heading', { name: PROJ, exact: true }).first().click()
+    await page.getByRole('button', { name: /backlog/i }).waitFor()
+    await page.getByRole('button', { name: /backlog/i }).click()
+
+    // Seed one epic + feature via CSV import so the export has real hierarchy rows
+    const csv = [
+      'Type,Epic,Feature,Story,Task,Template,ResourceType,HoursEffort,DurationDays,Description,Assumptions,EpicStatus,FeatureStatus,StoryStatus,EpicMode,FeatureMode,EpicDependsOn,FeatureDependsOn',
+      'Epic,E2E DepEpic,,,,,,,,,,active,,,sequential,,, ',
+      'Feature,E2E DepEpic,E2E DepFeature,,,,,,,,,,,,,sequential,,',
+    ].join('\n')
+    const tmpFile = path.join(os.tmpdir(), `csv-dep-export-${Date.now()}.csv`)
+    fs.writeFileSync(tmpFile, csv)
+
+    await page.getByRole('button', { name: /import csv/i }).click()
+    const fileInput = page.locator('input[type="file"]')
+    await fileInput.setInputFiles(tmpFile)
+    fs.unlinkSync(tmpFile)
+
+    await page.getByRole('button', { name: /review & confirm/i }).click({ timeout: 10_000 })
+    await page.getByRole('button', { name: /import backlog/i }).click({ timeout: 10_000 })
+    await expect(page.getByText('E2E DepEpic')).toBeVisible({ timeout: 10_000 })
+
+    // Export and verify that both new dependency columns are present in the header
+    const downloadPromise = page.waitForEvent('download')
+    await page.getByRole('button', { name: /export csv/i }).click()
+    const download = await downloadPromise
+    const exportPath = await download.path()
+    const content = fs.readFileSync(exportPath!, 'utf-8')
+    const headerCols = content.trim().split(/\r?\n/)[0].split(',').map(c => c.trim())
+
+    expect(headerCols).toContain('EpicDependsOn')
+    expect(headerCols).toContain('FeatureDependsOn')
+  })
+
+  test('epic rows on backlog page show Add dep button', async ({ page }) => {
+    const PROJ = `E2E Dep UI ${Date.now()}`
+    await login(page)
+    await createProject(page, PROJ)
+    await page.getByRole('heading', { name: PROJ, exact: true }).first().click()
+    await page.getByRole('button', { name: /backlog/i }).waitFor()
+    await page.getByRole('button', { name: /backlog/i }).click()
+
+    // Add an epic so the epic row is rendered
+    await page.getByRole('button', { name: /add epic/i }).click()
+    await page.getByPlaceholder(/epic name/i).fill('E2E Dep UI Epic')
+    await page.getByRole('button', { name: /save epic/i }).click()
+    await expect(page.getByText('E2E Dep UI Epic')).toBeVisible({ timeout: 8_000 })
+
+    // The "＋ dep" button (title="Add epic dependency") must be visible on the epic row
+    await expect(page.getByTitle('Add epic dependency').first()).toBeVisible({ timeout: 8_000 })
+  })
+})

--- a/server/prisma/migrations/20260427050951_add_epic_dependency/migration.sql
+++ b/server/prisma/migrations/20260427050951_add_epic_dependency/migration.sql
@@ -1,0 +1,14 @@
+-- CreateTable
+CREATE TABLE "EpicDependency" (
+    "epicId" TEXT NOT NULL,
+    "dependsOnId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "EpicDependency_pkey" PRIMARY KEY ("epicId","dependsOnId")
+);
+
+-- AddForeignKey
+ALTER TABLE "EpicDependency" ADD CONSTRAINT "EpicDependency_epicId_fkey" FOREIGN KEY ("epicId") REFERENCES "Epic"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "EpicDependency" ADD CONSTRAINT "EpicDependency_dependsOnId_fkey" FOREIGN KEY ("dependsOnId") REFERENCES "Epic"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -159,10 +159,22 @@ model Epic {
   project           Project  @relation(fields: [projectId], references: [id], onDelete: Cascade)
   projectId         String
   features          Feature[]
+  epicDependencies  EpicDependency[]  @relation("EpicDeps")
+  epicDependents    EpicDependency[]  @relation("EpicDepsOn")
   createdAt         DateTime @default(now())
   updatedAt         DateTime @updatedAt
 
   @@index([projectId, order])
+}
+
+model EpicDependency {
+  epic        Epic     @relation("EpicDeps", fields: [epicId], references: [id], onDelete: Cascade)
+  epicId      String
+  dependsOn   Epic     @relation("EpicDepsOn", fields: [dependsOnId], references: [id], onDelete: Cascade)
+  dependsOnId String
+  createdAt   DateTime @default(now())
+
+  @@id([epicId, dependsOnId])
 }
 
 model Feature {

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -25,6 +25,7 @@ import discountRoutes from './routes/discounts.js'
 import overheadRoutes from './routes/overhead.js'
 import resourceProfileRoutes from './routes/resourceProfile.js'
 import featureDependenciesRouter from './routes/featureDependencies.js'
+import epicDependenciesRouter from './routes/epicDependencies.js'
 import rateCardRoutes, { applyRateCardRouter } from './routes/rateCards.js'
 import namedResourceRoutes from './routes/namedResources.js'
 import orgRoutes from './routes/orgs.js'
@@ -67,6 +68,7 @@ app.use('/api/projects/:projectId/overhead', overheadRoutes)
 app.use('/api/projects/:projectId/resource-profile', resourceProfileRoutes)
 app.use('/api/projects/:projectId/resource-types/:rtId/named-resources', namedResourceRoutes)
 app.use('/api/projects/:projectId/feature-dependencies', featureDependenciesRouter)
+app.use('/api/projects/:projectId/epic-dependencies', epicDependenciesRouter)
 app.use('/api/rate-cards', rateCardRoutes)
 app.use('/api/projects/:projectId/apply-rate-card', applyRateCardRouter)
 app.use('/api/projects/:projectId/documents', documentRoutes)

--- a/server/src/routes/csv.ts
+++ b/server/src/routes/csv.ts
@@ -18,6 +18,7 @@ const CSV_HEADERS = [
   'Description', 'Assumptions',
   'EpicStatus', 'FeatureStatus', 'StoryStatus',
   'EpicMode', 'FeatureMode',
+  'EpicDependsOn', 'FeatureDependsOn',
 ]
 
 interface CsvRow {
@@ -31,6 +32,8 @@ interface CsvRow {
   StoryStatus: string
   EpicMode: string
   FeatureMode: string
+  EpicDependsOn: string
+  FeatureDependsOn: string
   Template: string
   ResourceType: string
   // legacy fields — kept for backwards compat (old CSVs may still have these)
@@ -57,6 +60,8 @@ export interface StagedRow {
   storyStatus: boolean
   epicMode: string
   featureMode: string
+  epicDependsOn: string[]   // array of epic names
+  featureDependsOn: string[]  // array of feature names
   template: string
   resourceType: string
   // legacy fields kept for backwards compat
@@ -121,9 +126,32 @@ router.get('/export-csv', asyncHandler(async (req: AuthRequest, res: Response) =
 
   const rows: string[][] = [CSV_HEADERS]
 
+  // Build dependency lookup maps for export
+  const epicDepsRaw = await prisma.epicDependency.findMany({
+    where: { epic: { projectId: req.params.projectId as string } },
+    include: { dependsOn: { select: { name: true } } },
+  })
+  const epicDepNames = new Map<string, string[]>()
+  for (const d of epicDepsRaw) {
+    const arr = epicDepNames.get(d.epicId) ?? []
+    arr.push(d.dependsOn.name)
+    epicDepNames.set(d.epicId, arr)
+  }
+
+  const featureDepsRaw = await prisma.featureDependency.findMany({
+    where: { feature: { epic: { projectId: req.params.projectId as string } } },
+    include: { dependsOn: { select: { name: true } } },
+  })
+  const featureDepNames = new Map<string, string[]>()
+  for (const d of featureDepsRaw) {
+    const arr = featureDepNames.get(d.featureId) ?? []
+    arr.push(d.dependsOn.name)
+    featureDepNames.set(d.featureId, arr)
+  }
+
   if (epics.length === 0) {
     // blank template with one example row
-    rows.push(['Task', 'My Epic', 'My Feature', 'My Story', 'My Task', '', 'Developer', '', '', '', '', '', '', '', '', ''])
+    rows.push(['Task', 'My Epic', 'My Feature', 'My Story', 'My Task', '', 'Developer', '', '', '', '', '', '', '', '', '', '', ''])
   } else {
     for (const epic of epics) {
       // Epic row
@@ -133,6 +161,7 @@ router.get('/export-csv', asyncHandler(async (req: AuthRequest, res: Response) =
         sanitizeCsvCell(epic.description ?? ''), sanitizeCsvCell(epic.assumptions ?? ''),
         epic.isActive ? 'active' : 'inactive', '', '',
         epic.featureMode ?? 'sequential', '',
+        epicDepNames.get(epic.id)?.join(', ') ?? '', '',
       ])
 
       for (const feature of epic.features) {
@@ -143,6 +172,7 @@ router.get('/export-csv', asyncHandler(async (req: AuthRequest, res: Response) =
           sanitizeCsvCell(feature.description ?? ''), sanitizeCsvCell(feature.assumptions ?? ''),
           '', feature.isActive ? 'active' : 'inactive', '',
           '', feature.featureMode ?? 'sequential',
+          '', featureDepNames.get(feature.id)?.join(', ') ?? '',
         ])
 
         for (const story of feature.userStories) {
@@ -153,6 +183,7 @@ router.get('/export-csv', asyncHandler(async (req: AuthRequest, res: Response) =
             '', '', '',
             sanitizeCsvCell(story.description ?? ''), sanitizeCsvCell(story.assumptions ?? ''),
             '', '', story.isActive ? 'active' : 'inactive',
+            '', '',
             '', '',
           ])
 
@@ -167,6 +198,7 @@ router.get('/export-csv', asyncHandler(async (req: AuthRequest, res: Response) =
               sanitizeCsvCell(task.description ?? ''),
               sanitizeCsvCell(task.assumptions ?? ''),
               '', '', '',
+              '', '',
               '', '',
             ])
           }
@@ -240,6 +272,16 @@ router.post('/stage-csv', asyncHandler(async (req: AuthRequest, res: Response) =
     const featureMode = (rawFeatureMode === 'sequential' || rawFeatureMode === 'parallel') ? rawFeatureMode : 'sequential'
     const template = raw.Template?.trim() ?? ''
 
+    const epicDependsOn = (raw.EpicDependsOn ?? '')
+      .split(',')
+      .map(s => s.trim())
+      .filter(Boolean)
+
+    const featureDependsOn = (raw.FeatureDependsOn ?? '')
+      .split(',')
+      .map(s => s.trim())
+      .filter(Boolean)
+
     const resourceType = raw.ResourceType?.trim() ?? ''
 
     const errors: string[] = []
@@ -290,6 +332,8 @@ router.post('/stage-csv', asyncHandler(async (req: AuthRequest, res: Response) =
       storyStatus,
       epicMode,
       featureMode,
+      epicDependsOn,
+      featureDependsOn,
       template,
       resourceType,
       hoursExtraSmall: parseNum(raw.HoursExtraSmall),
@@ -305,6 +349,22 @@ router.post('/stage-csv', asyncHandler(async (req: AuthRequest, res: Response) =
       warnings,
     }
   })
+
+  // Cross-row dependency name validation (warnings only — import still proceeds)
+  const knownEpicNames = new Set(staged.filter(r => r.type === 'Epic').map(r => r.epic))
+  const knownFeatureNames = new Set(staged.filter(r => r.type === 'Feature').map(r => r.feature))
+  for (const row of staged) {
+    for (const depName of row.epicDependsOn) {
+      if (!knownEpicNames.has(depName)) {
+        row.warnings.push(`EpicDependsOn: '${depName}' not found in this import`)
+      }
+    }
+    for (const depName of row.featureDependsOn) {
+      if (!knownFeatureNames.has(depName)) {
+        row.warnings.push(`FeatureDependsOn: '${depName}' not found in this import`)
+      }
+    }
+  }
 
   const errorCount = staged.filter(r => r.errors.length > 0).length
   const warningCount = staged.filter(r => r.warnings.length > 0).length
@@ -579,6 +639,50 @@ router.post('/import-csv', asyncHandler(async (req: AuthRequest, res: Response) 
           },
         })
         tasksUpdated++
+      }
+    }
+
+    // ── Epic dependencies ─────────────────────────────────────────────────────
+    // Build name→id map from what was just created/updated
+    const epicNameToId = new Map<string, string>()
+    for (const [epicKey, epicId] of epicMap.entries()) {
+      epicNameToId.set(epicKey, epicId)
+    }
+    for (const row of rows) {
+      if (row.type !== 'Epic' || !row.epicDependsOn?.length) continue
+      const epicId = epicNameToId.get(row.epic)
+      if (!epicId) continue
+      for (const depName of row.epicDependsOn) {
+        const depEpicId = epicNameToId.get(depName)
+        if (!depEpicId || depEpicId === epicId) continue
+        await tx.epicDependency.upsert({
+          where: { epicId_dependsOnId: { epicId, dependsOnId: depEpicId } },
+          create: { epicId, dependsOnId: depEpicId },
+          update: {},
+        })
+      }
+    }
+
+    // ── Feature dependencies ──────────────────────────────────────────────────
+    // Build name→id map from what was just created/updated
+    const featureNameToId = new Map<string, string>()
+    for (const [featureKey, featureId] of featureMap.entries()) {
+      // featureKey is "epicName||featureName" — extract just the feature name
+      const featureName = featureKey.split('||')[1]
+      if (featureName) featureNameToId.set(featureName, featureId)
+    }
+    for (const row of rows) {
+      if (row.type !== 'Feature' || !row.featureDependsOn?.length) continue
+      const featureId = featureMap.get(`${row.epic}||${row.feature}`)
+      if (!featureId) continue
+      for (const depName of row.featureDependsOn) {
+        const depFeatureId = featureNameToId.get(depName)
+        if (!depFeatureId || depFeatureId === featureId) continue
+        await tx.featureDependency.upsert({
+          where: { featureId_dependsOnId: { featureId, dependsOnId: depFeatureId } },
+          create: { featureId, dependsOnId: depFeatureId },
+          update: {},
+        })
       }
     }
 

--- a/server/src/routes/epicDependencies.ts
+++ b/server/src/routes/epicDependencies.ts
@@ -1,0 +1,115 @@
+import { Router, Response } from 'express'
+import { prisma } from '../lib/prisma.js'
+import { asyncHandler } from '../lib/asyncHandler.js'
+import { authenticate, AuthRequest } from '../middleware/auth.js'
+
+const router = Router({ mergeParams: true })
+router.use(authenticate)
+
+async function ownedProject(projectId: string, userId: string) {
+  return prisma.project.findFirst({ where: { id: projectId, ownerId: userId } })
+}
+
+/** DFS-based cycle detection. Returns true if `targetId` can reach `startId` following existing deps. */
+async function wouldCreateCycle(epicId: string, dependsOnId: string): Promise<boolean> {
+  // We're about to add edge: epicId → dependsOnId (epicId depends on dependsOnId)
+  // A cycle exists if dependsOnId already transitively depends on epicId
+  // i.e., can we reach epicId starting from dependsOnId?
+  const visited = new Set<string>()
+  const stack = [dependsOnId]
+  while (stack.length > 0) {
+    const current = stack.pop()!
+    if (current === epicId) return true
+    if (visited.has(current)) continue
+    visited.add(current)
+    const deps = await prisma.epicDependency.findMany({
+      where: { epicId: current },
+      select: { dependsOnId: true },
+    })
+    for (const d of deps) stack.push(d.dependsOnId)
+  }
+  return false
+}
+
+// GET /api/projects/:projectId/epic-dependencies
+router.get('/', asyncHandler(async (req: AuthRequest, res: Response) => {
+  const project = await ownedProject(req.params.projectId as string, req.userId!)
+  if (!project) { res.status(404).json({ error: 'Project not found' }); return }
+
+  const deps = await prisma.epicDependency.findMany({
+    where: {
+      epic: { projectId: project.id },
+    },
+    include: {
+      epic: { select: { id: true, name: true } },
+      dependsOn: { select: { id: true, name: true } },
+    },
+  })
+  res.json(deps)
+}))
+
+// POST /api/projects/:projectId/epic-dependencies
+router.post('/', asyncHandler(async (req: AuthRequest, res: Response) => {
+  const project = await ownedProject(req.params.projectId as string, req.userId!)
+  if (!project) { res.status(404).json({ error: 'Project not found' }); return }
+
+  const { epicId, dependsOnId } = req.body
+  if (!epicId || !dependsOnId) {
+    res.status(400).json({ error: 'epicId and dependsOnId are required' }); return
+  }
+  if (epicId === dependsOnId) {
+    res.status(400).json({ error: 'An epic cannot depend on itself' }); return
+  }
+
+  // Validate both epics belong to this project
+  const [epicRecord, dependsOnRecord] = await Promise.all([
+    prisma.epic.findFirst({ where: { id: epicId, projectId: project.id } }),
+    prisma.epic.findFirst({ where: { id: dependsOnId, projectId: project.id } }),
+  ])
+  if (!epicRecord) { res.status(400).json({ error: 'epicId does not belong to this project' }); return }
+  if (!dependsOnRecord) { res.status(400).json({ error: 'dependsOnId does not belong to this project' }); return }
+
+  // Return existing dependency with 200 if already exists
+  const existing = await prisma.epicDependency.findUnique({
+    where: { epicId_dependsOnId: { epicId, dependsOnId } },
+    include: {
+      epic: { select: { id: true, name: true } },
+      dependsOn: { select: { id: true, name: true } },
+    },
+  })
+  if (existing) {
+    res.status(200).json(existing); return
+  }
+
+  // Check for circular dependency before inserting
+  if (await wouldCreateCycle(epicId, dependsOnId)) {
+    res.status(400).json({ error: 'This dependency would create a circular reference' }); return
+  }
+
+  const dep = await prisma.epicDependency.create({
+    data: { epicId, dependsOnId },
+    include: {
+      epic: { select: { id: true, name: true } },
+      dependsOn: { select: { id: true, name: true } },
+    },
+  })
+  res.status(201).json(dep)
+}))
+
+// DELETE /api/projects/:projectId/epic-dependencies/:epicId/:dependsOnId
+router.delete('/:epicId/:dependsOnId', asyncHandler(async (req: AuthRequest, res: Response) => {
+  const project = await ownedProject(req.params.projectId as string, req.userId!)
+  if (!project) { res.status(404).json({ error: 'Project not found' }); return }
+
+  await prisma.epicDependency.delete({
+    where: {
+      epicId_dependsOnId: {
+        epicId: req.params.epicId as string,
+        dependsOnId: req.params.dependsOnId as string,
+      },
+    },
+  })
+  res.json({ message: 'Deleted' })
+}))
+
+export default router

--- a/server/src/routes/timeline.ts
+++ b/server/src/routes/timeline.ts
@@ -117,6 +117,7 @@ function buildResponse(
   }> = [],
   featureDeps: Array<{ featureId: string; dependsOnId: string }> = [],
   storyDeps: Array<{ storyId: string; dependsOnId: string }> = [],
+  epicDeps: Array<{ epicId: string; dependsOnId: string }> = [],
   resourceTypes: ResourceTypeWithNamed[] = [],
   simulatedDemand?: Map<string, number>,  // key: `${rtName}|${week}` → days consumed
 ) {
@@ -273,6 +274,7 @@ function buildResponse(
     storyEntries,
     featureDependencies: featureDeps,
     storyDependencies: storyDeps,
+    epicDependencies: epicDeps,
     weeklyDemand,
     weeklyCapacity,
     namedResources: namedResourcesList,
@@ -437,6 +439,10 @@ router.get('/', asyncHandler(async (req: AuthRequest, res: Response) => {
     where: { featureId: { in: allFeatureIds } },
     select: { featureId: true, dependsOnId: true },
   })
+  const epicDependencies = await prisma.epicDependency.findMany({
+    where: { epic: { projectId: project.id } },
+    select: { epicId: true, dependsOnId: true },
+  })
   const activeFeatureIdSet = new Set(allFeatureIds)
   const activeStoryTimelineEntries = storyTimelineEntries.filter(e => activeFeatureIdSet.has(e.story.featureId))
   const allStoryIds = activeStoryTimelineEntries.map(e => e.storyId)
@@ -456,7 +462,7 @@ router.get('/', asyncHandler(async (req: AuthRequest, res: Response) => {
   const simulatedDemand = project.weeklyDemandCache
     ? new Map<string, number>(Object.entries(project.weeklyDemandCache as Record<string, number>))
     : undefined
-  res.json(buildResponse(project, activeEntries, parallelWarnings, mappedStoryEntries, featureDependencies, storyDependencies, resourceTypes, simulatedDemand))
+  res.json(buildResponse(project, activeEntries, parallelWarnings, mappedStoryEntries, featureDependencies, storyDependencies, epicDependencies, resourceTypes, simulatedDemand))
 }))
 
 // POST /api/projects/:projectId/timeline/schedule
@@ -558,6 +564,12 @@ router.post('/schedule', asyncHandler(async (req: AuthRequest, res: Response) =>
   })
   const manualStoryWeeks = new Map(existingStoryEntries.map(e => [e.storyId, e.startWeek]))
 
+  // Load epic dependencies for hard constraint edges in the topological sort
+  const epicDeps = await prisma.epicDependency.findMany({
+    where: { epic: { projectId: project.id } },
+    select: { epicId: true, dependsOnId: true },
+  })
+
   // Kahn's topological sort over features
   const inDegree = new Map<string, number>()
   const adjList = new Map<string, string[]>()   // from → [to, ...]
@@ -632,6 +644,19 @@ router.post('/schedule', asyncHandler(async (req: AuthRequest, res: Response) =>
   for (const f of allFeatures) {
     for (const dep of (f.dependencies ?? [])) {
       addEdge(dep.dependsOnId, dep.featureId)
+    }
+  }
+
+  // 4. Epic dependency hard constraints
+  //    All features of dependsOn epic → all features of dependent epic
+  for (const epicDep of epicDeps) {
+    const fromEpic = epics.find(e => e.id === epicDep.dependsOnId)
+    const toEpic = epics.find(e => e.id === epicDep.epicId)
+    if (!fromEpic || !toEpic) continue
+    for (const fromFeature of fromEpic.features) {
+      for (const toFeature of toEpic.features) {
+        addEdge(fromFeature.id, toFeature.id)
+      }
     }
   }
 
@@ -1055,6 +1080,10 @@ router.post('/schedule', asyncHandler(async (req: AuthRequest, res: Response) =>
     where: { featureId: { in: allFeatureIds } },
     select: { featureId: true, dependsOnId: true },
   })
+  const epicDependenciesForResponse = await prisma.epicDependency.findMany({
+    where: { epic: { projectId: project.id } },
+    select: { epicId: true, dependsOnId: true },
+  })
   const allStoryIds = storyTimelineEntries.map(e => e.storyId)
   const storyDependencies = await prisma.storyDependency.findMany({
     where: { storyId: { in: allStoryIds } },
@@ -1076,7 +1105,7 @@ router.post('/schedule', asyncHandler(async (req: AuthRequest, res: Response) =>
     data: { weeklyDemandCache: Object.fromEntries(weeklyConsumptionMap) },
   })
 
-  res.json(buildResponse(project, entries, parallelWarnings, mappedStoryEntries, featureDependencies, storyDependencies, resourceTypes, weeklyConsumptionMap))
+  res.json(buildResponse(project, entries, parallelWarnings, mappedStoryEntries, featureDependencies, storyDependencies, epicDependenciesForResponse, resourceTypes, weeklyConsumptionMap))
 }))
 
 // PUT /api/projects/:projectId/timeline/stories/:storyId — manual story timeline override

--- a/server/src/test/setup.ts
+++ b/server/src/test/setup.ts
@@ -27,6 +27,7 @@ vi.mock('../lib/prisma.js', () => ({
     projectOverhead: { findMany: vi.fn(), findFirst: vi.fn(), create: vi.fn(), update: vi.fn(), delete: vi.fn(), deleteMany: vi.fn() },
     timelineEntry: { findFirst: vi.fn(), findMany: vi.fn(), findUnique: vi.fn(), create: vi.fn(), update: vi.fn(), upsert: vi.fn(), delete: vi.fn(), deleteMany: vi.fn() },
     featureDependency: { findMany: vi.fn().mockResolvedValue([]), create: vi.fn(), delete: vi.fn() },
+    epicDependency: { findMany: vi.fn().mockResolvedValue([]), findUnique: vi.fn().mockResolvedValue(null), create: vi.fn(), delete: vi.fn() },
     storyDependency: { findMany: vi.fn().mockResolvedValue([]), create: vi.fn(), upsert: vi.fn().mockResolvedValue({}), delete: vi.fn(), deleteMany: vi.fn() },
     storyTimelineEntry: { findMany: vi.fn().mockResolvedValue([]), findFirst: vi.fn(), upsert: vi.fn().mockResolvedValue({}), deleteMany: vi.fn() },
     backlogSnapshot: { findFirst: vi.fn(), findMany: vi.fn(), findUnique: vi.fn(), create: vi.fn(), update: vi.fn(), delete: vi.fn() },


### PR DESCRIPTION
## Summary

Implements full dependency tracking for epics and features. Closes #226

---

## What's included

### Schema & API
- New `EpicDependency` model (junction table with cascade deletes)
- `GET/POST/DELETE /api/projects/:id/epic-dependencies` routes
- Circular dependency detection (DFS) on create — returns 400 if cycle detected
- Prisma migration: `20260427050951_add_epic_dependency`

### Timeline Scheduler
- Epic dep hard constraints added to topological sort: all features of `dependsOn` epic must finish before any feature of the dependent epic starts
- `epicDependencies` returned in timeline response JSON

### Timeline Page UI
- Epic→epic dependency arrows rendered on Gantt chart (bezier curves, same style as feature dep arrows)
- Inline dep UI on each epic row in `GanttLabelPanel`: `→ EpicName ×` chips + `＋` dropdown picker
- `addEpicDep` / `removeEpicDep` mutations — invalidates both `epicDeps` and `timeline` queries on change

### Backlog Page UI
- Epic rows: dependency chips + picker (calls epic-dependencies API)
- Feature rows: dependency chips + picker (calls feature-dependencies API)
- Circular dep attempts show inline error message

### CSV Import/Export
- New columns: `EpicDependsOn`, `FeatureDependsOn` (comma-separated names)
- Export: populates from DB dependency records
- Stage: parses + warns on unresolved names (not errors)
- Import: resolves names → IDs and upserts dependency records after hierarchy is created

---

## Checklist
- [x] `npx tsc --noEmit` passes in both `/server` and `/client`
- [x] 142/142 server tests passing
- [x] Servers restarted and smoke-tested locally
- [ ] E2E tests
- [ ] README update