### PR TITLE
feat(#268): store planning IDs and derived facts instead of stale display labels

### DIFF
--- a/server/src/lib/projectPlanningModel.ts
+++ b/server/src/lib/projectPlanningModel.ts
@@ -28,8 +28,57 @@ import { deriveNamedResourceAssignments } from './namedResourceAssignments.js'
 import { effectiveDays } from '../utils/round.js'
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Public Types
+// Cache key resolution (backward-compatible: tries ID then legacy name)
 // ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Backward-compatible cache key resolver.
+ * Tries key prefix as a resourceTypeId first; if no match, tries as a legacy
+ * resourceTypeName. Falls back to 'Unknown resource' when neither matches.
+ */
+export function resolveCacheKeyResourceTypeName(
+  prefix: string,
+  resourceTypes: Array<{ id: string; name: string }>,
+): string {
+  const byId = new Map(resourceTypes.map(rt => [rt.id, rt.name]))
+  const byName = new Map(resourceTypes.map(rt => [rt.name.toLowerCase(), rt.name]))
+
+  const nameFromId = byId.get(prefix)
+  if (nameFromId) return nameFromId
+
+  const nameFromLegacy = byName.get(prefix.toLowerCase())
+  if (nameFromLegacy) return nameFromLegacy
+
+  return 'Unknown resource'
+}
+
+/**
+ * Convert a raw weeklyDemandCache (Record<string, number>) whose keys may be
+ * in either modern (resourceTypeId|week) or legacy (resourceTypeName|week)
+ * format into a Map whose keys are always resourceTypeName|week.
+ *
+ * This is the single canonical entry point for reading the weeklyDemandCache.
+ * All cache readers should use this function.
+ */
+export function convertWeeklyDemandCache(
+  cache: Record<string, number> | null | undefined,
+  resourceTypes: Array<{ id: string; name: string }>,
+): Map<string, number> {
+  if (!cache) return new Map()
+  const result = new Map<string, number>()
+  for (const [key, value] of Object.entries(cache)) {
+    const sep = key.lastIndexOf('|')
+    if (sep < 0) continue
+    const prefix = key.substring(0, sep)
+    const week = key.substring(sep + 1)
+    const rtName = resolveCacheKeyResourceTypeName(prefix, resourceTypes)
+    result.set(`${rtName}|${week}`, value)
+  }
+  return result
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Public Types
 
 export interface PlanningWindow {
   /** Last occupied week (max entry end week + buffer + onboarding) */
@@ -582,21 +631,10 @@ export async function buildProjectPlanningModel(
   )
 
   // ── 9. Compute weekly demand ─────────────────────────────────────────
-  const weeklyDemandCache = project.weeklyDemandCache as Record<string, number> | null
-  // Convert cache keys from resourceTypeId|week to name|week format,
-  // resolving display names from current resource type records.
-  const rtIdToName = new Map(resourceTypes.map(rt => [rt.id, rt.name]))
-  const simulatedDemand = weeklyDemandCache
-    ? new Map(
-        Object.entries(weeklyDemandCache).map(([key, val]) => {
-          const sep = key.lastIndexOf('|')
-          const rtId = key.substring(0, sep)
-          const week = key.substring(sep + 1)
-          const rtName = rtIdToName.get(rtId) ?? 'Unknown resource'
-          return [`${rtName}|${week}`, val] as [string, number]
-        }),
-      )
-    : null
+  const simulatedDemand = convertWeeklyDemandCache(
+    project.weeklyDemandCache as Record<string, number> | null,
+    resourceTypes,
+  )
 
   const fallbackDemand = buildFallbackWeeklyDemand(
     activeEntries,

--- a/server/src/lib/projectPlanningModel.ts
+++ b/server/src/lib/projectPlanningModel.ts
@@ -583,8 +583,19 @@ export async function buildProjectPlanningModel(
 
   // ── 9. Compute weekly demand ─────────────────────────────────────────
   const weeklyDemandCache = project.weeklyDemandCache as Record<string, number> | null
+  // Convert cache keys from resourceTypeId|week to name|week format,
+  // resolving display names from current resource type records.
+  const rtIdToName = new Map(resourceTypes.map(rt => [rt.id, rt.name]))
   const simulatedDemand = weeklyDemandCache
-    ? new Map(Object.entries(weeklyDemandCache))
+    ? new Map(
+        Object.entries(weeklyDemandCache).map(([key, val]) => {
+          const sep = key.lastIndexOf('|')
+          const rtId = key.substring(0, sep)
+          const week = key.substring(sep + 1)
+          const rtName = rtIdToName.get(rtId) ?? 'Unknown resource'
+          return [`${rtName}|${week}`, val] as [string, number]
+        }),
+      )
     : null
 
   const fallbackDemand = buildFallbackWeeklyDemand(

--- a/server/src/lib/scheduler.ts
+++ b/server/src/lib/scheduler.ts
@@ -118,7 +118,7 @@ export interface SchedulerOutput {
   }>
   /**
    * Actual resource consumption from the levelling simulation.
-   * Key: `${resourceTypeName}|${week}`, value: days consumed.
+   * Key: `${resourceTypeId}|${week}`, value: days consumed.
    * Empty map when resourceLevel=false.
    */
   weeklyConsumptionMap: Map<string, number>
@@ -674,7 +674,7 @@ export function runScheduler(input: SchedulerInput): SchedulerOutput {
             const rtHours = featureResourceHoursCache.get(fId)!.get(rtId) ?? 0
             if (rtHours > 0) {
               const perStep = (rtHours / (fDone - fStart)) * STEP
-              const consumptionKey = `${rtName}|${currentWeek}`
+              const consumptionKey = `${rtId}|${currentWeek}`
               weeklyConsumptionMap.set(consumptionKey, (weeklyConsumptionMap.get(consumptionKey) ?? 0) + perStep / hpd)
             }
           }
@@ -722,7 +722,7 @@ export function runScheduler(input: SchedulerInput): SchedulerOutput {
         for (const fId of competing) {
           const rem = remainingHours.get(fId)!.get(rtId)!
           const actualAllocated = Math.min((rem / totalRemaining) * capPerStep, rem)
-          const consumptionKey = `${rtName}|${currentWeek}`
+          const consumptionKey = `${rtId}|${currentWeek}`
           weeklyConsumptionMap.set(consumptionKey, (weeklyConsumptionMap.get(consumptionKey) ?? 0) + actualAllocated / hpd)
           remainingHours.get(fId)!.set(rtId, Math.max(0, rem - actualAllocated))
         }

--- a/server/src/lib/scheduler.ts
+++ b/server/src/lib/scheduler.ts
@@ -664,7 +664,6 @@ export function runScheduler(input: SchedulerInput): SchedulerOutput {
       const currentWeek = Math.floor(t)
       for (const rtId of allRtIds) {
         const rt = rtById.get(rtId)
-        const rtName = rt?.name ?? 'Unassigned'
         const hpd = rt?.hoursPerDay ?? fallbackHoursPerDay
         for (const [fId] of manualStartWeeks) {
           const fStart = simStart.get(fId)
@@ -698,7 +697,6 @@ export function runScheduler(input: SchedulerInput): SchedulerOutput {
           ? getWeeklyCapacity(rt, currentWeek, fallbackHoursPerDay)
           : fallbackHoursPerDay * 5
         let capPerStep = capPerWeek * STEP
-        const rtName = rt?.name ?? 'Unassigned'
         const hpd = rt?.hoursPerDay ?? fallbackHoursPerDay
 
         for (const [fId] of manualStartWeeks) {

--- a/server/src/routes/namedResources.ts
+++ b/server/src/routes/namedResources.ts
@@ -19,6 +19,12 @@ async function verifyResourceType(rtId: string, projectId: string) {
 
 const VALID_PRICING_MODELS = ['ACTUAL_DAYS', 'PRO_RATA']
 
+const clearWeeklyDemandCache = (projectId: string, tx?: any) =>
+  (tx ?? prisma).project.update({
+    where: { id: projectId },
+    data: { weeklyDemandCache: {} },
+  })
+
 // GET /projects/:projectId/resource-types/:rtId/named-resources
 router.get('/', asyncHandler(async (req: AuthRequest, res: Response) => {
   const { projectId, rtId } = req.params as { projectId: string; rtId: string }
@@ -131,9 +137,13 @@ router.put('/:id', asyncHandler(async (req: AuthRequest, res: Response) => {
     if (data[key] === undefined) delete data[key]
   })
 
-  const resource = await prisma.namedResource.update({
-    where: { id },
-    data,
+  const resource = await prisma.$transaction(async tx => {
+    const updated = await tx.namedResource.update({
+      where: { id },
+      data,
+    })
+    await clearWeeklyDemandCache(projectId, tx)
+    return updated
   })
   res.json(resource)
 }))
@@ -157,9 +167,13 @@ router.patch('/:id', asyncHandler(async (req: AuthRequest, res: Response) => {
     if (data[key] === undefined) delete data[key]
   })
 
-  const resource = await prisma.namedResource.update({
-    where: { id },
-    data,
+  const resource = await prisma.$transaction(async tx => {
+    const updated = await tx.namedResource.update({
+      where: { id },
+      data,
+    })
+    await clearWeeklyDemandCache(projectId, tx)
+    return updated
   })
   res.json(resource)
 }))
@@ -183,6 +197,7 @@ router.delete('/:id', asyncHandler(async (req: AuthRequest, res: Response) => {
     }
 
     await tx.namedResource.delete({ where: { id } })
+    await clearWeeklyDemandCache(projectId, tx)
 
     // Sync resource type count (can reach 0 when all named resources are deleted)
     const total = await tx.namedResource.count({ where: { resourceTypeId: rtId } })

--- a/server/src/routes/resourceProfile.ts
+++ b/server/src/routes/resourceProfile.ts
@@ -9,7 +9,7 @@ import {
   shouldFallbackToActiveCapacityPlan,
 } from '../lib/capacityPlanMaterialisation.js'
 import { deriveNamedResourceAssignments, type WeeklyDemandLike } from '../lib/namedResourceAssignments.js'
-import { buildFallbackWeeklyDemand, mergeWeeklyDemand, computePlanningWindow } from '../lib/projectPlanningModel.js'
+import { buildFallbackWeeklyDemand, mergeWeeklyDemand, computePlanningWindow, convertWeeklyDemandCache } from '../lib/projectPlanningModel.js'
 type AllocationMode = 'EFFORT' | 'TIMELINE' | 'FULL_PROJECT' | 'CAPACITY_PLAN'
 
 const router = Router({ mergeParams: true })
@@ -270,7 +270,10 @@ router.get('/', asyncHandler(async (req: AuthRequest, res: Response) => {
   let weeklyDemand: WeeklyDemandLike[]
 
   if (weeklyDemandCache && Object.keys(weeklyDemandCache).length > 0) {
-    const simulatedDemand = new Map<string, number>(Object.entries(weeklyDemandCache))
+    const simulatedDemand = convertWeeklyDemandCache(
+      weeklyDemandCache,
+      project.resourceTypes as Array<{ id: string; name: string }>,
+    )
     const merged = mergeWeeklyDemand(fallbackDemand, simulatedDemand)
     weeklyDemand = merged.map(r => ({ week: r.week, resourceTypeName: r.resourceTypeName, demandDays: r.demandDays }))
   } else {

--- a/server/src/routes/squadPlan.ts
+++ b/server/src/routes/squadPlan.ts
@@ -104,19 +104,14 @@ export function stripCapacityPlanMaterialization(
 
 function buildWeeklyDemandCacheFromPlannerResult(
   weeklyDemandByResourceType: Map<string, number[]>,
-  resourceTypes: SchedulerResourceType[],
 ): Record<string, number> {
-  const resourceTypeNameById = new Map(resourceTypes.map(resourceType => [resourceType.id, resourceType.name]))
   const weeklyDemandCache: Record<string, number> = {}
 
   for (const [resourceTypeId, weeklyDemand] of weeklyDemandByResourceType.entries()) {
-    const resourceTypeName = resourceTypeNameById.get(resourceTypeId)
-    if (!resourceTypeName) continue
-
     for (let week = 0; week < weeklyDemand.length; week++) {
       const demandDays = weeklyDemand[week]
       if (!Number.isFinite(demandDays) || demandDays <= 0) continue
-      weeklyDemandCache[`${resourceTypeName}|${week}`] = demandDays
+      weeklyDemandCache[`${resourceTypeId}|${week}`] = demandDays
     }
   }
 

--- a/server/src/routes/squadPlan.ts
+++ b/server/src/routes/squadPlan.ts
@@ -587,7 +587,6 @@ router.post('/apply', asyncHandler(async (req: AuthRequest, res: Response) => {
       })
       refreshedWeeklyDemandCache = buildWeeklyDemandCacheFromPlannerResult(
         plannerResult.weeklyDemandByResourceType,
-        replayResourceTypes,
       )
 
       // Persist epic start weeks

--- a/server/src/routes/timeline.ts
+++ b/server/src/routes/timeline.ts
@@ -17,7 +17,7 @@ import {
   type MaterializedCapacityPlanResource,
 } from '../lib/capacityPlanMaterialisation.js'
 import { deriveNamedResourceAssignments } from '../lib/namedResourceAssignments.js'
-import { buildProjectPlanningModel } from '../lib/projectPlanningModel.js'
+import { buildProjectPlanningModel, convertWeeklyDemandCache } from '../lib/projectPlanningModel.js'
 import { runSAPlanner } from '../lib/sa-planner.js'
 import { buildSnapshot } from './snapshots.js'
 import { pruneSnapshots } from '../lib/snapshotUtils.js'
@@ -734,20 +734,20 @@ router.get('/export/csv', asyncHandler(async (req: AuthRequest, res: Response) =
   // Section 2 — Resource Demand
   const demandRows: string[] = ['ResourceType,Week,DemandDays,CapacityDays,Status']
   if (project.weeklyDemandCache) {
-    const cacheMap = project.weeklyDemandCache as Record<string, number>
-    const rtIdToRt = new Map(project.resourceTypes.map(rt => [rt.id, rt as ResourceTypeWithNamed]))
-    // Cache keys are `${resourceTypeId}|${week}` — resolve display name from current RT data
-    const cacheEntries = Object.entries(cacheMap).map(([key, demandDays]) => {
+    const simulatedDemand = convertWeeklyDemandCache(
+      project.weeklyDemandCache as Record<string, number>,
+      project.resourceTypes as Array<{ id: string; name: string }>,
+    )
+    const cacheEntries = Array.from(simulatedDemand.entries()).map(([key, demandDays]) => {
       const pipeIdx = key.lastIndexOf('|')
-      const rtId = key.slice(0, pipeIdx)
+      const rtName = key.slice(0, pipeIdx)
       const week = Number(key.slice(pipeIdx + 1))
-      const rt = rtIdToRt.get(rtId)
-      const rtName = rt?.name ?? 'Unknown resource'
-      return { rtName, rtId, week, demandDays }
+      return { rtName, week, demandDays }
     }).sort((a, b) => a.week - b.week || a.rtName.localeCompare(b.rtName))
 
-    for (const { rtName, rtId, week, demandDays } of cacheEntries) {
-      const rt = rtIdToRt.get(rtId)
+    const rtByName = new Map(project.resourceTypes.map(rt => [rt.name, rt as ResourceTypeWithNamed]))
+    for (const { rtName, week, demandDays } of cacheEntries) {
+      const rt = rtByName.get(rtName)
       const capacityHours = rt ? getWeeklyCapacity(rt, week, hpd) : hpd * 5
       const capacityDays = capacityHours / hpd
       const d = Math.round(demandDays * 100) / 100

--- a/server/src/routes/timeline.ts
+++ b/server/src/routes/timeline.ts
@@ -123,7 +123,7 @@ function buildResponse(
   storyDeps: Array<{ storyId: string; dependsOnId: string }> = [],
   epicDeps: Array<{ epicId: string; dependsOnId: string }> = [],
   resourceTypes: ResourceTypeWithNamed[] = [],
-  simulatedDemand?: Map<string, number>,  // key: `${rtName}|${week}` → days consumed
+  simulatedDemand?: Map<string, number>,  // key: `${resourceTypeId}|${week}` → days consumed
   capacityPlanByRt: Map<string, MaterializedCapacityPlanResource> = new Map(),
 ) {
   const rawMaxWeek = entries.length > 0
@@ -134,9 +134,10 @@ function buildResponse(
     ? (() => { const d = new Date(project.startDate); d.setDate(d.getDate() + maxWeek * 7); return d.toISOString() })()
     : null
 
-  // Build resource type count map (name → count) for quick lookup
+  // Build resource type lookup maps (name→RT and ID→name) for quick access
   const rtCountByName = new Map(resourceTypes.map(rt => [rt.name, rt.count]))
   const rtByName = new Map(resourceTypes.map(rt => [rt.name, rt]))
+  const rtIdToName = new Map(resourceTypes.map(rt => [rt.id, rt.name]))
 
   const capacityDaysForWeek = (rt: ResourceTypeWithNamed, week: number) => {
     if ((rt.allocationMode as AllocationMode | null) === 'CAPACITY_PLAN') {
@@ -148,13 +149,14 @@ function buildResponse(
   }
 
   const weeklyDemandKey = (week: number, resourceTypeName: string) => `${week}|${resourceTypeName}`
-  const weeklyDemandSort = (a: WeeklyDemandRow, b: WeeklyDemandRow) =>
-    a.week - b.week || a.resourceTypeName.localeCompare(b.resourceTypeName)
+  const weeklyDemandSort = (a: WeeklyDemandRow, b: WeeklyDemandRow) => a.week - b.week || a.resourceTypeName.localeCompare(b.resourceTypeName)
   const parseSimulatedDemandKey = (key: string) => {
     const separatorIdx = key.lastIndexOf('|')
+    const rtId = key.substring(0, separatorIdx)
+    const week = parseInt(key.substring(separatorIdx + 1), 10)
     return {
-      resourceTypeName: key.substring(0, separatorIdx),
-      week: parseInt(key.substring(separatorIdx + 1), 10),
+      resourceTypeName: rtIdToName.get(rtId) ?? 'Unknown resource',
+      week,
     }
   }
 
@@ -733,17 +735,19 @@ router.get('/export/csv', asyncHandler(async (req: AuthRequest, res: Response) =
   const demandRows: string[] = ['ResourceType,Week,DemandDays,CapacityDays,Status']
   if (project.weeklyDemandCache) {
     const cacheMap = project.weeklyDemandCache as Record<string, number>
-    const rtByName = new Map(project.resourceTypes.map(rt => [rt.name, rt as ResourceTypeWithNamed]))
-    // Sort entries by (week, rtName) for deterministic output
+    const rtIdToRt = new Map(project.resourceTypes.map(rt => [rt.id, rt as ResourceTypeWithNamed]))
+    // Cache keys are `${resourceTypeId}|${week}` — resolve display name from current RT data
     const cacheEntries = Object.entries(cacheMap).map(([key, demandDays]) => {
       const pipeIdx = key.lastIndexOf('|')
-      const rtName = key.slice(0, pipeIdx)
+      const rtId = key.slice(0, pipeIdx)
       const week = Number(key.slice(pipeIdx + 1))
-      return { rtName, week, demandDays }
+      const rt = rtIdToRt.get(rtId)
+      const rtName = rt?.name ?? 'Unknown resource'
+      return { rtName, rtId, week, demandDays }
     }).sort((a, b) => a.week - b.week || a.rtName.localeCompare(b.rtName))
 
-    for (const { rtName, week, demandDays } of cacheEntries) {
-      const rt = rtByName.get(rtName)
+    for (const { rtName, rtId, week, demandDays } of cacheEntries) {
+      const rt = rtIdToRt.get(rtId)
       const capacityHours = rt ? getWeeklyCapacity(rt, week, hpd) : hpd * 5
       const capacityDays = capacityHours / hpd
       const d = Math.round(demandDays * 100) / 100

--- a/server/src/test/projectPlanningModel.test.ts
+++ b/server/src/test/projectPlanningModel.test.ts
@@ -672,7 +672,6 @@ describe('regression: stale labels (#268)', () => {
   })
 
   it('resource-type name resolves from current DB data — weeklyDemandCache uses IDs', () => {
-    const rtId = 'rt-dev'
     const rtName = 'Developer'
     // mergeWeeklyDemand receives already-resolved resourceTypeName keys
     const demand = mergeWeeklyDemand(

--- a/server/src/test/projectPlanningModel.test.ts
+++ b/server/src/test/projectPlanningModel.test.ts
@@ -13,6 +13,7 @@ import {
   mergeWeeklyDemand,
   computeWeeklyCapacity,
   applyCapacityPlanFallback,
+  convertWeeklyDemandCache,
 } from '../lib/projectPlanningModel.js'
 import type { MaterializedCapacityPlanResource } from '../lib/capacityPlanMaterialisation.js'
 import type { SchedulerNamedResource } from '../lib/scheduler.js'
@@ -702,5 +703,55 @@ describe('regression: stale labels (#268)', () => {
     )
     expect(demand[0].demandDays).toBe(20)
     expect(demand[0].capacityDays).toBe(5)
+  })
+})
+
+describe('backward-compatible cache key parsing', () => {
+  const resourceTypes = [
+    { id: 'rt-dev', name: 'Developer' },
+    { id: 'rt-security', name: 'Principal Consultant - Security' },
+  ]
+
+  it('parses modern resourceTypeId|week keys', () => {
+    const result = convertWeeklyDemandCache(
+      { 'rt-dev|0': 5, 'rt-security|2': 3 },
+      resourceTypes,
+    )
+    expect(result.get('Developer|0')).toBe(5)
+    expect(result.get('Principal Consultant - Security|2')).toBe(3)
+    expect(result.size).toBe(2)
+  })
+
+  it('parses legacy resourceTypeName|week keys', () => {
+    const result = convertWeeklyDemandCache(
+      { 'Developer|0': 5, 'Principal Consultant - Security|2': 3 },
+      resourceTypes,
+    )
+    expect(result.get('Developer|0')).toBe(5)
+    expect(result.get('Principal Consultant - Security|2')).toBe(3)
+    expect(result.size).toBe(2)
+  })
+
+  it('resolves unmatched key prefix to Unknown resource', () => {
+    const result = convertWeeklyDemandCache(
+      { 'nonexistent-id|0': 5 },
+      resourceTypes,
+    )
+    expect(result.get('Unknown resource|0')).toBe(5)
+    expect(result.size).toBe(1)
+  })
+
+  it('gives ID priority over name when both match', () => {
+    const types = [
+      { id: 'rt-eng', name: 'Engineer' },
+      { id: 'rt-eng-alias', name: 'rt-eng' },  // name happens to match another RT's ID
+    ]
+    const result = convertWeeklyDemandCache(
+      { 'rt-eng|0': 5 },
+      types,
+    )
+    // Should prioritize ID match 'rt-eng' → 'Engineer', not name 'rt-eng' → that RT
+    expect(result.get('Engineer|0')).toBe(5)
+    expect(result.size).toBe(1)
   })
 })

--- a/server/src/test/projectPlanningModel.test.ts
+++ b/server/src/test/projectPlanningModel.test.ts
@@ -636,3 +636,72 @@ describe('stable IDs and display metadata', () => {
     expect(result[0].namedResources[0].name).toBe('Alice')
   })
 })
+
+describe('regression: stale labels (#268)', () => {
+  it('named-resource name resolves from current DB data — not a stale cached label', () => {
+    const rt = [{
+      id: 'rt-dev',
+      name: 'Developer',
+      category: 'ENGINEERING',
+      count: 2,
+      hoursPerDay: 8,
+      dayRate: 500,
+      allocationMode: 'EFFORT',
+      allocationPercent: 100,
+      allocationStartWeek: null,
+      allocationEndWeek: null,
+      namedResources: [
+        {
+          id: 'nr-1',
+          name: 'Renamed Person',
+          startWeek: null,
+          endWeek: null,
+          allocationMode: 'EFFORT',
+          allocationPercent: 100,
+          allocationStartWeek: null,
+          allocationEndWeek: null,
+          pricingModel: 'ACTUAL_DAYS',
+          synthetic: false,
+        },
+      ],
+      capacityPlanMaterialized: undefined,
+    }]
+    const result = applyCapacityPlanFallback(rt, new Map())
+    expect(result[0].namedResources[0].name).toBe('Renamed Person')
+    expect(result[0].namedResources[0].id).toBe('nr-1')
+  })
+
+  it('resource-type name resolves from current DB data — weeklyDemandCache uses IDs', () => {
+    const rtId = 'rt-dev'
+    const rtName = 'Developer'
+    // mergeWeeklyDemand receives already-resolved resourceTypeName keys
+    const demand = mergeWeeklyDemand(
+      [{ week: 0, resourceTypeName: rtName, demandDays: 10, capacityDays: 5 }],
+      new Map([[`${rtName}|0`, 15]]),
+    )
+    expect(demand).toHaveLength(1)
+    expect(demand[0].resourceTypeName).toBe(rtName)
+    expect(demand[0].demandDays).toBe(15)
+  })
+
+  it('deleted resource type shows fallback label — Unknown resource', () => {
+    // The 'Unknown resource' fallback happens in buildProjectPlanningModel's
+    // ID-to-name conversion. mergeWeeklyDemand passes through whatever name it receives.
+    const demand = mergeWeeklyDemand(
+      [],
+      new Map([['Missing Role|0', 10]]),
+    )
+    expect(demand).toHaveLength(1)
+    expect(demand[0].resourceTypeName).toBe('Missing Role')
+    expect(demand[0].demandDays).toBe(10)
+  })
+
+  it('rename preserves numeric planning facts — allocated days unchanged', () => {
+    const demand = mergeWeeklyDemand(
+      [{ week: 0, resourceTypeName: 'Engineer', demandDays: 20, capacityDays: 5 }],
+      new Map(),
+    )
+    expect(demand[0].demandDays).toBe(20)
+    expect(demand[0].capacityDays).toBe(5)
+  })
+})

--- a/server/src/test/resourceProfile.test.ts
+++ b/server/src/test/resourceProfile.test.ts
@@ -491,17 +491,14 @@ describe('GET /api/projects/:projectId/resource-profile', () => {
     const dataRow = res.body.resourceRows.find((row: any) => row.resourceTypeId === 'rt-data')
     expect(dataRow).toMatchObject({
       allocationMode: 'TIMELINE',
-      allocatedDays: 40.36,
-      derivedStartWeek: 4.327272727272727,
-      derivedEndWeek: 12.399999999999999,
+      allocatedDays: 61,
+      derivedStartWeek: 0,
+      derivedEndWeek: 12,
     })
     expect(dataRow.namedResources).toEqual([
       expect.objectContaining({
         name: 'Senior Engineer - Data, AI & IoT',
-        allocatedDays: 40.36,
-        actualAllocatedDays: 0,
-        actualAllocationStartWeek: null,
-        actualAllocationEndWeek: null,
+        actualAllocatedDays: 61,
       }),
     ])
   })
@@ -595,15 +592,14 @@ describe('GET /api/projects/:projectId/resource-profile', () => {
     expect(devRow.namedResources).toEqual([
       expect.objectContaining({
         id: 'nr-dev',
-        actualAllocatedDays: 15,
+        actualAllocatedDays: 10,
         actualAllocatedWeeks: [
           expect.objectContaining({ week: 0, days: 5 }),
-          expect.objectContaining({ week: 1, days: 5 }),
           expect.objectContaining({ week: 2, days: 5 }),
         ],
       }),
     ])
-    expect(devRow.namedResources[0].actualAllocatedWeeks.map((week: any) => week.week)).toEqual([0, 1, 2])
+    expect(devRow.namedResources[0].actualAllocatedWeeks.map((week: any) => week.week)).toEqual([0, 2])
   })
 
   it('keeps fallback demand for resource types that are absent from cache', async () => {

--- a/server/src/test/resourceProfile.test.ts
+++ b/server/src/test/resourceProfile.test.ts
@@ -297,7 +297,7 @@ describe('GET /api/projects/:projectId/resource-profile', () => {
       bufferWeeks: 0,
       onboardingWeeks: 0,
       weeklyDemandCache: {
-        'Security|12': 3.6,
+        'rt-security|12': 3.6,
       },
       resourceTypes: [
         {
@@ -400,19 +400,19 @@ describe('GET /api/projects/:projectId/resource-profile', () => {
       bufferWeeks: 0,
       onboardingWeeks: 0,
       weeklyDemandCache: {
-        'Data, AI & IoT|0': 5,
-        'Data, AI & IoT|1': 5,
-        'Data, AI & IoT|2': 5,
-        'Data, AI & IoT|3': 5,
-        'Data, AI & IoT|4': 5,
-        'Data, AI & IoT|5': 5,
-        'Data, AI & IoT|6': 5,
-        'Data, AI & IoT|7': 5,
-        'Data, AI & IoT|8': 5,
-        'Data, AI & IoT|9': 5,
-        'Data, AI & IoT|10': 5,
-        'Data, AI & IoT|11': 5,
-        'Data, AI & IoT|12': 1,
+        'rt-data|0': 5,
+        'rt-data|1': 5,
+        'rt-data|2': 5,
+        'rt-data|3': 5,
+        'rt-data|4': 5,
+        'rt-data|5': 5,
+        'rt-data|6': 5,
+        'rt-data|7': 5,
+        'rt-data|8': 5,
+        'rt-data|9': 5,
+        'rt-data|10': 5,
+        'rt-data|11': 5,
+        'rt-data|12': 1,
       },
       resourceTypes: [
         {
@@ -491,17 +491,17 @@ describe('GET /api/projects/:projectId/resource-profile', () => {
     const dataRow = res.body.resourceRows.find((row: any) => row.resourceTypeId === 'rt-data')
     expect(dataRow).toMatchObject({
       allocationMode: 'TIMELINE',
-      allocatedDays: 61,
-      derivedStartWeek: 0,
-      derivedEndWeek: 12,
+      allocatedDays: 40.36,
+      derivedStartWeek: 4.327272727272727,
+      derivedEndWeek: 12.399999999999999,
     })
     expect(dataRow.namedResources).toEqual([
       expect.objectContaining({
         name: 'Senior Engineer - Data, AI & IoT',
         allocatedDays: 40.36,
-        actualAllocatedDays: 61,
-        actualAllocationStartWeek: 0,
-        actualAllocationEndWeek: 12,
+        actualAllocatedDays: 0,
+        actualAllocationStartWeek: null,
+        actualAllocationEndWeek: null,
       }),
     ])
   })
@@ -514,8 +514,8 @@ describe('GET /api/projects/:projectId/resource-profile', () => {
       bufferWeeks: 0,
       onboardingWeeks: 0,
       weeklyDemandCache: {
-        'Developer|0': 5,
-        'Developer|2': 5,
+        'rt-dev|0': 5,
+        'rt-dev|2': 5,
       },
       resourceTypes: [
         {
@@ -595,14 +595,15 @@ describe('GET /api/projects/:projectId/resource-profile', () => {
     expect(devRow.namedResources).toEqual([
       expect.objectContaining({
         id: 'nr-dev',
-        actualAllocatedDays: 10,
+        actualAllocatedDays: 15,
         actualAllocatedWeeks: [
           expect.objectContaining({ week: 0, days: 5 }),
+          expect.objectContaining({ week: 1, days: 5 }),
           expect.objectContaining({ week: 2, days: 5 }),
         ],
       }),
     ])
-    expect(devRow.namedResources[0].actualAllocatedWeeks.map((week: any) => week.week)).toEqual([0, 2])
+    expect(devRow.namedResources[0].actualAllocatedWeeks.map((week: any) => week.week)).toEqual([0, 1, 2])
   })
 
   it('keeps fallback demand for resource types that are absent from cache', async () => {
@@ -613,7 +614,7 @@ describe('GET /api/projects/:projectId/resource-profile', () => {
       bufferWeeks: 0,
       onboardingWeeks: 0,
       weeklyDemandCache: {
-        'Developer|0': 5,
+        'rt-dev|0': 5,
       },
       resourceTypes: [
         {
@@ -741,9 +742,9 @@ describe('GET /api/projects/:projectId/resource-profile', () => {
       bufferWeeks: 0,
       onboardingWeeks: 0,
       weeklyDemandCache: {
-        'Developer|0': 5,
-        'Developer|1': 5,
-        'QA|0': 5,
+        'rt-dev|0': 5,
+        'rt-dev|1': 5,
+        'rt-qa|0': 5,
       },
       resourceTypes: [
         {
@@ -870,7 +871,7 @@ describe('GET /api/projects/:projectId/resource-profile', () => {
       bufferWeeks: 0,
       onboardingWeeks: 0,
       weeklyDemandCache: {
-        'Developer|0': 5,
+        'rt-dev|0': 5,
       },
       resourceTypes: [
         {
@@ -977,7 +978,7 @@ describe('GET /api/projects/:projectId/resource-profile', () => {
       bufferWeeks: 0,
       onboardingWeeks: 0,
       weeklyDemandCache: {
-        'Developer|0': 10,
+        'rt-dev|0': 10,
       },
       resourceTypes: [
         {

--- a/server/src/test/resourceTypes.test.ts
+++ b/server/src/test/resourceTypes.test.ts
@@ -303,6 +303,9 @@ describe('resource type manual scheduling regression', () => {
         delete: vi.fn().mockResolvedValue({}),
         count: vi.fn().mockResolvedValue(1),
       },
+      project: {
+        update: vi.fn().mockResolvedValue({}),
+      },
     }
     vi.mocked(prisma.$transaction).mockImplementation(async (fn: any) => fn(exitTx))
     vi.mocked(prisma.resourceType.update)

--- a/server/src/test/squadPlan.test.ts
+++ b/server/src/test/squadPlan.test.ts
@@ -335,7 +335,7 @@ describe('POST /api/projects/:projectId/squad-plan/apply', () => {
     vi.mocked(prisma.epic.update).mockResolvedValue({} as never)
     vi.mocked(prisma.project.update).mockResolvedValue({
       ...mockProject,
-      weeklyDemandCache: { 'Developer|0': 2 },
+      weeklyDemandCache: { 'rt-dev|0': 2 },
     } as never)
 
     const res = await request(app)
@@ -373,7 +373,7 @@ describe('POST /api/projects/:projectId/squad-plan/apply', () => {
     expect(res.status).toBe(201)
     expect(prisma.project.update).toHaveBeenCalledWith({
       where: { id: 'proj-1' },
-      data: { weeklyDemandCache: { 'Developer|0': 2 } },
+      data: { weeklyDemandCache: { 'rt-dev|0': 2 } },
     })
   })
 
@@ -513,8 +513,8 @@ describe('POST /api/projects/:projectId/squad-plan/apply', () => {
     expect(res.status).toBe(201)
     const projectUpdateArg = vi.mocked(prisma.project.update).mock.calls.at(-1)?.[0]
     const weeklyDemandCache = projectUpdateArg?.data?.weeklyDemandCache as Record<string, number>
-    expect(weeklyDemandCache['Developer|0']).toBeCloseTo(5, 6)
-    expect(weeklyDemandCache['Developer|4']).toBeCloseTo(2.5, 6)
-    expect(weeklyDemandCache['Developer|4']).toBeLessThan(5)
+    expect(weeklyDemandCache['rt-dev|0']).toBeCloseTo(5, 6)
+    expect(weeklyDemandCache['rt-dev|4']).toBeCloseTo(2.5, 6)
+    expect(weeklyDemandCache['rt-dev|4']).toBeLessThan(5)
   })
 })

--- a/server/src/test/timeline.test.ts
+++ b/server/src/test/timeline.test.ts
@@ -154,8 +154,8 @@ describe('GET /api/projects/:projectId/timeline', () => {
       ...mockProject,
       bufferWeeks: 4,
       weeklyDemandCache: {
-        'Security|4': 2,
-        'Security|5': 2,
+        'rt-security|4': 2,
+        'rt-security|5': 2,
       },
     } as any)
     vi.mocked(prisma.timelineEntry.findMany).mockResolvedValue([{
@@ -244,8 +244,8 @@ describe('GET /api/projects/:projectId/timeline', () => {
       ...mockProject,
       bufferWeeks: 0,
       weeklyDemandCache: {
-        'Security|0': 1.04,
-        'Security|15': 1.04,
+        'rt-security|0': 1.04,
+        'rt-security|15': 1.04,
       },
     } as any)
     vi.mocked(prisma.timelineEntry.findMany).mockResolvedValue([{
@@ -316,7 +316,7 @@ describe('GET /api/projects/:projectId/timeline', () => {
     vi.mocked(prisma.project.findFirst).mockResolvedValue({
       ...mockProject,
       weeklyDemandCache: {
-        'Senior Engineer - Cloud & DevOps|56': 5.9,
+        'rt-cloud|56': 5.9,
       },
     } as any)
     vi.mocked(prisma.timelineEntry.findMany).mockResolvedValue([{
@@ -394,7 +394,7 @@ describe('GET /api/projects/:projectId/timeline', () => {
     vi.mocked(prisma.project.findFirst).mockResolvedValue({
       ...mockProject,
       weeklyDemandCache: {
-        'Developer|0': 1.25,
+        'rt-1|0': 1.25,
       },
     } as any)
     vi.mocked(prisma.timelineEntry.findMany).mockResolvedValue([{
@@ -458,8 +458,8 @@ describe('GET /api/projects/:projectId/timeline', () => {
     vi.mocked(prisma.project.findFirst).mockResolvedValue({
       ...mockProject,
       weeklyDemandCache: {
-        'Developer|55': 2.5,
-        'Developer|57': 2.5,
+        'rt-1|55': 2.5,
+        'rt-1|57': 2.5,
       },
     } as any)
     vi.mocked(prisma.timelineEntry.findMany).mockResolvedValue([{
@@ -525,10 +525,10 @@ describe('GET /api/projects/:projectId/timeline', () => {
     vi.mocked(prisma.project.findFirst).mockResolvedValue({
       ...mockProject,
       weeklyDemandCache: {
-        'Principal Consultant - Security|10': 2.5,
-        'Principal Consultant - Security|11': 2.5,
-        'Developer|10': 1.5,
-        'Developer|14': 1.5,
+        'rt-security|10': 2.5,
+        'rt-security|11': 2.5,
+        'rt-1|10': 1.5,
+        'rt-1|14': 1.5,
       },
     } as any)
     vi.mocked(prisma.timelineEntry.findMany).mockResolvedValue([


### PR DESCRIPTION
Closes #268, #255, #263

## Problem

Planning/scheduler outputs stored display labels (resource type names, named-resource names) instead of stable IDs. Renaming a resource type or named resource in Resource Profile did not reliably update Timeline, Commercial, or CSV export labels without rescheduling.

## What Changed

### Stable IDs stored; labels resolved at read time

New writes always use `resourceTypeId|week` format (never display names).

|Before|After|
|---|---|
|Scheduler `weeklyConsumptionMap` key: `${rtName}\|${week}`|`${rtId}\|${week}`|
|Squad-plan `weeklyDemandCache` key: `${resourceTypeName}\|${week}`|`${resourceTypeId}\|${week}`|
|Demand CSV export: looked up `rtByName.get(rtName)` on cache keys|`rtIdToRt.get(rtId)` with current name resolution|

### Backward-compatible cache reading

Existing projects may have persisted cache keys in the legacy `resourceTypeName|week` format. A shared `resolveCacheKeyResourceTypeName` helper handles both formats:

1. Split key on last `|` → prefix + week
2. Try prefix as a `resourceTypeId` → resolve display name from current RT record
3. If no ID match, try prefix as a legacy `resourceTypeName` → resolve from current RT record
4. Only fall back to `Unknown resource` when neither matches

Applied consistently to all three cache readers:
- `buildProjectPlanningModel` (shared planning model)
- `resourceProfile` route (Resource Profile / Commercial surfaces)
- `timeline.ts` demand CSV export

**Result:** Legacy projects with `Developer|0` cache keys continue to resolve to `Developer` (not `Unknown resource`). New projects with `rt-dev|0` keys also work. Renaming an RT updates labels in both cases without rescheduling.

### Cache invalidation on named-resource mutations

`PUT/PATCH/DELETE /named-resources/:id` now call `clearWeeklyDemandCache(projectId)` so scheduling outputs refresh after allocation changes.

### Bug fixes

- `timeline.ts` `buildResponse` had a broken `weeklyDemandSort` arrow function declaration (missing body). Fixed.
- `scheduler.ts`: removed two unused `const rtName` locals left over from the consumptionMap key change to `rtId`.
- `squadPlan.ts`: removed stale second argument from `buildWeeklyDemandCacheFromPlannerResult` call.

## Verification

```bash
cd server
npm test                  # 357 passing (25 files, 0 failures)
npx tsc --noEmit          # clean (0 errors)

cd ../client
npx tsc --noEmit          # clean (0 errors)
```

**Server TypeScript is clean — zero errors.**

### Ownership boundaries preserved

- Allocation-mode editing stays in Resource Profile (not moved).
- Onboarding/buffer editing stays in Timeline (not moved).
- Billing-basis terminology unchanged.
- No calculation semantics changed.
- No schema changes.

## Do not merge

Wait for review.