### PR TITLE
fix: reject durationDays=0 to prevent silent timeline demand loss (#259)

### DIFF
--- a/client/src/components/backlog/TaskList.tsx
+++ b/client/src/components/backlog/TaskList.tsx
@@ -205,7 +205,7 @@ function TaskForm({ initial, resourceTypes, hoursPerDay, onSave, onCancel, savin
         </div>
         <div className="col-span-2">
           <label className="block text-xs text-gray-400 dark:text-gray-500 mb-0.5">Duration override (days) — optional</label>
-          <input type="number" placeholder="Leave blank to use hours/day rate" min="0" step="0.5" value={form.durationDays} onChange={f('durationDays')} className="w-full border border-gray-200 dark:border-gray-600 rounded px-2 py-1 text-xs text-gray-600 dark:text-gray-400 bg-white dark:bg-gray-700 focus:outline-none focus:ring-1 focus:ring-blue-400" />
+          <input type="number" placeholder="Leave blank to use hours/day rate" min="1" step="0.5" value={form.durationDays} onChange={f('durationDays')} className="w-full border border-gray-200 dark:border-gray-600 rounded px-2 py-1 text-xs text-gray-600 dark:text-gray-400 bg-white dark:bg-gray-700 focus:outline-none focus:ring-1 focus:ring-blue-400" />
           {errors.durationDays && <p className="text-xs text-red-500 mt-0.5">{errors.durationDays}</p>}
         </div>
       </div>

--- a/client/src/components/backlog/TaskList.tsx
+++ b/client/src/components/backlog/TaskList.tsx
@@ -145,14 +145,17 @@ function TaskForm({ initial, resourceTypes, hoursPerDay, onSave, onCancel, savin
   saving: boolean
 }) {
   const [form, setForm] = useState(initial)
+  const [errors, setErrors] = useState<Record<string, string>>({})
   const [days, setDays] = useState(
     initial.hoursEffort && parseFloat(initial.hoursEffort) > 0
       ? String(parseFloat((parseFloat(initial.hoursEffort) / hoursPerDay).toFixed(2)))
       : ''
   )
 
-  const f = (field: keyof typeof form) => (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) =>
+  const f = (field: keyof typeof form) => (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
     setForm(v => ({ ...v, [field]: e.target.value }))
+    if (field === 'durationDays') setErrors(v => ({ ...v, durationDays: '' }))
+  }
 
   const onHoursChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const h = e.target.value
@@ -203,10 +206,19 @@ function TaskForm({ initial, resourceTypes, hoursPerDay, onSave, onCancel, savin
         <div className="col-span-2">
           <label className="block text-xs text-gray-400 dark:text-gray-500 mb-0.5">Duration override (days) — optional</label>
           <input type="number" placeholder="Leave blank to use hours/day rate" min="0" step="0.5" value={form.durationDays} onChange={f('durationDays')} className="w-full border border-gray-200 dark:border-gray-600 rounded px-2 py-1 text-xs text-gray-600 dark:text-gray-400 bg-white dark:bg-gray-700 focus:outline-none focus:ring-1 focus:ring-blue-400" />
+          {errors.durationDays && <p className="text-xs text-red-500 mt-0.5">{errors.durationDays}</p>}
         </div>
       </div>
       <div className="flex gap-2">
-        <button onClick={() => onSave(form)} disabled={!form.name || !form.resourceTypeId || saving}
+        <button onClick={() => {
+          const dd = form.durationDays.trim()
+          if (dd && (parseFloat(dd) <= 0 || isNaN(parseFloat(dd)))) {
+            setErrors(v => ({ ...v, durationDays: 'Duration must be at least 1 day' }))
+            return
+          }
+          setErrors({})
+          onSave(form)
+        }} disabled={!form.name || !form.resourceTypeId || saving}
           className="bg-lab3-navy text-white px-3 py-1 rounded text-xs font-medium hover:bg-lab3-blue disabled:opacity-50">
           {saving ? 'Saving…' : 'Save'}
         </button>

--- a/client/src/test/TaskList.test.tsx
+++ b/client/src/test/TaskList.test.tsx
@@ -48,3 +48,56 @@ describe('TaskList', () => {
     expect(screen.getByText(/0\.5d/)).toBeInTheDocument()
   })
 })
+
+describe('TaskList — durationDays validation', () => {
+  it('shows error when saving with duration override of 0', () => {
+    render(<TaskList storyId="s-1" tasks={[]} resourceTypes={resourceTypes} projectId="proj-1" hoursPerDay={7.6} />, { wrapper })
+    fireEvent.click(screen.getByText('+ Add task'))
+    fireEvent.change(screen.getByPlaceholderText('Task name *'), { target: { value: 'Test task' } })
+    const rtSelect = screen.getByRole('combobox')
+    fireEvent.change(rtSelect, { target: { value: 'rt-1' } })
+    const overrideInput = screen.getByPlaceholderText('Leave blank to use hours/day rate')
+    fireEvent.change(overrideInput, { target: { value: '0' } })
+    fireEvent.click(screen.getByText('Save'))
+    expect(screen.getByText('Duration must be at least 1 day')).toBeInTheDocument()
+  })
+
+  it('shows error when saving with negative duration override', () => {
+    render(<TaskList storyId="s-1" tasks={[]} resourceTypes={resourceTypes} projectId="proj-1" hoursPerDay={7.6} />, { wrapper })
+    fireEvent.click(screen.getByText('+ Add task'))
+    fireEvent.change(screen.getByPlaceholderText('Task name *'), { target: { value: 'Test task' } })
+    const rtSelect = screen.getByRole('combobox')
+    fireEvent.change(rtSelect, { target: { value: 'rt-1' } })
+    const overrideInput = screen.getByPlaceholderText('Leave blank to use hours/day rate')
+    fireEvent.change(overrideInput, { target: { value: '-1' } })
+    fireEvent.click(screen.getByText('Save'))
+    expect(screen.getByText('Duration must be at least 1 day')).toBeInTheDocument()
+  })
+
+  it('clears error when duration override is changed after failed validation', () => {
+    render(<TaskList storyId="s-1" tasks={[]} resourceTypes={resourceTypes} projectId="proj-1" hoursPerDay={7.6} />, { wrapper })
+    fireEvent.click(screen.getByText('+ Add task'))
+    const rtSelect = screen.getByRole('combobox')
+    fireEvent.change(rtSelect, { target: { value: 'rt-1' } })
+    fireEvent.change(screen.getByPlaceholderText('Task name *'), { target: { value: 'Test task' } })
+    const overrideInput = screen.getByPlaceholderText('Leave blank to use hours/day rate')
+    fireEvent.change(overrideInput, { target: { value: '0' } })
+    fireEvent.click(screen.getByText('Save'))
+    expect(screen.getByText('Duration must be at least 1 day')).toBeInTheDocument()
+    // Change duration to a valid value — error should clear
+    fireEvent.change(overrideInput, { target: { value: '3' } })
+    expect(screen.queryByText('Duration must be at least 1 day')).not.toBeInTheDocument()
+  })
+
+  it('saves successfully with valid positive duration override', () => {
+    render(<TaskList storyId="s-1" tasks={[]} resourceTypes={resourceTypes} projectId="proj-1" hoursPerDay={7.6} />, { wrapper })
+    fireEvent.click(screen.getByText('+ Add task'))
+    const rtSelect = screen.getByRole('combobox')
+    fireEvent.change(rtSelect, { target: { value: 'rt-1' } })
+    fireEvent.change(screen.getByPlaceholderText('Task name *'), { target: { value: 'Test task' } })
+    const overrideInput = screen.getByPlaceholderText('Leave blank to use hours/day rate')
+    fireEvent.change(overrideInput, { target: { value: '3' } })
+    fireEvent.click(screen.getByText('Save'))
+    expect(screen.queryByText('Duration must be at least 1 day')).not.toBeInTheDocument()
+  })
+})

--- a/server/src/lib/leveller.ts
+++ b/server/src/lib/leveller.ts
@@ -15,6 +15,7 @@ import {
   type SchedulerInput,
   type SchedulerResourceType,
 } from './scheduler.js'
+import { effectiveDays } from '../utils/round.js'
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Types
@@ -88,7 +89,7 @@ export function levelEpicStarts(input: SchedulerInput): LevellingResult {
       for (const [rtId, tasks] of byRt) {
         const personDays = tasks.reduce((sum, t) => {
           const rtHpd = t.resourceType?.hoursPerDay ?? hpd
-          return sum + (t.durationDays ?? (t.hoursEffort / rtHpd))
+          return sum + effectiveDays(t.durationDays, t.hoursEffort, rtHpd)
         }, 0)
         const rawCount = rtId ? (rtCountMap.get(rtId) ?? 1) : 1
         const count = input.maxParallelismPerFeature
@@ -114,7 +115,7 @@ export function levelEpicStarts(input: SchedulerInput): LevellingResult {
         for (const task of story.tasks) {
           if (!task.resourceTypeId) continue
           const rtHpd = task.resourceType?.hoursPerDay ?? hpd
-          const demandDays = task.durationDays ?? (task.hoursEffort / rtHpd)
+          const demandDays = effectiveDays(task.durationDays, task.hoursEffort, rtHpd)
           demandByRt.set(
             task.resourceTypeId,
             (demandByRt.get(task.resourceTypeId) ?? 0) + demandDays,
@@ -252,7 +253,7 @@ export function levelEpicStarts(input: SchedulerInput): LevellingResult {
         for (const task of story.tasks) {
           if (!task.resourceTypeId) continue
           const rtHpd = task.resourceType?.hoursPerDay ?? hpd
-          const demandDays = task.durationDays ?? (task.hoursEffort / rtHpd)
+          const demandDays = effectiveDays(task.durationDays, task.hoursEffort, rtHpd)
           demandByRt.set(task.resourceTypeId, (demandByRt.get(task.resourceTypeId) ?? 0) + demandDays)
         }
       }

--- a/server/src/lib/sa-planner.ts
+++ b/server/src/lib/sa-planner.ts
@@ -13,6 +13,7 @@ import {
   type SchedulerInput,
   type SchedulerResourceType,
 } from './scheduler.js'
+import { effectiveDays } from '../utils/round.js'
 
 // ─── Config ──────────────────────────────────────────────────────────────────
 
@@ -111,7 +112,7 @@ export function runSAPlanner(
         for (const task of story.tasks) {
           if (!task.resourceTypeId) continue
           const rtHpd = task.resourceType?.hoursPerDay ?? hpd
-          const days = task.durationDays ?? (task.hoursEffort / rtHpd)
+          const days = effectiveDays(task.durationDays, task.hoursEffort, rtHpd)
           totalDaysByRt.set(task.resourceTypeId, (totalDaysByRt.get(task.resourceTypeId) ?? 0) + days)
         }
       }

--- a/server/src/lib/scheduler.ts
+++ b/server/src/lib/scheduler.ts
@@ -9,6 +9,7 @@
  * Phase 2 extraction: issue #233
  */
 
+import { effectiveDays } from '../utils/round.js'
 // ─────────────────────────────────────────────────────────────────────────────
 // Input / Output types
 // ─────────────────────────────────────────────────────────────────────────────
@@ -288,7 +289,7 @@ export function computeParallelWarnings(
         for (const task of story.tasks) {
           const rtId = task.resourceTypeId ?? '_unassigned'
           const hpd = task.resourceType?.hoursPerDay ?? fallbackHoursPerDay
-          const days = task.durationDays ?? (task.hoursEffort / hpd)
+          const days = effectiveDays(task.durationDays, task.hoursEffort, hpd)
           if (!demandMap.has(rtId)) {
             demandMap.set(rtId, {
               name: task.resourceType?.name ?? 'Unassigned',
@@ -380,7 +381,7 @@ export function runScheduler(input: SchedulerInput): SchedulerOutput {
       for (const task of tasks) {
         if (!task.resourceTypeId) continue
         const hpd = task.resourceType?.hoursPerDay ?? fallbackHoursPerDay
-        const demand = task.durationDays ?? (task.hoursEffort / hpd)
+        const demand = effectiveDays(task.durationDays, task.hoursEffort, hpd)
         totalDemandByRt.set(
           task.resourceTypeId,
           (totalDemandByRt.get(task.resourceTypeId) ?? 0) + demand,
@@ -418,7 +419,7 @@ export function runScheduler(input: SchedulerInput): SchedulerOutput {
     for (const [rtId, tasks] of byRt) {
       const personDays = tasks.reduce((sum, t) => {
         const hpd = t.resourceType?.hoursPerDay ?? fallbackHoursPerDay
-        return sum + (t.durationDays ?? (t.hoursEffort / hpd))
+        return sum + effectiveDays(t.durationDays, t.hoursEffort, hpd)
       }, 0)
       const count = rtId ? (rtCountMap.get(rtId) ?? 1) : 1
       const days = personDays / count
@@ -597,7 +598,7 @@ export function runScheduler(input: SchedulerInput): SchedulerOutput {
         for (const task of story.tasks) {
           const rtId = task.resourceTypeId ?? '_unassigned'
           const hpd = task.resourceType?.hoursPerDay ?? fallbackHoursPerDay
-          const hours = (task.durationDays ?? (task.hoursEffort / hpd)) * hpd
+          const hours = effectiveDays(task.durationDays, task.hoursEffort, hpd) * hpd
           result.set(rtId, (result.get(rtId) ?? 0) + hours)
         }
       }
@@ -763,7 +764,7 @@ export function runScheduler(input: SchedulerInput): SchedulerOutput {
     for (const task of story.tasks) {
       const rtId = task.resourceTypeId ?? '_unassigned'
       const hpd = task.resourceType?.hoursPerDay ?? fallbackHoursPerDay
-      const hours = (task.durationDays ?? (task.hoursEffort / hpd)) * hpd
+      const hours = effectiveDays(task.durationDays, task.hoursEffort, hpd) * hpd
       result.set(rtId, (result.get(rtId) ?? 0) + hours)
     }
     return result

--- a/server/src/routes/resourceProfile.ts
+++ b/server/src/routes/resourceProfile.ts
@@ -3,6 +3,7 @@ import { ResourceCategory } from '@prisma/client'
 import { prisma } from '../lib/prisma.js'
 import { asyncHandler } from '../lib/asyncHandler.js'
 import { authenticate, AuthRequest } from '../middleware/auth.js'
+import { effectiveDays } from '../utils/round.js'
 import {
   materializeCapacityPlanResources,
   shouldFallbackToActiveCapacityPlan,
@@ -140,7 +141,7 @@ router.get('/', asyncHandler(async (req: AuthRequest, res: Response) => {
           if (!effectiveHoursPerDay) continue
 
           const hours = task.hoursEffort ?? 0
-          const days = task.durationDays ?? (hours / effectiveHoursPerDay)
+          const days = effectiveDays(task.durationDays, hours, effectiveHoursPerDay)
           if (!resourceAgg.has(resourceType.id)) {
             resourceAgg.set(resourceType.id, {
               resourceTypeId: resourceType.id,
@@ -240,7 +241,7 @@ router.get('/', asyncHandler(async (req: AuthRequest, res: Response) => {
               : fallbackHoursPerDay
           if (!effectiveHoursPerDay) continue
 
-          const demandDays = task.durationDays ?? ((task.hoursEffort ?? 0) / effectiveHoursPerDay)
+          const demandDays = effectiveDays(task.durationDays, task.hoursEffort ?? 0, effectiveHoursPerDay)
           const startWeek = entry.startWeek
           const endWeek = entry.startWeek + entry.durationWeeks
           for (let week = Math.floor(startWeek); week < Math.ceil(endWeek); week += 1) {

--- a/server/src/routes/squadPlan.ts
+++ b/server/src/routes/squadPlan.ts
@@ -10,6 +10,7 @@ import { Router, Response } from 'express'
 import { prisma } from '../lib/prisma.js'
 import { asyncHandler } from '../lib/asyncHandler.js'
 import { authenticate, AuthRequest } from '../middleware/auth.js'
+import { effectiveDays } from '../utils/round.js'
 import { ownedProject } from '../lib/ownership.js'
 import { buildSnapshot } from './snapshots.js'
 import { pruneSnapshots } from '../lib/snapshotUtils.js'
@@ -649,7 +650,7 @@ router.post('/apply', asyncHandler(async (req: AuthRequest, res: Response) => {
             for (const task of story.tasks) {
               if (!task.resourceTypeId) continue
               const rtHpd = task.resourceType?.hoursPerDay ?? hpd
-              const days = task.durationDays ?? (task.hoursEffort / rtHpd)
+              const days = effectiveDays(task.durationDays, task.hoursEffort, rtHpd)
               demandByRt.set(task.resourceTypeId, (demandByRt.get(task.resourceTypeId) ?? 0) + days)
             }
           }
@@ -670,7 +671,7 @@ router.post('/apply', asyncHandler(async (req: AuthRequest, res: Response) => {
             for (const task of story.tasks) {
               if (!task.resourceTypeId) continue
               const rtHpd = task.resourceType?.hoursPerDay ?? hpd
-              storyDays += task.durationDays ?? (task.hoursEffort / rtHpd)
+              storyDays += effectiveDays(task.durationDays, task.hoursEffort, rtHpd)
             }
             const proportion = totalFeatureDays > 0 ? storyDays / totalFeatureDays : 0
             const storyDuration = Math.max(1, Math.ceil(span.durationWeeks * proportion))

--- a/server/src/routes/tasks.ts
+++ b/server/src/routes/tasks.ts
@@ -5,6 +5,14 @@ import { authenticate, AuthRequest } from '../middleware/auth.js'
 import { calcDurationDays } from '../utils/round.js'
 import { ownedStory } from '../lib/ownership.js'
 
+function validateDurationDays(value: unknown): string | null {
+  if (value === undefined || value === null) return null
+  if (typeof value !== 'number' || isNaN(value) || value <= 0) {
+    return 'durationDays must be a positive number'
+  }
+  return null
+}
+
 const router = Router({ mergeParams: true })
 router.use(authenticate)
 
@@ -24,16 +32,19 @@ router.get('/', asyncHandler(async (req: AuthRequest, res: Response) => {
 router.post('/', asyncHandler(async (req: AuthRequest, res: Response) => {
   const story = await ownedStory(req.params.storyId as string, req.userId!)
   if (!story) { res.status(404).json({ error: 'Story not found' }); return }
-  const { name, description, assumptions, hoursEffort, resourceTypeId } = req.body
+  const { name, description, assumptions, hoursEffort, resourceTypeId, durationDays } = req.body
   if (!name || !resourceTypeId) { res.status(400).json({ error: 'name and resourceTypeId are required' }); return }
   if (hoursEffort !== undefined && hoursEffort < 0) { res.status(400).json({ error: 'hoursEffort must be non-negative' }); return }
+  const durErr = validateDurationDays(durationDays)
+  if (durErr) { res.status(400).json({ error: durErr }); return }
   const hoursPerDay = story.feature.epic.project.hoursPerDay ?? 7.6
   const count = await prisma.task.count({ where: { userStoryId: req.params.storyId as string } })
+  const resolvedDuration = durationDays !== undefined ? durationDays : calcDurationDays(hoursEffort ?? 0, hoursPerDay)
   const task = await prisma.task.create({
     data: {
       name, description, assumptions,
       hoursEffort: hoursEffort ?? 0,
-      durationDays: calcDurationDays(hoursEffort ?? 0, hoursPerDay),
+      durationDays: resolvedDuration,
       resourceTypeId,
       userStoryId: req.params.storyId as string,
       order: count,
@@ -48,9 +59,8 @@ router.put('/:id', asyncHandler(async (req: AuthRequest, res: Response) => {
   const story = await ownedStory(req.params.storyId as string, req.userId!)
   if (!story) { res.status(404).json({ error: 'Story not found' }); return }
   const { name, description, assumptions, hoursEffort, resourceTypeId, order, durationDays } = req.body
-  if (durationDays !== undefined && durationDays !== null && (typeof durationDays !== 'number' || isNaN(durationDays) || durationDays <= 0)) {
-    res.status(400).json({ error: 'durationDays must be a positive number' }); return
-  }
+  const durErr = validateDurationDays(durationDays)
+  if (durErr) { res.status(400).json({ error: durErr }); return }
   const hoursPerDay = story.feature.epic.project.hoursPerDay ?? 7.6
   const resolvedDuration = durationDays !== undefined ? durationDays
     : hoursEffort !== undefined ? calcDurationDays(hoursEffort, hoursPerDay)

--- a/server/src/routes/tasks.ts
+++ b/server/src/routes/tasks.ts
@@ -48,6 +48,9 @@ router.put('/:id', asyncHandler(async (req: AuthRequest, res: Response) => {
   const story = await ownedStory(req.params.storyId as string, req.userId!)
   if (!story) { res.status(404).json({ error: 'Story not found' }); return }
   const { name, description, assumptions, hoursEffort, resourceTypeId, order, durationDays } = req.body
+  if (durationDays !== undefined && durationDays !== null && (typeof durationDays !== 'number' || isNaN(durationDays) || durationDays <= 0)) {
+    res.status(400).json({ error: 'durationDays must be a positive number' }); return
+  }
   const hoursPerDay = story.feature.epic.project.hoursPerDay ?? 7.6
   const resolvedDuration = durationDays !== undefined ? durationDays
     : hoursEffort !== undefined ? calcDurationDays(hoursEffort, hoursPerDay)

--- a/server/src/routes/timeline.ts
+++ b/server/src/routes/timeline.ts
@@ -2,6 +2,7 @@ import { Router, Response } from 'express'
 import { prisma } from '../lib/prisma.js'
 import { asyncHandler } from '../lib/asyncHandler.js'
 import { authenticate, AuthRequest } from '../middleware/auth.js'
+import { effectiveDays } from '../utils/round.js'
 import {
   runScheduler,
   getWeeklyCapacity,
@@ -58,7 +59,7 @@ function computeResourceBreakdown(
       const key = task.resourceTypeId ?? '_unassigned'
       const name = task.resourceType?.name ?? 'Unassigned'
       const hpd = task.resourceType?.hoursPerDay ?? fallbackHpd
-      const days = task.durationDays ?? (task.hoursEffort / hpd)
+      const days = effectiveDays(task.durationDays, task.hoursEffort, hpd)
       const existing = byRt.get(key) ?? { name, days: 0 }
       byRt.set(key, { name, days: existing.days + days })
     }

--- a/server/src/test/tasks.test.ts
+++ b/server/src/test/tasks.test.ts
@@ -57,3 +57,56 @@ describe('PUT /api/stories/:storyId/tasks/:id', () => {
     expect(res.body.hoursEffort).toBe(8)
   })
 })
+
+describe('PUT /api/stories/:storyId/tasks/:id — durationDays validation', () => {
+  it('rejects durationDays = 0', async () => {
+    vi.mocked(prisma.userStory.findFirst).mockResolvedValue(mockStory as any)
+    const res = await request(app)
+      .put('/api/stories/story-1/tasks/task-1')
+      .set('Authorization', authHeader)
+      .send({ durationDays: 0 })
+    expect(res.status).toBe(400)
+    expect(res.body.error).toContain('positive')
+  })
+
+  it('rejects negative durationDays', async () => {
+    vi.mocked(prisma.userStory.findFirst).mockResolvedValue(mockStory as any)
+    const res = await request(app)
+      .put('/api/stories/story-1/tasks/task-1')
+      .set('Authorization', authHeader)
+      .send({ durationDays: -1 })
+    expect(res.status).toBe(400)
+    expect(res.body.error).toContain('positive')
+  })
+
+  it('rejects NaN durationDays', async () => {
+    vi.mocked(prisma.userStory.findFirst).mockResolvedValue(mockStory as any)
+    const res = await request(app)
+      .put('/api/stories/story-1/tasks/task-1')
+      .set('Authorization', authHeader)
+      .send({ durationDays: 'abc' })
+    expect(res.status).toBe(400)
+  })
+
+  it('accepts null durationDays as valid (auto-compute)', async () => {
+    vi.mocked(prisma.userStory.findFirst).mockResolvedValue(mockStory as any)
+    vi.mocked(prisma.task.update).mockResolvedValue({ ...mockTask, hoursEffort: 4, durationDays: null, resourceType: { name: 'Developer' } } as any)
+    const res = await request(app)
+      .put('/api/stories/story-1/tasks/task-1')
+      .set('Authorization', authHeader)
+      .send({ durationDays: null })
+    expect(res.status).toBe(200)
+    expect(res.body.durationDays).toBeNull()
+  })
+
+  it('accepts positive durationDays', async () => {
+    vi.mocked(prisma.userStory.findFirst).mockResolvedValue(mockStory as any)
+    vi.mocked(prisma.task.update).mockResolvedValue({ ...mockTask, hoursEffort: 4, durationDays: 5, resourceType: { name: 'Developer' } } as any)
+    const res = await request(app)
+      .put('/api/stories/story-1/tasks/task-1')
+      .set('Authorization', authHeader)
+      .send({ durationDays: 5 })
+    expect(res.status).toBe(200)
+    expect(res.body.durationDays).toBe(5)
+  })
+})

--- a/server/src/test/tasks.test.ts
+++ b/server/src/test/tasks.test.ts
@@ -41,6 +41,68 @@ describe('POST /api/stories/:storyId/tasks', () => {
 
     expect(res.status).toBe(400)
   })
+
+  it('rejects durationDays = 0 on create', async () => {
+    vi.mocked(prisma.userStory.findFirst).mockResolvedValue(mockStory as any)
+    const res = await request(app)
+      .post('/api/stories/story-1/tasks')
+      .set('Authorization', authHeader)
+      .send({ name: 'Task', hoursEffort: 4, resourceTypeId: 'rt-1', durationDays: 0 })
+    expect(res.status).toBe(400)
+    expect(res.body.error).toContain('positive')
+  })
+
+  it('rejects negative durationDays on create', async () => {
+    vi.mocked(prisma.userStory.findFirst).mockResolvedValue(mockStory as any)
+    const res = await request(app)
+      .post('/api/stories/story-1/tasks')
+      .set('Authorization', authHeader)
+      .send({ name: 'Task', hoursEffort: 4, resourceTypeId: 'rt-1', durationDays: -1 })
+    expect(res.status).toBe(400)
+    expect(res.body.error).toContain('positive')
+  })
+
+  it('rejects NaN durationDays on create', async () => {
+    vi.mocked(prisma.userStory.findFirst).mockResolvedValue(mockStory as any)
+    const res = await request(app)
+      .post('/api/stories/story-1/tasks')
+      .set('Authorization', authHeader)
+      .send({ name: 'Task', hoursEffort: 4, resourceTypeId: 'rt-1', durationDays: 'abc' })
+    expect(res.status).toBe(400)
+  })
+
+  it('accepts omitted durationDays on create', async () => {
+    vi.mocked(prisma.userStory.findFirst).mockResolvedValue(mockStory as any)
+    vi.mocked(prisma.task.findMany).mockResolvedValue([])
+    vi.mocked(prisma.task.create).mockResolvedValue({ ...mockTask, resourceType: { name: 'Developer' } } as any)
+    const res = await request(app)
+      .post('/api/stories/story-1/tasks')
+      .set('Authorization', authHeader)
+      .send({ name: 'Task', hoursEffort: 4, resourceTypeId: 'rt-1' })
+    expect(res.status).toBe(201)
+  })
+
+  it('accepts null durationDays on create', async () => {
+    vi.mocked(prisma.userStory.findFirst).mockResolvedValue(mockStory as any)
+    vi.mocked(prisma.task.findMany).mockResolvedValue([])
+    vi.mocked(prisma.task.create).mockResolvedValue({ ...mockTask, resourceType: { name: 'Developer' } } as any)
+    const res = await request(app)
+      .post('/api/stories/story-1/tasks')
+      .set('Authorization', authHeader)
+      .send({ name: 'Task', hoursEffort: 4, resourceTypeId: 'rt-1', durationDays: null })
+    expect(res.status).toBe(201)
+  })
+
+  it('accepts positive durationDays on create', async () => {
+    vi.mocked(prisma.userStory.findFirst).mockResolvedValue(mockStory as any)
+    vi.mocked(prisma.task.findMany).mockResolvedValue([])
+    vi.mocked(prisma.task.create).mockResolvedValue({ ...mockTask, resourceType: { name: 'Developer' } } as any)
+    const res = await request(app)
+      .post('/api/stories/story-1/tasks')
+      .set('Authorization', authHeader)
+      .send({ name: 'Task', hoursEffort: 4, resourceTypeId: 'rt-1', durationDays: 3 })
+    expect(res.status).toBe(201)
+  })
 })
 
 describe('PUT /api/stories/:storyId/tasks/:id', () => {

--- a/server/src/utils/round.ts
+++ b/server/src/utils/round.ts
@@ -4,3 +4,15 @@ export const round2 = (n: number): number => Math.round(n * 100) / 100
 /** Calculate task duration in days from effort hours, rounded to 2dp. */
 export const calcDurationDays = (hoursEffort: number, hoursPerDay: number): number =>
   round2(hoursEffort / hoursPerDay)
+
+/**
+ * Get effective days for demand calculation.
+ * Falls through to hours/hpd when durationDays is null, undefined, 0, negative, or NaN.
+ * This provides defensive hardening against invalid persisted data.
+ */
+export const effectiveDays = (
+  durationDays: number | null | undefined,
+  hoursEffort: number,
+  hoursPerDay: number,
+): number =>
+  durationDays && durationDays > 0 ? durationDays : (hoursEffort / hoursPerDay)


### PR DESCRIPTION
## Summary

Three-layer hardening against `durationDays=0` silently removing resource demand from the timeline. Server-side validation catches it at the API boundary on both task create and update, client-side validation prevents the save, and a defensive `effectiveDays()` helper treats invalid duration as fallback-to-hours across all calculation sites.

## Related issue

Closes #259

## Changes

- **Shared validation helper** (`server/src/routes/tasks.ts`): `validateDurationDays()` used by both POST and PUT — rejects `durationDays` ≤ 0, NaN, non-numeric with clear 400 error
- **Server validation for create** (`server/src/routes/tasks.ts`): POST `/stories/:storyId/tasks` now destructures and validates `durationDays` from the request body, using it when valid (falls back to auto-calc from `hoursEffort` when omitted/null)
- **Server validation for update** (`server/src/routes/tasks.ts`): PUT `/stories/:storyId/tasks/:id` now uses the shared helper instead of inline check
- **Client validation** (`client/src/components/backlog/TaskList.tsx`): Save handler checks `durationDays` is > 0; shows inline error *"Duration must be at least 1 day"* and prevents the save. Input `min` changed from `0` to `1`.
- **Defensive helper** (`server/src/utils/round.ts`): `effectiveDays(durationDays, hoursEffort, hoursPerDay)` — returns `durationDays` only when it's a positive number, otherwise `hoursEffort / hoursPerDay`
- **Hardened all 14 calculation sites** across `timeline.ts`, `resourceProfile.ts`, `squadPlan.ts`, `scheduler.ts`, `leveller.ts`, `sa-planner.ts` — each now uses `effectiveDays()`
- **Tests**: 11 new tests — 6 POST validation (rejects 0, negative, NaN; accepts omitted, null, positive), 5 existing PUT validation tests preserved, 4 client duration-override tests

## Testing

- [x] `npm test` passes in `/server` — all 291 tests pass
- [x] `npx tsc --noEmit` passes in `/server`
- [x] `npx tsc --noEmit` passes in `/client`
- [ ] E2E tests not run (locally may require specific setup)

## Notes

- Pre-existing type error in `server/src/lib/pdfRenderer.ts` (TS2322 — unrelated)
- Pre-existing test failures in `authSession.test.tsx` (`localStorage` unavailable in jsdom — unrelated)
- **Do not merge** — keep PR focused on #259 only