### PR TITLE
test(#269): add canonical cross-surface consistency regression fixture

### DIFF
--- a/client/src/test/canonical-commercial-consistency.test.ts
+++ b/client/src/test/canonical-commercial-consistency.test.ts
@@ -1,0 +1,182 @@
+/**
+ * canonical-commercial-consistency.test.ts — Client-side commercial regression
+ * fixture proving computeCommercialData uses the same scheduled-day facts as
+ * the server-side Timeline/Resource Profile surfaces.
+ *
+ * The fixture shape mirrors server/src/test/canonical-consistency.test.ts
+ * so that Timeline NR days, Resource Profile NR days, and Commercial
+ * billable days are all derived from the same underlying data.
+ */
+
+import { describe, expect, it } from 'vitest'
+import { computeCommercialData } from '../utils/financialCalculations'
+import type { ResourceProfile } from '../types/backlog'
+
+/**
+ * Build a minimal ResourceProfile that mirrors the canonical server fixture:
+ *   1 resource type (Developer, dayRate 500)
+ *   2 named resources (Alice ACTUAL_DAYS, Bob PRO_RATA)
+ *   Cached weekly demand produces 20 allocated days / 20 actual allocated days
+ */
+function buildCanonicalProfile(): ResourceProfile {
+  return {
+    projectId: 'proj-1',
+    hoursPerDay: 8,
+    projectDurationWeeks: 7,
+    bufferWeeks: 2,
+    onboardingWeeks: 1,
+    resourceRows: [
+      {
+        resourceTypeId: 'rt-dev',
+        name: 'Developer',
+        category: 'ENGINEERING',
+        count: 2,
+        hoursPerDay: 8,
+        dayRate: 500,
+        totalHours: 160,
+        totalDays: 20,
+        effortDays: 20,
+        allocatedDays: 20,
+        estimatedCost: 10000,
+        allocationMode: 'EFFORT',
+        allocationPercent: 100,
+        allocationStartWeek: null,
+        allocationEndWeek: null,
+        derivedStartWeek: 0,
+        derivedEndWeek: 4,
+        epics: [],
+        namedResources: [
+          {
+            id: 'nr-alice',
+            name: 'Alice',
+            pricingModel: 'ACTUAL_DAYS',
+            allocationMode: 'EFFORT',
+            allocationPercent: 100,
+            allocationStartWeek: null,
+            allocationEndWeek: null,
+            startWeek: null,
+            endWeek: null,
+            allocatedDays: 10,
+            derivedStartWeek: 0,
+            derivedEndWeek: 4,
+            actualAllocatedDays: 10,
+            actualAllocationStartWeek: 0,
+            actualAllocationEndWeek: 4,
+            actualAllocatedWeeks: [
+              { week: 0, days: 2.5, capacityDays: 5 },
+              { week: 1, days: 2.5, capacityDays: 5 },
+              { week: 2, days: 2.5, capacityDays: 5 },
+              { week: 3, days: 2.5, capacityDays: 5 },
+            ],
+            actualAllocationSegments: [
+              { startWeek: 0, endWeek: 4, days: 10 },
+            ],
+            synthetic: false,
+          },
+          {
+            id: 'nr-bob',
+            name: 'Bob',
+            pricingModel: 'PRO_RATA',
+            allocationMode: 'EFFORT',
+            allocationPercent: 100,
+            allocationStartWeek: null,
+            allocationEndWeek: null,
+            startWeek: null,
+            endWeek: null,
+            allocatedDays: 10,
+            derivedStartWeek: 0,
+            derivedEndWeek: 4,
+            actualAllocatedDays: 0,
+            actualAllocationStartWeek: null,
+            actualAllocationEndWeek: null,
+            actualAllocatedWeeks: [],
+            actualAllocationSegments: [],
+            synthetic: false,
+          },
+        ],
+      },
+    ],
+    overheadRows: [],
+    summary: {
+      totalHours: 160,
+      totalDays: 20,
+      totalCost: 10000,
+      hasCost: true,
+    },
+  }
+}
+
+describe('canonical commercial consistency', () => {
+  it('ACTUAL_DAYS named resource: billable days match actual scheduled days', () => {
+    const profile = buildCanonicalProfile()
+    const result = computeCommercialData(profile, [], { taxRate: null, taxLabel: 'GST' })
+
+    expect(result).not.toBeNull()
+    const aliceRow = result!.rows.find(r => r.id === 'nr-alice')
+    expect(aliceRow).toBeDefined()
+    expect(aliceRow!.kind).toBe('named-resource')
+
+    // For ACTUAL_DAYS, billable days = actualAllocatedDays
+    expect(aliceRow!.allocatedDays).toBe(10)
+    expect(aliceRow!.totalDays).toBe(10)
+    expect(aliceRow!.subtotal).toBe(10 * 500) // 5000
+    expect(aliceRow!.pricingModel).toBe('ACTUAL_DAYS')
+  })
+
+  it('PRO_RATA named resource: billable days use allocatedDays (planned)', () => {
+    const profile = buildCanonicalProfile()
+    const result = computeCommercialData(profile, [], { taxRate: null, taxLabel: 'GST' })
+
+    expect(result).not.toBeNull()
+    const bobRow = result!.rows.find(r => r.id === 'nr-bob')
+    expect(bobRow).toBeDefined()
+    expect(bobRow!.kind).toBe('named-resource')
+
+    // For PRO_RATA, billable days = allocatedDays (planned allocation)
+    expect(bobRow!.allocatedDays).toBe(10)
+    expect(bobRow!.totalDays).toBe(10)
+    expect(bobRow!.subtotal).toBe(10 * 500) // 5000
+    expect(bobRow!.pricingModel).toBe('PRO_RATA')
+  })
+
+  it('commercial subtotal equals sum of NR billable days * day rate', () => {
+    const profile = buildCanonicalProfile()
+    const result = computeCommercialData(profile, [], { taxRate: null, taxLabel: 'GST' })
+
+    expect(result).not.toBeNull()
+    // Alice: 10 actual days x $500 = $5,000
+    // Bob: 10 allocated days x $500 = $5,000
+    // Total: $10,000
+    expect(result!.subtotal).toBe(10000)
+  })
+
+  it('grand total includes tax when taxRate is set', () => {
+    const profile = buildCanonicalProfile()
+    const result = computeCommercialData(profile, [], { taxRate: 10, taxLabel: 'GST' })
+
+    expect(result).not.toBeNull()
+    // Subtotal: $10,000
+    // No discounts
+    // Tax 10%: $1,000
+    // Grand total: $11,000
+    expect(result!.subtotal).toBe(10000)
+    expect(result!.taxRate).toBe(10)
+    expect(result!.taxLabel).toBe('GST')
+    expect(result!.taxEnabled).toBe(true)
+    expect(result!.taxAmount).toBe(1000)
+    expect(result!.grandTotal).toBe(11000)
+  })
+
+  it('commercial rows preserve resource type metadata', () => {
+    const profile = buildCanonicalProfile()
+    const result = computeCommercialData(profile, [], { taxRate: null, taxLabel: 'GST' })
+
+    expect(result).not.toBeNull()
+    for (const row of result!.rows) {
+      expect(row.dayRate).toBe(500)
+      expect(row.resourceTypeId).toBe('rt-dev')
+      expect(typeof row.subtotal).toBe('number')
+      expect(row.subtotal).toBeGreaterThan(0)
+    }
+  })
+})

--- a/server/src/test/canonical-consistency.test.ts
+++ b/server/src/test/canonical-consistency.test.ts
@@ -1,0 +1,320 @@
+/**
+ * canonical-consistency.test.ts — Canonical regression fixture proving Timeline,
+ * Resource Profile, Commercial, and exports agree on the same planning/commercial
+ * facts after recent ownership-boundary and stale-label work.
+ *
+ * Fixture scenario:
+ *   - 1 resource type (Developer), 1 named resource (Alice)
+ *   - 1 onboarding week, 2 buffer weeks
+ *   - Cached weekly demand for weeks 0-3
+ *   - 1 timeline entry for a feature with task hours
+ *
+ * Invariants protected:
+ *   1. Named-resource `actualAllocatedDays` is identical in Timeline and Resource Profile.
+ *   2. Named-resource `name` uses the current DB label (not a stale cached label).
+ *   3. Onboarding weeks shift the planning window start.
+ *   4. Buffer weeks extend the planning window end.
+ *   5. CSV named-resource rows contain the same label and day values.
+ *   6. Resource Profile `bufferWeeks` matches the project.
+ *
+ * These invariants guard against future drift between surfaces after changes to
+ * the shared planning model, cache-key format, or ownership boundaries.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import request from 'supertest'
+import jwt from 'jsonwebtoken'
+import { app } from '../index.js'
+import { prisma } from '../lib/prisma.js'
+
+process.env.JWT_SECRET = 'test-secret'
+
+const userId = 'user-1'
+const token = jwt.sign({ userId }, 'test-secret')
+const authHeader = `Bearer ${token}`
+
+/** Base project fields that both Timeline and Resource Profile routes need. */
+function baseProjectFixture() {
+  return {
+    id: 'proj-1',
+    ownerId: userId,
+    name: 'Consistency Project',
+    startDate: new Date('2026-01-05T00:00:00.000Z'),
+    hoursPerDay: 8,
+    bufferWeeks: 2,
+    onboardingWeeks: 1,
+    weeklyDemandCache: { 'rt-dev|0': 5, 'rt-dev|1': 5, 'rt-dev|2': 5, 'rt-dev|3': 5 },
+    // Relations needed by the resource profile route
+    resourceTypes: [],
+    epics: [],
+    overheads: [],
+    timelineEntries: [],
+    storyTimelineEntries: [],
+    capacityPlans: [],
+  }
+}
+
+/** Single resource type with one named resource. */
+function resourceTypeWithAlice() {
+  return [{
+    id: 'rt-dev',
+    name: 'Developer',
+    category: 'ENGINEERING',
+    count: 1,
+    hoursPerDay: 8,
+    dayRate: 500,
+    allocationMode: 'EFFORT',
+    allocationPercent: 100,
+    allocationStartWeek: null,
+    allocationEndWeek: null,
+    globalType: null,
+    namedResources: [{
+      id: 'nr-alice',
+      name: 'Alice',
+      startWeek: null,
+      endWeek: null,
+      allocationPct: 100,
+      allocationMode: 'EFFORT',
+      allocationPercent: 100,
+      allocationStartWeek: null,
+      allocationEndWeek: null,
+      pricingModel: 'ACTUAL_DAYS',
+    }],
+  }]
+}
+
+/** A timeline-entry-shaped fixture with a feature task. */
+function timelineEntryFixture() {
+  return [{
+    id: 'entry-auth',
+    projectId: 'proj-1',
+    featureId: 'feat-auth',
+    startWeek: 0,
+    durationWeeks: 4,
+    isManual: false,
+    feature: {
+      id: 'feat-auth',
+      name: 'Authentication',
+      order: 0,
+      isActive: true,
+      timelineColour: null,
+      epic: {
+        id: 'epic-1',
+        name: 'Platform',
+        order: 0,
+        isActive: true,
+        featureMode: 'sequential',
+        scheduleMode: 'auto',
+        timelineStartWeek: null,
+      },
+      userStories: [{
+        isActive: true,
+        tasks: [{
+          resourceTypeId: 'rt-dev',
+          hoursEffort: 160,
+          durationDays: null,
+          resourceType: { id: 'rt-dev', name: 'Developer', hoursPerDay: 8 },
+        }],
+      }],
+    },
+  }]
+}
+
+beforeEach(() => vi.clearAllMocks())
+
+describe('canonical cross-surface consistency', () => {
+  it('Timeline reports correct named-resource label and allocation days', async () => {
+    // buildProjectPlanningModel Prisma call sequence:
+    //   1. project.findFirst
+    //   2. resourceType.findMany
+    //   3-4. timelineEntry.findMany + storyTimelineEntry.findMany (parallel)
+    //   5-7. deps (default mock returns [])
+    //   8. capacityPlan.findFirst
+    // GET /timeline handler then does:
+    //   9. timelineEntry.findMany (reload for response)
+
+    vi.mocked(prisma.project.findFirst).mockResolvedValueOnce(baseProjectFixture() as never)
+    vi.mocked(prisma.resourceType.findMany).mockResolvedValueOnce(resourceTypeWithAlice() as never)
+    vi.mocked(prisma.timelineEntry.findMany).mockResolvedValueOnce(timelineEntryFixture() as never)
+    vi.mocked(prisma.storyTimelineEntry.findMany).mockResolvedValueOnce([] as never)
+    vi.mocked(prisma.capacityPlan.findFirst).mockResolvedValueOnce(null as never)
+    vi.mocked(prisma.timelineEntry.findMany).mockResolvedValueOnce(timelineEntryFixture() as never)
+
+    const res = await request(app)
+      .get('/api/projects/proj-1/timeline')
+      .set('Authorization', authHeader)
+
+    expect(res.status).toBe(200)
+
+    const nrs = res.body.namedResources
+    expect(nrs.length).toBeGreaterThan(0)
+    expect(nrs[0].name).toBe('Alice')
+    expect(nrs[0].resourceTypeName).toBe('Developer')
+    expect(typeof nrs[0].actualAllocatedDays).toBe('number')
+    expect(nrs[0].actualAllocatedDays).toBeGreaterThan(0)
+
+    expect(res.body.onboardingWeeks).toBe(1)
+    expect(res.body.bufferWeeks).toBe(2)
+    expect(res.body.projectedEndDate).toBe('2026-02-23T00:00:00.000Z')
+  })
+
+  it('Resource Profile reports the same named-resource label and allocation days', async () => {
+    const projectFixture = {
+      ...baseProjectFixture(),
+      resourceTypes: resourceTypeWithAlice(),
+      epics: [{
+        id: 'epic-1',
+        name: 'Platform',
+        order: 0,
+        isActive: true,
+        featureMode: 'sequential',
+        scheduleMode: 'auto',
+        features: [{
+          id: 'feat-auth',
+          name: 'Authentication',
+          order: 0,
+          isActive: true,
+          featureMode: 'sequential',
+          timelineStartWeek: null,
+          userStories: [{
+            isActive: true,
+            tasks: [{
+              resourceTypeId: 'rt-dev',
+              hoursEffort: 160,
+              durationDays: null,
+              resourceType: { id: 'rt-dev', name: 'Developer', hoursPerDay: 8 },
+            }],
+          }],
+        }],
+      }],
+      overheads: [],
+      timelineEntries: [{ featureId: 'feat-auth', startWeek: 0, durationWeeks: 4 }],
+      storyTimelineEntries: [],
+      capacityPlans: [],
+    }
+
+    vi.mocked(prisma.project.findFirst).mockResolvedValueOnce(projectFixture as never)
+
+    const res = await request(app)
+      .get('/api/projects/proj-1/resource-profile')
+      .set('Authorization', authHeader)
+
+    expect(res.status).toBe(200)
+
+    const devRow = res.body.resourceRows.find(
+      (r: { resourceTypeId: string }) => r.resourceTypeId === 'rt-dev',
+    )
+    expect(devRow).toBeTruthy()
+
+    const nrs = devRow.namedResources
+    expect(nrs.length).toBeGreaterThan(0)
+    expect(nrs[0].name).toBe('Alice')
+    expect(typeof nrs[0].actualAllocatedDays).toBe('number')
+    expect(nrs[0].actualAllocatedDays).toBeGreaterThan(0)
+
+    expect(res.body.bufferWeeks).toBe(2)
+  })
+
+  it('Timeline and Resource Profile agree on actualAllocatedDays for the same NR', async () => {
+    // Timeline
+    vi.mocked(prisma.project.findFirst).mockResolvedValueOnce(baseProjectFixture() as never)
+    vi.mocked(prisma.resourceType.findMany).mockResolvedValueOnce(resourceTypeWithAlice() as never)
+    vi.mocked(prisma.timelineEntry.findMany).mockResolvedValueOnce(timelineEntryFixture() as never)
+    vi.mocked(prisma.storyTimelineEntry.findMany).mockResolvedValueOnce([] as never)
+    vi.mocked(prisma.capacityPlan.findFirst).mockResolvedValueOnce(null as never)
+    vi.mocked(prisma.timelineEntry.findMany).mockResolvedValueOnce(timelineEntryFixture() as never)
+
+    const timelineRes = await request(app)
+      .get('/api/projects/proj-1/timeline')
+      .set('Authorization', authHeader)
+    expect(timelineRes.status).toBe(200)
+    const timelineDays: number = timelineRes.body.namedResources[0].actualAllocatedDays
+
+    // Resource Profile
+    const profileFixture = {
+      ...baseProjectFixture(),
+      resourceTypes: resourceTypeWithAlice(),
+      epics: [{
+        id: 'epic-1',
+        name: 'Platform',
+        order: 0,
+        isActive: true,
+        featureMode: 'sequential',
+        scheduleMode: 'auto',
+        features: [{
+          id: 'feat-auth',
+          name: 'Authentication',
+          order: 0,
+          isActive: true,
+          featureMode: 'sequential',
+          timelineStartWeek: null,
+          userStories: [{
+            isActive: true,
+            tasks: [{
+              resourceTypeId: 'rt-dev',
+              hoursEffort: 160,
+              durationDays: null,
+              resourceType: { id: 'rt-dev', name: 'Developer', hoursPerDay: 8 },
+            }],
+          }],
+        }],
+      }],
+      overheads: [],
+      timelineEntries: [{ featureId: 'feat-auth', startWeek: 0, durationWeeks: 4 }],
+      storyTimelineEntries: [],
+      capacityPlans: [],
+    }
+    vi.mocked(prisma.project.findFirst).mockResolvedValueOnce(profileFixture as never)
+
+    const profileRes = await request(app)
+      .get('/api/projects/proj-1/resource-profile')
+      .set('Authorization', authHeader)
+    expect(profileRes.status).toBe(200)
+
+    const devRow = profileRes.body.resourceRows.find(
+      (r: { resourceTypeId: string }) => r.resourceTypeId === 'rt-dev',
+    )
+    const profileDays: number = devRow.namedResources[0].actualAllocatedDays
+
+    // Same cached demand must produce the same allocated day count
+    expect(timelineDays).toBe(profileDays)
+  })
+
+  it('Timeline CSV export uses current named-resource label', async () => {
+    vi.mocked(prisma.project.findFirst).mockResolvedValueOnce({
+      ...baseProjectFixture(),
+      resourceTypes: resourceTypeWithAlice(),
+    } as never)
+    vi.mocked(prisma.timelineEntry.findMany).mockResolvedValueOnce(timelineEntryFixture() as never)
+    vi.mocked(prisma.storyTimelineEntry.findMany).mockResolvedValueOnce([] as never)
+    vi.mocked(prisma.task.findMany).mockResolvedValueOnce([] as never)
+    vi.mocked(prisma.namedResource.findMany).mockResolvedValueOnce([
+      {
+        id: 'nr-alice',
+        name: 'Alice',
+        resourceTypeId: 'rt-dev',
+        startWeek: null,
+        endWeek: null,
+        allocationPct: 100,
+        allocationMode: 'EFFORT',
+        allocationPercent: 100,
+        allocationStartWeek: null,
+        allocationEndWeek: null,
+        pricingModel: 'ACTUAL_DAYS',
+        resourceType: { id: 'rt-dev', name: 'Developer' },
+      },
+    ] as never)
+
+    const res = await request(app)
+      .get('/api/projects/proj-1/timeline/export/csv')
+      .set('Authorization', authHeader)
+
+    expect(res.status).toBe(200)
+    const csv: string = res.text
+
+    expect(csv).toContain('Alice')
+    expect(csv).toContain('Developer')
+    expect(csv).toContain('T&M')
+    expect(csv).toContain('Developer,0,5')
+  })
+})

--- a/server/src/test/canonical-consistency.test.ts
+++ b/server/src/test/canonical-consistency.test.ts
@@ -153,18 +153,22 @@ describe('canonical cross-surface consistency', () => {
 
     expect(res.status).toBe(200)
 
-    // Named-resource labels are the current DB values, not stale cached labels
-    const nrs = res.body.namedResources
-    expect(nrs.length).toBeGreaterThanOrEqual(2)
-    expect(nrs[0].name).toBe('Alice')
-    expect(nrs[0].resourceTypeName).toBe('Developer')
-    expect(nrs[0].actualAllocatedDays).toBeGreaterThan(0)
-    expect(nrs[1].name).toBe('Bob')
-    expect(nrs[1].resourceTypeName).toBe('Developer')
-    expect(typeof nrs[1].actualAllocatedDays).toBe('number')
+    // Named-resource labels are the current DB values, not stale cached labels.
+    // Find by stable ID rather than assuming array ordering.
+    const alice = res.body.namedResources.find((nr: { id: string }) => nr.id === 'nr-alice')
+    const bob = res.body.namedResources.find((nr: { id: string }) => nr.id === 'nr-bob')
+    expect(alice).toBeTruthy()
+    expect(bob).toBeTruthy()
+    expect(alice.name).toBe('Alice')
+    expect(alice.resourceTypeName).toBe('Developer')
+    expect(alice.actualAllocatedDays).toBeGreaterThan(0)
+    expect(bob.name).toBe('Bob')
+    expect(bob.resourceTypeName).toBe('Developer')
+    expect(typeof bob.actualAllocatedDays).toBe('number')
 
     // Entry-level start date is shifted by onboarding weeks:
     // startWeek=0, 1 onboarding week → startDate = Jan 5 + 7 days = Jan 12
+    expect(res.body.entries.length).toBe(1)
     expect(res.body.entries[0].startDate).toBe('2026-01-12T00:00:00.000Z')
     expect(res.body.entries[0].endDate).toBe('2026-02-09T00:00:00.000Z')
 
@@ -236,19 +240,26 @@ describe('canonical cross-surface consistency', () => {
     expect(bob.name).toBe('Bob')
     expect(alice.pricingModel).toBe('ACTUAL_DAYS')
     expect(bob.pricingModel).toBe('PRO_RATA')
-    expect(alice.actualAllocatedDays).toBeGreaterThan(0)
-
-    // Commercial-relevant fields on the resource row
+    // Commercial-relevant fields on the resource row.
+    // estimatedCost must be internally consistent with day rate and allocated days.
     expect(devRow.dayRate).toBe(500)
     expect(devRow.estimatedCost).toBeGreaterThan(0)
+    expect(devRow.estimatedCost).toBe(devRow.allocatedDays * devRow.dayRate)
 
-    // Summary proves commercial totals are computed from shared facts
+    // Summary proves commercial totals are computed from shared facts.
+    // totalCost should equal row estimatedCost when there are no overheads.
     expect(res.body.summary.hasCost).toBe(true)
     expect(res.body.summary.totalCost).toBeGreaterThan(0)
+    const rowCostSum = res.body.resourceRows.reduce(
+      (sum: number, r: { estimatedCost: number | null }) => sum + (r.estimatedCost ?? 0), 0,
+    )
+    const overheadCostSum = res.body.overheadRows.reduce(
+      (sum: number, r: { estimatedCost: number | null }) => sum + (r.estimatedCost ?? 0), 0,
+    )
+    expect(res.body.summary.totalCost).toBe(rowCostSum + overheadCostSum)
   })
 
   it('Timeline and Resource Profile agree on actualAllocatedDays for the same NR', async () => {
-    // Timeline
     vi.mocked(prisma.project.findFirst).mockResolvedValueOnce(baseProjectFixture() as never)
     vi.mocked(prisma.resourceType.findMany).mockResolvedValueOnce(resourceTypeWithNamedResources() as never)
     vi.mocked(prisma.timelineEntry.findMany).mockResolvedValueOnce(timelineEntryFixture() as never)
@@ -260,9 +271,13 @@ describe('canonical cross-surface consistency', () => {
       .get('/api/projects/proj-1/timeline')
       .set('Authorization', authHeader)
     expect(timelineRes.status).toBe(200)
-    const timelineDays: number = timelineRes.body.namedResources[0].actualAllocatedDays
+    const timelineAlice = timelineRes.body.namedResources.find(
+      (nr: { id: string }) => nr.id === 'nr-alice',
+    )
+    expect(timelineAlice).toBeTruthy()
+    const timelineDays: number = timelineAlice.actualAllocatedDays
+    expect(timelineDays).toBeGreaterThan(0)
 
-    // Resource Profile
     const profileFixture = {
       ...baseProjectFixture(),
       resourceTypes: resourceTypeWithNamedResources(),
@@ -306,9 +321,13 @@ describe('canonical cross-surface consistency', () => {
     const devRow = profileRes.body.resourceRows.find(
       (r: { resourceTypeId: string }) => r.resourceTypeId === 'rt-dev',
     )
-    const profileDays: number = devRow.namedResources[0].actualAllocatedDays
+    const profileAlice = devRow.namedResources.find(
+      (nr: { id: string }) => nr.id === 'nr-alice',
+    )
+    expect(profileAlice).toBeTruthy()
+    const profileDays: number = profileAlice.actualAllocatedDays
 
-    // Same cached demand produces the same allocated day count across both surfaces
+    expect(profileDays).toBeGreaterThan(0)
     expect(timelineDays).toBe(profileDays)
   })
 
@@ -340,7 +359,6 @@ describe('canonical cross-surface consistency', () => {
     const res = await request(app)
       .get('/api/projects/proj-1/timeline/export/csv')
       .set('Authorization', authHeader)
-
     expect(res.status).toBe(200)
     const csv: string = res.text
 
@@ -348,19 +366,15 @@ describe('canonical cross-surface consistency', () => {
     const sections = csv.split('\n\n')
     expect(sections.length).toBeGreaterThanOrEqual(3)
 
-    // Section 3 is the Named Resources section
+    // Section 3 is the Named Resources section. Find the Alice row by content.
     const nrSection = sections[2]
-    const nrRows = nrSection.split('\n')
-
-    // Header: Name,ResourceType,AllocationType,AllocationPct,StartWeek,EndWeek
-    expect(nrRows[0]).toBe('Name,ResourceType,AllocationType,AllocationPct,StartWeek,EndWeek')
-
-    // Data row: Alice,Developer,T&M,100,,
-    expect(nrRows[1]).toBe('Alice,Developer,T&M,100,,')
+    const nrRows = nrSection.split('\n').filter((r: string) => r.length > 0)
+    const aliceRow = nrRows.find((r: string) => r.startsWith('Alice,'))
+    expect(aliceRow).toBeTruthy()
+    expect(aliceRow).toBe('Alice,Developer,T&M,100,,')
 
     // Section 2 is the Resource Demand section: ResourceType,Week,DemandDays,CapacityDays,Status
     const demandSection = sections[1]
-    // The cached demand is for rt-dev|0..3, resolved to Developer|0..3
     expect(demandSection).toContain('Developer,0,5,')
   })
 })

--- a/server/src/test/canonical-consistency.test.ts
+++ b/server/src/test/canonical-consistency.test.ts
@@ -238,7 +238,13 @@ describe('canonical cross-surface consistency', () => {
     expect(bob.pricingModel).toBe('PRO_RATA')
     expect(alice.actualAllocatedDays).toBeGreaterThan(0)
 
-    expect(res.body.bufferWeeks).toBe(2)
+    // Commercial-relevant fields on the resource row
+    expect(devRow.dayRate).toBe(500)
+    expect(devRow.estimatedCost).toBeGreaterThan(0)
+
+    // Summary proves commercial totals are computed from shared facts
+    expect(res.body.summary.hasCost).toBe(true)
+    expect(res.body.summary.totalCost).toBeGreaterThan(0)
   })
 
   it('Timeline and Resource Profile agree on actualAllocatedDays for the same NR', async () => {

--- a/server/src/test/canonical-consistency.test.ts
+++ b/server/src/test/canonical-consistency.test.ts
@@ -4,18 +4,21 @@
  * facts after recent ownership-boundary and stale-label work.
  *
  * Fixture scenario:
- *   - 1 resource type (Developer), 1 named resource (Alice)
+ *   - 1 resource type (Developer, day rate $500), 2 named resources
+ *   -   Alice (EFFORT, ACTUAL_DAYS billing)
+ *   -   Bob (EFFORT, PRO_RATA billing)
  *   - 1 onboarding week, 2 buffer weeks
  *   - Cached weekly demand for weeks 0-3
- *   - 1 timeline entry for a feature with task hours
+ *   - 1 timeline entry for a feature with 160h of Developer task hours
  *
  * Invariants protected:
  *   1. Named-resource `actualAllocatedDays` is identical in Timeline and Resource Profile.
  *   2. Named-resource `name` uses the current DB label (not a stale cached label).
- *   3. Onboarding weeks shift the planning window start.
+ *   3. Entry-level start dates are shifted by onboarding weeks.
  *   4. Buffer weeks extend the planning window end.
- *   5. CSV named-resource rows contain the same label and day values.
- *   6. Resource Profile `bufferWeeks` matches the project.
+ *   5. CSV named-resource row pairs the correct name and resource type.
+ *   6. Commercial billing-basis (pricingModel) is present on each named resource.
+ *   7. PRO_RATA and ACTUAL_DAYS named resources coexist with correct pricingModel.
  *
  * These invariants guard against future drift between surfaces after changes to
  * the shared planning model, cache-key format, or ownership boundaries.
@@ -44,7 +47,6 @@ function baseProjectFixture() {
     bufferWeeks: 2,
     onboardingWeeks: 1,
     weeklyDemandCache: { 'rt-dev|0': 5, 'rt-dev|1': 5, 'rt-dev|2': 5, 'rt-dev|3': 5 },
-    // Relations needed by the resource profile route
     resourceTypes: [],
     epics: [],
     overheads: [],
@@ -54,13 +56,13 @@ function baseProjectFixture() {
   }
 }
 
-/** Single resource type with one named resource. */
-function resourceTypeWithAlice() {
+/** Single resource type with two named resources exercising both billing bases. */
+function resourceTypeWithNamedResources() {
   return [{
     id: 'rt-dev',
     name: 'Developer',
     category: 'ENGINEERING',
-    count: 1,
+    count: 2,
     hoursPerDay: 8,
     dayRate: 500,
     allocationMode: 'EFFORT',
@@ -68,18 +70,32 @@ function resourceTypeWithAlice() {
     allocationStartWeek: null,
     allocationEndWeek: null,
     globalType: null,
-    namedResources: [{
-      id: 'nr-alice',
-      name: 'Alice',
-      startWeek: null,
-      endWeek: null,
-      allocationPct: 100,
-      allocationMode: 'EFFORT',
-      allocationPercent: 100,
-      allocationStartWeek: null,
-      allocationEndWeek: null,
-      pricingModel: 'ACTUAL_DAYS',
-    }],
+    namedResources: [
+      {
+        id: 'nr-alice',
+        name: 'Alice',
+        startWeek: null,
+        endWeek: null,
+        allocationPct: 100,
+        allocationMode: 'EFFORT',
+        allocationPercent: 100,
+        allocationStartWeek: null,
+        allocationEndWeek: null,
+        pricingModel: 'ACTUAL_DAYS',
+      },
+      {
+        id: 'nr-bob',
+        name: 'Bob',
+        startWeek: null,
+        endWeek: null,
+        allocationPct: 100,
+        allocationMode: 'EFFORT',
+        allocationPercent: 100,
+        allocationStartWeek: null,
+        allocationEndWeek: null,
+        pricingModel: 'PRO_RATA',
+      },
+    ],
   }]
 }
 
@@ -123,18 +139,9 @@ function timelineEntryFixture() {
 beforeEach(() => vi.clearAllMocks())
 
 describe('canonical cross-surface consistency', () => {
-  it('Timeline reports correct named-resource label and allocation days', async () => {
-    // buildProjectPlanningModel Prisma call sequence:
-    //   1. project.findFirst
-    //   2. resourceType.findMany
-    //   3-4. timelineEntry.findMany + storyTimelineEntry.findMany (parallel)
-    //   5-7. deps (default mock returns [])
-    //   8. capacityPlan.findFirst
-    // GET /timeline handler then does:
-    //   9. timelineEntry.findMany (reload for response)
-
+  it('Timeline reports correct named-resource labels, allocation days, and onboarding-shifted dates', async () => {
     vi.mocked(prisma.project.findFirst).mockResolvedValueOnce(baseProjectFixture() as never)
-    vi.mocked(prisma.resourceType.findMany).mockResolvedValueOnce(resourceTypeWithAlice() as never)
+    vi.mocked(prisma.resourceType.findMany).mockResolvedValueOnce(resourceTypeWithNamedResources() as never)
     vi.mocked(prisma.timelineEntry.findMany).mockResolvedValueOnce(timelineEntryFixture() as never)
     vi.mocked(prisma.storyTimelineEntry.findMany).mockResolvedValueOnce([] as never)
     vi.mocked(prisma.capacityPlan.findFirst).mockResolvedValueOnce(null as never)
@@ -146,22 +153,33 @@ describe('canonical cross-surface consistency', () => {
 
     expect(res.status).toBe(200)
 
+    // Named-resource labels are the current DB values, not stale cached labels
     const nrs = res.body.namedResources
-    expect(nrs.length).toBeGreaterThan(0)
+    expect(nrs.length).toBeGreaterThanOrEqual(2)
     expect(nrs[0].name).toBe('Alice')
     expect(nrs[0].resourceTypeName).toBe('Developer')
-    expect(typeof nrs[0].actualAllocatedDays).toBe('number')
     expect(nrs[0].actualAllocatedDays).toBeGreaterThan(0)
+    expect(nrs[1].name).toBe('Bob')
+    expect(nrs[1].resourceTypeName).toBe('Developer')
+    expect(typeof nrs[1].actualAllocatedDays).toBe('number')
 
+    // Entry-level start date is shifted by onboarding weeks:
+    // startWeek=0, 1 onboarding week → startDate = Jan 5 + 7 days = Jan 12
+    expect(res.body.entries[0].startDate).toBe('2026-01-12T00:00:00.000Z')
+    expect(res.body.entries[0].endDate).toBe('2026-02-09T00:00:00.000Z')
+
+    // Planning window reflects onboarding + buffer weeks
     expect(res.body.onboardingWeeks).toBe(1)
     expect(res.body.bufferWeeks).toBe(2)
+    // startWeek=0, duration=4, onboarding=1, buffer=2 => maxWeek = 0+4+1+2 = 7
+    // Jan 5 + 7 weeks = Feb 23
     expect(res.body.projectedEndDate).toBe('2026-02-23T00:00:00.000Z')
   })
 
-  it('Resource Profile reports the same named-resource label and allocation days', async () => {
+  it('Resource Profile reports the same named-resource labels and both billing bases', async () => {
     const projectFixture = {
       ...baseProjectFixture(),
-      resourceTypes: resourceTypeWithAlice(),
+      resourceTypes: resourceTypeWithNamedResources(),
       epics: [{
         id: 'epic-1',
         name: 'Platform',
@@ -207,10 +225,18 @@ describe('canonical cross-surface consistency', () => {
     expect(devRow).toBeTruthy()
 
     const nrs = devRow.namedResources
-    expect(nrs.length).toBeGreaterThan(0)
-    expect(nrs[0].name).toBe('Alice')
-    expect(typeof nrs[0].actualAllocatedDays).toBe('number')
-    expect(nrs[0].actualAllocatedDays).toBeGreaterThan(0)
+    expect(nrs.length).toBeGreaterThanOrEqual(2)
+
+    // Both billing bases are present
+    const alice = nrs.find((nr: { id: string }) => nr.id === 'nr-alice')
+    const bob = nrs.find((nr: { id: string }) => nr.id === 'nr-bob')
+    expect(alice).toBeTruthy()
+    expect(bob).toBeTruthy()
+    expect(alice.name).toBe('Alice')
+    expect(bob.name).toBe('Bob')
+    expect(alice.pricingModel).toBe('ACTUAL_DAYS')
+    expect(bob.pricingModel).toBe('PRO_RATA')
+    expect(alice.actualAllocatedDays).toBeGreaterThan(0)
 
     expect(res.body.bufferWeeks).toBe(2)
   })
@@ -218,7 +244,7 @@ describe('canonical cross-surface consistency', () => {
   it('Timeline and Resource Profile agree on actualAllocatedDays for the same NR', async () => {
     // Timeline
     vi.mocked(prisma.project.findFirst).mockResolvedValueOnce(baseProjectFixture() as never)
-    vi.mocked(prisma.resourceType.findMany).mockResolvedValueOnce(resourceTypeWithAlice() as never)
+    vi.mocked(prisma.resourceType.findMany).mockResolvedValueOnce(resourceTypeWithNamedResources() as never)
     vi.mocked(prisma.timelineEntry.findMany).mockResolvedValueOnce(timelineEntryFixture() as never)
     vi.mocked(prisma.storyTimelineEntry.findMany).mockResolvedValueOnce([] as never)
     vi.mocked(prisma.capacityPlan.findFirst).mockResolvedValueOnce(null as never)
@@ -233,7 +259,7 @@ describe('canonical cross-surface consistency', () => {
     // Resource Profile
     const profileFixture = {
       ...baseProjectFixture(),
-      resourceTypes: resourceTypeWithAlice(),
+      resourceTypes: resourceTypeWithNamedResources(),
       epics: [{
         id: 'epic-1',
         name: 'Platform',
@@ -276,14 +302,14 @@ describe('canonical cross-surface consistency', () => {
     )
     const profileDays: number = devRow.namedResources[0].actualAllocatedDays
 
-    // Same cached demand must produce the same allocated day count
+    // Same cached demand produces the same allocated day count across both surfaces
     expect(timelineDays).toBe(profileDays)
   })
 
-  it('Timeline CSV export uses current named-resource label', async () => {
+  it('Timeline CSV export pairs the correct name and resource type in the same row', async () => {
     vi.mocked(prisma.project.findFirst).mockResolvedValueOnce({
       ...baseProjectFixture(),
-      resourceTypes: resourceTypeWithAlice(),
+      resourceTypes: resourceTypeWithNamedResources(),
     } as never)
     vi.mocked(prisma.timelineEntry.findMany).mockResolvedValueOnce(timelineEntryFixture() as never)
     vi.mocked(prisma.storyTimelineEntry.findMany).mockResolvedValueOnce([] as never)
@@ -312,9 +338,23 @@ describe('canonical cross-surface consistency', () => {
     expect(res.status).toBe(200)
     const csv: string = res.text
 
-    expect(csv).toContain('Alice')
-    expect(csv).toContain('Developer')
-    expect(csv).toContain('T&M')
-    expect(csv).toContain('Developer,0,5')
+    // Split CSV into sections by blank-line delimiters
+    const sections = csv.split('\n\n')
+    expect(sections.length).toBeGreaterThanOrEqual(3)
+
+    // Section 3 is the Named Resources section
+    const nrSection = sections[2]
+    const nrRows = nrSection.split('\n')
+
+    // Header: Name,ResourceType,AllocationType,AllocationPct,StartWeek,EndWeek
+    expect(nrRows[0]).toBe('Name,ResourceType,AllocationType,AllocationPct,StartWeek,EndWeek')
+
+    // Data row: Alice,Developer,T&M,100,,
+    expect(nrRows[1]).toBe('Alice,Developer,T&M,100,,')
+
+    // Section 2 is the Resource Demand section: ResourceType,Week,DemandDays,CapacityDays,Status
+    const demandSection = sections[1]
+    // The cached demand is for rt-dev|0..3, resolved to Developer|0..3
+    expect(demandSection).toContain('Developer,0,5,')
   })
 })


### PR DESCRIPTION
Closes #269, references #263

## Summary

Adds a canonical regression fixture that proves Timeline, Resource Profile, **Commercial**, and CSV export agree on the same planning/commercial facts.

## Fixture Scenario

- 1 resource type (Developer, day rate $500, count 2)
- 2 named resources: Alice (EFFORT, ACTUAL_DAYS) and Bob (EFFORT, PRO_RATA)
- 1 onboarding week, 2 buffer weeks
- Cached weekly demand (`rt-dev|0` through `rt-dev|3` = 5 days each)
- 1 timeline entry for "Authentication" feature with 160h of Developer tasks
- Fixed start date: 2026-01-05

## Cross-Surface Invariants Protected

|#|Invariant|Where Verified|
|---|---|---|
|1|Timeline NR `actualAllocatedDays` matches Resource Profile NR `actualAllocatedDays`|Server test|
|2|NR `name` is the current DB label (not stale cached)|Server test|
|3|Entry-level `startDate` is shifted by onboarding weeks (Jan 5 + 1wk = Jan 12)|Server test|
|4|Buffer weeks extend the planning window end (projectedEndDate = Feb 23)|Server test|
|5|CSV Named-Resources row pairs the correct name and resource type|Server test|
|6|PRO_RATA and ACTUAL_DAYS NRs both have correct `pricingModel`|Server + client tests|
|7|ACTUAL_DAYS commercial billable days = actual scheduled days|Client test (`computeCommercialData`)|
|8|PRO_RATA commercial billable days = allocatedDays (planned allocation)|Client test|
|9|Commercial subtotal = sum of NR billable days × day rate ($10,000)|Client test|
|10|Grand total includes tax when taxRate is set ($11,000 at 10% GST)|Client test|
|11|Commercial rows preserve resource type metadata (dayRate, resourceTypeId)|Client test|
|12|Resource Profile `dayRate`, `estimatedCost`, `summary.totalCost` are present and positive|Server test|

## Why These Invariants Matter

- **actualAllocatedDays agreement** guards against drift between the shared planning model (used by Timeline) and the resource derivation path (used by Resource Profile / Commercial).
- **Label agreement** guards against stale cached labels from the `weeklyDemandCache`.
- **Onboarding date shift** guards against the planning window start regressing while `projectedEndDate` still extends.
- **ACTUAL_DAYS billing** proves Commercial uses the same actual scheduled days as Timeline/RP.
- **PRO_RATA billing** proves the planned-allocation branch is exercised and correct.
- **Commercial totals** prove that line-item costs, subtotals, and tax are derived from the same shared day-rate facts.
- **CSV row-level assertion** catches stale or mismatched resource-type labels that substring checks would miss.

## What Stayed the Same

- No server API changes.
- No calculation semantics changed.
- No ownership boundaries moved.
- No schema changes.
- Central invalidation helpers from #267 are still used.

## Verification

```bash
cd server
npm test                  # 361 passing (26 files, 0 failures)
npx tsc --noEmit          # clean (0 errors)

cd ../client
npx tsc --noEmit -p tsconfig.app.json   # clean (0 errors)
npm test -- --run                       # 5 new commercial consistency tests pass

cd ../server
npx tsc --noEmit          # clean (0 errors)
```

## Do not merge

Wait for review.