### PR TITLE
fix: paginate Gantt chart in PDF export to show all epics/features

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@ Day rates per resource type (global defaults + project overrides) and cost colum
 | Quick wins — dark mode description contrast, project settings tax/onboarding fields, backlog feature mode (sequential/parallel) badges, scope toggle pill redesign, CSV import row colouring, unrated resource warning improvements; Gantt PDF sanitize-html fix + landscape page; pin axios to 1.14.0 (supply chain safety) | #220 |
 | Backlog dependency tracking — EpicDependency schema + API (circular dep detection), epic dep hard constraints in timeline scheduler, epic dep arrows on Timeline Gantt, dep selector UI on backlog epic/feature rows, EpicDependsOn/FeatureDependsOn columns in CSV import/export | #228 |
 | Timeline scale toggle (week/month/quarter/year), cross-epic FeatureDependsOn in CSV, TemplateSize column in backlog CSV for template task auto-expand; Year scale (H1/H2 top row, Q1–Q4 bottom row); allocation mode/% + timeline start/end weeks in Resource Counts; Expand All / Collapse All toggle; dep picker search filter; top scrollbar mirror; full-width Gantt layout; named resource per-person T&M histogram; onboarding/buffer zone calc fix; auto-reschedule prevention on resource changes | #231 |
+| Document export — paginate Project Timeline Gantt across multiple A4-landscape pages so all epics and features are visible on large projects (previously clipped to the first ~3-4 epics) | #238 |
 
 ---
 

--- a/server/src/lib/scopeDocumentRenderer.ts
+++ b/server/src/lib/scopeDocumentRenderer.ts
@@ -99,23 +99,91 @@ interface TimelineData {
   onboardingWeeks: number
 }
 
-function renderGanttSvg(td: TimelineData): string {
-  const ROW_H = 28
-  const LABEL_W = 200
-  const COL_W = 28
-  const HEADER_H = 40
-  const EPIC_HEADER_H = 24
-  const PAD = 2
+const GANTT_DIMS = {
+  ROW_H: 28,
+  LABEL_W: 200,
+  COL_W: 28,
+  HEADER_H: 40,
+  EPIC_HEADER_H: 24,
+  PAD: 2,
+} as const
 
+// A4 landscape printable area in CSS px (Puppeteer default 96dpi):
+//   width  ≈ 297mm ≈ 1123px, minus ~80px horizontal margins ≈ 1043px
+//   height ≈ 210mm ≈  794px, minus ~80px vertical margins   ≈  714px
+// We budget less than the full content height so the page heading and
+// intro paragraph still fit alongside the chart on the first page,
+// and to leave a safety margin against rounding/scaling drift.
+const GANTT_PRINT_WIDTH_PX = 1043
+const GANTT_PRINT_HEIGHT_PX = 600
+
+interface GanttEpicGroup {
+  epicName: string
+  epicOrder: number
+  features: GanttEntry[]
+}
+
+interface GanttChunkGroup {
+  epicName: string
+  features: GanttEntry[]
+  isContinuation: boolean
+}
+
+/**
+ * Split epic groups into page-sized chunks for the PDF Gantt chart.
+ *
+ * The renderer produces one SVG per chunk; each chunk is rendered on its
+ * own A4-landscape page so all epics/features are visible in the export.
+ * If an epic has more features than fit on a single page, it is split
+ * across consecutive pages with continuation pages flagged so the label
+ * can show "(continued)".
+ */
+function chunkEpicGroups(epicsArr: GanttEpicGroup[], rowsPerPage: number): GanttChunkGroup[][] {
+  const chunks: GanttChunkGroup[][] = []
+  let current: GanttChunkGroup[] = []
+  let usedRows = 0
+
+  for (const ep of epicsArr) {
+    let remaining = ep.features.slice()
+    let isContinuation = false
+
+    while (remaining.length > 0) {
+      const epicHeaderCost = 1
+      const available = rowsPerPage - usedRows - epicHeaderCost
+      if (available <= 0) {
+        if (current.length > 0) chunks.push(current)
+        current = []
+        usedRows = 0
+        continue
+      }
+      const take = Math.min(remaining.length, available)
+      current.push({ epicName: ep.epicName, features: remaining.slice(0, take), isContinuation })
+      usedRows += epicHeaderCost + take
+      remaining = remaining.slice(take)
+      isContinuation = true
+      if (remaining.length > 0) {
+        chunks.push(current)
+        current = []
+        usedRows = 0
+      }
+    }
+  }
+  if (current.length > 0) chunks.push(current)
+  return chunks
+}
+
+function renderGanttSvgs(td: TimelineData): string[] {
+  const { ROW_H, LABEL_W, COL_W, HEADER_H, EPIC_HEADER_H, PAD } = GANTT_DIMS
   const entries = td.entries ?? []
-  if (entries.length === 0) return ''
+  if (entries.length === 0) return []
 
-  // Compute total weeks
+  // Compute total weeks once — shared across all chunks so the time header
+  // is identical on every page.
   const maxEnd = Math.max(...entries.map(e => e.startWeek + e.durationWeeks))
   const totalWeeks = Math.max(4, Math.ceil(maxEnd) + 1)
 
   // Group by epic (sorted by epicOrder, features by featureOrder)
-  const epicMap = new Map<string, { epicName: string; epicOrder: number; features: GanttEntry[] }>()
+  const epicMap = new Map<string, GanttEpicGroup>()
   for (const e of entries) {
     if (!epicMap.has(e.epicId)) epicMap.set(e.epicId, { epicName: e.epicName, epicOrder: e.epicOrder, features: [] })
     epicMap.get(e.epicId)!.features.push(e)
@@ -123,12 +191,42 @@ function renderGanttSvg(td: TimelineData): string {
   const epicsArr = [...epicMap.values()].sort((a, b) => a.epicOrder - b.epicOrder)
   for (const ep of epicsArr) ep.features.sort((a, b) => a.featureOrder - b.featureOrder)
 
-  // Compute dimensions
-  const totalRows = epicsArr.reduce((acc, ep) => acc + 1 + ep.features.length, 0)
   const svgW = LABEL_W + totalWeeks * COL_W
+  // Width-fit scale used by the browser when rendering the SVG at width=100%.
+  // Height grows linearly with rows × ROW_H, so once the scaled height exceeds
+  // the printable area the rest is clipped — we chunk to avoid that.
+  const widthScale = Math.min(1, GANTT_PRINT_WIDTH_PX / svgW)
+  const availableContentPx = GANTT_PRINT_HEIGHT_PX / widthScale
+  const rowsPerPage = Math.max(8, Math.floor((availableContentPx - HEADER_H) / ROW_H))
+
+  const chunks = chunkEpicGroups(epicsArr, rowsPerPage)
+  return chunks.map(chunk => renderGanttSvgChunk(td, totalWeeks, chunk, svgW, {
+    ROW_H, LABEL_W, COL_W, HEADER_H, EPIC_HEADER_H, PAD,
+  }))
+}
+
+interface GanttChunkDims {
+  ROW_H: number
+  LABEL_W: number
+  COL_W: number
+  HEADER_H: number
+  EPIC_HEADER_H: number
+  PAD: number
+}
+
+function renderGanttSvgChunk(
+  td: TimelineData,
+  totalWeeks: number,
+  chunk: GanttChunkGroup[],
+  svgW: number,
+  dims: GanttChunkDims,
+): string {
+  const { ROW_H, LABEL_W, COL_W, HEADER_H, EPIC_HEADER_H, PAD } = dims
+
+  // Each group contributes 1 epic-header row + N feature rows.
+  const totalRows = chunk.reduce((acc, g) => acc + 1 + g.features.length, 0)
   const svgH = HEADER_H + totalRows * ROW_H
 
-  // Date helpers
   function weekToDate(week: number): Date | null {
     if (!td.startDate) return null
     const d = new Date(td.startDate)
@@ -206,10 +304,11 @@ function renderGanttSvg(td: TimelineData): string {
   // Render epic groups and feature rows
   let currentY = HEADER_H
 
-  for (const ep of epicsArr) {
+  for (const ep of chunk) {
+    const epicLabel = ep.isContinuation ? `${ep.epicName} (continued)` : ep.epicName
     // Epic header row
     parts.push(`<rect x="0" y="${currentY}" width="${svgW}" height="${EPIC_HEADER_H}" fill="#f9fafb" stroke="#e5e7eb" stroke-width="1"/>`)
-    parts.push(`<text x="8" y="${currentY + EPIC_HEADER_H / 2 + 4}" font-family="Inter, Helvetica, Arial, sans-serif" font-size="11" font-weight="600" fill="#374151">${esc(ep.epicName)}</text>`)
+    parts.push(`<text x="8" y="${currentY + EPIC_HEADER_H / 2 + 4}" font-family="Inter, Helvetica, Arial, sans-serif" font-size="11" font-weight="600" fill="#374151">${esc(epicLabel)}</text>`)
     currentY += EPIC_HEADER_H
 
     // Feature rows
@@ -532,14 +631,18 @@ export function renderScopeDocumentHtml(props: ScopeDocumentProps): string {
     const startDateLabel = td.startDate
       ? ` starting ${formatDate(td.startDate)}`
       : ''
-    ganttHtml = `
+    // Render the Gantt as one or more A4-landscape pages so all epics and
+    // features are visible. The first page carries the heading + intro;
+    // subsequent pages just show the next slice of the chart.
+    const svgChunks = renderGanttSvgs(td)
+    ganttHtml = svgChunks.map((svg, i) => `
   <div class="gantt-page-section">
-    <div class="section-heading">Project Timeline</div>
-    <p style="font-size:12px;color:#6b7280;margin-bottom:12px;">
+    <div class="section-heading">Project Timeline${i === 0 ? '' : ' (continued)'}</div>
+    ${i === 0 ? `<p style="font-size:12px;color:#6b7280;margin-bottom:12px;">
       Gantt chart showing feature scheduling across ${totalWeeks} weeks${startDateLabel}.
-    </p>
-    ${renderGanttSvg(td)}
-  </div>`
+    </p>` : ''}
+    ${svg}
+  </div>`).join('')
   }
 
   return `<!DOCTYPE html>

--- a/server/src/test/scopeDocumentRenderer.test.ts
+++ b/server/src/test/scopeDocumentRenderer.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, vi } from 'vitest'
+
+// The global test setup mocks this module to avoid pulling in heavy
+// rendering deps in unrelated tests; here we want the real implementation.
+vi.unmock('../lib/scopeDocumentRenderer.js')
+
+const { renderScopeDocumentHtml } = await vi.importActual<typeof import('../lib/scopeDocumentRenderer.js')>(
+  '../lib/scopeDocumentRenderer.js'
+)
+
+interface GanttFixtureEntry {
+  featureId: string
+  featureName: string
+  epicId: string
+  epicName: string
+  epicOrder: number
+  featureOrder: number
+  startWeek: number
+  durationWeeks: number
+  timelineColour: string | null
+}
+
+function buildEntries(epicCount: number, featuresPerEpic: number): GanttFixtureEntry[] {
+  const entries: GanttFixtureEntry[] = []
+  for (let e = 0; e < epicCount; e++) {
+    for (let f = 0; f < featuresPerEpic; f++) {
+      entries.push({
+        featureId: `e${e}-f${f}`,
+        featureName: `Feature ${e}.${f}`,
+        epicId: `epic-${e}`,
+        epicName: `Epic ${e}`,
+        epicOrder: e,
+        featureOrder: f,
+        startWeek: f,
+        durationWeeks: 2,
+        timelineColour: '#3b82f6',
+      })
+    }
+  }
+  return entries
+}
+
+function buildProps(entries: GanttFixtureEntry[]) {
+  return {
+    project: {
+      name: 'Test Project',
+      customer: null,
+      description: null,
+      startDate: '2025-01-01',
+      endDate: null,
+    },
+    sections: {
+      cover: false,
+      scope: false,
+      effort: false,
+      timeline: false,
+      resourceProfile: false,
+      assumptions: false,
+      ganttChart: true,
+    },
+    effortData: null,
+    timelineData: {
+      startDate: '2025-01-01',
+      projectedEndDate: null,
+      entries,
+      bufferWeeks: 0,
+      onboardingWeeks: 0,
+    },
+    resourceProfileData: null,
+    epics: [],
+    generatedBy: 'tester',
+    documentLabel: 'doc',
+  }
+}
+
+function countOccurrences(haystack: string, needle: string): number {
+  let count = 0
+  let idx = 0
+  while ((idx = haystack.indexOf(needle, idx)) !== -1) {
+    count++
+    idx += needle.length
+  }
+  return count
+}
+
+const PAGE_DIV = '<div class="gantt-page-section">'
+
+describe('renderScopeDocumentHtml — Gantt chart pagination', () => {
+  it('renders a single page when all rows fit', () => {
+    const html = renderScopeDocumentHtml(buildProps(buildEntries(2, 3)))
+    expect(countOccurrences(html, PAGE_DIV)).toBe(1)
+    // Project Timeline heading appears exactly once (no continued)
+    expect(countOccurrences(html, 'Project Timeline</div>')).toBe(1)
+    expect(html).not.toContain('(continued)')
+  })
+
+  it('splits the chart across multiple pages when there are many features', () => {
+    // 30 epics × 10 features = 300 rows — far exceeds a single A4 landscape page
+    const html = renderScopeDocumentHtml(buildProps(buildEntries(30, 10)))
+    const pageSections = countOccurrences(html, PAGE_DIV)
+    expect(pageSections).toBeGreaterThan(1)
+    // Continuation heading appears on every page after the first
+    expect(countOccurrences(html, 'Project Timeline (continued)')).toBe(pageSections - 1)
+    // Every epic name shows up in the rendered output (none are dropped)
+    for (let e = 0; e < 30; e++) {
+      expect(html).toContain(`Epic ${e}`)
+    }
+    // Every feature name shows up in the rendered output (none are dropped)
+    for (let e = 0; e < 30; e++) {
+      for (let f = 0; f < 10; f++) {
+        expect(html).toContain(`Feature ${e}.${f}`)
+      }
+    }
+  })
+
+  it('flags an epic split across pages with "(continued)"', () => {
+    // One epic with enough features to overflow a single page
+    const html = renderScopeDocumentHtml(buildProps(buildEntries(1, 200)))
+    expect(countOccurrences(html, PAGE_DIV)).toBeGreaterThan(1)
+    // "(continued)" appears on the epic header for split pages, alongside the
+    // section heading continuation marker
+    expect(html).toContain('Epic 0 (continued)')
+  })
+
+  it('returns a single page section when the chart is empty', () => {
+    const html = renderScopeDocumentHtml(buildProps([]))
+    // Empty entries → no Gantt rendered at all
+    expect(html).not.toContain(PAGE_DIV)
+  })
+})


### PR DESCRIPTION
## Problem
The Project Timeline Gantt chart in document PDF exports was clipped to only the first ~3-4 epics for large projects (e.g. Coles AI Factory with 23 epics × 248 features). Most epics and features were silently dropped from the export.

## Root cause
The Gantt was rendered as a single SVG with `width="100%"`. Puppeteer width-fit scaled it to A4 landscape (~1043px CSS px), so its height grew proportional to row count × 28px. Once the scaled height exceeded the printable page height, anything beyond the first page was clipped — SVG elements don't break across PDF pages.

## Fix
Split the chart into multiple A4-landscape pages, each rendered as a self-contained SVG with its own time-axis header. Continuation pages are marked with **Project Timeline (continued)** and an epic that spans a page break has **(continued)** appended to its label.

- Refactored `renderGanttSvg` → `renderGanttSvgs` (returns array of per-page SVGs)
- Added `chunkEpicGroups` helper that splits epic groups across pages, handling intra-epic splits
- Added `renderGanttSvgChunk` for rendering one page's SVG with full time-axis header
- `rowsPerPage` is computed dynamically from the width-fit scale, so wider charts (more weeks) automatically allow more rows per page in original-pixel units
- Each chunk uses the existing `.gantt-page-section` CSS class which already has `page-break-before: always` for landscape `@page gantt-page` — so each chunk lands on its own page

## Tests
- 4 new unit tests in `server/src/test/scopeDocumentRenderer.test.ts` covering:
  - Single-page case (no continuation)
  - Multi-page case (30 epics × 10 features) — every epic/feature name appears
  - Intra-epic split (1 epic × 200 features) — `Epic 0 (continued)` appears
  - Empty entries (no Gantt rendered)
- All **186 server tests pass** (`npm test` in /server)
- TypeScript clean (`tsc --noEmit`)

## Backwards compatibility
Existing single-page projects render identically (one chunk, no '(continued)'). No client-side changes — the data shape sent to the server is unchanged.

## Manual verification recommended
After merge, regenerate a PDF for a Coles-sized project and confirm all epics + features now appear across the multi-page Gantt.