### PR TITLE
docs: add simplicity review instructions

### DIFF
--- a/.github/instructions/simplicity-review.instructions.md
+++ b/.github/instructions/simplicity-review.instructions.md
@@ -1,0 +1,47 @@
+---
+applyTo: "client/**,server/**,e2e/**"
+---
+
+# Simplicity and Review Instructions
+
+These instructions apply to implementation and review work in Monrad Estimator. They complement `.github/copilot-instructions.md` and `AGENTS.md`.
+
+## Simplicity Rule
+
+Prefer the smallest correct change. Do not add abstractions, dependencies, duplicated state, wrappers, generic configuration, or future-proofing unless the issue explicitly requires it or there are at least two real call sites now.
+
+Before writing code, check whether the work can be solved by:
+
+1. not building it because the behaviour is unnecessary
+2. the standard library
+3. a native browser, React, Express, Prisma, Playwright, or platform feature
+4. an already-installed dependency
+5. direct code with fewer moving parts
+6. only then, the minimum new code that works
+
+Deletion beats addition when behaviour remains correct.
+
+## Do Not Cut Required Safeguards
+
+Do not remove or weaken validation, ownership checks, migration safety, rollback safety, accessibility, loading states, empty states, focused tests, requested scope, or error handling needed to avoid silent failure or data corruption.
+
+## Review Procedure
+
+Use two passes for PR review:
+
+1. Correctness pass: behaviour, data model, API contracts, tests, migrations, safety, accessibility, cache invalidation, and UX.
+2. Simplicity pass: over-engineering only. Look for dead props, duplicated state, helpers with one caller, abstractions with one implementation, unused flexibility, hand-rolled platform features, unnecessary dependencies, and code that can be deleted.
+
+Correctness wins over simplicity.
+
+When reporting simplicity findings, use concise lines:
+
+```text
+<file>:<line>: delete|stdlib|native|yagni|shrink: <what to cut>. <what replaces it>.
+```
+
+If there is nothing meaningful to simplify, say: `Lean already. Ship.`
+
+## Monrad Ownership Check
+
+When a change touches Timeline, Resource Profile, Commercial, or Document export, explicitly check that there is a single source of truth for scheduling, resource allocation, onboarding/buffer weeks, and commercial calculations. Avoid mirrored state and duplicated calculation logic across tabs.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,74 @@
+# Agent Instructions — Monrad Estimator
+
+These instructions apply to the whole repository.
+
+Monrad Estimator is a full-stack project estimation tool. Follow the detailed project workflow, stack, testing, database, UI, and communication rules in `.github/copilot-instructions.md` as the operational source of truth.
+
+## Simplicity / Ponytail Rule
+
+Prefer the smallest correct change. Boring, direct code is better than clever or speculative code.
+
+Before writing code, stop at the first option that holds:
+
+1. Does this need to be built at all? If not, do not build it.
+2. Does the standard library already do this? Use it.
+3. Does the browser, React, Express, Prisma, Playwright, or another existing platform feature already cover it? Use that.
+4. Does an already-installed dependency solve it? Use it instead of adding another dependency.
+5. Can the same behaviour be expressed directly with fewer moving parts? Prefer that.
+6. Only then write the minimum code that solves the issue.
+
+Do not add abstractions, wrappers, factories, generic configuration, new state ownership, or dependency layers unless the issue requires them or there are at least two real call sites that need the abstraction now.
+
+Deletion beats addition when the behaviour remains correct.
+
+## What Must Not Be Simplified Away
+
+Never use the simplicity rule to remove or weaken:
+
+- authentication, authorisation, ownership checks, or trust-boundary validation
+- database backup, migration safety, rollback safety, or data-loss prevention
+- accessibility, labels, keyboard support, contrast, loading states, and empty states
+- tests that cover non-trivial business logic, permissions, scheduling, document output, or user flows
+- user-requested scope, especially timeline/resource/commercial consistency
+- explicit error handling needed to prevent silent failure or data corruption
+
+A small focused test is not bloat. Non-trivial logic should leave behind the smallest runnable check that would fail if the behaviour regresses.
+
+## Monrad-Specific Ownership Rules
+
+Be especially careful not to duplicate ownership across these areas:
+
+- Timeline owns scheduling, dependency, onboarding, and buffer planning behaviour.
+- Resource Profile should aggregate and explain resource demand rather than re-own scheduling settings.
+- Commercial should calculate and display pricing/commercial impact rather than maintain separate planning state.
+- Document generation should render from the same source data used by the app, not recreate scheduling or costing rules.
+
+If a change touches Timeline, Resource Profile, Commercial, or Document export, explicitly check for duplicated state, duplicated calculations, stale props, and cache invalidation gaps.
+
+## PR Review Procedure
+
+Use two review passes:
+
+1. **Correctness pass** — check behaviour, data model consistency, tests, migrations, security, permissions, accessibility, API contracts, and UX impact.
+2. **Ponytail pass** — review for over-engineering only. Look for code that can be deleted, props that no longer need to exist, duplicated state, helpers with one caller, abstractions with one implementation, unused flexibility, hand-rolled platform features, or unnecessary dependencies.
+
+Do not let the Ponytail pass override correctness. If correctness and simplicity conflict, correctness wins.
+
+When reporting Ponytail findings, use concise lines:
+
+```text
+<file>:<line>: delete|stdlib|native|yagni|shrink: <what to cut>. <what replaces it>.
+```
+
+If there is nothing meaningful to simplify, say: `Lean already. Ship.`
+
+## Implementation Checklist
+
+Before completing work or recommending merge:
+
+- Confirm the source of truth for any changed state.
+- Remove dead props, unused helpers, obsolete UI copy, and stale tests.
+- Reuse existing API/client helpers and query invalidation patterns.
+- Keep migrations and schema changes deliberately small.
+- Add or update the smallest useful automated test for changed behaviour.
+- Include manual smoke-test notes when UI behaviour changes.


### PR DESCRIPTION
## Summary

- Adds repo-wide `AGENTS.md` with a Ponytail-inspired simplicity rule for implementation and review work.
- Adds `.github/instructions/simplicity-review.instructions.md` so Copilot-style agents get the same implementation/review guidance when working in `client/`, `server/`, or `e2e/`.
- Defines a two-pass PR review model: correctness first, then a simplification/over-engineering pass.
- Calls out Monrad-specific ownership checks for Timeline, Resource Profile, Commercial, and Document export to avoid duplicated state/calculation ownership.

## Validation

- Docs-only change; no automated tests run.
- Spot-checked both new instruction files on the branch after creation.

## Notes

No issue attached; this follows the repo instruction/process improvement discussed in chat.