### PR TITLE
feat(#240): overhead FTE scaling — computed FTE + count warning in Resource Profile

### DIFF
--- a/client/src/components/resource-profile/ResourceProfileTab.tsx
+++ b/client/src/components/resource-profile/ResourceProfileTab.tsx
@@ -304,26 +304,56 @@ export default function ResourceProfileTab({
                 </Fragment>
               ))}
 
-              {profile.overheadRows.map(row => (
-                <tr key={row.overheadId} className="bg-amber-50 dark:bg-amber-950 text-gray-700 dark:text-gray-300 italic border-b border-amber-100 dark:border-amber-900">
-                  <td className="px-6 py-3">
-                    <div className="font-medium">{row.name}</div>
-                    {row.resourceTypeName && <p className="text-xs text-gray-500 dark:text-gray-400 normal-case not-italic">Linked to: {row.resourceTypeName}</p>}
-                  </td>
-                  <td className="text-center px-4 py-3">{profile.projectDurationWeeks > 0 ? formatNumber(row.computedDays / (profile.projectDurationWeeks * 5), 2) : '—'}</td>
-                  <td className="px-4 py-3">
-                    {row.type === 'PERCENTAGE' ? `— ${row.value}% of task days`
-                      : row.type === 'DAYS_PER_WEEK' ? `— ${formatNumber(row.value, 2)} d/wk × ${formatNumber(profile.projectDurationWeeks)} wks`
-                      : `— ${formatNumber(row.value, 2)} fixed days`}
-                  </td>
-                  <td className="text-center px-4 py-3">—</td>
-                  <td className="text-right px-4 py-3 font-medium text-gray-900 dark:text-white">{formatNumber(row.computedDays, 2)} d</td>
-                  <td className="px-4 py-3">—</td>
-                  <td className="px-4 py-3 text-xs text-gray-500 dark:text-gray-400">—</td>
-                  <td className="text-right px-4 py-3">{row.dayRate != null ? `$${formatNumber(row.dayRate, 0)}` : '—'}</td>
-                  {hasCost && <td className="text-right px-6 py-3 font-medium text-gray-900 dark:text-white">{row.estimatedCost != null ? `$${formatNumber(row.estimatedCost, 0)}` : '—'}</td>}
-                </tr>
-              ))}
+              {profile.overheadRows.map(row => {
+                const fteExceedsCount = row.currentCount != null && row.requiredFTE > row.currentCount
+                return (
+                  <tr key={row.overheadId} className={`border-b border-amber-100 dark:border-amber-900 ${
+                    fteExceedsCount
+                      ? 'bg-red-50 dark:bg-red-950 text-red-700 dark:text-red-300'
+                      : 'bg-amber-50 dark:bg-amber-950 text-gray-700 dark:text-gray-300 italic'
+                  }`}>
+                    <td className="px-6 py-3">
+                      <div className="font-medium">{row.name}</div>
+                      {row.resourceTypeName && <p className="text-xs text-gray-500 dark:text-gray-400 normal-case not-italic">Linked to: {row.resourceTypeName}</p>}
+                    </td>
+                    <td className="text-center px-4 py-3 font-medium">
+                      {row.currentCount != null ? (
+                        <span>
+                          {row.currentCount}
+                          {row.currentCount > 0 && (
+                            <span title="Current count"></span>
+                          )}
+                        </span>
+                      ) : '—'}
+                    </td>
+                    <td className="px-4 py-3">
+                      {row.type === 'PERCENTAGE' ? `— ${row.value}% of task days`
+                        : row.type === 'DAYS_PER_WEEK' ? `— ${formatNumber(row.value, 2)} d/wk × ${formatNumber(profile.projectDurationWeeks)} wks`
+                        : `— ${formatNumber(row.value, 2)} fixed days`}
+                    </td>
+                    <td className="text-center px-4 py-3">—</td>
+                    <td className="text-right px-4 py-3 font-medium text-gray-900 dark:text-white">{formatNumber(row.computedDays, 2)} d</td>
+                    <td className="px-4 py-3">
+                      <div className="flex items-center gap-1.5">
+                        <span className={`font-medium ${fteExceedsCount ? 'text-red-600 dark:text-red-400' : ''}`}>
+                          {formatNumber(row.requiredFTE, 2)} FTE
+                        </span>
+                        {fteExceedsCount && (
+                          <span
+                            className="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-bold uppercase bg-red-100 dark:bg-red-900 text-red-700 dark:text-red-300"
+                            title={`${row.requiredFTE.toFixed(2)} FTE required but only ${row.currentCount!} configured`}
+                          >
+                            ⚠ Short {Math.ceil(row.requiredFTE - row.currentCount!)}
+                          </span>
+                        )}
+                      </div>
+                    </td>
+                    <td className="px-4 py-3 text-xs text-gray-500 dark:text-gray-400">—</td>
+                    <td className="text-right px-4 py-3">{row.dayRate != null ? `$${formatNumber(row.dayRate, 0)}` : '—'}</td>
+                    {hasCost && <td className="text-right px-6 py-3 font-medium text-gray-900 dark:text-white">{row.estimatedCost != null ? `$${formatNumber(row.estimatedCost, 0)}` : '—'}</td>}
+                  </tr>
+                )
+              })}
 
               {profile && (
                 <tr className="bg-gray-900 text-white font-semibold">

--- a/client/src/types/backlog.ts
+++ b/client/src/types/backlog.ts
@@ -311,6 +311,10 @@ export interface OverheadProfileRow {
   value: number
   computedDays: number
   estimatedCost: number | null
+  /** FTE required to deliver this overhead workload (computedDays / (projectDurationWeeks × 5)) */
+  requiredFTE: number
+  /** Current count of the linked resource type, if linked */
+  currentCount: number | null
 }
 
 export interface ResourceProfile {

--- a/server/src/routes/resourceProfile.ts
+++ b/server/src/routes/resourceProfile.ts
@@ -549,13 +549,19 @@ router.get('/', asyncHandler(async (req: AuthRequest, res: Response) => {
   const overheadRows = project.overheads.map(overhead => {
     const dayRate = overhead.resourceType?.dayRate ?? overhead.resourceType?.globalType?.defaultDayRate ?? null
     const resourceTypeName = overhead.resourceType?.name ?? null
+    const currentCount = overhead.resourceType?.count ?? null
     const computedDays =
       overhead.type === 'PERCENTAGE'
-        ? round2((overhead.value / 100) * totalEffortDays)  // % of effort, not allocated days
+        ? round2((overhead.value / 100) * totalEffortDays)
         : overhead.type === 'DAYS_PER_WEEK'
           ? round2(overhead.value * projectDurationWeeks)
           : round2(overhead.value)
     const estimatedCost = dayRate != null ? round2(computedDays * dayRate) : null
+    // Compute the effective FTE this overhead workload represents.
+    // requiredFTE = computedDays / (projectDurationWeeks * 5 working days/week).
+    const requiredFTE = projectDurationWeeks > 0
+      ? round2(computedDays / (projectDurationWeeks * 5))
+      : 0
     return {
       overheadId: overhead.id,
       name: overhead.name,
@@ -566,6 +572,8 @@ router.get('/', asyncHandler(async (req: AuthRequest, res: Response) => {
       value: overhead.value,
       computedDays,
       estimatedCost,
+      requiredFTE,
+      currentCount,
     }
   })
 

--- a/server/src/test/resourceProfile.test.ts
+++ b/server/src/test/resourceProfile.test.ts
@@ -1639,3 +1639,195 @@ describe('GET /api/projects/:projectId/resource-profile', () => {
     expect(nr.actualAllocatedDays).toBe(10)
   })
 })
+
+
+describe('overhead FTE scaling', () => {
+  it('computes requiredFTE for percentage-based overhead linked to a resource type', async () => {
+    vi.mocked(prisma.project.findFirst).mockResolvedValue({
+      id: 'proj-1',
+      ownerId: userId,
+      name: 'FTE Test',
+      startDate: new Date('2026-01-05T00:00:00.000Z'),
+      hoursPerDay: 8,
+      bufferWeeks: 0,
+      onboardingWeeks: 0,
+      weeklyDemandCache: null,
+      resourceTypes: [{
+        id: 'rt-dev',
+        name: 'Developer',
+        category: 'ENGINEERING',
+        count: 3,
+        hoursPerDay: 8,
+        dayRate: 500,
+        allocationMode: 'EFFORT',
+        allocationPercent: 100,
+        allocationStartWeek: null,
+        allocationEndWeek: null,
+        globalType: null,
+        namedResources: [
+          { id: 'nr-1', name: 'Dev 1', startWeek: null, endWeek: null, allocationPct: 100, allocationMode: 'EFFORT', allocationPercent: 100, allocationStartWeek: null, allocationEndWeek: null, pricingModel: 'ACTUAL_DAYS' },
+        ],
+      }],
+      epics: [{
+        id: 'epic-1',
+        name: 'Platform',
+        order: 0,
+        isActive: true,
+        featureMode: 'sequential',
+        scheduleMode: 'auto',
+        features: [{
+          id: 'feat-1',
+          name: 'Delivery',
+          order: 0,
+          isActive: true,
+          featureMode: 'sequential',
+          timelineStartWeek: null,
+          userStories: [{
+            isActive: true,
+            tasks: [{
+              resourceTypeId: 'rt-dev',
+              hoursEffort: 800,
+              durationDays: null,
+              resourceType: { id: 'rt-dev', name: 'Developer', hoursPerDay: 8 },
+            }],
+          }],
+        }],
+      }],
+      overheads: [{
+        id: 'oh-1',
+        name: 'Project Manager',
+        resourceTypeId: 'rt-pm',
+        type: 'PERCENTAGE',
+        value: 22,
+        order: 0,
+        resourceType: {
+          id: 'rt-pm',
+          name: 'Project Manager',
+          category: 'PROJECT_MANAGEMENT',
+          count: 1,
+          hoursPerDay: 8,
+          dayRate: 600,
+          allocationMode: 'EFFORT',
+          allocationPercent: 100,
+          allocationStartWeek: null,
+          allocationEndWeek: null,
+          globalType: null,
+          namedResources: [],
+        },
+      }],
+      timelineEntries: [{ featureId: 'feat-1', startWeek: 0, durationWeeks: 10 }],
+      storyTimelineEntries: [],
+      capacityPlans: [],
+    } as never)
+
+    const res = await request(app)
+      .get('/api/projects/proj-1/resource-profile')
+      .set('Authorization', authHeader)
+
+    expect(res.status).toBe(200)
+
+    const pmRow = res.body.overheadRows.find((r: any) => r.overheadId === 'oh-1')
+    expect(pmRow).toBeDefined()
+    expect(pmRow.requiredFTE).toBeGreaterThan(0)
+    expect(pmRow.currentCount).toBe(1)
+
+    // requiredFTE = computedDays / (projectDurationWeeks * 5)
+    // 800h / 8hpd = 100 days effort → 22% = 22 computed days
+    // projectDurationWeeks = 10, so FTE = 22 / (10 * 5) = 0.44
+    expect(pmRow.computedDays).toBe(22)
+    expect(pmRow.requiredFTE).toBe(0.44)
+  })
+
+  it('sets requiredFTE to 0 when projectDurationWeeks is 0', async () => {
+    vi.mocked(prisma.project.findFirst).mockResolvedValue({
+      id: 'proj-1',
+      ownerId: userId,
+      name: 'Zero Weeks',
+      startDate: new Date('2026-01-05T00:00:00.000Z'),
+      hoursPerDay: 8,
+      bufferWeeks: 0,
+      onboardingWeeks: 0,
+      weeklyDemandCache: null,
+      resourceTypes: [{
+        id: 'rt-dev', name: 'Developer', category: 'ENGINEERING', count: 1, hoursPerDay: 8,
+        dayRate: 500, allocationMode: 'EFFORT', allocationPercent: 100,
+        allocationStartWeek: null, allocationEndWeek: null, globalType: null,
+        namedResources: [],
+      }],
+      epics: [{
+        id: 'epic-1', name: 'E1', order: 0, isActive: true, featureMode: 'sequential',
+        scheduleMode: 'auto', features: [{
+          id: 'feat-1', name: 'F1', order: 0, isActive: true, featureMode: 'sequential',
+          timelineStartWeek: null,
+          userStories: [{ isActive: true, tasks: [] }],
+        }],
+      }],
+      overheads: [{
+        id: 'oh-1', name: 'PM', resourceTypeId: null, type: 'PERCENTAGE', value: 22, order: 0,
+        resourceType: null,
+      }],
+      timelineEntries: [],
+      storyTimelineEntries: [],
+      capacityPlans: [],
+    } as never)
+
+    const res = await request(app)
+      .get('/api/projects/proj-1/resource-profile')
+      .set('Authorization', authHeader)
+
+    expect(res.status).toBe(200)
+    const pmRow = res.body.overheadRows.find((r: any) => r.overheadId === 'oh-1')
+    expect(pmRow).toBeDefined()
+    expect(pmRow.requiredFTE).toBe(0)
+    expect(pmRow.currentCount).toBeNull()
+  })
+
+  it('FTE warning is triggered when requiredFTE exceeds currentCount', async () => {
+    // Set count=1 for the PM RT but FTE > 1 (e.g. 60% overhead on 200 effort days over 10 weeks)
+    vi.mocked(prisma.project.findFirst).mockResolvedValue({
+      id: 'proj-1',
+      ownerId: userId,
+      name: 'FTE Warn',
+      startDate: new Date('2026-01-05T00:00:00.000Z'),
+      hoursPerDay: 8,
+      bufferWeeks: 0,
+      onboardingWeeks: 0,
+      weeklyDemandCache: null,
+      resourceTypes: [{
+        id: 'rt-dev', name: 'Developer', category: 'ENGINEERING', count: 5, hoursPerDay: 8,
+        dayRate: 500, allocationMode: 'EFFORT', allocationPercent: 100,
+        allocationStartWeek: null, allocationEndWeek: null, globalType: null,
+        namedResources: [],
+      }],
+      epics: [{
+        id: 'epic-1', name: 'E1', order: 0, isActive: true, featureMode: 'sequential',
+        scheduleMode: 'auto', features: [{
+          id: 'feat-1', name: 'F1', order: 0, isActive: true, featureMode: 'sequential',
+          timelineStartWeek: null,
+          userStories: [{ isActive: true, tasks: [{ resourceTypeId: 'rt-dev', hoursEffort: 1600, durationDays: null, resourceType: { id: 'rt-dev', name: 'Developer', hoursPerDay: 8 } }] }],
+        }],
+      }],
+      overheads: [{
+        id: 'oh-1', name: 'PM', resourceTypeId: 'rt-pm', type: 'PERCENTAGE', value: 60, order: 0,
+        resourceType: { id: 'rt-pm', name: 'Project Manager', category: 'PROJECT_MANAGEMENT', count: 1, hoursPerDay: 8, dayRate: 600, allocationMode: 'EFFORT', allocationPercent: 100, allocationStartWeek: null, allocationEndWeek: null, globalType: null, namedResources: [] },
+      }],
+      timelineEntries: [{ featureId: 'feat-1', startWeek: 0, durationWeeks: 10 }],
+      storyTimelineEntries: [],
+      capacityPlans: [],
+    } as never)
+
+    const res = await request(app)
+      .get('/api/projects/proj-1/resource-profile')
+      .set('Authorization', authHeader)
+
+    expect(res.status).toBe(200)
+    const pmRow = res.body.overheadRows.find((r: any) => r.overheadId === 'oh-1')
+    expect(pmRow).toBeDefined()
+
+    // 1600h / 8hpd = 200 effort days, 60% = 120 computed days
+    // 120 / (10 * 5) = 2.4 FTE
+    expect(pmRow.requiredFTE).toBe(2.4)
+    expect(pmRow.currentCount).toBe(1)
+    expect(pmRow.requiredFTE).toBeGreaterThan(pmRow.currentCount)
+  })
+})


### PR DESCRIPTION
Closes #240

## Summary

Resource Profile now shows computed FTE need for overhead-linked resource types, with a warning when demand exceeds configured headcount.

## Server changes

`resourceProfile.ts` — each overhead row now includes:
- `requiredFTE`: computed as `computedDays / (projectDurationWeeks × 5)` using the same working-day convention as the rest of the app
- `currentCount`: from the linked resource type's count field (null for unlinked overheads)

Safe for zero-week periods (returns 0), unlinked overheads (currentCount is null).

## Client changes

`ResourceProfileTab.tsx` — overhead rows now display:
- The current count of the linked resource type (or "—" if unlinked)
- The computed required FTE value with formatting
- A red warning badge ("⚠ Short N") when required FTE exceeds the configured count
- Red background on the row when the warning is active

## Tests

3 new server tests:
1. Normal PERCENTAGE overhead: verifies 22% of 100 effort days = 22 computed days, 0.44 FTE over 10 weeks
2. Zero-duration safety: requiredFTE = 0, currentCount = null when projectDurationWeeks = 0
3. FTE-exceeds-count: 2.4 FTE required but only 1 PM configured — verifies the warning scenario

## Not implemented (deferred)

- Auto-scaling overhead RT count on Capacity Plan apply. The issue notes this as an option; for now the warning is clear enough. If auto-scale is desired later, it's a focused follow-up.

## Verification

```bash
cd server
npm test                  # 366 passing (26 files, 0 failures)
npx tsc --noEmit          # clean

cd ../client
npx tsc --noEmit -p tsconfig.app.json  # clean
npm test -- --run         # 74 passing, 3 pre-existing authSession failures only
```

## Do not merge

Wait for review.