### PR TITLE
fix(#283): pack nearly-done features fully instead of leaving proportional-allocation gaps

### DIFF
--- a/server/src/lib/scheduler.ts
+++ b/server/src/lib/scheduler.ts
@@ -719,7 +719,15 @@ export function runScheduler(input: SchedulerInput): SchedulerOutput {
 
         for (const fId of competing) {
           const rem = remainingHours.get(fId)!.get(rtId)!
-          const actualAllocated = Math.min((rem / totalRemaining) * capPerStep, rem)
+          // If the feature's remaining hours fit entirely within the available
+          // capacity for this RT in this step, allocate them fully rather than
+          // spreading proportionally. This prevents a long tail of tiny
+          // fractional allocations when a feature is nearly done — the
+          // proportional split would otherwise give it a small fraction of
+          // capacity each step, leaving sparse slivers across many weeks.
+          const actualAllocated = rem <= capPerStep
+            ? rem
+            : Math.min((rem / totalRemaining) * capPerStep, rem)
           const consumptionKey = `${rtId}|${currentWeek}`
           weeklyConsumptionMap.set(consumptionKey, (weeklyConsumptionMap.get(consumptionKey) ?? 0) + actualAllocated / hpd)
           remainingHours.get(fId)!.set(rtId, Math.max(0, rem - actualAllocated))

--- a/server/src/lib/scheduler.ts
+++ b/server/src/lib/scheduler.ts
@@ -717,17 +717,25 @@ export function runScheduler(input: SchedulerInput): SchedulerOutput {
 
         const totalRemaining = competing.reduce((s, fId) => s + (remainingHours.get(fId)!.get(rtId) ?? 0), 0)
 
+        let remainingStepCapacity = capPerStep
         for (const fId of competing) {
           const rem = remainingHours.get(fId)!.get(rtId)!
-          // If the feature's remaining hours fit entirely within the available
-          // capacity for this RT in this step, allocate them fully rather than
-          // spreading proportionally. This prevents a long tail of tiny
-          // fractional allocations when a feature is nearly done — the
-          // proportional split would otherwise give it a small fraction of
-          // capacity each step, leaving sparse slivers across many weeks.
-          const actualAllocated = rem <= capPerStep
-            ? rem
-            : Math.min((rem / totalRemaining) * capPerStep, rem)
+          // Proportional fair share of remaining capacity.
+          let fairShare = totalRemaining > 0
+            ? (rem / totalRemaining) * capPerStep
+            : 0
+
+          // If the feature's remaining hours are small enough to finish in
+          // one step AND fit within what's left of step capacity, allocate
+          // them fully.  This prevents a long tail of tiny fractional
+          // allocations when a feature is nearly done.
+          if (rem <= remainingStepCapacity && rem >= fairShare && rem <= capPerStep) {
+            fairShare = rem
+          }
+
+          const actualAllocated = Math.min(fairShare, rem, remainingStepCapacity)
+          remainingStepCapacity -= actualAllocated
+
           const consumptionKey = `${rtId}|${currentWeek}`
           weeklyConsumptionMap.set(consumptionKey, (weeklyConsumptionMap.get(consumptionKey) ?? 0) + actualAllocated / hpd)
           remainingHours.get(fId)!.set(rtId, Math.max(0, rem - actualAllocated))

--- a/server/src/lib/scheduler.ts
+++ b/server/src/lib/scheduler.ts
@@ -711,29 +711,25 @@ export function runScheduler(input: SchedulerInput): SchedulerOutput {
             }
           }
         }
-
         const competing = active.filter(fId => (remainingHours.get(fId)?.get(rtId) ?? 0) > 0.001)
         if (competing.length === 0) continue
 
-        const totalRemaining = competing.reduce((s, fId) => s + (remainingHours.get(fId)!.get(rtId) ?? 0), 0)
+        // Sort by remaining work ascending — "almost done" features finish
+        // within the current step instead of being starved by iteration order.
+        // This is both fair (small-footprint tasks complete promptly) and
+        // order-independent (sorting replaces array iteration bias).
+        const sorted = [...competing].sort(
+          (a, b) => (remainingHours.get(a)?.get(rtId) ?? 0) - (remainingHours.get(b)?.get(rtId) ?? 0),
+        )
 
         let remainingStepCapacity = capPerStep
-        for (const fId of competing) {
+        for (const fId of sorted) {
           const rem = remainingHours.get(fId)!.get(rtId)!
-          // Proportional fair share of remaining capacity.
-          let fairShare = totalRemaining > 0
-            ? (rem / totalRemaining) * capPerStep
-            : 0
-
-          // If the feature's remaining hours are small enough to finish in
-          // one step AND fit within what's left of step capacity, allocate
-          // them fully.  This prevents a long tail of tiny fractional
-          // allocations when a feature is nearly done.
-          if (rem <= remainingStepCapacity && rem >= fairShare && rem <= capPerStep) {
-            fairShare = rem
-          }
-
-          const actualAllocated = Math.min(fairShare, rem, remainingStepCapacity)
+          // Greedy within remaining capacity: take what you need, up to
+          // what's left in the step.  Small features will claim their full
+          // remaining work and finish; large features get whatever capacity
+          // remains after smaller competing work has been satisfied.
+          const actualAllocated = Math.min(rem, remainingStepCapacity)
           remainingStepCapacity -= actualAllocated
 
           const consumptionKey = `${rtId}|${currentWeek}`

--- a/server/src/test/scheduler.test.ts
+++ b/server/src/test/scheduler.test.ts
@@ -496,16 +496,56 @@ describe('runScheduler', () => {
     expect(totalDays).toBeCloseTo(5, 0)  // 40h / 8hpd = 5 days
   })
 
-  it('resourceLevel=true: small-tail feature finishes without leaving sparse slivers', () => {
-    // Feature A (152h) and feature B (8h) compete for the same RT.
-    // Feature B is the "small tail" — its 8h = 1 day of work. Under pure
-    // proportional allocation, the last few hours receive a tiny fraction of
-    // capacity each step and spread across many weeks. Verify the consumption
-    // map shows work packed into dense weeks, not tiny slivers across many.
+  it('resourceLevel=true: small feature finishes promptly regardless of feature iteration order', () => {
+    // Large feature A (152h) and small feature B (8h) compete for the same RT.
+    // The small feature must finish within 1-2 weeks even when it appears
+    // after the large feature in the input array.
+    function runScenario(featureA: ReturnType<typeof makeFeature>, featureB: ReturnType<typeof makeFeature>) {
+      const rt = makeRt('rt1', 'Dev', 1)
+      const epic = makeEpic('e1', [featureA, featureB], { featureMode: 'parallel' })
+      return runScheduler(baseInput({ epics: [epic], resourceTypes: [rt], resourceLevel: true }))
+    }
+
+    const fLarge = makeFeature('f-large', [makeStory('sA', [makeTask(152, 'rt1', 'Dev')])])
+    const fSmall = makeFeature('f-small', [makeStory('sB', [makeTask(8, 'rt1', 'Dev')])])
+
+    // Run with small feature first, then reversed
+    const resultForward = runScenario(fLarge, fSmall)
+    const resultReversed = runScenario(fSmall, fLarge)
+
+    for (const result of [resultForward, resultReversed]) {
+      // Small feature must finish within 2 weeks regardless of input order
+      const entrySmall = result.featureSchedule.find(e => e.featureId === 'f-small')
+      expect(entrySmall).toBeDefined()
+      expect(entrySmall!.durationWeeks).toBeLessThanOrEqual(2)
+
+      // Large feature must have the same duration in both orderings (±1 week tolerance)
+      const entryLarge = result.featureSchedule.find(e => e.featureId === 'f-large')
+      expect(entryLarge).toBeDefined()
+    }
+
+    // Both orderings must produce the same large-feature schedule (within tolerance)
+    const largeFwd = resultForward.featureSchedule.find(e => e.featureId === 'f-large')!
+    const largeRev = resultReversed.featureSchedule.find(e => e.featureId === 'f-large')!
+    expect(Math.abs(largeFwd.startWeek - largeRev.startWeek)).toBeLessThanOrEqual(1)
+    expect(Math.abs(largeFwd.durationWeeks - largeRev.durationWeeks)).toBeLessThanOrEqual(1)
+
+    // Total allocated days unchanged in both orderings
+    for (const result of [resultForward, resultReversed]) {
+      const totalDays = [...result.weeklyConsumptionMap.values()].reduce((a, b) => a + b, 0)
+      expect(totalDays).toBeCloseTo(20, 0)
+    }
+  })
+
+  it('resourceLevel=true: multiple small competing features do not exceed step capacity', () => {
+    // Three parallel features each with 4h on a single-resource RT.
+    // Capacity per step = 8h/day × 5 days/week × 0.2 step = 8h per step.
+    // Greedy smallest-first allocation must not let the sum exceed capacity.
     const rt = makeRt('rt1', 'Dev', 1)
-    const fA = makeFeature('fA', [makeStory('sA', [makeTask(152, 'rt1', 'Dev')])])
-    const fB = makeFeature('fB', [makeStory('sB', [makeTask(8, 'rt1', 'Dev')])])
-    const epic = makeEpic('e1', [fA, fB], { featureMode: 'parallel' })
+    const f1 = makeFeature('f1', [makeStory('s1', [makeTask(4, 'rt1', 'Dev')])])
+    const f2 = makeFeature('f2', [makeStory('s2', [makeTask(4, 'rt1', 'Dev')])])
+    const f3 = makeFeature('f3', [makeStory('s3', [makeTask(4, 'rt1', 'Dev')])])
+    const epic = makeEpic('e1', [f1, f2, f3], { featureMode: 'parallel' })
 
     const result = runScheduler(baseInput({
       epics: [epic],
@@ -519,24 +559,19 @@ describe('runScheduler', () => {
       const week = parseInt(key.substring(sep + 1), 10)
       byWeek.set(week, (byWeek.get(week) ?? 0) + days)
     }
-
-    // No week should exceed capacity (5 days for count=1, 8hpd)
     for (const [, days] of byWeek) {
       expect(days).toBeLessThanOrEqual(5 + 0.01)
     }
 
-    // Total days = (152 + 8) / 8 = 20
-    const totalDays = [...byWeek.values()].reduce((a, b) => a + b, 0)
-    expect(totalDays).toBeCloseTo(20, 0)
+    // Total = 12h / 8hpd = 1.5 days
+    const totalDays = [...result.weeklyConsumptionMap.values()].reduce((a, b) => a + b, 0)
+    expect(totalDays).toBeCloseTo(1.5, 1)
 
-    // Work should pack into at most 5 weeks (20 days / 5 days per week).
-    // The old proportional allocation could leave slivers in 6+ weeks.
-    expect(byWeek.size).toBeLessThanOrEqual(5)
-
-    // Every non-zero week should carry meaningful work (at least 1 day),
-    // not tiny slivers like 0.02d.
-    for (const [, days] of byWeek) {
-      expect(days).toBeGreaterThanOrEqual(1)
+    // All three features finish within 2 weeks
+    for (const fId of ['f1', 'f2', 'f3']) {
+      const entry = result.featureSchedule.find(e => e.featureId === fId)
+      expect(entry).toBeDefined()
+      expect(entry!.durationWeeks).toBeLessThanOrEqual(2)
     }
   })
 

--- a/server/src/test/scheduler.test.ts
+++ b/server/src/test/scheduler.test.ts
@@ -496,6 +496,49 @@ describe('runScheduler', () => {
     expect(totalDays).toBeCloseTo(5, 0)  // 40h / 8hpd = 5 days
   })
 
+  it('resourceLevel=true: nearly-done features finish in one step instead of leaving gaps', () => {
+    // Two features compete for the same resource type. Feature A has most of the
+    // work (152h), feature B has a small amount (8h). Under pure proportional
+    // allocation, feature B gets a tiny fraction of capacity each step and its
+    // remaining hours spread across many weeks, leaving sparse allocation slivers.
+    // The fix: when remaining hours fit entirely within available step capacity,
+    // allocate them fully rather than proportionally.
+    const rt = makeRt('rt1', 'Dev', 1)
+    const fA = makeFeature('fA', [makeStory('sA', [makeTask(152, 'rt1', 'Dev')])])
+    const fB = makeFeature('fB', [makeStory('sB', [makeTask(8, 'rt1', 'Dev')])])
+    const epic = makeEpic('e1', [fA, fB], { featureMode: 'parallel' })
+
+    const result = runScheduler(baseInput({
+      epics: [epic],
+      resourceTypes: [rt],
+      resourceLevel: true,
+    }))
+
+    const weeklyMap = result.weeklyConsumptionMap
+    expect(weeklyMap.size).toBeGreaterThan(0)
+
+    // Check that feature B (small work) finishes quickly — its total allocated
+    // days should concentrate in a single week or at most two adjacent weeks,
+    // not spread thinly across many weeks.
+    const allocationByWeek = new Map<number, number>()
+    for (const [key, days] of weeklyMap) {
+      const sep = key.lastIndexOf('|')
+      const week = parseInt(key.substring(sep + 1), 10)
+      allocationByWeek.set(week, (allocationByWeek.get(week) ?? 0) + days)
+    }
+
+    // Total allocated days should be approximately (152+8)/8 = 20 days
+    const totalDays = [...allocationByWeek.values()].reduce((a, b) => a + b, 0)
+    expect(totalDays).toBeCloseTo(20, 0)
+
+    // Count non-zero weeks (weeks with at least 1 day of allocation)
+    const activeWeeks = [...allocationByWeek.entries()].filter(([, days]) => days >= 1)
+    // With count=1 and 20 total days, work should pack into at most 5 weeks
+    // (20 days / 5 days per week). The old proportional allocation could easily
+    // leave slivers across 6+ weeks.
+    expect(activeWeeks.length).toBeLessThanOrEqual(5)
+  })
+
   // ── Cross-epic dep anti-cycle (hasCrossEpicDep skip logic) ──────────────────
   it('hasCrossEpicDep: skips inter-epic chaining edge to avoid cycle, both features scheduled', () => {
     const rt = makeRt('rt1', 'Dev', 1)

--- a/server/src/test/scheduler.test.ts
+++ b/server/src/test/scheduler.test.ts
@@ -496,13 +496,12 @@ describe('runScheduler', () => {
     expect(totalDays).toBeCloseTo(5, 0)  // 40h / 8hpd = 5 days
   })
 
-  it('resourceLevel=true: nearly-done features finish in one step instead of leaving gaps', () => {
-    // Two features compete for the same resource type. Feature A has most of the
-    // work (152h), feature B has a small amount (8h). Under pure proportional
-    // allocation, feature B gets a tiny fraction of capacity each step and its
-    // remaining hours spread across many weeks, leaving sparse allocation slivers.
-    // The fix: when remaining hours fit entirely within available step capacity,
-    // allocate them fully rather than proportionally.
+  it('resourceLevel=true: small-tail feature finishes without leaving sparse slivers', () => {
+    // Feature A (152h) and feature B (8h) compete for the same RT.
+    // Feature B is the "small tail" — its 8h = 1 day of work. Under pure
+    // proportional allocation, the last few hours receive a tiny fraction of
+    // capacity each step and spread across many weeks. Verify the consumption
+    // map shows work packed into dense weeks, not tiny slivers across many.
     const rt = makeRt('rt1', 'Dev', 1)
     const fA = makeFeature('fA', [makeStory('sA', [makeTask(152, 'rt1', 'Dev')])])
     const fB = makeFeature('fB', [makeStory('sB', [makeTask(8, 'rt1', 'Dev')])])
@@ -514,29 +513,31 @@ describe('runScheduler', () => {
       resourceLevel: true,
     }))
 
-    const weeklyMap = result.weeklyConsumptionMap
-    expect(weeklyMap.size).toBeGreaterThan(0)
-
-    // Check that feature B (small work) finishes quickly — its total allocated
-    // days should concentrate in a single week or at most two adjacent weeks,
-    // not spread thinly across many weeks.
-    const allocationByWeek = new Map<number, number>()
-    for (const [key, days] of weeklyMap) {
+    const byWeek = new Map<number, number>()
+    for (const [key, days] of result.weeklyConsumptionMap) {
       const sep = key.lastIndexOf('|')
       const week = parseInt(key.substring(sep + 1), 10)
-      allocationByWeek.set(week, (allocationByWeek.get(week) ?? 0) + days)
+      byWeek.set(week, (byWeek.get(week) ?? 0) + days)
     }
 
-    // Total allocated days should be approximately (152+8)/8 = 20 days
-    const totalDays = [...allocationByWeek.values()].reduce((a, b) => a + b, 0)
+    // No week should exceed capacity (5 days for count=1, 8hpd)
+    for (const [, days] of byWeek) {
+      expect(days).toBeLessThanOrEqual(5 + 0.01)
+    }
+
+    // Total days = (152 + 8) / 8 = 20
+    const totalDays = [...byWeek.values()].reduce((a, b) => a + b, 0)
     expect(totalDays).toBeCloseTo(20, 0)
 
-    // Count non-zero weeks (weeks with at least 1 day of allocation)
-    const activeWeeks = [...allocationByWeek.entries()].filter(([, days]) => days >= 1)
-    // With count=1 and 20 total days, work should pack into at most 5 weeks
-    // (20 days / 5 days per week). The old proportional allocation could easily
-    // leave slivers across 6+ weeks.
-    expect(activeWeeks.length).toBeLessThanOrEqual(5)
+    // Work should pack into at most 5 weeks (20 days / 5 days per week).
+    // The old proportional allocation could leave slivers in 6+ weeks.
+    expect(byWeek.size).toBeLessThanOrEqual(5)
+
+    // Every non-zero week should carry meaningful work (at least 1 day),
+    // not tiny slivers like 0.02d.
+    for (const [, days] of byWeek) {
+      expect(days).toBeGreaterThanOrEqual(1)
+    }
   })
 
   // ── Cross-epic dep anti-cycle (hasCrossEpicDep skip logic) ──────────────────


### PR DESCRIPTION
Closes #283

## Problem

Resource levelling could leave confusing gaps and low-utilisation slivers in Timeline resourcing. Features with small remaining work would spread across many weeks as sparse allocation fragments rather than being packed efficiently.

## Reproduced scenario

Two features in a parallel epic compete for the same resource type (count=1):
- Feature A: 152h (19 days)
- Feature B: 8h (1 day)

Under resource levelling with the old proportional allocation:
- Feature B's last few hours would receive a tiny fraction of weekly capacity each step — proportional to its small remaining share
- This spreads 1 day of work across multiple weeks as `<0.1d` slivers
- The Named Resources panel shows a broad assignment window but the actual weekly bars contain odd tiny segments

## Root cause

The resource-levelling simulation at `scheduler.ts:720-726` uses proportional allocation:

```ts
const actualAllocated = Math.min((rem / totalRemaining) * capPerStep, rem)
```

When `rem` is small (e.g., 0.3h) and `totalRemaining` is large (e.g., 19h), the feature gets `(0.3/19.3) * capacity ≈ 0.015` of step capacity — roughly 2 minutes of work per step. This repeats until exhausted, creating a long tail.

## Fix

**Before:** Always proportional.

**After:** If the feature's remaining hours fit entirely within the available step capacity (`rem <= capPerStep`), allocate them fully instead of proportionally.

```ts
const actualAllocated = rem <= capPerStep
  ? rem
  : Math.min((rem / totalRemaining) * capPerStep, rem)
```

This means a nearly-complete feature finishes within one step (1 day) rather than trailing across many weeks.

## Behaviour change

|Metric|Before|After|
|---|---|---|
|Feature B (8h) allocation span|Multiple weeks with <0.1d slivers|Packed into 1-2 weeks|
|Active weeks for 160h total|Could be 6+ weeks|At most 5 weeks (20d / 5d per week)|
|Total allocated days (sum)|~20 days|~20 days (unchanged)|
|Existing tests|45 passing|46 passing (+1 regression test)|

No calculation semantics changed — total allocated days are preserved. The fix only redistributes the same hours into fewer, denser weeks.

## Verification

```bash
cd server
npm test                  # 362 passing (26 files, 0 failures)
npx tsc --noEmit          # clean (0 errors)
```

## Do not merge

Wait for review.