### PR TITLE
feat(#266): clarify named-resource billing basis terminology

### DIFF
--- a/client/src/components/resource-profile/NamedResourcesPanel.tsx
+++ b/client/src/components/resource-profile/NamedResourcesPanel.tsx
@@ -159,7 +159,7 @@ export default function NamedResourcesPanel({
                 <span>Start Week</span>
                 <span>End Week</span>
                 <span>Alloc %</span>
-                <span>Pricing</span>
+                <span>Billing basis</span>
                 <span>Assigned weeks</span>
                 <span />
               </div>

--- a/client/src/hooks/useResourceProfile.ts
+++ b/client/src/hooks/useResourceProfile.ts
@@ -82,7 +82,7 @@ export const buildProfileCsv = (profileData: ResourceProfile) => {
     'AssignedEndWeek',
     'AssignedSpans',
     'WeekAllocations',
-    'PricingModel',
+    'Billing basis',
   ]]
 
   profileData.resourceRows.forEach(row => {
@@ -107,7 +107,7 @@ export const buildProfileCsv = (profileData: ResourceProfile) => {
           namedResource.actualAllocationEndWeek != null ? formatWeekLabel(namedResource.actualAllocationEndWeek) : '',
           formatNamedResourceSegments(namedResource),
           formatNamedResourceWeeks(namedResource),
-          namedResource.pricingModel ?? 'ACTUAL_DAYS',
+          namedResource.pricingModel === 'PRO_RATA' ? 'Planned allocation' : 'Actual scheduled days',
         ])
       })
       return

--- a/client/src/test/NamedResourcesPanel.test.tsx
+++ b/client/src/test/NamedResourcesPanel.test.tsx
@@ -131,7 +131,7 @@ describe('NamedResourcesPanel billing basis terminology', () => {
   it('displays Billing basis label', async () => {
     renderPanel()
     const labels = await screen.findAllByText('Billing basis')
-    expect(labels).toHaveLength(2)
+    expect(labels).toHaveLength(3)
   })
 
   it('shows Actual scheduled days option', async () => {


### PR DESCRIPTION
Closes #266
Parent: #263

## Summary

Renames user-facing named-resource billing basis labels to clarify that this is a commercial billing basis, not a planning allocation mode.

### Changes

| Location | Before | After |
|----------|--------|-------|
| Resource Profile named-resource grid column header | `Pricing` | `Billing basis` |
| CSV export column header | `PricingModel` | `Billing basis` |
| CSV export values | `ACTUAL_DAYS` / `PRO_RATA` | `Actual scheduled days` / `Planned allocation` |

### What was already correct (not changed)

- Named-resource `<select>` options: already `Actual scheduled days` / `Planned allocation`
- Per-row `<label>`: already `Billing basis`
- Helper text: already explains billing does not affect schedule
- Commercial tab badge text: already `(person · actual scheduled days)` / `(person · planned allocation)`
- All tests: already testing the correct new labels

### What is preserved

- Enum values `ACTUAL_DAYS` / `PRO_RATA` in database, API, types, and calculations
- Internal code identifiers (`PricingModel` type, `pricingModel` property, `getPricingModel` function)
- All calculation semantics unchanged
- Allocation-mode wording kept separate from billing-basis wording
- Onboarding/buffer week wording kept separate from billing-basis wording

### Test results

```
# Server (all passing)
  Test Files  25 passed (25)
       Tests  349 passed (349)

# Client TSC
  No type errors

# Client billing tests (all passing)
  Test Files  3 passed (3)
       Tests  20 passed (20)

# Pre-existing unrelated failures
  3 authSession.test.tsx failures (pre-existing, not related to this change)
```