### PR TITLE
fix(#253): align commercial days with actual allocations

### DIFF
--- a/client/src/utils/financialCalculations.test.ts
+++ b/client/src/utils/financialCalculations.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, it } from 'vitest'
+import { computeCommercialData } from './financialCalculations'
+import type { ResourceProfile } from '../types/backlog'
+
+function baseProfile(overrides: Partial<ResourceProfile>): ResourceProfile {
+  return {
+    projectId: 'proj-1',
+    hoursPerDay: 8,
+    projectDurationWeeks: 12,
+    bufferWeeks: 0,
+    onboardingWeeks: 0,
+    resourceRows: [],
+    overheadRows: [],
+    summary: {
+      totalHours: 0,
+      totalDays: 0,
+      totalCost: null,
+      hasCost: true,
+    },
+    ...overrides,
+  }
+}
+
+describe('computeCommercialData', () => {
+  it('uses actual named-resource assignment days by default', () => {
+    const profile = baseProfile({
+      resourceRows: [
+        {
+          resourceTypeId: 'rt-data',
+          name: 'Data, AI & IoT',
+          category: 'ENGINEERING',
+          count: 1,
+          hoursPerDay: 8,
+          dayRate: 1000,
+          totalHours: 488,
+          totalDays: 61,
+          effortDays: 61,
+          allocatedDays: 61,
+          allocationMode: 'TIMELINE',
+          allocationPercent: 100,
+          allocationStartWeek: null,
+          allocationEndWeek: null,
+          derivedStartWeek: 0,
+          derivedEndWeek: 12,
+          estimatedCost: 61000,
+          epics: [],
+          namedResources: [
+            {
+              id: 'nr-data',
+              name: 'Senior Engineer - Data, AI & IoT',
+              allocationMode: 'TIMELINE',
+              allocationPercent: 100,
+              allocationStartWeek: null,
+              allocationEndWeek: null,
+              startWeek: null,
+              endWeek: null,
+              allocatedDays: 40.36,
+              derivedStartWeek: 4.32,
+              derivedEndWeek: 12.4,
+              actualAllocatedDays: 61,
+              actualAllocationStartWeek: 0,
+              actualAllocationEndWeek: 12,
+              actualAllocatedWeeks: [],
+              actualAllocationSegments: [],
+              synthetic: false,
+            },
+          ],
+        },
+      ],
+    })
+
+    const result = computeCommercialData(profile, [], null)
+
+    expect(result?.rows).toHaveLength(1)
+    expect(result?.rows[0]).toMatchObject({
+      kind: 'named-resource',
+      allocatedDays: 61,
+      totalDays: 61,
+      subtotal: 61000,
+      pricingModel: 'ACTUAL_DAYS',
+    })
+    expect(result?.subtotal).toBe(61000)
+  })
+
+  it('uses planned/pro-rata named-resource days when pricingModel is PRO_RATA', () => {
+    const profile = baseProfile({
+      resourceRows: [
+        {
+          resourceTypeId: 'rt-data',
+          name: 'Data, AI & IoT',
+          category: 'ENGINEERING',
+          count: 1,
+          hoursPerDay: 8,
+          dayRate: 1000,
+          totalHours: 488,
+          totalDays: 61,
+          effortDays: 61,
+          allocatedDays: 61,
+          allocationMode: 'TIMELINE',
+          allocationPercent: 100,
+          allocationStartWeek: null,
+          allocationEndWeek: null,
+          derivedStartWeek: 0,
+          derivedEndWeek: 12,
+          estimatedCost: 61000,
+          epics: [],
+          namedResources: [
+            {
+              id: 'nr-data',
+              name: 'Senior Engineer - Data, AI & IoT',
+              allocationMode: 'TIMELINE',
+              allocationPercent: 100,
+              allocationStartWeek: null,
+              allocationEndWeek: null,
+              startWeek: null,
+              endWeek: null,
+              allocatedDays: 40.36,
+              derivedStartWeek: 4.32,
+              derivedEndWeek: 12.4,
+              actualAllocatedDays: 61,
+              actualAllocationStartWeek: 0,
+              actualAllocationEndWeek: 12,
+              actualAllocatedWeeks: [],
+              actualAllocationSegments: [],
+              synthetic: false,
+              pricingModel: 'PRO_RATA',
+            } as NonNullable<ResourceProfile['resourceRows'][number]['namedResources']>[number] & { pricingModel: 'PRO_RATA' },
+          ],
+        },
+      ],
+    })
+
+    const result = computeCommercialData(profile, [], null)
+
+    expect(result?.rows).toHaveLength(1)
+    expect(result?.rows[0]).toMatchObject({
+      kind: 'named-resource',
+      allocatedDays: 40.36,
+      totalDays: 40.36,
+      subtotal: 40360,
+      pricingModel: 'PRO_RATA',
+    })
+    expect(result?.subtotal).toBe(40360)
+  })
+
+  it('calculates aggregate resource subtotal from the displayed allocated days', () => {
+    const profile = baseProfile({
+      resourceRows: [
+        {
+          resourceTypeId: 'rt-pm',
+          name: 'Project Manager',
+          category: 'PROJECT_MANAGEMENT',
+          count: 1,
+          hoursPerDay: 8,
+          dayRate: 1200,
+          totalHours: 200,
+          totalDays: 25,
+          effortDays: 25,
+          allocatedDays: 40,
+          allocationMode: 'FULL_PROJECT',
+          allocationPercent: 100,
+          allocationStartWeek: null,
+          allocationEndWeek: null,
+          derivedStartWeek: null,
+          derivedEndWeek: null,
+          estimatedCost: 48000,
+          epics: [],
+          namedResources: [],
+        },
+      ],
+    })
+
+    const result = computeCommercialData(profile, [], null)
+
+    expect(result?.rows).toHaveLength(1)
+    expect(result?.rows[0]).toMatchObject({
+      kind: 'resource',
+      allocatedDays: 40,
+      totalDays: 40,
+      subtotal: 48000,
+    })
+    expect(result?.subtotal).toBe(48000)
+  })
+})

--- a/client/src/utils/financialCalculations.ts
+++ b/client/src/utils/financialCalculations.ts
@@ -1,5 +1,7 @@
 import type { ResourceProfile, ProjectDiscount } from '../types/backlog'
 
+type NamedResourcePricingModel = 'ACTUAL_DAYS' | 'PRO_RATA'
+
 export type CommercialRow = {
   id: string
   name: string
@@ -16,6 +18,7 @@ export type CommercialRow = {
   derivedStartWeek: number | null
   derivedEndWeek: number | null
   kind: 'resource' | 'named-resource' | 'overhead'
+  pricingModel: NamedResourcePricingModel | null
   /** For mutations — NR rows need their RT id for the PATCH URL */
   resourceTypeId: string
   appliedDiscounts: Array<{
@@ -42,6 +45,29 @@ export type CommercialData = {
   grandTotal: number
 }
 
+type CostRow = Omit<CommercialRow, 'appliedDiscounts' | 'netSubtotal'>
+
+type ResourceProfileNamedResource = NonNullable<ResourceProfile['resourceRows'][number]['namedResources']>[number]
+
+function getPricingModel(namedResource: ResourceProfileNamedResource): NamedResourcePricingModel {
+  const pricingModel = (namedResource as { pricingModel?: NamedResourcePricingModel }).pricingModel
+  return pricingModel === 'PRO_RATA' ? 'PRO_RATA' : 'ACTUAL_DAYS'
+}
+
+function getNamedResourceBillableDays(namedResource: ResourceProfileNamedResource) {
+  const pricingModel = getPricingModel(namedResource)
+  const billableDays = pricingModel === 'PRO_RATA'
+    ? namedResource.allocatedDays
+    : typeof namedResource.actualAllocatedDays === 'number'
+      ? namedResource.actualAllocatedDays
+      : namedResource.allocatedDays
+
+  return {
+    pricingModel,
+    billableDays,
+  }
+}
+
 /**
  * Pure function that computes the commercial cost breakdown from profile + discounts + project tax config.
  * Extracted from the commercialData useMemo in ResourceProfilePage.
@@ -54,46 +80,48 @@ export function computeCommercialData(
   if (!profile) return null
 
   // All rows (resource + overhead) with day rates
-  const costRows = [
-    ...profile.resourceRows.filter(r => r.dayRate != null).flatMap((r): Array<{
-      id: string; name: string; count: number; effortDays: number; allocatedDays: number;
-      totalDays: number; dayRate: number; subtotal: number; allocationMode: string;
-      allocationPercent: number; allocationStartWeek: number | null; allocationEndWeek: number | null;
-      derivedStartWeek: number | null; derivedEndWeek: number | null;
-      kind: 'named-resource' | 'resource'; resourceTypeId: string;
-    }> => {
+  const costRows: CostRow[] = [
+    ...profile.resourceRows.filter(r => r.dayRate != null).flatMap((r): CostRow[] => {
       if (r.namedResources && r.namedResources.length > 0) {
         // Per-NR rows only — no aggregate row in commercial tab
-        const nrRows = r.namedResources.map(nr => ({
-          id: nr.id,
-          name: nr.name,
-          count: 1,
-          effortDays: nr.allocatedDays,
-          allocatedDays: nr.allocatedDays,
-          totalDays: nr.allocatedDays,
-          dayRate: r.dayRate!,
-          subtotal: nr.allocatedDays * r.dayRate!,
-          allocationMode: nr.allocationMode,
-          allocationPercent: nr.allocationPercent,
-          allocationStartWeek: nr.allocationStartWeek ?? null,
-          allocationEndWeek: nr.allocationEndWeek ?? null,
-          derivedStartWeek: nr.derivedStartWeek ?? r.derivedStartWeek ?? null,
-          derivedEndWeek: nr.derivedEndWeek ?? r.derivedEndWeek ?? null,
-          kind: 'named-resource' as const,
-          resourceTypeId: r.resourceTypeId,
-        }))
+        const nrRows = r.namedResources.map(nr => {
+          const { pricingModel, billableDays } = getNamedResourceBillableDays(nr)
+
+          return {
+            id: nr.id,
+            name: nr.name,
+            count: 1,
+            effortDays: nr.allocatedDays,
+            allocatedDays: billableDays,
+            totalDays: billableDays,
+            dayRate: r.dayRate!,
+            subtotal: billableDays * r.dayRate!,
+            allocationMode: nr.allocationMode,
+            allocationPercent: nr.allocationPercent,
+            allocationStartWeek: nr.allocationStartWeek ?? null,
+            allocationEndWeek: nr.allocationEndWeek ?? null,
+            derivedStartWeek: nr.derivedStartWeek ?? r.derivedStartWeek ?? null,
+            derivedEndWeek: nr.derivedEndWeek ?? r.derivedEndWeek ?? null,
+            kind: 'named-resource' as const,
+            pricingModel,
+            resourceTypeId: r.resourceTypeId,
+          }
+        })
         return nrRows
       }
-      // No NRs — RT-level row as before
+
+      // No NRs — RT-level row as before. Keep subtotal based on the same days
+      // displayed as allocatedDays so commercial rows do not show one basis and bill another.
+      const billableDays = r.allocatedDays ?? r.totalDays
       return [{
         id: r.resourceTypeId,
         name: r.name,
         count: r.count,
         effortDays: r.effortDays ?? r.totalDays,
-        allocatedDays: r.allocatedDays ?? r.totalDays,
-        totalDays: r.totalDays,
+        allocatedDays: billableDays,
+        totalDays: billableDays,
         dayRate: r.dayRate!,
-        subtotal: r.totalDays * r.dayRate!,
+        subtotal: billableDays * r.dayRate!,
         allocationMode: r.allocationMode ?? 'EFFORT',
         allocationPercent: r.allocationPercent ?? 100,
         allocationStartWeek: r.allocationStartWeek ?? null,
@@ -101,6 +129,7 @@ export function computeCommercialData(
         derivedStartWeek: r.derivedStartWeek ?? null,
         derivedEndWeek: r.derivedEndWeek ?? null,
         kind: 'resource' as const,
+        pricingModel: null,
         resourceTypeId: r.resourceTypeId,
       }]
     }),
@@ -120,6 +149,7 @@ export function computeCommercialData(
       derivedStartWeek: null as number | null,
       derivedEndWeek: null as number | null,
       kind: 'overhead' as const,
+      pricingModel: null,
       resourceTypeId: r.overheadId,
     })),
   ]


### PR DESCRIPTION
## Summary

Initial fix for #253.

- Updates `computeCommercialData` so named-resource commercial rows default to actual assigned days (`actualAllocatedDays`) instead of planned/pro-rata days (`allocatedDays`).
- Keeps `PRO_RATA` behaviour available when `pricingModel: 'PRO_RATA'` is present on the named-resource profile row.
- Fixes aggregate/no-person commercial rows so subtotal is calculated from the same day value displayed as `allocatedDays`.
- Adds regression coverage for:
  - actual named-resource days greater than planned/pro-rata days;
  - explicit `PRO_RATA` named-resource behaviour;
  - aggregate resource rows where `allocatedDays !== totalDays`.

## Notes

This is intentionally a first pass on the commercial calculation layer. I did not update the server resource-profile response in this branch yet; if `pricingModel` is not currently included on `ResourceProfileRow.namedResources`, the client will default to `ACTUAL_DAYS`. That fixes the main Timeline/Profile vs Commercial mismatch for actual assignment days, but the `PRO_RATA` UI control still needs the server payload wired through to make that mode observable end-to-end.

## Testing

Not run locally from this environment.
