### PR TITLE
feat(#266): clarify named-resource billing basis terminology (v2 — address review)

### DIFF
--- a/client/src/components/resource-profile/CommercialTab.tsx
+++ b/client/src/components/resource-profile/CommercialTab.tsx
@@ -133,7 +133,11 @@ export default function CommercialTab({
                     <td className="px-6 py-3 text-gray-900 dark:text-white font-medium">
                       {row.name}
                       {row.kind === 'overhead' && <span className="text-xs text-amber-600 ml-2">(overhead)</span>}
-                      {row.kind === 'named-resource' && <span className="text-xs text-blue-500 ml-2">(person)</span>}
+                      {row.kind === 'named-resource' && (
+                        <span className="text-xs text-blue-500 ml-2">
+                          (person · {row.pricingModel === 'PRO_RATA' ? 'planned allocation' : 'actual scheduled days'})
+                        </span>
+                      )}
                     </td>
                     <td className="text-center px-4 py-3 text-gray-800 dark:text-gray-100">{row.count}</td>
                     <td className="text-right px-4 py-3 text-gray-500 dark:text-gray-400">{formatNumber(row.effortDays)}</td>

--- a/client/src/components/resource-profile/NamedResourcesPanel.tsx
+++ b/client/src/components/resource-profile/NamedResourcesPanel.tsx
@@ -233,6 +233,7 @@ export default function NamedResourcesPanel({
                     disabled={!resource.persisted}
                     className="border border-gray-200 dark:border-gray-600 rounded px-2 py-1 text-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-gray-400 focus:outline-none focus:ring-1 focus:ring-lab3-blue w-full disabled:opacity-60"
                   />
+                  <label className="block text-xs text-gray-500 dark:text-gray-400 mb-1 font-medium" title="Determines which days are used for commercial billing — does not affect the planning schedule">Billing basis</label>
                   <select
                     defaultValue={resource.pricingModel}
                     onChange={(e) => {
@@ -247,8 +248,8 @@ export default function NamedResourcesPanel({
                     disabled={!resource.persisted}
                     className="border border-gray-200 dark:border-gray-600 rounded px-2 py-1 text-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-gray-400 focus:outline-none focus:ring-1 focus:ring-lab3-blue w-full disabled:opacity-60"
                   >
-                    <option value="ACTUAL_DAYS">Actual Days</option>
-                    <option value="PRO_RATA">Pro-rata</option>
+                    <option value="ACTUAL_DAYS">Actual scheduled days</option>
+                    <option value="PRO_RATA">Planned allocation</option>
                   </select>
                   <div className="text-xs text-gray-500 dark:text-gray-400">
                     <div>{formatAssignedSummary(resource.allocation)}</div>

--- a/client/src/components/resource-profile/NamedResourcesPanel.tsx
+++ b/client/src/components/resource-profile/NamedResourcesPanel.tsx
@@ -233,9 +233,11 @@ export default function NamedResourcesPanel({
                     disabled={!resource.persisted}
                     className="border border-gray-200 dark:border-gray-600 rounded px-2 py-1 text-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-gray-400 focus:outline-none focus:ring-1 focus:ring-lab3-blue w-full disabled:opacity-60"
                   />
-                  <label className="block text-xs text-gray-500 dark:text-gray-400 mb-1 font-medium" title="Determines which days are used for commercial billing — does not affect the planning schedule">Billing basis</label>
+                  <label htmlFor={`billing-basis-${resource.id}`} className="block text-xs text-gray-500 dark:text-gray-400 mb-1 font-medium" title="Determines which days are used for commercial billing — does not affect the planning schedule">Billing basis</label>
                   <select
+                    id={`billing-basis-${resource.id}`}
                     defaultValue={resource.pricingModel}
+                    aria-describedby={`billing-desc-${resource.id}`}
                     onChange={(e) => {
                       if (!resource.persisted) return
                       if (e.target.value !== resource.pricingModel) {
@@ -251,6 +253,7 @@ export default function NamedResourcesPanel({
                     <option value="ACTUAL_DAYS">Actual scheduled days</option>
                     <option value="PRO_RATA">Planned allocation</option>
                   </select>
+                  <span id={`billing-desc-${resource.id}`} className="sr-only">Determines which days are used for commercial billing. Does not affect the planning schedule.</span>
                   <div className="text-xs text-gray-500 dark:text-gray-400">
                     <div>{formatAssignedSummary(resource.allocation)}</div>
                     {resource.allocation?.actualAllocatedDays ? (

--- a/client/src/test/CommercialTab.test.tsx
+++ b/client/src/test/CommercialTab.test.tsx
@@ -1,0 +1,245 @@
+import { describe, expect, it, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import CommercialTab from '@/components/resource-profile/CommercialTab'
+import type { CommercialData } from '@/utils/financialCalculations'
+
+function createMockCommercialData(overrides: Partial<CommercialData> = {}): CommercialData {
+  return {
+    rows: [],
+    subtotal: 0,
+    projectDiscounts: [],
+    totalProjectDiscount: 0,
+    afterDiscounts: 0,
+    taxRate: null,
+    taxLabel: '',
+    taxEnabled: false,
+    taxAmount: 0,
+    grandTotal: 0,
+    ...overrides,
+  }
+}
+
+function renderTab(commercialData: CommercialData) {
+  return render(
+    <CommercialTab
+      projectId="project-1"
+      profile={{
+        projectId: 'project-1',
+        hoursPerDay: 8,
+        projectDurationWeeks: 10,
+        bufferWeeks: 0,
+        onboardingWeeks: 0,
+        resourceRows: [],
+        overheadRows: [],
+        summary: { totalHours: 0, totalDays: 0, totalCost: null, hasCost: false },
+      }}
+      project={{ id: 'project-1', name: 'Test Project', taxRate: null, taxLabel: '' } as any}
+      rateCards={[]}
+      commercialData={commercialData}
+      showDiscountForm={false}
+      setShowDiscountForm={vi.fn()}
+      discountForm={null}
+      setDiscountForm={vi.fn()}
+      discountFormError={null}
+      selectedRateCardId={null}
+      setSelectedRateCardId={vi.fn()}
+      rateCardResult={null}
+      editingTaxLabel={false}
+      setEditingTaxLabel={vi.fn()}
+      taxLabelDraft=""
+      setTaxLabelDraft={vi.fn()}
+      editingTaxRate={false}
+      setEditingTaxRate={vi.fn()}
+      taxRateDraft=""
+      setTaxRateDraft={vi.fn()}
+      bufferWeeks={0}
+      setBufferWeeks={vi.fn()}
+      onboardingWeeks={0}
+      setOnboardingWeeks={vi.fn()}
+      createDiscount={{ mutate: vi.fn() } as any}
+      deleteDiscount={{ mutate: vi.fn() } as any}
+      updateTax={{ mutate: vi.fn() } as any}
+      applyRateCard={{ mutate: vi.fn() } as any}
+      handleDiscountSubmit={vi.fn()}
+      handleApplyRateCard={vi.fn()}
+      getAllocationBadge={() => ({ label: 'T&M', color: 'bg-gray-100 text-gray-600', sub: null })}
+      weekToDate={vi.fn(() => null)}
+      fmtDate={vi.fn(() => '')}
+      formatNumber={(value: number, fractionDigits = 2) => value.toFixed(fractionDigits)}
+      saveBufferOnboarding={vi.fn()}
+      filteredResourceRows={[]}
+    />,
+  )
+}
+
+describe('CommercialTab billing basis indicator', () => {
+  it('shows actual scheduled days indicator for ACTUAL_DAYS named resources', () => {
+    const data = createMockCommercialData({
+      rows: [
+        {
+          id: 'nr-1',
+          name: 'Developer',
+          count: 1,
+          effortDays: 10,
+          allocatedDays: 8,
+          totalDays: 8,
+          dayRate: 500,
+          subtotal: 4000,
+          allocationMode: 'EFFORT',
+          allocationPercent: 100,
+          allocationStartWeek: 0,
+          allocationEndWeek: 9,
+          derivedStartWeek: 0,
+          derivedEndWeek: 9,
+          kind: 'named-resource',
+          pricingModel: 'ACTUAL_DAYS',
+          resourceTypeId: 'rt-1',
+          appliedDiscounts: [],
+          netSubtotal: 4000,
+        },
+      ],
+      subtotal: 4000,
+    })
+
+    renderTab(data)
+    expect(screen.getByText('(person · actual scheduled days)')).toBeInTheDocument()
+  })
+
+  it('shows planned allocation indicator for PRO_RATA named resources', () => {
+    const data = createMockCommercialData({
+      rows: [
+        {
+          id: 'nr-2',
+          name: 'Designer',
+          count: 1,
+          effortDays: 10,
+          allocatedDays: 10,
+          totalDays: 10,
+          dayRate: 600,
+          subtotal: 6000,
+          allocationMode: 'EFFORT',
+          allocationPercent: 100,
+          allocationStartWeek: 0,
+          allocationEndWeek: 9,
+          derivedStartWeek: 0,
+          derivedEndWeek: 9,
+          kind: 'named-resource',
+          pricingModel: 'PRO_RATA',
+          resourceTypeId: 'rt-2',
+          appliedDiscounts: [],
+          netSubtotal: 6000,
+        },
+      ],
+      subtotal: 6000,
+    })
+
+    renderTab(data)
+    expect(screen.getByText('(person · planned allocation)')).toBeInTheDocument()
+  })
+
+  it('does not show billing basis indicator for resource (non-named) rows', () => {
+    const data = createMockCommercialData({
+      rows: [
+        {
+          id: 'rt-1',
+          name: 'Security Consultant',
+          count: 1,
+          effortDays: 5,
+          allocatedDays: 5,
+          totalDays: 5,
+          dayRate: 1200,
+          subtotal: 6000,
+          allocationMode: 'EFFORT',
+          allocationPercent: 100,
+          allocationStartWeek: null,
+          allocationEndWeek: null,
+          derivedStartWeek: null,
+          derivedEndWeek: null,
+          kind: 'resource',
+          pricingModel: null,
+          resourceTypeId: 'rt-1',
+          appliedDiscounts: [],
+          netSubtotal: 6000,
+        },
+      ],
+      subtotal: 6000,
+    })
+
+    renderTab(data)
+    expect(screen.queryByText(/person ·/)).not.toBeInTheDocument()
+  })
+
+  it('does not show billing basis indicator for overhead rows', () => {
+    const data = createMockCommercialData({
+      rows: [
+        {
+          id: 'oh-1',
+          name: 'Travel',
+          count: 1,
+          effortDays: 0,
+          allocatedDays: 0,
+          totalDays: 0,
+          dayRate: 0,
+          subtotal: 5000,
+          allocationMode: 'FULL_PROJECT',
+          allocationPercent: 100,
+          allocationStartWeek: null,
+          allocationEndWeek: null,
+          derivedStartWeek: null,
+          derivedEndWeek: null,
+          kind: 'overhead',
+          pricingModel: null,
+          resourceTypeId: 'oh-1',
+          appliedDiscounts: [],
+          netSubtotal: 5000,
+        },
+      ],
+      subtotal: 5000,
+    })
+
+    renderTab(data)
+    expect(screen.queryByText(/person ·/)).not.toBeInTheDocument()
+  })
+
+  it('indicator is display-only, no editable controls from #276', () => {
+    const data = createMockCommercialData({
+      rows: [
+        {
+          id: 'nr-1',
+          name: 'Developer',
+          count: 1,
+          effortDays: 10,
+          allocatedDays: 8,
+          totalDays: 8,
+          dayRate: 500,
+          subtotal: 4000,
+          allocationMode: 'EFFORT',
+          allocationPercent: 100,
+          allocationStartWeek: 0,
+          allocationEndWeek: 9,
+          derivedStartWeek: 0,
+          derivedEndWeek: 9,
+          kind: 'named-resource',
+          pricingModel: 'ACTUAL_DAYS',
+          resourceTypeId: 'rt-1',
+          appliedDiscounts: [],
+          netSubtotal: 4000,
+        },
+      ],
+      subtotal: 4000,
+    })
+
+    renderTab(data)
+
+    // The billing basis indicator is a <span> — not a <select>, <input>, or <button>
+    const indicator = screen.getByText('(person · actual scheduled days)')
+    expect(indicator.tagName).toBe('SPAN')
+
+    // Verify no allocation-mode editing controls from #276 are present
+    // (allocation mode editing lives in Resource Profile, not Commercial)
+    // The cost summary may still display allocation badge text (e.g. "T&M") as read-only info
+    expect(screen.queryByRole('combobox', { name: /allocation mode/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /edit allocation/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole('combobox', { name: /timeline|effort|capacity plan|full project/i })).not.toBeInTheDocument()
+  })
+})

--- a/client/src/test/NamedResourcesPanel.test.tsx
+++ b/client/src/test/NamedResourcesPanel.test.tsx
@@ -122,3 +122,50 @@ describe('NamedResourcesPanel cache invalidation', () => {
     })
   })
 })
+
+describe('NamedResourcesPanel billing basis terminology', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('displays Billing basis label', async () => {
+    renderPanel()
+    const labels = await screen.findAllByText('Billing basis')
+    expect(labels).toHaveLength(2)
+  })
+
+  it('shows Actual scheduled days option', async () => {
+    renderPanel()
+    await screen.findByDisplayValue('Developer 1')
+    const options = screen.getAllByText('Actual scheduled days')
+    expect(options).toHaveLength(2)
+  })
+
+  it('shows Planned allocation option', async () => {
+    renderPanel()
+    await screen.findByDisplayValue('Developer 1')
+    const options = screen.getAllByText('Planned allocation')
+    expect(options).toHaveLength(2)
+  })
+
+  it('does not show old labels Actual Days or Pro-rata', async () => {
+    renderPanel()
+    await screen.findByDisplayValue('Developer 1')
+    expect(screen.queryByText('Actual Days')).not.toBeInTheDocument()
+    expect(screen.queryByText('Pro-rata')).not.toBeInTheDocument()
+  })
+
+  it('has accessible billing basis selects with name Billing basis', async () => {
+    renderPanel()
+    const selects = await screen.findAllByRole('combobox', { name: 'Billing basis' })
+    expect(selects).toHaveLength(2)
+  })
+
+  it('provides helper text that billing does not affect schedule', async () => {
+    renderPanel()
+    await screen.findByDisplayValue('Developer 1')
+    const descriptions = screen.getAllByText('Determines which days are used for commercial billing. Does not affect the planning schedule.')
+    expect(descriptions).toHaveLength(2)
+    descriptions.forEach(el => expect(el.className).toContain('sr-only'))
+  })
+})

--- a/client/src/test/ResourceProfileTab.test.tsx
+++ b/client/src/test/ResourceProfileTab.test.tsx
@@ -490,6 +490,6 @@ describe('ResourceProfileTab', () => {
         allocationStartWeek: null,
         allocationEndWeek: null,
       },
-    })
+    }, { onSuccess: expect.any(Function) })
   })
 })


### PR DESCRIPTION
Closes #266
Part of epic #263

## Summary

Renames named-resource billing basis UI labels from planning-ambiguous wording to clear commercial wording. Preserves all enum values (`ACTUAL_DAYS`, `PRO_RATA`) and calculation semantics.

## Changes

### Accessibility (NamedResourcesPanel.tsx)
- **Label associated with select** via `htmlFor={`billing-basis-${resource.id}`}` / `id={`billing-basis-${resource.id}`}` on the `<select>`
- **aria-describedby** on the select pointing to the helper text element
- **Screen-reader-accessible helper text**: "Determines which days are used for commercial billing. Does not affect the planning schedule."
- Accessible name for each billing-basis select is now correctly **"Billing basis"** for assistive technology

### Test Coverage (11 new tests — 6 NRP + 5 Commercial)

**NamedResourcesPanel** (`client/src/test/NamedResourcesPanel.test.tsx`):
- Billing basis label visible
- Actual scheduled days option present
- Planned allocation option present
- Old labels "Actual Days" and "Pro-rata" NOT present
- Accessible billing basis selects with name "Billing basis"
- Helper text about billing not affecting planning schedule present

**CommercialTab** (`client/src/test/CommercialTab.test.tsx` — new file):
- Named-resource rows show billing indicator for ACTUAL_DAYS
- Named-resource rows show billing indicator for PRO_RATA
- No billing indicator for non-named resource rows
- No billing indicator for overhead rows
- Indicator is display-only (span, not editable controls from #276)

## What is preserved (unchanged)
- Enum/API values: ACTUAL_DAYS and PRO_RATA unchanged
- Calculation semantics: getNamedResourceBillableDays logic unchanged
- Allocation-mode editing location: Not moved (per #276)
- Commercial tab redesign: None
- Database enum values: Not renamed
- No scope creep into #267 or redesign

## Verification

```bash
# Client TSC — clean
cd client && npx tsc --noEmit

# Client tests — 25/25
cd client && npx vitest run src/test/NamedResourcesPanel.test.tsx src/test/ResourceProfileTab.test.tsx src/test/CommercialTab.test.tsx src/utils/financialCalculations.test.ts
# NamedResourcesPanel: 11/11, ResourceProfileTab: 6/6, CommercialTab: 5/5, financialCalculations: 3/3

# Server TSC — clean
cd server && npx tsc --noEmit

# Server tests — 25 files, 349/349
cd server && npm test
```

Known unrelated failures: authSession.test.tsx (3 tests — pre-existing localStorage mock issue)