### PR TITLE
feat(#264): extract shared project planning read model (partial - Timeline only)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "@tiptap/react": "^3.22.2",
         "@tiptap/starter-kit": "^3.22.2",
         "@types/dompurify": "^3.2.0",
-        "axios": "^1.14.0",
+        "axios": "1.14.0",
         "dompurify": "^3.3.3",
         "html-to-image": "^1.11.13",
         "jszip": "^3.10.1",

--- a/server/src/lib/projectPlanningModel.ts
+++ b/server/src/lib/projectPlanningModel.ts
@@ -1,0 +1,709 @@
+/**
+ * projectPlanningModel.ts — Shared project planning read model.
+ *
+ * Extracts duplicated planning derivation logic from timeline.ts, resourceProfile.ts,
+ * and export paths into one module. Owns planning/capacity-derived facts only:
+ * delivery effort comes from Backlog/Estimation inputs; commercial pricing rules
+ * are out of scope.
+ *
+ * Two entry points:
+ *   1. Pure computation functions (testable without a DB)
+ *   2. buildProjectPlanningModel() — thin data-loading wrapper
+ *
+ * Phase 5 extraction: issue #264 / PR #272
+ */
+
+import { prisma } from './prisma.js'
+import {
+  getWeeklyCapacity,
+  computeParallelWarnings,
+  type ParallelWarning,
+  type SchedulerNamedResource,
+} from './scheduler.js'
+import {
+  materializeCapacityPlanResources,
+  type MaterializedCapacityPlanResource,
+} from './capacityPlanMaterialisation.js'
+import { deriveNamedResourceAssignments } from './namedResourceAssignments.js'
+import { effectiveDays } from '../utils/round.js'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Public Types
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface PlanningWindow {
+  /** Last occupied week (max entry end week + buffer + onboarding) */
+  maxWeek: number | null
+  /** Projected end date as ISO string, or null */
+  projectedEndDate: string | null
+  /** Buffer weeks configured on the project */
+  bufferWeeks: number
+  /** Onboarding weeks configured on the project */
+  onboardingWeeks: number
+}
+
+export interface WeeklyDemandRow {
+  week: number
+  resourceTypeName: string
+  demandDays: number
+  capacityDays: number
+}
+
+export interface WeeklyCapacityRow {
+  week: number
+  resourceTypeName: string
+  capacityDays: number
+}
+
+/** Per-resource-type planning facts derived from resource type + capacity plan */
+export interface ResourceTypePlanningFact {
+  id: string
+  name: string
+  category: string
+  count: number
+  hoursPerDay: number | null
+  dayRate: number | null
+  allocationMode: string | null
+  allocationPercent: number | null
+  allocationStartWeek: number | null
+  allocationEndWeek: number | null
+  namedResources: PlanningNamedResource[]
+  /** Materialized capacity plan data for this RT (undefined if no active plan) */
+  capacityPlanMaterialized: MaterializedCapacityPlanResource | undefined
+}
+
+/** Named resource record with resolved source-record metadata */
+export interface PlanningNamedResource {
+  id: string
+  name: string
+  startWeek: number | null
+  endWeek: number | null
+  allocationMode: string | null
+  allocationPercent: number | null
+  allocationStartWeek: number | null
+  allocationEndWeek: number | null
+  pricingModel: string | null
+  synthetic: boolean
+}
+
+/** A resolved feature timeline entry with display metadata */
+export interface FeatureEntryDetail {
+  featureId: string
+  featureName: string
+  epicId: string
+  epicName: string
+  startWeek: number
+  durationWeeks: number
+  isManual: boolean
+}
+
+/** A resolved story timeline entry with display metadata */
+export interface StoryEntryDetail {
+  storyId: string
+  storyName: string
+  featureId: string
+  startWeek: number
+  durationWeeks: number
+  isManual: boolean
+}
+
+export interface ProjectPlanningModel {
+  /** Project identity */
+  projectId: string
+  startDate: string | null
+  hoursPerDay: number
+
+  /** Planning window derived from entries + buffer/onboarding weeks */
+  planningWindow: PlanningWindow
+
+  /** Weekly demand (cached scheduler demand merged with fallback) */
+  weeklyDemand: WeeklyDemandRow[]
+  /** Weekly capacity for every resource type and week with demand */
+  weeklyCapacity: WeeklyCapacityRow[]
+
+  /** Resource types enriched with capacity-plan facts */
+  resourceTypeFacts: ResourceTypePlanningFact[]
+  /** Materialized capacity plan map (rtId → materialized data) */
+  capacityPlanByRt: Map<string, MaterializedCapacityPlanResource>
+
+  /** Named resource assignments derived from demand + capacity plan */
+  namedResourceAssignments: ReturnType<typeof deriveNamedResourceAssignments>
+
+  /** Planning warnings (e.g. parallel feature conflicts) */
+  parallelWarnings: ParallelWarning[]
+
+  /** Feature timeline entries (active only, with resolved metadata) */
+  entries: FeatureEntryDetail[]
+  /** Story timeline entries (active only, with resolved metadata) */
+  storyEntries: StoryEntryDetail[]
+
+  /** Feature-level dependency edges */
+  featureDependencies: Array<{ featureId: string; dependsOnId: string }>
+  /** Story-level dependency edges */
+  storyDependencies: Array<{ storyId: string; dependsOnId: string }>
+  /** Epic-level dependency edges */
+  epicDependencies: Array<{ epicId: string; dependsOnId: string }>
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Pure computation helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+const weeklyDemandKey = (week: number, resourceTypeName: string) => `${week}|${resourceTypeName}`
+
+/**
+ * Compute the planning window — the span of weeks covered by the project
+ * from timeline entries, extended by buffer and onboarding weeks.
+ */
+export function computePlanningWindow(
+  entries: Array<{ startWeek: number; durationWeeks: number }>,
+  startDate: Date | null,
+  bufferWeeks: number,
+  onboardingWeeks: number,
+): PlanningWindow {
+  const rawMaxWeek =
+    entries.length > 0
+      ? Math.max(...entries.map(e => e.startWeek + e.durationWeeks))
+      : null
+  const maxWeek =
+    rawMaxWeek != null ? rawMaxWeek + bufferWeeks + onboardingWeeks : null
+  const projectedEndDate =
+    startDate && maxWeek != null
+      ? (() => {
+          const d = new Date(startDate)
+          d.setDate(d.getDate() + maxWeek * 7)
+          return d.toISOString()
+        })()
+      : null
+  return { maxWeek, projectedEndDate, bufferWeeks, onboardingWeeks }
+}
+
+/**
+ * Compute per-feature resource breakdown (name → days).
+ * Duplicates the same logic previously in timeline.ts computeResourceBreakdown.
+ */
+export function computeResourceBreakdown(
+  feature: {
+    userStories: Array<{
+      isActive: boolean | null
+      tasks: Array<{
+        resourceTypeId: string | null
+        hoursEffort: number
+        durationDays: number | null
+        resourceType: {
+          name: string
+          hoursPerDay: number | null
+        } | null
+      }>
+    }>
+  },
+  fallbackHpd: number,
+): Array<{ name: string; days: number }> {
+  const byRt = new Map<
+    string,
+    { name: string; days: number }
+  >()
+  for (const story of feature.userStories) {
+    if (story.isActive === false) continue
+    for (const task of story.tasks) {
+      const key = task.resourceTypeId ?? '_unassigned'
+      const name = task.resourceType?.name ?? 'Unassigned'
+      const hpd = task.resourceType?.hoursPerDay ?? fallbackHpd
+      const days = effectiveDays(task.durationDays, task.hoursEffort, hpd)
+      const existing = byRt.get(key) ?? { name, days: 0 }
+      byRt.set(key, { name, days: existing.days + days })
+    }
+  }
+  return Array.from(byRt.values()).map(r => ({
+    name: r.name,
+    days: Math.round(r.days * 10) / 10,
+  }))
+}
+
+/**
+ * Apply capacity-plan fallback for resource types with CAPACITY_PLAN
+ * allocation mode — virtual named resources replace real ones when
+ * the RT has no named resources and the capacity plan slots apply.
+ * Same logic as timeline.ts buildWarningResourceTypes / resourceProfile.ts
+ * capacity-plan fallback.
+ */
+export function applyCapacityPlanFallback(
+  resourceTypes: ResourceTypePlanningFact[],
+  capacityPlanByRt: Map<string, MaterializedCapacityPlanResource>,
+): ResourceTypePlanningFact[] {
+  return resourceTypes.map(rt => {
+    if (rt.allocationMode !== 'CAPACITY_PLAN') return rt
+
+    const materialized = capacityPlanByRt.get(rt.id)
+    const shouldFallback =
+      materialized != null &&
+      rt.namedResources.length === 0
+
+    if (!shouldFallback || !materialized) return rt
+
+    return {
+      ...rt,
+      namedResources: materialized.slotWindows.map((window, idx) => ({
+        id: `${rt.id}-capacity-plan-${idx + 1}`,
+        name: `${rt.name} ${idx + 1}`,
+        startWeek: window.startWeek,
+        endWeek: window.endWeek,
+        allocationMode: 'CAPACITY_PLAN',
+        allocationPercent: window.allocationPercent,
+        allocationStartWeek: null,
+        allocationEndWeek: null,
+        pricingModel: 'ACTUAL_DAYS',
+        synthetic: true,
+      })),
+    }
+  })
+}
+
+/**
+ * Build fallback weekly demand from timeline entries by uniform spread.
+ * Same logic as timeline.ts buildFallbackWeeklyDemand / resourceProfile.ts
+ * fallback weekly demand generation.
+ */
+export function buildFallbackWeeklyDemand(
+  entries: Array<{
+    startWeek: number
+    durationWeeks: number
+    feature: {
+      userStories: Array<{
+        isActive: boolean | null
+        tasks: Array<{
+          resourceTypeId: string | null
+          hoursEffort: number
+          durationDays: number | null
+          resourceType: {
+            name: string
+            hoursPerDay: number | null
+          } | null
+        }>
+      }>
+    }
+  }>,
+  resourceTypes: Array<{ name: string; id: string; hoursPerDay: number | null; allocationMode: string | null; count: number; namedResources: SchedulerNamedResource[] }>,
+  capacityPlanByRt: Map<string, MaterializedCapacityPlanResource>,
+  hoursPerDay: number,
+): WeeklyDemandRow[] {
+  const rtByName = new Map(resourceTypes.map(rt => [rt.name, rt]))
+  const weeklyDemandMap = new Map<string, { demandDays: number; capacityDays: number }>()
+
+  for (const e of entries) {
+    if (e.durationWeeks <= 0) continue
+    const featureStart = e.startWeek
+    const featureEnd = e.startWeek + e.durationWeeks
+    const breakdown = computeResourceBreakdown(e.feature, hoursPerDay)
+    for (const { name, days } of breakdown) {
+      const startW = Math.floor(featureStart)
+      const endW = Math.ceil(featureEnd)
+      const rt = rtByName.get(name)
+      for (let w = startW; w < endW; w++) {
+        const overlap = Math.min(w + 1, featureEnd) - Math.max(w, featureStart)
+        if (overlap <= 0) continue
+        const key = weeklyDemandKey(w, name)
+        let capDays = 5
+        if (rt) {
+          const isCp = (rt.allocationMode as string | null) === 'CAPACITY_PLAN'
+          if (isCp) {
+            const materialized = capacityPlanByRt.get(rt.id)
+            if (materialized) {
+              capDays = (materialized.weeklyHeadcount.get(w) ?? 0) * 5
+            }
+          } else {
+            const hpd = rt.hoursPerDay ?? hoursPerDay
+            capDays = getWeeklyCapacity(rt, w, hoursPerDay) / hpd
+          }
+        }
+        const keyDemand = days * (overlap / e.durationWeeks)
+        const existing = weeklyDemandMap.get(key) ?? { demandDays: 0, capacityDays: capDays }
+        existing.demandDays += keyDemand
+        existing.capacityDays = capDays
+        weeklyDemandMap.set(key, existing)
+      }
+    }
+  }
+
+  return Array.from(weeklyDemandMap.entries())
+    .map(([key, { demandDays, capacityDays }]) => {
+      const [weekStr, ...nameParts] = key.split('|')
+      return {
+        week: parseInt(weekStr, 10),
+        resourceTypeName: nameParts.join('|'),
+        demandDays: Math.round(demandDays * 10) / 10,
+        capacityDays,
+      }
+    })
+    .sort((a, b) => a.week - b.week || a.resourceTypeName.localeCompare(b.resourceTypeName))
+}
+
+/**
+ * Merge simulated (cached) demand with fallback demand.
+ * For cached resource types, fallback demand is suppressed for weeks
+ * up to and including the cached horizon. Cached values win for those weeks.
+ * Same logic as timeline.ts lines 202-248 and resourceProfile.ts lines 259-295.
+ */
+export function mergeWeeklyDemand(
+  fallbackDemand: WeeklyDemandRow[],
+  simulatedDemand: Map<string, number>,
+): WeeklyDemandRow[] {
+  const cachedResourceTypes = new Set<string>()
+  const cachedMaxWeekByRt = new Map<string, number>()
+
+  for (const key of simulatedDemand.keys()) {
+    const separatorIdx = key.lastIndexOf('|')
+    const resourceTypeName = key.substring(0, separatorIdx)
+    const week = parseInt(key.substring(separatorIdx + 1), 10)
+    cachedResourceTypes.add(resourceTypeName)
+    const prev = cachedMaxWeekByRt.get(resourceTypeName) ?? Number.NEGATIVE_INFINITY
+    cachedMaxWeekByRt.set(resourceTypeName, Math.max(prev, week))
+  }
+
+  const mergedDemand = new Map<string, WeeklyDemandRow>()
+
+  for (const row of fallbackDemand) {
+    const hasCached = cachedResourceTypes.has(row.resourceTypeName)
+    if (hasCached) {
+      const rtMaxWeek = cachedMaxWeekByRt.get(row.resourceTypeName)
+      if (rtMaxWeek != null && row.week <= rtMaxWeek) continue
+    }
+    mergedDemand.set(weeklyDemandKey(row.week, row.resourceTypeName), row)
+  }
+
+  for (const [key, days] of simulatedDemand.entries()) {
+    const separatorIdx = key.lastIndexOf('|')
+    const resourceTypeName = key.substring(0, separatorIdx)
+    const week = parseInt(key.substring(separatorIdx + 1), 10)
+    mergedDemand.set(weeklyDemandKey(week, resourceTypeName), {
+      week,
+      resourceTypeName,
+      demandDays: Math.round(days * 100) / 100,
+      capacityDays: 0, // will be resolved by caller
+    })
+  }
+
+  return Array.from(mergedDemand.values())
+    .filter(d => d.demandDays > 0)
+    .sort((a, b) => a.week - b.week || a.resourceTypeName.localeCompare(b.resourceTypeName))
+}
+
+/**
+ * Compute weekly capacity for every resource type for weeks 0..endWeek.
+ * Capacity for CAPACITY_PLAN RTs comes from the materialized plan; for others
+ * it comes from getWeeklyCapacity.
+ */
+export function computeWeeklyCapacity(
+  resourceTypes: Array<{
+    id: string
+    name: string
+    hoursPerDay: number | null
+    allocationMode: string | null
+    count: number
+    namedResources: SchedulerNamedResource[]
+  }>,
+  hoursPerDay: number,
+  endWeek: number,
+  capacityPlanByRt: Map<string, MaterializedCapacityPlanResource>,
+): WeeklyCapacityRow[] {
+  const result: WeeklyCapacityRow[] = []
+  if (endWeek <= 0) return result
+
+  for (const rt of resourceTypes) {
+    for (let w = 0; w < endWeek; w++) {
+      let capDays: number
+      if ((rt.allocationMode as string | null) === 'CAPACITY_PLAN') {
+        const materialized = capacityPlanByRt.get(rt.id)
+        capDays = materialized ? (materialized.weeklyHeadcount.get(w) ?? 0) * 5 : 0
+      } else {
+        const hpd = rt.hoursPerDay ?? hoursPerDay
+        capDays = getWeeklyCapacity(rt, w, hoursPerDay) / hpd
+      }
+      result.push({
+        week: w,
+        resourceTypeName: rt.name,
+        capacityDays: Math.round(capDays * 10) / 10,
+      })
+    }
+  }
+  return result
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Data-loading wrapper
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Load project planning data from the database and compute the shared
+ * planning read model. This is the main entry point for routes that
+ * need planning-derived facts.
+ */
+export async function buildProjectPlanningModel(
+  projectId: string,
+  userId: string,
+): Promise<ProjectPlanningModel> {
+  // ── 1. Load project with ownership check ───────────────────────────────
+  const project = await prisma.project.findFirst({
+    where: { id: projectId, ownerId: userId },
+  })
+
+  if (!project) {
+    throw new NotFoundError('Project not found')
+  }
+
+  // ── 2. Load resource types ─────────────────────────────────────────────
+  const resourceTypes = await prisma.resourceType.findMany({
+    where: { projectId },
+    include: {
+      namedResources: { orderBy: { createdAt: 'asc' } },
+    },
+  })
+  // ── 2. Load timeline entries ──────────────────────────────────────────
+  const [timelineEntries, storyTimelineEntries] = await Promise.all([
+    prisma.timelineEntry.findMany({
+      where: { projectId },
+      include: {
+        feature: {
+          include: {
+            epic: true,
+            userStories: {
+              include: {
+                tasks: { include: { resourceType: true } },
+              },
+            },
+          },
+        },
+      },
+      orderBy: { startWeek: 'asc' },
+    }),
+    prisma.storyTimelineEntry.findMany({
+      where: { projectId },
+      include: { story: { select: { name: true, featureId: true } } },
+    }),
+  ])
+
+  // ── 3. Load dependencies ──────────────────────────────────────────────
+  const allFeatureIds = timelineEntries.map(e => e.featureId)
+  const allStoryIds = storyTimelineEntries.map(e => e.storyId)
+  const [featureDeps, storyDeps, epicDeps] = await Promise.all([
+    prisma.featureDependency.findMany({
+      where: { featureId: { in: allFeatureIds } },
+      select: { featureId: true, dependsOnId: true },
+    }),
+    prisma.storyDependency.findMany({
+      where: { storyId: { in: allStoryIds } },
+      select: { storyId: true, dependsOnId: true },
+    }),
+    prisma.epicDependency.findMany({
+      where: { epic: { projectId } },
+      select: { epicId: true, dependsOnId: true },
+    }),
+  ])
+
+  // ── 4. Load active capacity plan ─────────────────────────────────────
+  const activeCapacityPlan = await prisma.capacityPlan.findFirst({
+    where: { projectId, isActive: true },
+    include: {
+      periods: {
+        include: { entries: true },
+        orderBy: { periodIndex: 'asc' },
+      },
+    },
+  })
+  const capacityPlanByRt = materializeCapacityPlanResources(activeCapacityPlan?.periods ?? [])
+
+  // ── 5. Filter active entries only ────────────────────────────────────
+  const activeEntries = timelineEntries.filter(
+    e => e.feature.isActive !== false && e.feature.epic.isActive !== false,
+  )
+  const activeFeatureIdSet = new Set(allFeatureIds)
+  const activeStoryEntries = storyTimelineEntries.filter(e =>
+    activeFeatureIdSet.has(e.story.featureId),
+  )
+
+  // ── 6. Resolved entries (with display metadata) ──────────────────────
+  const resolvedEntries: FeatureEntryDetail[] = activeEntries.map(e => ({
+    featureId: e.featureId,
+    featureName: e.feature.name,
+    epicId: e.feature.epic.id,
+    epicName: e.feature.epic.name,
+    startWeek: e.startWeek,
+    durationWeeks: e.durationWeeks,
+    isManual: e.isManual,
+  }))
+
+  const resolvedStoryEntries: StoryEntryDetail[] = activeStoryEntries.map(e => ({
+    storyId: e.storyId,
+    storyName: e.story.name,
+    featureId: e.story.featureId,
+    startWeek: e.startWeek,
+    durationWeeks: e.durationWeeks,
+    isManual: e.isManual,
+  }))
+
+  // ── 7. Build resource type planning facts ────────────────────────────
+  const resourceTypeFacts: ResourceTypePlanningFact[] = resourceTypes.map(rt => ({
+    id: rt.id,
+    name: rt.name,
+    category: rt.category,
+    count: rt.count,
+    hoursPerDay: rt.hoursPerDay,
+    dayRate: rt.dayRate,
+    allocationMode: rt.allocationMode,
+    allocationPercent: rt.allocationPercent,
+    allocationStartWeek: rt.allocationStartWeek,
+    allocationEndWeek: rt.allocationEndWeek,
+    namedResources: (rt.namedResources ?? []).map(nr => ({
+      id: nr.id,
+      name: nr.name,
+      startWeek: nr.startWeek,
+      endWeek: nr.endWeek,
+      allocationMode: nr.allocationMode,
+      allocationPercent: nr.allocationPercent,
+      allocationStartWeek: nr.allocationStartWeek,
+      allocationEndWeek: nr.allocationEndWeek,
+      pricingModel: nr.pricingModel,
+      synthetic: false,
+    })),
+    capacityPlanMaterialized: capacityPlanByRt.get(rt.id),
+  }))
+
+  // Apply capacity plan fallback for CAPACITY_PLAN RTs with no named resources
+  const enrichedFacts = applyCapacityPlanFallback(resourceTypeFacts, capacityPlanByRt)
+
+  // ── 8. Compute planning window ───────────────────────────────────────
+  const planningWindow = computePlanningWindow(
+    activeEntries,
+    project.startDate,
+    project.bufferWeeks ?? 0,
+    project.onboardingWeeks ?? 0,
+  )
+
+  // ── 9. Compute weekly demand ─────────────────────────────────────────
+  const weeklyDemandCache = project.weeklyDemandCache as Record<string, number> | null
+  const simulatedDemand = weeklyDemandCache
+    ? new Map(Object.entries(weeklyDemandCache))
+    : null
+
+  const fallbackDemand = buildFallbackWeeklyDemand(
+    activeEntries,
+    resourceTypes.map(rt => ({
+      name: rt.name,
+      id: rt.id,
+      hoursPerDay: rt.hoursPerDay,
+      allocationMode: rt.allocationMode,
+      count: rt.count,
+      namedResources: (rt.namedResources ?? []) as unknown as SchedulerNamedResource[],
+    })),
+    capacityPlanByRt,
+    project.hoursPerDay,
+  )
+
+  const weeklyDemand =
+    simulatedDemand && simulatedDemand.size > 0
+      ? mergeWeeklyDemand(fallbackDemand, simulatedDemand)
+      : fallbackDemand
+
+  // ── 10. Compute weekly capacity ──────────────────────────────────────
+  const maxDemandWeek =
+    weeklyDemand.length > 0 ? Math.max(...weeklyDemand.map(d => d.week)) : 0
+  const capacityEndWeek = Math.max(
+    planningWindow.maxWeek != null ? Math.ceil(planningWindow.maxWeek) : 0,
+    maxDemandWeek + 1,
+  )
+
+  const rtNamesWithDemand = new Set(weeklyDemand.map(d => d.resourceTypeName))
+  const capacityRelevantRTs = resourceTypes.filter(rt =>
+    rtNamesWithDemand.has(rt.name),
+  )
+
+  const weeklyCapacity = computeWeeklyCapacity(
+    capacityRelevantRTs,
+    project.hoursPerDay,
+    capacityEndWeek,
+    capacityPlanByRt,
+  )
+
+  // ── 11. Reconcile capacity on demand rows ────────────────────────────
+  // Some demand rows from mergeWeeklyDemand have capacityDays=0 when they come
+  // from simulated demand. Fill in the correct capacity from weeklyCapacity.
+  const capMap = new Map<string, number>()
+  for (const cap of weeklyCapacity) {
+    capMap.set(weeklyDemandKey(cap.week, cap.resourceTypeName), cap.capacityDays)
+  }
+  for (const d of weeklyDemand) {
+    const key = weeklyDemandKey(d.week, d.resourceTypeName)
+    if (capMap.has(key)) {
+      d.capacityDays = capMap.get(key)!
+    }
+  }
+
+  // ── 12. Derive named resource assignments ────────────────────────────
+  const namedResourceAssignments = deriveNamedResourceAssignments({
+    resourceTypes: resourceTypes as unknown as Parameters<typeof deriveNamedResourceAssignments>[0]['resourceTypes'],
+    weeklyDemand,
+    capacityPlanByRt,
+  })
+
+  // ── 13. Compute parallel warnings ────────────────────────────────────
+  const activeFeatures = activeEntries.map(e => e.feature)
+
+  // Apply capacity-plan fallback to resource types for parallel warnings
+  // (same logic as timeline.ts buildWarningResourceTypes)
+  const warningResourceTypes = resourceTypes.map(rt => {
+    if (rt.allocationMode !== 'CAPACITY_PLAN') return rt
+    const materialized = capacityPlanByRt.get(rt.id)
+    if (!materialized) return rt
+    // Only fall back when the RT has no named resources
+    if ((rt.namedResources ?? []).length > 0) return rt
+    return {
+      ...rt,
+      namedResources: materialized.slotWindows.map((window, idx) => ({
+        id: `${rt.id}-capacity-plan-${idx + 1}`,
+        name: `${rt.name ?? ''} ${idx + 1}`,
+        endWeek: window.endWeek,
+        allocationMode: 'CAPACITY_PLAN',
+        allocationPercent: window.allocationPercent,
+        allocationStartWeek: null,
+        allocationEndWeek: null,
+        pricingModel: undefined,
+      })),
+    }
+  }) as Array<typeof resourceTypes[number]>
+
+  const parallelWarnings = computeParallelWarnings(
+    project.hoursPerDay,
+    activeEntries,
+    activeFeatures,
+    warningResourceTypes,
+  )
+
+  return {
+    projectId: project.id,
+    startDate: project.startDate?.toISOString() ?? null,
+    hoursPerDay: project.hoursPerDay,
+    planningWindow,
+    weeklyDemand,
+    weeklyCapacity,
+    resourceTypeFacts: enrichedFacts,
+    capacityPlanByRt,
+    namedResourceAssignments,
+    parallelWarnings,
+    entries: resolvedEntries,
+    storyEntries: resolvedStoryEntries,
+    featureDependencies: featureDeps,
+    storyDependencies: storyDeps,
+    epicDependencies: epicDeps,
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Private helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+class NotFoundError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'NotFoundError'
+  }
+}

--- a/server/src/lib/projectPlanningModel.ts
+++ b/server/src/lib/projectPlanningModel.ts
@@ -482,16 +482,27 @@ export async function buildProjectPlanningModel(
     }),
   ])
 
-  // ── 3. Load dependencies ──────────────────────────────────────────────
-  const allFeatureIds = timelineEntries.map(e => e.featureId)
-  const allStoryIds = storyTimelineEntries.map(e => e.storyId)
+  // ── 3. Filter active entries ──────────────────────────────────────────
+  const activeEntries = timelineEntries.filter(
+    e => e.feature.isActive !== false && e.feature.epic.isActive !== false,
+  )
+  const activeFeatureIds = activeEntries.map(e => e.featureId)
+  const activeFeatureIdSet = new Set(activeFeatureIds)
+  const activeStoryIds = storyTimelineEntries
+    .filter(e => activeFeatureIdSet.has(e.story.featureId))
+    .map(e => e.storyId)
+  const activeStoryEntries = storyTimelineEntries.filter(e =>
+    activeFeatureIdSet.has(e.story.featureId),
+  )
+
+  // ── 4. Load dependencies (active-only) ────────────────────────────────
   const [featureDeps, storyDeps, epicDeps] = await Promise.all([
     prisma.featureDependency.findMany({
-      where: { featureId: { in: allFeatureIds } },
+      where: { featureId: { in: activeFeatureIds } },
       select: { featureId: true, dependsOnId: true },
     }),
     prisma.storyDependency.findMany({
-      where: { storyId: { in: allStoryIds } },
+      where: { storyId: { in: activeStoryIds } },
       select: { storyId: true, dependsOnId: true },
     }),
     prisma.epicDependency.findMany({
@@ -500,7 +511,7 @@ export async function buildProjectPlanningModel(
     }),
   ])
 
-  // ── 4. Load active capacity plan ─────────────────────────────────────
+  // ── 5. Load active capacity plan ─────────────────────────────────────
   const activeCapacityPlan = await prisma.capacityPlan.findFirst({
     where: { projectId, isActive: true },
     include: {
@@ -511,15 +522,6 @@ export async function buildProjectPlanningModel(
     },
   })
   const capacityPlanByRt = materializeCapacityPlanResources(activeCapacityPlan?.periods ?? [])
-
-  // ── 5. Filter active entries only ────────────────────────────────────
-  const activeEntries = timelineEntries.filter(
-    e => e.feature.isActive !== false && e.feature.epic.isActive !== false,
-  )
-  const activeFeatureIdSet = new Set(allFeatureIds)
-  const activeStoryEntries = storyTimelineEntries.filter(e =>
-    activeFeatureIdSet.has(e.story.featureId),
-  )
 
   // ── 6. Resolved entries (with display metadata) ──────────────────────
   const resolvedEntries: FeatureEntryDetail[] = activeEntries.map(e => ({

--- a/server/src/routes/resourceProfile.ts
+++ b/server/src/routes/resourceProfile.ts
@@ -9,7 +9,7 @@ import {
   shouldFallbackToActiveCapacityPlan,
 } from '../lib/capacityPlanMaterialisation.js'
 import { deriveNamedResourceAssignments, type WeeklyDemandLike } from '../lib/namedResourceAssignments.js'
-
+import { mergeWeeklyDemand } from '../lib/projectPlanningModel.js'
 type AllocationMode = 'EFFORT' | 'TIMELINE' | 'FULL_PROJECT' | 'CAPACITY_PLAN'
 
 const router = Router({ mergeParams: true })
@@ -253,56 +253,30 @@ router.get('/', asyncHandler(async (req: AuthRequest, res: Response) => {
       }
     }
   }
-
-  const weeklyDemandMap = new Map<string, number>(fallbackWeeklyDemandMap)
-
-  if (project.weeklyDemandCache && Object.keys(project.weeklyDemandCache as Record<string, number>).length > 0) {
-    const cachedResourceTypes = new Set<string>()
-    const cachedMaxWeekByRt = new Map<string, number>()
-
-    for (const [key] of Object.entries(project.weeklyDemandCache as Record<string, number>)) {
-      const separatorIdx = key.lastIndexOf('|')
-      if (separatorIdx === -1) continue
-      const resourceTypeName = key.substring(0, separatorIdx)
-      const week = Number(key.substring(separatorIdx + 1))
-      if (!Number.isFinite(week)) continue
-      cachedResourceTypes.add(resourceTypeName)
-      const prev = cachedMaxWeekByRt.get(resourceTypeName) ?? Number.NEGATIVE_INFINITY
-      cachedMaxWeekByRt.set(resourceTypeName, Math.max(prev, week))
-    }
-
-    for (const key of Array.from(weeklyDemandMap.keys())) {
+  // Convert fallback demand map to WeeklyDemandRow[] for mergeWeeklyDemand
+  const fallbackRows: Array<{ week: number; resourceTypeName: string; demandDays: number; capacityDays: number }> =
+    Array.from(fallbackWeeklyDemandMap.entries()).map(([key, demandDays]) => {
       const separatorIdx = key.indexOf('|')
-      if (separatorIdx === -1) continue
-      const week = Number(key.substring(0, separatorIdx))
-      const resourceTypeName = key.substring(separatorIdx + 1)
-      if (cachedResourceTypes.has(resourceTypeName)) {
-        const rtMaxWeek = cachedMaxWeekByRt.get(resourceTypeName)
-        if (rtMaxWeek != null && week <= rtMaxWeek) {
-          weeklyDemandMap.delete(key)
-        }
+      return {
+        week: Number(key.substring(0, separatorIdx)),
+        resourceTypeName: key.substring(separatorIdx + 1),
+        demandDays,
+        capacityDays: 0,
       }
-    }
+    })
 
-    for (const [key, demandDays] of Object.entries(project.weeklyDemandCache as Record<string, number>)) {
-      const separatorIdx = key.lastIndexOf('|')
-      if (separatorIdx === -1) continue
-      const resourceTypeName = key.substring(0, separatorIdx)
-      const week = Number(key.substring(separatorIdx + 1))
-      if (!Number.isFinite(week) || !Number.isFinite(demandDays) || demandDays <= 0) continue
-      weeklyDemandMap.set(weeklyDemandKey(week, resourceTypeName), round2(demandDays))
-    }
+  const weeklyDemandCache = project.weeklyDemandCache as Record<string, number> | null
+  let weeklyDemand: WeeklyDemandLike[]
+
+  if (weeklyDemandCache && Object.keys(weeklyDemandCache).length > 0) {
+    const simulatedDemand = new Map<string, number>(Object.entries(weeklyDemandCache))
+    const merged = mergeWeeklyDemand(fallbackRows, simulatedDemand)
+    weeklyDemand = merged.map(r => ({ week: r.week, resourceTypeName: r.resourceTypeName, demandDays: r.demandDays }))
+  } else {
+    weeklyDemand = fallbackRows.map(r => ({ week: r.week, resourceTypeName: r.resourceTypeName, demandDays: r.demandDays }))
   }
 
-  const weeklyDemand: WeeklyDemandLike[] = Array.from(weeklyDemandMap.entries()).map(([key, demandDays]) => {
-    const separatorIdx = key.indexOf('|')
-    return {
-      week: Number(key.substring(0, separatorIdx)),
-      resourceTypeName: key.substring(separatorIdx + 1),
-      demandDays,
-    }
-  }).filter(row => row.demandDays > 0)
-
+  weeklyDemand = weeklyDemand.filter(row => row.demandDays > 0)
   const namedResourceAssignments = deriveNamedResourceAssignments({
     resourceTypes: project.resourceTypes,
     weeklyDemand,

--- a/server/src/routes/resourceProfile.ts
+++ b/server/src/routes/resourceProfile.ts
@@ -9,7 +9,7 @@ import {
   shouldFallbackToActiveCapacityPlan,
 } from '../lib/capacityPlanMaterialisation.js'
 import { deriveNamedResourceAssignments, type WeeklyDemandLike } from '../lib/namedResourceAssignments.js'
-import { mergeWeeklyDemand } from '../lib/projectPlanningModel.js'
+import { mergeWeeklyDemand, computePlanningWindow } from '../lib/projectPlanningModel.js'
 type AllocationMode = 'EFFORT' | 'TIMELINE' | 'FULL_PROJECT' | 'CAPACITY_PLAN'
 
 const router = Router({ mergeParams: true })
@@ -87,10 +87,13 @@ router.get('/', asyncHandler(async (req: AuthRequest, res: Response) => {
   }
 
   // Project duration in weeks from the latest timeline entry end point + buffer weeks + onboarding weeks
-  const projectDurationWeeks =
-    (project.timelineEntries.length > 0
-      ? Math.max(...project.timelineEntries.map(te => te.startWeek + te.durationWeeks))
-      : 0) + (project.bufferWeeks ?? 0) + (project.onboardingWeeks ?? 0)
+  const planningWindow = computePlanningWindow(
+    project.timelineEntries,
+    project.startDate,
+    project.bufferWeeks ?? 0,
+    project.onboardingWeeks ?? 0,
+  )
+  const projectDurationWeeks = planningWindow.maxWeek ?? 0
 
   // Build lookup maps for timeline entries
   const featureEntryMap = new Map(project.timelineEntries.map(e => [e.featureId, e]))

--- a/server/src/routes/timeline.ts
+++ b/server/src/routes/timeline.ts
@@ -17,10 +17,10 @@ import {
   type MaterializedCapacityPlanResource,
 } from '../lib/capacityPlanMaterialisation.js'
 import { deriveNamedResourceAssignments } from '../lib/namedResourceAssignments.js'
+import { buildProjectPlanningModel } from '../lib/projectPlanningModel.js'
 import { runSAPlanner } from '../lib/sa-planner.js'
 import { buildSnapshot } from './snapshots.js'
 import { pruneSnapshots } from '../lib/snapshotUtils.js'
-
 const router = Router({ mergeParams: true })
 router.use(authenticate)
 
@@ -348,77 +348,104 @@ function buildResponse(
 
 // GET /api/projects/:projectId/timeline
 router.get('/', asyncHandler(async (req: AuthRequest, res: Response) => {
-  const project = await ownedProject(req.params.projectId as string, req.userId!)
-  if (!project) { res.status(404).json({ error: 'Project not found' }); return }
+  const model = await buildProjectPlanningModel(req.params.projectId as string, req.userId!)
+    .catch(() => { res.status(404).json({ error: 'Project not found' }); return null })
+  if (!model) return
 
-  const entries = await prisma.timelineEntry.findMany({
-    where: { projectId: project.id },
+  const { projectId, planningWindow, storyEntries } = model
+
+  // Build entries with resource breakdown (route-specific formatting)
+  // Need the full feature objects to compute breakdown
+  // Reload raw entries for the breakdown computation — TODO: move breakdown into model
+  const rawEntries = await prisma.timelineEntry.findMany({
+    where: { projectId },
     include: {
       feature: {
         include: {
           epic: true,
           userStories: {
             include: {
-              tasks: { include: { resourceType: true } }
-            }
-          }
-        }
-      }
+              tasks: { include: { resourceType: true } },
+            },
+          },
+        },
+      },
     },
     orderBy: { startWeek: 'asc' },
   })
+  const activeRawEntries = rawEntries.filter(
+    e => e.feature.isActive !== false && e.feature.epic.isActive !== false,
+  )
 
-  // Filter out inactive epics/features
-  const activeEntries = entries.filter(e => e.feature.isActive !== false && e.feature.epic.isActive !== false)
+  // Group named resources by resource type for the response
+  const rtNameById = new Map(model.resourceTypeFacts.map(rt => [rt.id, rt.name]))
 
-  // Load resource types before computing warnings (passed in to avoid redundant queries)
-  const resourceTypes = await prisma.resourceType.findMany({ where: { projectId: project.id }, include: { namedResources: true } })
-  const activeCapacityPlan = await prisma.capacityPlan.findFirst({
-    where: { projectId: project.id, isActive: true },
-    include: { periods: { include: { entries: true }, orderBy: { periodIndex: 'asc' } } },
-  })
-  const capacityPlanByRt = materializeCapacityPlanResources(activeCapacityPlan?.periods ?? [])
-  const warningResourceTypes = buildWarningResourceTypes(resourceTypes, capacityPlanByRt)
+  const namedResourcesList = Array.from(model.namedResourceAssignments.entries()).flatMap(([rtId, assignment]) =>
+    assignment.namedResources.map(nr => ({
+      id: nr.id,
+      resourceTypeId: rtId,
+      resourceTypeName: rtNameById.get(rtId) ?? '',
+      name: nr.name,
+      startWeek: nr.startWeek,
+      endWeek: nr.endWeek,
+      allocationPct: nr.allocationMode === 'EFFORT' ? 100 : Math.round(nr.allocationPercent),
+      allocationMode: nr.allocationMode,
+      allocationPercent: nr.allocationPercent,
+      allocationStartWeek: nr.allocationStartWeek,
+      allocationEndWeek: nr.allocationEndWeek,
+      pricingModel: nr.pricingModel,
+      actualAllocatedDays: nr.actualAllocatedDays,
+      actualAllocationStartWeek: nr.actualAllocationStartWeek,
+      actualAllocationEndWeek: nr.actualAllocationEndWeek,
+      actualAllocatedWeeks: nr.actualAllocatedWeeks,
+      actualAllocationSegments: nr.actualAllocationSegments,
+      synthetic: nr.synthetic,
+    }))
+  )
 
-  // #178: pass pre-loaded features and resource types — no extra DB queries inside
-  const activeFeatures = activeEntries.map(e => e.feature)
-  const parallelWarnings = computeParallelWarnings(project.hoursPerDay, activeEntries, activeFeatures, warningResourceTypes)
-
-  const storyTimelineEntries = await prisma.storyTimelineEntry.findMany({
-    where: { projectId: project.id },
-    include: { story: { select: { name: true, featureId: true } } },
+  res.json({
+    projectId,
+    startDate: model.startDate,
+    hoursPerDay: model.hoursPerDay,
+    projectedEndDate: planningWindow.projectedEndDate,
+    bufferWeeks: planningWindow.bufferWeeks,
+    onboardingWeeks: planningWindow.onboardingWeeks,
+    parallelWarnings: model.parallelWarnings,
+    storyEntries,
+    featureDependencies: model.featureDependencies,
+    storyDependencies: model.storyDependencies,
+    epicDependencies: model.epicDependencies,
+    weeklyDemand: model.weeklyDemand,
+    weeklyCapacity: model.weeklyCapacity,
+    namedResources: namedResourcesList,
+    entries: activeRawEntries.map(e => {
+      const breakdown = computeResourceBreakdown(e.feature, model.hoursPerDay)
+      const durationWeeksActual = Math.max(e.durationWeeks, 0.01)
+      const effectiveEngineers = breakdown.map(({ name, days }) => ({
+        name,
+        engineerEquivalent: Math.round((days / (durationWeeksActual * 5)) * 100) / 100,
+      }))
+      return {
+        featureId: e.featureId,
+        featureName: e.feature.name,
+        epicId: e.feature.epic.id,
+        epicName: e.feature.epic.name,
+        epicOrder: e.feature.epic.order,
+        epicFeatureMode: e.feature.epic.featureMode,
+        epicScheduleMode: e.feature.epic.scheduleMode,
+        epicTimelineStartWeek: e.feature.epic.timelineStartWeek,
+        featureOrder: e.feature.order,
+        timelineColour: e.feature.timelineColour ?? null,
+        startWeek: e.startWeek,
+        durationWeeks: e.durationWeeks,
+        isManual: e.isManual,
+        resourceBreakdown: breakdown,
+        effectiveEngineers,
+        ...computeDates(new Date(model.startDate ?? ''), e.startWeek, e.durationWeeks, planningWindow.onboardingWeeks),
+      }
+    }),
   })
-  const allFeatureIds = activeEntries.map(e => e.featureId)
-  const featureDependencies = await prisma.featureDependency.findMany({
-    where: { featureId: { in: allFeatureIds } },
-    select: { featureId: true, dependsOnId: true },
-  })
-  const epicDependencies = await prisma.epicDependency.findMany({
-    where: { epic: { projectId: project.id } },
-    select: { epicId: true, dependsOnId: true },
-  })
-  const activeFeatureIdSet = new Set(allFeatureIds)
-  const activeStoryTimelineEntries = storyTimelineEntries.filter(e => activeFeatureIdSet.has(e.story.featureId))
-  const allStoryIds = activeStoryTimelineEntries.map(e => e.storyId)
-  const storyDependencies = await prisma.storyDependency.findMany({
-    where: { storyId: { in: allStoryIds } },
-    select: { storyId: true, dependsOnId: true },
-  })
-  const mappedStoryEntries = activeStoryTimelineEntries.map(e => ({
-    storyId: e.storyId,
-    storyName: e.story.name,
-    featureId: e.story.featureId,
-    startWeek: e.startWeek,
-    durationWeeks: e.durationWeeks,
-    isManual: e.isManual,
-  }))
-
-  const simulatedDemand = project.weeklyDemandCache
-    ? new Map<string, number>(Object.entries(project.weeklyDemandCache as Record<string, number>))
-    : undefined
-  res.json(buildResponse(project, activeEntries, parallelWarnings, mappedStoryEntries, featureDependencies, storyDependencies, epicDependencies, resourceTypes, simulatedDemand, capacityPlanByRt))
 }))
-
 // POST /api/projects/:projectId/timeline/schedule
 router.post('/schedule', asyncHandler(async (req: AuthRequest, res: Response) => {
   let project = await ownedProject(req.params.projectId as string, req.userId!)

--- a/server/src/routes/timeline.ts
+++ b/server/src/routes/timeline.ts
@@ -356,7 +356,8 @@ router.get('/', asyncHandler(async (req: AuthRequest, res: Response) => {
 
   // Build entries with resource breakdown (route-specific formatting)
   // Need the full feature objects to compute breakdown
-  // Reload raw entries for the breakdown computation — TODO: move breakdown into model
+  // Reload raw entries for the breakdown computation
+  // TODO(#268): move feature-entry presentation formatting into the shared model
   const rawEntries = await prisma.timelineEntry.findMany({
     where: { projectId },
     include: {
@@ -403,6 +404,7 @@ router.get('/', asyncHandler(async (req: AuthRequest, res: Response) => {
     }))
   )
 
+  const projectStartDate = model.startDate ? new Date(model.startDate) : null
   res.json({
     projectId,
     startDate: model.startDate,
@@ -441,7 +443,7 @@ router.get('/', asyncHandler(async (req: AuthRequest, res: Response) => {
         isManual: e.isManual,
         resourceBreakdown: breakdown,
         effectiveEngineers,
-        ...computeDates(new Date(model.startDate ?? ''), e.startWeek, e.durationWeeks, planningWindow.onboardingWeeks),
+        ...computeDates(projectStartDate, e.startWeek, e.durationWeeks, planningWindow.onboardingWeeks),
       }
     }),
   })

--- a/server/src/test/projectPlanningModel.test.ts
+++ b/server/src/test/projectPlanningModel.test.ts
@@ -15,7 +15,9 @@ import {
   applyCapacityPlanFallback,
 } from '../lib/projectPlanningModel.js'
 import type { MaterializedCapacityPlanResource } from '../lib/capacityPlanMaterialisation.js'
+import type { SchedulerNamedResource } from '../lib/scheduler.js'
 
+type MockRTNamedResources = SchedulerNamedResource[]
 // ─────────────────────────────────────────────────────────────────────────────
 // computePlanningWindow
 // ─────────────────────────────────────────────────────────────────────────────
@@ -283,7 +285,7 @@ describe('buildFallbackWeeklyDemand', () => {
       hoursPerDay: 8,
       allocationMode: 'EFFORT',
       count: 2,
-      namedResources: [] as Array<{ id: string }>,
+      namedResources: [] as MockRTNamedResources,
     },
   ]
 
@@ -479,8 +481,8 @@ describe('computeWeeklyCapacity', () => {
 
   it('computes capacity for each RT for each week', () => {
     const rts = [
-      { id: 'rt-dev', name: 'Developer', hoursPerDay: 8, allocationMode: 'EFFORT', count: 2, namedResources: [] as Array<{ id: string }> },
-      { id: 'rt-qa', name: 'QA', hoursPerDay: 8, allocationMode: 'EFFORT', count: 1, namedResources: [] as Array<{ id: string }> },
+      { id: 'rt-dev', name: 'Developer', hoursPerDay: 8, allocationMode: 'EFFORT', count: 2, namedResources: [] as MockRTNamedResources },
+      { id: 'rt-qa', name: 'QA', hoursPerDay: 8, allocationMode: 'EFFORT', count: 1, namedResources: [] as MockRTNamedResources },
     ]
     const result = computeWeeklyCapacity(rts, 8, 3, new Map())
     // 2 RTs × 3 weeks = 6 rows
@@ -506,7 +508,7 @@ describe('computeWeeklyCapacity', () => {
     cpMap.set('rt-cp', materialized)
 
     const rts = [
-      { id: 'rt-cp', name: 'Security', hoursPerDay: 8, allocationMode: 'CAPACITY_PLAN', count: 1, namedResources: [] as Array<{ id: string }> },
+      { id: 'rt-cp', name: 'Security', hoursPerDay: 8, allocationMode: 'CAPACITY_PLAN', count: 1, namedResources: [] as MockRTNamedResources },
     ]
     const result = computeWeeklyCapacity(rts, 8, 2, cpMap)
     expect(result).toHaveLength(2)
@@ -522,7 +524,7 @@ describe('computeWeeklyCapacity', () => {
 describe('weekly demand integration', () => {
   it('pipeline: fallback → merge → produce final weeklyDemand', () => {
     const rts = [
-      { name: 'Developer', id: 'rt-dev', hoursPerDay: 8, allocationMode: 'EFFORT', count: 2, namedResources: [] as Array<{ id: string }> },
+      { name: 'Developer', id: 'rt-dev', hoursPerDay: 8, allocationMode: 'EFFORT', count: 2, namedResources: [] as MockRTNamedResources },
     ]
     const entry = {
       startWeek: 0,
@@ -592,7 +594,7 @@ describe('stable IDs and display metadata', () => {
       allocationPercent: 100,
       allocationStartWeek: null,
       allocationEndWeek: null,
-      namedResources: [] as Array<{ id: string; name: string; startWeek: number | null; endWeek: number | null; allocationMode: string | null; allocationPercent: number | null; allocationStartWeek: number | null; allocationEndWeek: number | null; pricingModel: string | null; synthetic: boolean }>,
+      namedResources: [] as any,
       capacityPlanMaterialized: materialized,
     }]
     const result = applyCapacityPlanFallback(rt, cpMap)

--- a/server/src/test/projectPlanningModel.test.ts
+++ b/server/src/test/projectPlanningModel.test.ts
@@ -1,0 +1,636 @@
+/**
+ * projectPlanningModel.test.ts — Unit tests for the shared planning read model.
+ *
+ * Tests the pure computation functions directly (no DB mocking needed).
+ * These functions take plain data in and return plain data out.
+ */
+
+import { describe, expect, it } from 'vitest'
+import {
+  computePlanningWindow,
+  computeResourceBreakdown,
+  buildFallbackWeeklyDemand,
+  mergeWeeklyDemand,
+  computeWeeklyCapacity,
+  applyCapacityPlanFallback,
+} from '../lib/projectPlanningModel.js'
+import type { MaterializedCapacityPlanResource } from '../lib/capacityPlanMaterialisation.js'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// computePlanningWindow
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('computePlanningWindow', () => {
+  it('returns null maxWeek when no entries', () => {
+    const result = computePlanningWindow([], new Date('2026-01-01'), 0, 0)
+    expect(result.maxWeek).toBeNull()
+    expect(result.projectedEndDate).toBeNull()
+    expect(result.bufferWeeks).toBe(0)
+    expect(result.onboardingWeeks).toBe(0)
+  })
+
+  it('computes maxWeek from entries with buffer and onboarding', () => {
+    const entries = [
+      { startWeek: 0, durationWeeks: 5 },
+      { startWeek: 3, durationWeeks: 4 },
+    ]
+    const result = computePlanningWindow(entries, new Date('2026-01-01'), 2, 1)
+    // max entry end = max(5, 7) = 7; maxWeek = 7 + 2 + 1 = 10
+    expect(result.maxWeek).toBe(10)
+  })
+
+  it('projects end date from start date and maxWeek', () => {
+    const startDate = new Date('2026-01-05T00:00:00Z') // Monday
+    const entries = [{ startWeek: 0, durationWeeks: 4 }]
+    const result = computePlanningWindow(entries, startDate, 0, 0)
+    expect(result.maxWeek).toBe(4)
+    expect(result.projectedEndDate).toBe('2026-02-02T00:00:00.000Z')
+  })
+
+  it('returns null projectedEndDate when startDate is null', () => {
+    const entries = [{ startWeek: 0, durationWeeks: 4 }]
+    const result = computePlanningWindow(entries, null, 0, 0)
+    expect(result.projectedEndDate).toBeNull()
+  })
+
+  it('handles onboarding weeks properly', () => {
+    const entries = [{ startWeek: 0, durationWeeks: 3 }]
+    const result = computePlanningWindow(entries, null, 0, 2)
+    expect(result.onboardingWeeks).toBe(2)
+    expect(result.maxWeek).toBe(5) // 3 + 0 + 2
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// computeResourceBreakdown
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('computeResourceBreakdown', () => {
+  it('aggregates task hours into resource types', () => {
+    const feature = {
+      userStories: [
+        {
+          isActive: true,
+          tasks: [
+            {
+              resourceTypeId: 'rt-dev',
+              hoursEffort: 16,
+              durationDays: null,
+              resourceType: { name: 'Developer', hoursPerDay: 8 },
+            },
+            {
+              resourceTypeId: 'rt-dev',
+              hoursEffort: 8,
+              durationDays: null,
+              resourceType: { name: 'Developer', hoursPerDay: 8 },
+            },
+          ],
+        },
+      ],
+    }
+    const result = computeResourceBreakdown(feature, 8)
+    expect(result).toHaveLength(1)
+    expect(result[0].name).toBe('Developer')
+    expect(result[0].days).toBe(3) // (16+8)/8 = 3
+  })
+
+  it('skips inactive stories', () => {
+    const feature = {
+      userStories: [
+        {
+          isActive: false,
+          tasks: [
+            {
+              resourceTypeId: 'rt-dev',
+              hoursEffort: 999,
+              durationDays: null,
+              resourceType: { name: 'Developer', hoursPerDay: 8 },
+            },
+          ],
+        },
+      ],
+    }
+    const result = computeResourceBreakdown(feature, 8)
+    expect(result).toHaveLength(0)
+  })
+
+  it('uses durationDays when provided', () => {
+    const feature = {
+      userStories: [
+        {
+          isActive: true,
+          tasks: [
+            {
+              resourceTypeId: 'rt-dev',
+              hoursEffort: 8,
+              durationDays: 3,
+              resourceType: { name: 'Developer', hoursPerDay: 8 },
+            },
+          ],
+        },
+      ],
+    }
+    const result = computeResourceBreakdown(feature, 8)
+    // effectiveDays(3, 8, 8) = max(3, 8/8) = 3
+    expect(result[0].days).toBe(3)
+  })
+
+  it('uses fallback hoursPerDay when task resourceType lacks it', () => {
+    const feature = {
+      userStories: [
+        {
+          isActive: true,
+          tasks: [
+            {
+              resourceTypeId: 'rt-dev',
+              hoursEffort: 16,
+              durationDays: null,
+              resourceType: { name: 'Developer', hoursPerDay: null },
+            },
+          ],
+        },
+      ],
+    }
+    const result = computeResourceBreakdown(feature, 6)
+    expect(result[0].days).toBeCloseTo(2.7, 1) // 16/6 ≈ 2.7
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// applyCapacityPlanFallback
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('applyCapacityPlanFallback', () => {
+  it('does not modify non-CAPACITY_PLAN resource types', () => {
+    const rt: Parameters<typeof applyCapacityPlanFallback>[0] = [
+      {
+        id: 'rt-1',
+        name: 'Dev',
+        category: 'ENGINEERING',
+        count: 1,
+        hoursPerDay: 8,
+        dayRate: null,
+        allocationMode: 'EFFORT',
+        allocationPercent: 100,
+        allocationStartWeek: null,
+        allocationEndWeek: null,
+        namedResources: [],
+        capacityPlanMaterialized: undefined,
+      },
+    ]
+    const result = applyCapacityPlanFallback(rt, new Map())
+    expect(result[0].namedResources).toHaveLength(0)
+    expect(result[0].allocationMode).toBe('EFFORT')
+  })
+
+  it('injects capacity plan slot windows as virtual named resources for CAPACITY_PLAN RTs without named resources', () => {
+    const materialized: MaterializedCapacityPlanResource = {
+      resourceTypeId: 'rt-cp',
+      totalDays: 50,
+      weeklyHeadcount: new Map(),
+      slotWindows: [
+        { startWeek: 0, endWeek: 4, allocationPercent: 100 },
+        { startWeek: 5, endWeek: 9, allocationPercent: 50 },
+      ],
+      startWeek: 0,
+      endWeek: 9,
+    }
+    const cpMap = new Map<string, MaterializedCapacityPlanResource>()
+    cpMap.set('rt-cp', materialized)
+
+    const rt: Parameters<typeof applyCapacityPlanFallback>[0] = [
+      {
+        id: 'rt-cp',
+        name: 'Security',
+        category: 'ENGINEERING',
+        count: 1,
+        hoursPerDay: 8,
+        dayRate: null,
+        allocationMode: 'CAPACITY_PLAN',
+        allocationPercent: 100,
+        allocationStartWeek: null,
+        allocationEndWeek: null,
+        namedResources: [],
+        capacityPlanMaterialized: materialized,
+      },
+    ]
+    const result = applyCapacityPlanFallback(rt, cpMap)
+    expect(result[0].namedResources).toHaveLength(2)
+    expect(result[0].namedResources[0].id).toContain('capacity-plan-1')
+    expect(result[0].namedResources[0].name).toBe('Security 1')
+    expect(result[0].namedResources[0].allocationMode).toBe('CAPACITY_PLAN')
+    expect(result[0].namedResources[0].allocationPercent).toBe(100)
+    expect(result[0].namedResources[0].synthetic).toBe(true)
+  })
+
+  it('does not inject virtual resources when CAPACITY_PLAN RT already has named resources', () => {
+    const materialized: MaterializedCapacityPlanResource = {
+      resourceTypeId: 'rt-cp',
+      totalDays: 50,
+      weeklyHeadcount: new Map(),
+      slotWindows: [{ startWeek: 0, endWeek: 9, allocationPercent: 100 }],
+      startWeek: 0,
+      endWeek: 9,
+    }
+    const cpMap = new Map<string, MaterializedCapacityPlanResource>()
+    cpMap.set('rt-cp', materialized)
+
+    const rt: Parameters<typeof applyCapacityPlanFallback>[0] = [
+      {
+        id: 'rt-cp',
+        name: 'Security',
+        category: 'ENGINEERING',
+        count: 1,
+        hoursPerDay: 8,
+        dayRate: null,
+        allocationMode: 'CAPACITY_PLAN',
+        allocationPercent: 100,
+        allocationStartWeek: null,
+        allocationEndWeek: null,
+        namedResources: [
+          {
+            id: 'nr-1',
+            name: 'Alice',
+            startWeek: null,
+            endWeek: null,
+            allocationMode: 'CAPACITY_PLAN',
+            allocationPercent: 100,
+            allocationStartWeek: null,
+            allocationEndWeek: null,
+            pricingModel: 'ACTUAL_DAYS',
+            synthetic: false,
+          },
+        ],
+        capacityPlanMaterialized: materialized,
+      },
+    ]
+    const result = applyCapacityPlanFallback(rt, cpMap)
+    // Should keep the real named resource, not inject virtual ones
+    expect(result[0].namedResources).toHaveLength(1)
+    expect(result[0].namedResources[0].id).toBe('nr-1')
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// buildFallbackWeeklyDemand
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('buildFallbackWeeklyDemand', () => {
+  const makeResourceTypes = () => [
+    {
+      name: 'Developer',
+      id: 'rt-dev',
+      hoursPerDay: 8,
+      allocationMode: 'EFFORT',
+      count: 2,
+      namedResources: [] as Array<{ id: string }>,
+    },
+  ]
+
+  it('builds uniform-spread demand from entries', () => {
+    const entries = [
+      {
+        startWeek: 0,
+        durationWeeks: 2,
+        feature: {
+          userStories: [
+            {
+              isActive: true,
+              tasks: [
+                {
+                  resourceTypeId: 'rt-dev',
+                  hoursEffort: 32,
+                  durationDays: null,
+                  resourceType: { name: 'Developer', hoursPerDay: 8 },
+                },
+              ],
+            },
+          ],
+        },
+      },
+    ]
+    const result = buildFallbackWeeklyDemand(entries, makeResourceTypes(), new Map(), 8)
+    // 32 hours / 8 hpd = 4 days spread over 2 weeks = 2 days/week
+    expect(result).toHaveLength(2)
+    expect(result[0].week).toBe(0)
+    expect(result[0].demandDays).toBe(2)
+    expect(result[1].week).toBe(1)
+    expect(result[1].demandDays).toBe(2)
+  })
+
+  it('returns empty array for zero-duration entries', () => {
+    const entries = [
+      {
+        startWeek: 0,
+        durationWeeks: 0,
+        feature: { userStories: [] },
+      },
+    ]
+    const result = buildFallbackWeeklyDemand(entries, makeResourceTypes(), new Map(), 8)
+    expect(result).toHaveLength(0)
+  })
+
+  it('skips inactive stories', () => {
+    const entries = [
+      {
+        startWeek: 0,
+        durationWeeks: 2,
+        feature: {
+          userStories: [
+            {
+              isActive: false,
+              tasks: [
+                {
+                  resourceTypeId: 'rt-dev',
+                  hoursEffort: 999,
+                  durationDays: null,
+                  resourceType: { name: 'Developer', hoursPerDay: 8 },
+                },
+              ],
+            },
+          ],
+        },
+      },
+    ]
+    const result = buildFallbackWeeklyDemand(entries, makeResourceTypes(), new Map(), 8)
+    expect(result).toHaveLength(0)
+  })
+
+  it('handles partial-week overlaps', () => {
+    const entries = [
+      {
+        startWeek: 1.5,
+        durationWeeks: 1,
+        feature: {
+          userStories: [
+            {
+              isActive: true,
+              tasks: [
+                {
+                  resourceTypeId: 'rt-dev',
+                  hoursEffort: 8,
+                  durationDays: null,
+                  resourceType: { name: 'Developer', hoursPerDay: 8 },
+                },
+              ],
+            },
+          ],
+        },
+      },
+    ]
+    const result = buildFallbackWeeklyDemand(entries, makeResourceTypes(), new Map(), 8)
+    // 1 day spread over weeks 1 and 2 (0.5 overlap in week 1 and 0.5 in week 2)
+    expect(result).toHaveLength(2)
+    expect(result[0].week).toBe(1)
+    expect(result[1].week).toBe(2)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// mergeWeeklyDemand
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('mergeWeeklyDemand', () => {
+  it('uses simulated demand for cached RT within horizon, fallback beyond', () => {
+    const fallback = [
+      { week: 0, resourceTypeName: 'Dev', demandDays: 2, capacityDays: 10 },
+      { week: 1, resourceTypeName: 'Dev', demandDays: 2, capacityDays: 10 },
+      { week: 2, resourceTypeName: 'Dev', demandDays: 2, capacityDays: 10 },
+      { week: 3, resourceTypeName: 'Dev', demandDays: 2, capacityDays: 10 },
+    ]
+    const simulated = new Map<string, number>([
+      ['Dev|0', 5],
+      ['Dev|1', 5],
+    ])
+    const result = mergeWeeklyDemand(fallback, simulated)
+    // Cache covers weeks 0-1 (max week 1), so fallback for those weeks is suppressed
+    // Week 0,1 use simulated (5 each), weeks 2,3 use fallback (2 each)
+    expect(result).toHaveLength(4)
+    expect(result.find(r => r.week === 0)?.demandDays).toBe(5)
+    expect(result.find(r => r.week === 1)?.demandDays).toBe(5)
+    expect(result.find(r => r.week === 2)?.demandDays).toBe(2)
+    expect(result.find(r => r.week === 3)?.demandDays).toBe(2)
+  })
+
+  it('suppresses fallback for cached RT weeks even when simulated has gaps', () => {
+    const fallback = [
+      { week: 0, resourceTypeName: 'Dev', demandDays: 2, capacityDays: 10 },
+      { week: 1, resourceTypeName: 'Dev', demandDays: 2, capacityDays: 10 },
+      { week: 2, resourceTypeName: 'Dev', demandDays: 2, capacityDays: 10 },
+    ]
+    // Simulated only has week 0 and 2, but horizon is week 2
+    const simulated = new Map<string, number>([
+      ['Dev|0', 5],
+      ['Dev|2', 5],
+    ])
+    const result = mergeWeeklyDemand(fallback, simulated)
+    // Horizon = max week = 2, so fallback for weeks 0,1,2 are suppressed
+    // Week 0 and 2 have simulated demand (5 each), week 1 gets 0 and is filtered out
+    expect(result.find(r => r.week === 0)?.demandDays).toBe(5)
+    expect(result.find(r => r.week === 1)).toBeUndefined()
+    expect(result.find(r => r.week === 2)?.demandDays).toBe(5)
+  })
+
+  it('returns fallback when simulated is empty', () => {
+    const fallback = [
+      { week: 0, resourceTypeName: 'Dev', demandDays: 2, capacityDays: 10 },
+    ]
+    const result = mergeWeeklyDemand(fallback, new Map())
+    expect(result).toHaveLength(1)
+    expect(result[0].demandDays).toBe(2)
+  })
+
+  it('handles multiple resource types independently', () => {
+    const fallback = [
+      { week: 0, resourceTypeName: 'Dev', demandDays: 2, capacityDays: 10 },
+      { week: 0, resourceTypeName: 'QA', demandDays: 1, capacityDays: 5 },
+      { week: 1, resourceTypeName: 'Dev', demandDays: 2, capacityDays: 10 },
+    ]
+    // Only Dev has cached demand
+    const simulated = new Map<string, number>([['Dev|0', 5]])
+    const result = mergeWeeklyDemand(fallback, simulated)
+    // Dev week 0 uses simulated (5), Dev week 1 uses fallback (2), QA week 0 uses fallback (1)
+    expect(result.find(r => r.week === 0 && r.resourceTypeName === 'Dev')?.demandDays).toBe(5)
+    expect(result.find(r => r.week === 1 && r.resourceTypeName === 'Dev')?.demandDays).toBe(2)
+    expect(result.find(r => r.week === 0 && r.resourceTypeName === 'QA')?.demandDays).toBe(1)
+  })
+
+  it('filters out zero-demand rows', () => {
+    const fallback: Array<{ week: number; resourceTypeName: string; demandDays: number; capacityDays: number }> = []
+    const simulated = new Map<string, number>([
+      ['Dev|0', -1], // negative should be filtered... actually checked as demandDays <= 0 after rounding
+    ])
+    const result = mergeWeeklyDemand(fallback, simulated)
+    // -1 rounds to -1, so it passes the demandDays > 0 filter...
+    // Actually Math.round(-1*100)/100 = -1, which is not > 0, so it's filtered
+    expect(result).toHaveLength(0)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// computeWeeklyCapacity
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('computeWeeklyCapacity', () => {
+  it('returns empty for endWeek <= 0', () => {
+    const result = computeWeeklyCapacity([], 8, 0, new Map())
+    expect(result).toHaveLength(0)
+  })
+
+  it('computes capacity for each RT for each week', () => {
+    const rts = [
+      { id: 'rt-dev', name: 'Developer', hoursPerDay: 8, allocationMode: 'EFFORT', count: 2, namedResources: [] as Array<{ id: string }> },
+      { id: 'rt-qa', name: 'QA', hoursPerDay: 8, allocationMode: 'EFFORT', count: 1, namedResources: [] as Array<{ id: string }> },
+    ]
+    const result = computeWeeklyCapacity(rts, 8, 3, new Map())
+    // 2 RTs × 3 weeks = 6 rows
+    expect(result).toHaveLength(6)
+    // Developer: count=2 → 2*5=10 days/week (at 8hpd)
+    const devWeek0 = result.find(r => r.resourceTypeName === 'Developer' && r.week === 0)
+    expect(devWeek0?.capacityDays).toBe(10)
+    // QA: count=1 → 1*5=5 days/week
+    const qaWeek0 = result.find(r => r.resourceTypeName === 'QA' && r.week === 0)
+    expect(qaWeek0?.capacityDays).toBe(5)
+  })
+
+  it('uses CAPACITY_PLAN weekly headcount when applicable', () => {
+    const materialized: MaterializedCapacityPlanResource = {
+      resourceTypeId: 'rt-cp',
+      totalDays: 0,
+      weeklyHeadcount: new Map([[0, 1.5], [1, 1.5]]),
+      slotWindows: [],
+      startWeek: 0,
+      endWeek: 1,
+    }
+    const cpMap = new Map<string, MaterializedCapacityPlanResource>()
+    cpMap.set('rt-cp', materialized)
+
+    const rts = [
+      { id: 'rt-cp', name: 'Security', hoursPerDay: 8, allocationMode: 'CAPACITY_PLAN', count: 1, namedResources: [] as Array<{ id: string }> },
+    ]
+    const result = computeWeeklyCapacity(rts, 8, 2, cpMap)
+    expect(result).toHaveLength(2)
+    expect(result[0].capacityDays).toBe(7.5) // 1.5 * 5
+    expect(result[1].capacityDays).toBe(7.5)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Integration: fallback demand + capacity + merge
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('weekly demand integration', () => {
+  it('pipeline: fallback → merge → produce final weeklyDemand', () => {
+    const rts = [
+      { name: 'Developer', id: 'rt-dev', hoursPerDay: 8, allocationMode: 'EFFORT', count: 2, namedResources: [] as Array<{ id: string }> },
+    ]
+    const entry = {
+      startWeek: 0,
+      durationWeeks: 4,
+      feature: {
+        userStories: [
+          {
+            isActive: true,
+            tasks: [
+              {
+                resourceTypeId: 'rt-dev',
+                hoursEffort: 64,
+                durationDays: null,
+                resourceType: { name: 'Developer', hoursPerDay: 8 },
+              },
+            ],
+          },
+        ],
+      },
+    }
+
+    const fallback = buildFallbackWeeklyDemand([entry], rts, new Map(), 8)
+    // 64/8 = 8 days spread over 4 weeks = 2 days/week
+    expect(fallback).toHaveLength(4)
+    expect(fallback[0].demandDays).toBe(2)
+
+    // Merge with cached demand (simulated replaces weeks 0-1)
+    const simulated = new Map<string, number>([
+      ['Developer|0', 4],
+      ['Developer|1', 4],
+    ])
+    const merged = mergeWeeklyDemand(fallback, simulated)
+    expect(merged).toHaveLength(4)
+    expect(merged.find(r => r.week === 0)?.demandDays).toBe(4)
+    expect(merged.find(r => r.week === 2)?.demandDays).toBe(2)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Stable IDs and display metadata
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('stable IDs and display metadata', () => {
+  it('capacity plan fallback synthetic IDs are deterministic', () => {
+    const materialized: MaterializedCapacityPlanResource = {
+      resourceTypeId: 'rt-cp',
+      totalDays: 50,
+      weeklyHeadcount: new Map(),
+      slotWindows: [
+        { startWeek: 0, endWeek: 4, allocationPercent: 100 },
+        { startWeek: 5, endWeek: 9, allocationPercent: 50 },
+      ],
+      startWeek: 0,
+      endWeek: 9,
+    }
+    const cpMap = new Map<string, MaterializedCapacityPlanResource>()
+    cpMap.set('rt-cp', materialized)
+
+    const rt = [{
+      id: 'rt-cp',
+      name: 'Security',
+      category: 'ENGINEERING' as const,
+      count: 1,
+      hoursPerDay: 8,
+      dayRate: null,
+      allocationMode: 'CAPACITY_PLAN',
+      allocationPercent: 100,
+      allocationStartWeek: null,
+      allocationEndWeek: null,
+      namedResources: [] as Array<{ id: string; name: string; startWeek: number | null; endWeek: number | null; allocationMode: string | null; allocationPercent: number | null; allocationStartWeek: number | null; allocationEndWeek: number | null; pricingModel: string | null; synthetic: boolean }>,
+      capacityPlanMaterialized: materialized,
+    }]
+    const result = applyCapacityPlanFallback(rt, cpMap)
+    // IDs are deterministic: rt-id + capacity-plan-N
+    expect(result[0].namedResources[0].id).toBe('rt-cp-capacity-plan-1')
+    expect(result[0].namedResources[1].id).toBe('rt-cp-capacity-plan-2')
+  })
+
+  it('named resource IDs are passed through from source records', () => {
+    const rt = [{
+      id: 'rt-dev',
+      name: 'Developer',
+      category: 'ENGINEERING' as const,
+      count: 2,
+      hoursPerDay: 8,
+      dayRate: null,
+      allocationMode: 'EFFORT',
+      allocationPercent: 100,
+      allocationStartWeek: null,
+      allocationEndWeek: null,
+      namedResources: [
+        {
+          id: 'nr-alice',
+          name: 'Alice',
+          startWeek: null,
+          endWeek: null,
+          allocationMode: 'EFFORT' as const,
+          allocationPercent: 100,
+          allocationStartWeek: null,
+          allocationEndWeek: null,
+          pricingModel: 'ACTUAL_DAYS' as const,
+          synthetic: false as const,
+        },
+      ],
+      capacityPlanMaterialized: undefined,
+    }]
+    const result = applyCapacityPlanFallback(rt, new Map())
+    expect(result[0].namedResources[0].id).toBe('nr-alice')
+    expect(result[0].namedResources[0].name).toBe('Alice')
+  })
+})

--- a/server/src/test/resourceProfile.test.ts
+++ b/server/src/test/resourceProfile.test.ts
@@ -1055,4 +1055,34 @@ describe('GET /api/projects/:projectId/resource-profile', () => {
       }),
     ]))
   })
+  it('uses shared computePlanningWindow and handles null startDate', async () => {
+    vi.mocked(prisma.project.findFirst).mockResolvedValue({
+      id: 'proj-1',
+      ownerId: userId,
+      hoursPerDay: 8,
+      startDate: null,
+      name: 'Test Project',
+      weeklyDemandCache: null,
+      bufferWeeks: 2,
+      onboardingWeeks: 1,
+      resourceTypes: [],
+      epics: [],
+      overheads: [],
+      timelineEntries: [
+        { featureId: 'feat-1', startWeek: 0, durationWeeks: 4 },
+      ],
+      storyTimelineEntries: [],
+      capacityPlans: [],
+    } as any)
+
+    const res = await request(app)
+      .get('/api/projects/proj-1/resource-profile')
+      .set('Authorization', authHeader)
+
+    expect(res.status).toBe(200)
+    // max entry end = 4, maxWeek = 4 + 2 + 1 = 7
+    expect(res.body.projectDurationWeeks).toBe(7)
+    expect(res.body.bufferWeeks).toBe(2)
+    expect(res.body.onboardingWeeks).toBe(1)
+  })
 })

--- a/server/src/test/timeline.test.ts
+++ b/server/src/test/timeline.test.ts
@@ -130,6 +130,24 @@ describe('GET /api/projects/:projectId/timeline', () => {
     // durationWeeks=2 => endDate = +14 days
     expect(entry.endDate).toBe('2026-03-15T00:00:00.000Z')
   })
+  it('handles null startDate gracefully without throwing', async () => {
+    vi.mocked(prisma.project.findFirst).mockResolvedValue({
+      ...mockProject,
+      startDate: null,
+    } as any)
+    vi.mocked(prisma.timelineEntry.findMany).mockResolvedValue(mockEntries as any)
+    vi.mocked(prisma.resourceType.findMany).mockResolvedValue([])
+
+    const res = await request(app)
+      .get('/api/projects/proj-1/timeline')
+      .set('Authorization', authHeader)
+
+    expect(res.status).toBe(200)
+    const entry = res.body.entries[0]
+    expect(entry.startDate).toBeNull()
+    expect(entry.endDate).toBeNull()
+    expect(res.body.projectedEndDate).toBeNull()
+  })
 
   it('derives CAPACITY_PLAN weekly capacity and named-resource windows from the active plan when persisted windows are stale', async () => {
     vi.mocked(prisma.project.findFirst).mockResolvedValue({
@@ -749,6 +767,69 @@ describe('GET /api/projects/:projectId/timeline', () => {
         endWeek: 4,
       }),
     ]))
+  })
+  it('excludes story entries for inactive features from storyEntries', async () => {
+    vi.mocked(prisma.project.findFirst).mockResolvedValue(mockProject as any)
+    vi.mocked(prisma.timelineEntry.findMany).mockResolvedValue([
+      {
+        id: 'entry-active',
+        projectId: 'proj-1',
+        featureId: 'feat-active',
+        startWeek: 0,
+        durationWeeks: 2,
+        isManual: false,
+        feature: {
+          id: 'feat-active',
+          name: 'Active Feature',
+          order: 0,
+          isActive: true,
+          epic: { id: 'epic-1', name: 'Main Epic', isActive: true, order: 0, featureMode: 'SEQUENTIAL', scheduleMode: 'AUTO', timelineStartWeek: null },
+          userStories: [],
+        },
+      },
+      {
+        id: 'entry-inactive',
+        projectId: 'proj-1',
+        featureId: 'feat-inactive',
+        startWeek: 3,
+        durationWeeks: 2,
+        isManual: false,
+        feature: {
+          id: 'feat-inactive',
+          name: 'Inactive Feature',
+          order: 1,
+          isActive: false,
+          epic: { id: 'epic-1', name: 'Main Epic', isActive: true, order: 0, featureMode: 'SEQUENTIAL', scheduleMode: 'AUTO', timelineStartWeek: null },
+          userStories: [],
+        },
+      },
+    ] as any)
+    vi.mocked(prisma.resourceType.findMany).mockResolvedValue([])
+    vi.mocked(prisma.storyTimelineEntry.findMany).mockResolvedValue([
+      {
+        storyId: 'story-active',
+        startWeek: 0,
+        durationWeeks: 2,
+        isManual: false,
+        story: { name: 'Active Story', featureId: 'feat-active' },
+      },
+      {
+        storyId: 'story-inactive',
+        startWeek: 3,
+        durationWeeks: 2,
+        isManual: false,
+        story: { name: 'Inactive Story', featureId: 'feat-inactive' },
+      },
+    ] as any)
+
+    const res = await request(app)
+      .get('/api/projects/proj-1/timeline')
+      .set('Authorization', authHeader)
+
+    expect(res.status).toBe(200)
+    expect(res.body.storyEntries).toHaveLength(1)
+    expect(res.body.storyEntries[0].storyName).toBe('Active Story')
+    expect(res.body.storyEntries[0].featureId).toBe('feat-active')
   })
 })
 

--- a/server/src/test/timeline.test.ts
+++ b/server/src/test/timeline.test.ts
@@ -831,6 +831,69 @@ describe('GET /api/projects/:projectId/timeline', () => {
     expect(res.body.storyEntries[0].storyName).toBe('Active Story')
     expect(res.body.storyEntries[0].featureId).toBe('feat-active')
   })
+  it('excludes story entries for inactive epic from storyEntries', async () => {
+    vi.mocked(prisma.project.findFirst).mockResolvedValue(mockProject as any)
+    vi.mocked(prisma.timelineEntry.findMany).mockResolvedValue([
+      {
+        id: 'entry-active-epic',
+        projectId: 'proj-1',
+        featureId: 'feat-active-epic',
+        startWeek: 0,
+        durationWeeks: 2,
+        isManual: false,
+        feature: {
+          id: 'feat-active-epic',
+          name: 'Feature in Active Epic',
+          order: 0,
+          isActive: true,
+          epic: { id: 'epic-active', name: 'Active Epic', isActive: true, order: 0, featureMode: 'SEQUENTIAL', scheduleMode: 'AUTO', timelineStartWeek: null },
+          userStories: [],
+        },
+      },
+      {
+        id: 'entry-inactive-epic',
+        projectId: 'proj-1',
+        featureId: 'feat-inactive-epic',
+        startWeek: 3,
+        durationWeeks: 2,
+        isManual: false,
+        feature: {
+          id: 'feat-inactive-epic',
+          name: 'Feature in Inactive Epic',
+          order: 1,
+          isActive: true,
+          epic: { id: 'epic-inactive', name: 'Inactive Epic', isActive: false, order: 1, featureMode: 'SEQUENTIAL', scheduleMode: 'AUTO', timelineStartWeek: null },
+          userStories: [],
+        },
+      },
+    ] as any)
+    vi.mocked(prisma.resourceType.findMany).mockResolvedValue([])
+    vi.mocked(prisma.storyTimelineEntry.findMany).mockResolvedValue([
+      {
+        storyId: 'story-active-epic',
+        startWeek: 0,
+        durationWeeks: 2,
+        isManual: false,
+        story: { name: 'Active Epic Story', featureId: 'feat-active-epic' },
+      },
+      {
+        storyId: 'story-inactive-epic',
+        startWeek: 3,
+        durationWeeks: 2,
+        isManual: false,
+        story: { name: 'Inactive Epic Story', featureId: 'feat-inactive-epic' },
+      },
+    ] as any)
+
+    const res = await request(app)
+      .get('/api/projects/proj-1/timeline')
+      .set('Authorization', authHeader)
+
+    expect(res.status).toBe(200)
+    expect(res.body.storyEntries).toHaveLength(1)
+    expect(res.body.storyEntries[0].storyName).toBe('Active Epic Story')
+    expect(res.body.storyEntries[0].featureId).toBe('feat-active-epic')
+  })
 })
 
 describe('POST /api/projects/:projectId/timeline/schedule', () => {


### PR DESCRIPTION
## Summary

Extracts duplicated planning derivation logic from `timeline.ts` into a single shared server module (`server/src/lib/projectPlanningModel.ts`). The read model owns planning/capacity-derived facts only — delivery effort; commercial pricing rules remain out of scope.

This is a **partial extraction** scoped to Timeline. Resource Profile extraction is tracked in follow-up issue #274.

**Does NOT close #264.** The parent issue will be closed once Resource Profile also consumes the shared model (#274).

---

### Latest review round (commit `e376467`)

| Review finding | Fix |
|---|---|
| **Inactive story leakage** — `activeFeatureIdSet` built from `allFeatureIds` | Restructured: filter active entries before loading deps; `activeFeatureIdSet` now built from `activeEntries.map(e => e.featureId)` |
| **Inactive epic story leakage** — not tested | Added test: story entry for feature in inactive epic is excluded from `storyEntries` |
| **Dependency queries include inactive entries** | Feature/story dependency queries now use active feature/story IDs only |
| **#264 scope overreach** — claims `Closes #264` but RP still partly independent | Re-scoped: this PR is Timeline-only; new issue #274 tracks RP consumption |

### Previous review round (commit `7ce11b0`)

| Finding | Fix |
|---|---|
| **Null startDate** — `new Date(model.startDate ?? '')` creates Invalid Date | Safe conversion: `model.startDate ? new Date(model.startDate) : null` |
| **Resource Profile** still duplicated planning computation | Imports `computePlanningWindow()` from shared model (partial RP alignment) |
| **Stale PR reference** — header said PR #272 | Corrected to PR #273 |
| **Vague TODO** | Updated with explicit issue link (#268) |

### What's in the shared module

| Fact | Now lives in model | Consumed by |
|---|---|---|
| Planning window (weeks, projected end date) | `computePlanningWindow()` | `timeline.ts`, `resourceProfile.ts` |
| Weekly demand (cache+fallback merge) | `buildFallbackWeeklyDemand()` + `mergeWeeklyDemand()` | `timeline.ts`, `resourceProfile.ts` (`mergeWeeklyDemand`) |
| Weekly capacity (with CAPACITY_PLAN support) | `computeWeeklyCapacity()` | `timeline.ts` |
| Resource type facts with capacity plan materialization | `applyCapacityPlanFallback()` | `timeline.ts` |
| Named resource assignments | `deriveNamedResourceAssignments()` | `timeline.ts`, `resourceProfile.ts` |
| Planning warnings (parallel features) | `computeParallelWarnings()` | `timeline.ts` |

### What did NOT change

- CSV export route — still computes demand inline (simplified version)
- `squadPlan.ts` — still uses its own `loadSchedulerInput` pattern
- Scheduling/rescheduling command paths (POST `/schedule`, leveller, SA-planner)
- Commercial pricing logic — not introduced into the read model per domain boundary rules
- Resource Profile response shape (backward compatible)

### Remaining route-local duplication (tracked in #268)

- `timeline.ts` GET → reloads raw entries for feature-entry presentation formatting (resource breakdown, effective engineers)
- `resourceProfile.ts` → fallback demand generation iterates project hierarchy rather than timeline entries (structural difference; tracked in #274)
- CSV export route → inline simplified demand

### Testing

```
Test Files  25 passed (25)
      Tests  344 passed (344)
Server: tsc --noEmit — clean
Client: tsc --noEmit — clean
```

**New tests added:**
1. `GET /timeline` with null `startDate` returns `startDate: null`, `endDate: null`, `projectedEndDate: null`
2. `GET /timeline` excludes story entries for inactive features from `storyEntries`
3. `GET /timeline` excludes story entries for inactive epic from `storyEntries`
4. `GET /resource-profile` with null `startDate` uses `computePlanningWindow` correctly

### Files changed

| File | What |
|---|---|
| `server/src/lib/projectPlanningModel.ts` | Shared read model (pure functions + thin data-loading wrapper) |
| `server/src/test/projectPlanningModel.test.ts` | 27 unit tests for pure functions |
| `server/src/routes/timeline.ts` | GET `/timeline` → calls `buildProjectPlanningModel` |
| `server/src/routes/resourceProfile.ts` | GET `/resource-profile` → uses `computePlanningWindow` from shared model |
| `server/src/test/timeline.test.ts` | +3 tests (null startDate, inactive feature, inactive epic) |
| `server/src/test/resourceProfile.test.ts` | +1 test (null startDate via shared model) |