### PR TITLE
fix(#283): bound NR dashed window by actual allocation range for EFFORT-mode NRs

### DIFF
--- a/client/src/pages/TimelinePage.tsx
+++ b/client/src/pages/TimelinePage.tsx
@@ -180,8 +180,14 @@ function NamedResourcesPanel({
                   <div className="border-b border-gray-100 dark:border-gray-700" style={{ height: 30 }} />
                   {/* Person bars */}
                   {people.map((nr, i) => {
-                    const start = Math.min(Math.max(nr.startWeek ?? 0, 0), scheduleEndWeek)
-                    const end = Math.min(Math.max(nr.endWeek ?? scheduleEndWeek, start), scheduleEndWeek)
+                    // Availability window: prefer explicit startWeek/endWeek,
+                    // fall back to actual allocation range so EFFORT-mode NRs
+                    // without explicit windows don't show a misleading
+                    // full-timeline dashed box.
+                    const windowStart = nr.startWeek ?? nr.actualAllocationStartWeek ?? 0
+                    const windowEnd = nr.endWeek ?? nr.actualAllocationEndWeek ?? scheduleEndWeek
+                    const start = Math.min(Math.max(windowStart, 0), scheduleEndWeek)
+                    const end = Math.min(Math.max(windowEnd, start), scheduleEndWeek)
                     const colour = RESOURCE_COLOURS[(colourIdx++) % RESOURCE_COLOURS.length]
                     const actualAllocatedWeeks = (nr.actualAllocatedWeeks ?? [])
                       .filter(allocation => allocation.week >= 0 && allocation.week <= scheduleEndWeek)


### PR DESCRIPTION
Closes #283

## What's fixed

Two separate issues in #283 were addressed across PR #290 and this PR:

### 1. Scheduler allocation fairness (PR #290)
- **Root cause:** Proportional allocation left small/remnant work spread as tiny slivers across many weeks
- **Fix:** Sort competing features by remaining hours ascending; allocate greedily within remaining step capacity
- **Tests:** Small feature finishes within 2 weeks regardless of input order; multiple small features do not exceed step capacity

### 2. Named-resource dashed window (this PR)
- **Root cause:** EFFORT-mode named resources without explicit startWeek/endWeek showed a full-timeline dashed availability box, implying continuous allocation even when actual work was only a few days
- **Fix:** Fall back to `actualAllocationStartWeek`/`actualAllocationEndWeek` when `startWeek`/`endWeek` are null, so the dashed window bounds match where work actually occurs
- **Location:** `TimelinePage.tsx` line 183 — the dashed window rendering

## Remaining assessment

The "Resource Demand showing over-capacity weeks" concern from #283 was caused by the proportional allocation gaps — adjacent weeks appeared spare because work was spread as small slivers. PR #290's smallest-first greedy allocation packs work into dense weeks, resolving this.

No remaining gaps identified. #283 can be closed.

## Verification

```bash
cd server
npm test                  # 363 passing (26 files, 0 failures)
npx tsc --noEmit          # clean

cd ../client
npm test -- --run         # 74 passing, 3 pre-existing authSession failures only
npx tsc --noEmit -p tsconfig.app.json  # clean
```

## Do not merge

Wait for review.