### PR TITLE
feat(#298): deep clone preserves dependencies, timeline entries, capacity plans

### DIFF
--- a/server/src/routes/projects.ts
+++ b/server/src/routes/projects.ts
@@ -207,10 +207,17 @@ router.post('/:id/clone', asyncHandler(async (req: AuthRequest, res: Response) =
           },
         })
         for (const entry of period.entries ?? []) {
+          const newRtId = rtIdMap.get(entry.resourceTypeId)
+          if (!newRtId) {
+            throw new Error(
+              `Clone failed: capacity plan entry references resource type "${entry.resourceTypeId}" which was not cloned. ` +
+              `All resource types must be cloned for a valid deep copy.`,
+            )
+          }
           await tx.capacityPlanEntry.create({
             data: {
               periodId: newPeriod.id,
-              resourceTypeId: rtIdMap.get(entry.resourceTypeId) ?? entry.resourceTypeId,
+              resourceTypeId: newRtId,
               headcount: entry.headcount,
               demandFTE: entry.demandFTE,
               utilisationPct: entry.utilisationPct,

--- a/server/src/routes/projects.ts
+++ b/server/src/routes/projects.ts
@@ -85,12 +85,31 @@ router.post('/:id/clone', asyncHandler(async (req: AuthRequest, res: Response) =
       resourceTypes: { include: { namedResources: true } },
       overheads: true,
       discounts: true,
+      timelineEntries: true,
+      storyTimelineEntries: true,
+      capacityPlans: {
+        include: {
+          periods: {
+            include: { entries: true },
+          },
+        },
+      },
       epics: {
         include: {
+          epicDependencies: true,
+          epicDependents: true,
           features: {
             include: {
+              dependencies: true,
+              dependents: true,
+              timelineEntry: true,
               userStories: {
-                include: { tasks: true },
+                include: {
+                  dependencies: true,
+                  dependents: true,
+                  timelineEntry: true,
+                  tasks: true,
+                },
               },
             },
           },
@@ -102,8 +121,11 @@ router.post('/:id/clone', asyncHandler(async (req: AuthRequest, res: Response) =
 
   // #176: wrap entire clone in a transaction so partial failures roll back cleanly
   const clonedProject = await prisma.$transaction(async (tx) => {
-    // Build resource type id map: old id → new id
+    // Build ID maps for all cloned entities
     const rtIdMap = new Map<string, string>()
+    const epicIdMap = new Map<string, string>()
+    const featureIdMap = new Map<string, string>()
+    const storyIdMap = new Map<string, string>()
 
     const newProject = await tx.project.create({
       data: {
@@ -112,9 +134,10 @@ router.post('/:id/clone', asyncHandler(async (req: AuthRequest, res: Response) =
         customerId: source.customerId,
         orgId: source.orgId,
         status: 'DRAFT',
-        hoursPerDay: source.hoursPerDay,
+        onboardingWeeks: source.onboardingWeeks,
         bufferWeeks: source.bufferWeeks,
         startDate: source.startDate,
+        hoursPerDay: source.hoursPerDay,
         taxRate: source.taxRate,
         taxLabel: source.taxLabel,
         ownerId: req.userId!,
@@ -160,6 +183,43 @@ router.post('/:id/clone', asyncHandler(async (req: AuthRequest, res: Response) =
       }
     }
 
+    // Copy capacity plans, periods, and entries (remap resourceTypeId)
+    for (const plan of source.capacityPlans ?? []) {
+      const newPlan = await tx.capacityPlan.create({
+        data: {
+          projectId: newProject.id,
+          name: plan.name,
+          targetWeeks: plan.targetWeeks,
+          periodWeeks: plan.periodWeeks,
+          maxDelta: plan.maxDelta,
+          isActive: plan.isActive,
+          totalCost: plan.totalCost,
+          deliveryWeeks: plan.deliveryWeeks,
+        },
+      })
+      for (const period of plan.periods ?? []) {
+        const newPeriod = await tx.capacityPlanPeriod.create({
+          data: {
+            planId: newPlan.id,
+            periodIndex: period.periodIndex,
+            startWeek: period.startWeek,
+            endWeek: period.endWeek,
+          },
+        })
+        for (const entry of period.entries ?? []) {
+          await tx.capacityPlanEntry.create({
+            data: {
+              periodId: newPeriod.id,
+              resourceTypeId: rtIdMap.get(entry.resourceTypeId) ?? entry.resourceTypeId,
+              headcount: entry.headcount,
+              demandFTE: entry.demandFTE,
+              utilisationPct: entry.utilisationPct,
+            },
+          })
+        }
+      }
+    }
+
     // Copy overheads
     for (const oh of source.overheads) {
       await tx.projectOverhead.create({
@@ -188,7 +248,7 @@ router.post('/:id/clone', asyncHandler(async (req: AuthRequest, res: Response) =
       })
     }
 
-    // Copy epics → features → stories → tasks
+    // Copy epics → features → stories → tasks, building ID maps
     for (const epic of source.epics) {
       const newEpic = await tx.epic.create({
         data: {
@@ -203,6 +263,7 @@ router.post('/:id/clone', asyncHandler(async (req: AuthRequest, res: Response) =
           projectId: newProject.id,
         },
       })
+      epicIdMap.set(epic.id, newEpic.id)
 
       for (const feature of epic.features) {
         const newFeature = await tx.feature.create({
@@ -212,9 +273,13 @@ router.post('/:id/clone', asyncHandler(async (req: AuthRequest, res: Response) =
             assumptions: feature.assumptions,
             order: feature.order,
             isActive: feature.isActive,
+            featureMode: feature.featureMode,
+            timelineColour: feature.timelineColour,
+            timelineStartWeek: feature.timelineStartWeek,
             epicId: newEpic.id,
           },
         })
+        featureIdMap.set(feature.id, newFeature.id)
 
         for (const story of feature.userStories) {
           const newStory = await tx.userStory.create({
@@ -228,6 +293,7 @@ router.post('/:id/clone', asyncHandler(async (req: AuthRequest, res: Response) =
               featureId: newFeature.id,
             },
           })
+          storyIdMap.set(story.id, newStory.id)
 
           for (const task of story.tasks) {
             await tx.task.create({
@@ -242,6 +308,79 @@ router.post('/:id/clone', asyncHandler(async (req: AuthRequest, res: Response) =
                 resourceTypeId: task.resourceTypeId ? (rtIdMap.get(task.resourceTypeId) ?? null) : null,
               },
             })
+          }
+        }
+      }
+    }
+
+    // Recreate epic dependencies (remap both epicId and dependsOnId)
+    for (const epic of source.epics) {
+      for (const dep of epic.epicDependencies ?? []) {
+        const newEpicId = epicIdMap.get(dep.epicId)
+        const newDependsOnId = epicIdMap.get(dep.dependsOnId)
+        if (newEpicId && newDependsOnId) {
+          await tx.epicDependency.create({
+            data: { epicId: newEpicId, dependsOnId: newDependsOnId },
+          })
+        }
+      }
+    }
+
+    // Recreate feature dependencies + timeline entries
+    for (const epic of source.epics) {
+      for (const feature of epic.features) {
+        for (const dep of feature.dependencies ?? []) {
+          const newFeatureId = featureIdMap.get(dep.featureId)
+          const newDependsOnId = featureIdMap.get(dep.dependsOnId)
+          if (newFeatureId && newDependsOnId) {
+            await tx.featureDependency.create({
+              data: { featureId: newFeatureId, dependsOnId: newDependsOnId },
+            })
+          }
+        }
+        if (feature.timelineEntry) {
+          const newFeatureId = featureIdMap.get(feature.id)
+          if (newFeatureId) {
+            await tx.timelineEntry.create({
+              data: {
+                projectId: newProject.id,
+                featureId: newFeatureId,
+                startWeek: feature.timelineEntry.startWeek,
+                durationWeeks: feature.timelineEntry.durationWeeks,
+                isManual: feature.timelineEntry.isManual,
+              },
+            })
+          }
+        }
+      }
+    }
+
+    // Recreate story dependencies + story timeline entries
+    for (const epic of source.epics) {
+      for (const feature of epic.features) {
+        for (const story of feature.userStories) {
+          for (const dep of story.dependencies ?? []) {
+            const newStoryId = storyIdMap.get(dep.storyId)
+            const newDependsOnId = storyIdMap.get(dep.dependsOnId)
+            if (newStoryId && newDependsOnId) {
+              await tx.storyDependency.create({
+                data: { storyId: newStoryId, dependsOnId: newDependsOnId },
+              })
+            }
+          }
+          if (story.timelineEntry) {
+            const newStoryId = storyIdMap.get(story.id)
+            if (newStoryId) {
+              await tx.storyTimelineEntry.create({
+                data: {
+                  projectId: newProject.id,
+                  storyId: newStoryId,
+                  startWeek: story.timelineEntry.startWeek,
+                  durationWeeks: story.timelineEntry.durationWeeks,
+                  isManual: story.timelineEntry.isManual,
+                },
+              })
+            }
           }
         }
       }

--- a/server/src/test/projects.clone.test.ts
+++ b/server/src/test/projects.clone.test.ts
@@ -44,7 +44,11 @@ const mockClonedProject = {
 
 function baseTx() {
   return {
-    project: { create: vi.fn().mockResolvedValue({ id: 'proj-clone-1', name: 'Copy of Original Project' }), findFirst: vi.fn().mockResolvedValue(mockClonedProject), update: vi.fn() },
+    project: {
+      create: vi.fn().mockResolvedValue({ id: 'proj-clone-1', name: 'Copy of Original Project' }),
+      findFirst: vi.fn().mockResolvedValue(mockClonedProject),
+      update: vi.fn(),
+    },
     resourceType: { create: vi.fn() },
     namedResource: { create: vi.fn() },
     projectOverhead: { create: vi.fn() },
@@ -105,18 +109,32 @@ describe('POST /api/projects/:id/clone', () => {
       return fn(tx)
     })
     await request(app).post('/api/projects/proj-1/clone').set('Authorization', authHeader)
-    expect(vi.mocked(prisma.$transaction)).toHaveBeenCalledWith(expect.any(Function), expect.objectContaining({ timeout: 30000 }))
+    expect(vi.mocked(prisma.$transaction)).toHaveBeenCalledWith(
+      expect.any(Function),
+      expect.objectContaining({ timeout: 30000 }),
+    )
   })
 
-  // ── Deep-copy regression tests (#298) ──────────────────────────────
+  // ── Planning fields ────────────────────────────────────────────────────
 
   it('preserves planning fields on cloned project', async () => {
-    const src = { ...mockSource, onboardingWeeks: 2, bufferWeeks: 3, startDate: new Date('2026-06-01'), hoursPerDay: 7.5, taxRate: 0.1, taxLabel: 'GST' }
+    const src = {
+      ...mockSource,
+      onboardingWeeks: 2,
+      bufferWeeks: 3,
+      startDate: new Date('2026-06-01'),
+      hoursPerDay: 7.5,
+      taxRate: 0.1,
+      taxLabel: 'GST',
+    }
     vi.mocked(prisma.project.findFirst).mockResolvedValue(src as any)
     let captured: Record<string, unknown> = {}
     vi.mocked(prisma.$transaction).mockImplementation(async (fn: any) => {
       const tx = baseTx()
-      tx.project.create = vi.fn(({ data }: any) => { captured = data; return { id: 'proj-clone-1' } })
+      tx.project.create = vi.fn(({ data }: any) => {
+        captured = data
+        return { id: 'proj-clone-1' }
+      })
       return fn(tx)
     })
     await request(app).post('/api/projects/proj-1/clone').set('Authorization', authHeader)
@@ -128,15 +146,44 @@ describe('POST /api/projects/:id/clone', () => {
     expect(captured.taxLabel).toBe('GST')
   })
 
+  // ── Feature metadata ───────────────────────────────────────────────────
+
   it('preserves featureMode, timelineColour, timelineStartWeek on cloned features', async () => {
-    const src = { ...mockSource, epics: [{ id: 'epic-1', featureMode: 'parallel', scheduleMode: 'sequential', timelineStartWeek: null, epicDependencies: [], epicDependents: [], features: [{ id: 'feat-1', featureMode: 'parallel', timelineColour: '#ff0000', timelineStartWeek: 3, dependencies: [], dependents: [], timelineEntry: null, userStories: [] }] }] }
+    const src = {
+      ...mockSource,
+      epics: [
+        {
+          id: 'epic-1',
+          featureMode: 'parallel',
+          scheduleMode: 'sequential',
+          timelineStartWeek: null,
+          epicDependencies: [],
+          epicDependents: [],
+          features: [
+            {
+              id: 'feat-1',
+              featureMode: 'parallel',
+              timelineColour: '#ff0000',
+              timelineStartWeek: 3,
+              dependencies: [],
+              dependents: [],
+              timelineEntry: null,
+              userStories: [],
+            },
+          ],
+        },
+      ],
+    }
     vi.mocked(prisma.project.findFirst).mockResolvedValue(src as any)
     let captured: Record<string, unknown> = {}
     vi.mocked(prisma.$transaction).mockImplementation(async (fn: any) => {
       const tx = baseTx()
       tx.project.create = vi.fn().mockResolvedValue({ id: 'proj-clone-1' })
       tx.epic.create = vi.fn().mockResolvedValue({ id: 'epic-clone-1' })
-      tx.feature.create = vi.fn(({ data }: any) => { captured = data; return { id: 'feat-clone-1' } })
+      tx.feature.create = vi.fn(({ data }: any) => {
+        captured = data
+        return { id: 'feat-clone-1' }
+      })
       return fn(tx)
     })
     await request(app).post('/api/projects/proj-1/clone').set('Authorization', authHeader)
@@ -145,77 +192,428 @@ describe('POST /api/projects/:id/clone', () => {
     expect(captured.timelineStartWeek).toBe(3)
   })
 
-  it('recreates epic dependencies with remapped IDs', async () => {
-    const src = { ...mockSource, epics: [{ id: 'epic-a', featureMode: 'sequential', scheduleMode: 'sequential', timelineStartWeek: null, epicDependencies: [{ epicId: 'epic-a', dependsOnId: 'epic-b' }], epicDependents: [], features: [] }, { id: 'epic-b', featureMode: 'sequential', scheduleMode: 'sequential', timelineStartWeek: null, epicDependencies: [], epicDependents: [{ epicId: 'epic-a', dependsOnId: 'epic-b' }], features: [] }] }
+  // ── Epic dependency remapping ──────────────────────────────────────────
+
+  it('epic dependencies use cloned epic IDs, not source IDs', async () => {
+    const src = {
+      ...mockSource,
+      epics: [
+        {
+          id: 'epic-a',
+          featureMode: 'sequential',
+          scheduleMode: 'sequential',
+          timelineStartWeek: null,
+          epicDependencies: [{ epicId: 'epic-a', dependsOnId: 'epic-b' }],
+          epicDependents: [],
+          features: [],
+        },
+        {
+          id: 'epic-b',
+          featureMode: 'sequential',
+          scheduleMode: 'sequential',
+          timelineStartWeek: null,
+          epicDependencies: [],
+          epicDependents: [{ epicId: 'epic-a', dependsOnId: 'epic-b' }],
+          features: [],
+        },
+      ],
+    }
     vi.mocked(prisma.project.findFirst).mockResolvedValue(src as any)
     const ids: string[] = []
-    let depCalled = false
+    const depDataList: any[] = []
     vi.mocked(prisma.$transaction).mockImplementation(async (fn: any) => {
       const tx = baseTx()
       tx.project.create = vi.fn().mockResolvedValue({ id: 'proj-clone-1' })
-      tx.epic.create = vi.fn(() => { const id = `epic-c-${ids.length + 1}`; ids.push(id); return { id } })
-      tx.epicDependency.create = vi.fn(() => { depCalled = true; return {} })
+      tx.epic.create = vi.fn(() => {
+        const id = `epic-c-${ids.length + 1}`
+        ids.push(id)
+        return { id }
+      })
+      tx.epicDependency.create = vi.fn(({ data }: any) => {
+        depDataList.push(data)
+        return {}
+      })
       return fn(tx)
     })
     await request(app).post('/api/projects/proj-1/clone').set('Authorization', authHeader)
     expect(ids).toHaveLength(2)
-    expect(depCalled).toBe(true)
+    expect(depDataList).toHaveLength(1)
+    // Both fields use cloned epic IDs, not source IDs "epic-a" / "epic-b"
+    expect(depDataList[0].epicId).toBe('epic-c-1')
+    expect(depDataList[0].dependsOnId).toBe('epic-c-2')
   })
 
-  it('recreates feature deps and timeline entries', async () => {
-    const src = { ...mockSource, epics: [{ id: 'epic-1', featureMode: 'sequential', scheduleMode: 'sequential', timelineStartWeek: null, epicDependencies: [], epicDependents: [], features: [{ id: 'feat-1', featureMode: 'sequential', timelineColour: null, timelineStartWeek: null, dependencies: [{ featureId: 'feat-1', dependsOnId: 'feat-2' }], dependents: [], timelineEntry: { startWeek: 2, durationWeeks: 4, isManual: true }, userStories: [] }, { id: 'feat-2', featureMode: 'sequential', timelineColour: null, timelineStartWeek: null, dependencies: [], dependents: [{ featureId: 'feat-1', dependsOnId: 'feat-2' }], timelineEntry: null, userStories: [] }] }] }
+  // ── Feature deps and timeline entries ───────────────────────────────────
+
+  it('feature dependencies and timeline entries use cloned IDs and preserve values', async () => {
+    const src = {
+      ...mockSource,
+      epics: [
+        {
+          id: 'epic-1',
+          featureMode: 'sequential',
+          scheduleMode: 'sequential',
+          timelineStartWeek: null,
+          epicDependencies: [],
+          epicDependents: [],
+          features: [
+            {
+              id: 'feat-1',
+              featureMode: 'sequential',
+              timelineColour: null,
+              timelineStartWeek: null,
+              dependencies: [{ featureId: 'feat-1', dependsOnId: 'feat-2' }],
+              dependents: [],
+              timelineEntry: { startWeek: 2, durationWeeks: 4, isManual: true },
+              userStories: [],
+            },
+            {
+              id: 'feat-2',
+              featureMode: 'sequential',
+              timelineColour: null,
+              timelineStartWeek: null,
+              dependencies: [],
+              dependents: [{ featureId: 'feat-1', dependsOnId: 'feat-2' }],
+              timelineEntry: null,
+              userStories: [],
+            },
+          ],
+        },
+      ],
+    }
     vi.mocked(prisma.project.findFirst).mockResolvedValue(src as any)
-    let depCalled = false; let teCalled = false
+    const depDataList: any[] = []
+    const teDataList: any[] = []
     vi.mocked(prisma.$transaction).mockImplementation(async (fn: any) => {
       const tx = baseTx()
       tx.project.create = vi.fn().mockResolvedValue({ id: 'proj-clone-1' })
-      tx.epic.create = vi.fn().mockResolvedValue({ id: 'epic-c-1' })
-      let fi = 0; tx.feature.create = vi.fn(() => { fi++; return { id: `feat-c-${fi}` } })
-      tx.featureDependency.create = vi.fn(() => { depCalled = true; return {} })
-      tx.timelineEntry.create = vi.fn(() => { teCalled = true; return {} })
+      tx.epic.create = vi.fn().mockResolvedValue({ id: 'epic-clone-1' })
+      let fi = 0
+      tx.feature.create = vi.fn(() => {
+        fi++
+        return { id: `feat-c-${fi}` }
+      })
+      tx.featureDependency.create = vi.fn(({ data }: any) => {
+        depDataList.push(data)
+        return {}
+      })
+      tx.timelineEntry.create = vi.fn(({ data }: any) => {
+        teDataList.push(data)
+        return {}
+      })
       return fn(tx)
     })
     await request(app).post('/api/projects/proj-1/clone').set('Authorization', authHeader)
-    expect(depCalled).toBe(true)
-    expect(teCalled).toBe(true)
+    // Feature dependency uses cloned feature IDs
+    expect(depDataList).toHaveLength(1)
+    expect(depDataList[0].featureId).toBe('feat-c-1')
+    expect(depDataList[0].dependsOnId).toBe('feat-c-2')
+    // Timeline entry uses cloned feature ID and project ID, preserves values
+    expect(teDataList).toHaveLength(1)
+    expect(teDataList[0].projectId).toBe('proj-clone-1')
+    expect(teDataList[0].featureId).toBe('feat-c-1')
+    expect(teDataList[0].startWeek).toBe(2)
+    expect(teDataList[0].durationWeeks).toBe(4)
+    expect(teDataList[0].isManual).toBe(true)
   })
 
-  it('recreates story deps and story timeline entries', async () => {
-    const src = { ...mockSource, epics: [{ id: 'epic-1', featureMode: 'sequential', scheduleMode: 'sequential', timelineStartWeek: null, epicDependencies: [], epicDependents: [], features: [{ id: 'feat-1', featureMode: 'sequential', timelineColour: null, timelineStartWeek: null, dependencies: [], dependents: [], timelineEntry: null, userStories: [{ id: 'story-1', dependencies: [{ storyId: 'story-1', dependsOnId: 'story-2' }], dependents: [], timelineEntry: { startWeek: 1, durationWeeks: 3, isManual: false }, tasks: [] }, { id: 'story-2', dependencies: [], dependents: [{ storyId: 'story-1', dependsOnId: 'story-2' }], timelineEntry: null, tasks: [] }] }] }] }
+  // ── Story deps and story timeline entries ───────────────────────────────
+
+  it('story dependencies and story timeline entries use cloned IDs and preserve values', async () => {
+    const src = {
+      ...mockSource,
+      epics: [
+        {
+          id: 'epic-1',
+          featureMode: 'sequential',
+          scheduleMode: 'sequential',
+          timelineStartWeek: null,
+          epicDependencies: [],
+          epicDependents: [],
+          features: [
+            {
+              id: 'feat-1',
+              featureMode: 'sequential',
+              timelineColour: null,
+              timelineStartWeek: null,
+              dependencies: [],
+              dependents: [],
+              timelineEntry: null,
+              userStories: [
+                {
+                  id: 'story-1',
+                  dependencies: [{ storyId: 'story-1', dependsOnId: 'story-2' }],
+                  dependents: [],
+                  timelineEntry: { startWeek: 1, durationWeeks: 3, isManual: false },
+                  tasks: [],
+                },
+                {
+                  id: 'story-2',
+                  dependencies: [],
+                  dependents: [{ storyId: 'story-1', dependsOnId: 'story-2' }],
+                  timelineEntry: null,
+                  tasks: [],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    }
     vi.mocked(prisma.project.findFirst).mockResolvedValue(src as any)
-    let depCalled = false; let steCalled = false
+    const depDataList: any[] = []
+    const steDataList: any[] = []
     vi.mocked(prisma.$transaction).mockImplementation(async (fn: any) => {
       const tx = baseTx()
       tx.project.create = vi.fn().mockResolvedValue({ id: 'proj-clone-1' })
-      tx.epic.create = vi.fn().mockResolvedValue({ id: 'epic-c-1' })
+      tx.epic.create = vi.fn().mockResolvedValue({ id: 'epic-clone-1' })
       tx.feature.create = vi.fn().mockResolvedValue({ id: 'feat-c-1' })
-      let si = 0; tx.userStory.create = vi.fn(() => { si++; return { id: `story-c-${si}` } })
-      tx.storyDependency.create = vi.fn(() => { depCalled = true; return {} })
-      tx.storyTimelineEntry.create = vi.fn(() => { steCalled = true; return {} })
+      let si = 0
+      tx.userStory.create = vi.fn(() => {
+        si++
+        return { id: `story-c-${si}` }
+      })
+      tx.storyDependency.create = vi.fn(({ data }: any) => {
+        depDataList.push(data)
+        return {}
+      })
+      tx.storyTimelineEntry.create = vi.fn(({ data }: any) => {
+        steDataList.push(data)
+        return {}
+      })
       return fn(tx)
     })
     await request(app).post('/api/projects/proj-1/clone').set('Authorization', authHeader)
-    expect(depCalled).toBe(true)
-    expect(steCalled).toBe(true)
+    // Story dependency uses cloned story IDs
+    expect(depDataList).toHaveLength(1)
+    expect(depDataList[0].storyId).toBe('story-c-1')
+    expect(depDataList[0].dependsOnId).toBe('story-c-2')
+    // Story timeline entry uses cloned story ID and project ID, preserves values
+    expect(steDataList).toHaveLength(1)
+    expect(steDataList[0].projectId).toBe('proj-clone-1')
+    expect(steDataList[0].storyId).toBe('story-c-1')
+    expect(steDataList[0].startWeek).toBe(1)
+    expect(steDataList[0].durationWeeks).toBe(3)
+    expect(steDataList[0].isManual).toBe(false)
   })
 
-  it('recreates capacity plans with remapped resourceTypeId', async () => {
-    const src = { ...mockSource, resourceTypes: [{ id: 'rt-1', namedResources: [] }], capacityPlans: [{ id: 'cp-1', name: 'Monthly', targetWeeks: 12, periodWeeks: 4, maxDelta: 2, isActive: true, totalCost: 5000, deliveryWeeks: 10, periods: [{ id: 'per-1', periodIndex: 0, startWeek: 0, endWeek: 4, entries: [{ resourceTypeId: 'rt-1', headcount: 2, demandFTE: 1.5, utilisationPct: 0.75 }] }] }] }
+  // ── Capacity plan ───────────────────────────────────────────────────────
+
+  it('capacity plan entry resourceTypeId is remapped to cloned RT', async () => {
+    const src = {
+      ...mockSource,
+      resourceTypes: [{ id: 'rt-1', namedResources: [] }],
+      capacityPlans: [
+        {
+          id: 'cp-1',
+          name: 'Monthly',
+          targetWeeks: 12,
+          periodWeeks: 4,
+          maxDelta: 2,
+          isActive: true,
+          totalCost: 5000,
+          deliveryWeeks: 10,
+          periods: [
+            {
+              id: 'per-1',
+              periodIndex: 0,
+              startWeek: 0,
+              endWeek: 4,
+              entries: [{ resourceTypeId: 'rt-1', headcount: 2, demandFTE: 1.5, utilisationPct: 0.75 }],
+            },
+          ],
+        },
+      ],
+    }
     vi.mocked(prisma.project.findFirst).mockResolvedValue(src as any)
-    let planC = false, periodC = false, entryC = false, entryData: any = {}
+    let entryData: any = {}
     vi.mocked(prisma.$transaction).mockImplementation(async (fn: any) => {
       const tx = baseTx()
       tx.project.create = vi.fn().mockResolvedValue({ id: 'proj-clone-1' })
-      tx.resourceType.create = vi.fn(() => { return { id: 'rt-c-1' } })
-      tx.capacityPlan.create = vi.fn(() => { planC = true; return { id: 'cp-c-1' } })
-      tx.capacityPlanPeriod.create = vi.fn(() => { periodC = true; return { id: 'per-c-1' } })
-      tx.capacityPlanEntry.create = vi.fn(({ data }: any) => { entryC = true; entryData = data; return {} })
+      tx.resourceType.create = vi.fn(() => ({ id: 'rt-c-1' }))
+      tx.capacityPlan.create = vi.fn(() => ({ id: 'cp-c-1' }))
+      tx.capacityPlanPeriod.create = vi.fn(() => ({ id: 'per-c-1' }))
+      tx.capacityPlanEntry.create = vi.fn(({ data }: any) => {
+        entryData = data
+        return {}
+      })
       return fn(tx)
     })
     await request(app).post('/api/projects/proj-1/clone').set('Authorization', authHeader)
-    expect(planC).toBe(true)
-    expect(periodC).toBe(true)
-    expect(entryC).toBe(true)
     expect(entryData.resourceTypeId).toBe('rt-c-1')
+  })
+
+  it('capacity plan entry throws when resource type is not in rtIdMap', async () => {
+    // The source has a capacity plan entry referencing a resource type that
+    // is not included in source.resourceTypes, so it cannot be remapped.
+    const src = {
+      ...mockSource,
+      capacityPlans: [
+        {
+          id: 'cp-1',
+          name: 'Monthly',
+          targetWeeks: 12,
+          periodWeeks: 4,
+          maxDelta: 2,
+          isActive: true,
+          totalCost: null,
+          deliveryWeeks: null,
+          periods: [
+            {
+              id: 'per-1',
+              periodIndex: 0,
+              startWeek: 0,
+              endWeek: 4,
+              entries: [{ resourceTypeId: 'rt-missing', headcount: 2, demandFTE: 1.5, utilisationPct: 0.75 }],
+            },
+          ],
+        },
+      ],
+    }
+    vi.mocked(prisma.project.findFirst).mockResolvedValue(src as any)
+    vi.mocked(prisma.$transaction).mockImplementation(async (fn: any) => {
+      const tx = baseTx()
+      tx.project.create = vi.fn().mockResolvedValue({ id: 'proj-clone-1' })
+      tx.resourceType.create = vi.fn(() => ({ id: 'rt-c-1' }))
+      tx.capacityPlan.create = vi.fn(() => ({ id: 'cp-c-1' }))
+      tx.capacityPlanPeriod.create = vi.fn(() => ({ id: 'per-c-1' }))
+      return fn(tx)
+    })
+    const res = await request(app).post('/api/projects/proj-1/clone').set('Authorization', authHeader)
+    expect(res.status).toBe(500)
+  })
+
+  // ── Named resources ─────────────────────────────────────────────────────
+
+  it('named resources are cloned under the cloned resource type ID', async () => {
+    const src = {
+      ...mockSource,
+      resourceTypes: [
+        {
+          id: 'rt-1',
+          namedResources: [
+            { name: 'Alice', startWeek: 1, endWeek: 10, allocationPct: 100, allocationMode: 'EFFORT', allocationPercent: 100, allocationStartWeek: null, allocationEndWeek: null, pricingModel: 'ACTUAL_DAYS' },
+          ],
+        },
+      ],
+    }
+    vi.mocked(prisma.project.findFirst).mockResolvedValue(src as any)
+    const nrDataList: any[] = []
+    vi.mocked(prisma.$transaction).mockImplementation(async (fn: any) => {
+      const tx = baseTx()
+      tx.project.create = vi.fn().mockResolvedValue({ id: 'proj-clone-1' })
+      tx.resourceType.create = vi.fn(() => ({ id: 'rt-c-1' }))
+      tx.namedResource.create = vi.fn(({ data }: any) => {
+        nrDataList.push(data)
+        return {}
+      })
+      return fn(tx)
+    })
+    await request(app).post('/api/projects/proj-1/clone').set('Authorization', authHeader)
+    expect(nrDataList).toHaveLength(1)
+    expect(nrDataList[0].name).toBe('Alice')
+    expect(nrDataList[0].resourceTypeId).toBe('rt-c-1')
+    expect(nrDataList[0].startWeek).toBe(1)
+    expect(nrDataList[0].endWeek).toBe(10)
+  })
+
+  // ── Overhead RT remapping ───────────────────────────────────────────────
+
+  it('project overhead with resourceTypeId is remapped to cloned RT', async () => {
+    const src = {
+      ...mockSource,
+      resourceTypes: [{ id: 'rt-1', namedResources: [] }],
+      overheads: [
+        { name: 'PM', resourceTypeId: 'rt-1', type: 'FIXED', value: 10000, order: 0 },
+      ],
+    }
+    vi.mocked(prisma.project.findFirst).mockResolvedValue(src as any)
+    const ohDataList: any[] = []
+    vi.mocked(prisma.$transaction).mockImplementation(async (fn: any) => {
+      const tx = baseTx()
+      tx.project.create = vi.fn().mockResolvedValue({ id: 'proj-clone-1' })
+      tx.resourceType.create = vi.fn(() => ({ id: 'rt-c-1' }))
+      tx.projectOverhead.create = vi.fn(({ data }: any) => {
+        ohDataList.push(data)
+        return {}
+      })
+      return fn(tx)
+    })
+    await request(app).post('/api/projects/proj-1/clone').set('Authorization', authHeader)
+    expect(ohDataList).toHaveLength(1)
+    expect(ohDataList[0].resourceTypeId).toBe('rt-c-1')
+    expect(ohDataList[0].name).toBe('PM')
+  })
+
+  it('project overhead with null resourceTypeId passes null', async () => {
+    const src = {
+      ...mockSource,
+      overheads: [
+        { name: 'Fixed Cost', resourceTypeId: null, type: 'FIXED', value: 5000, order: 0 },
+      ],
+    }
+    vi.mocked(prisma.project.findFirst).mockResolvedValue(src as any)
+    const ohDataList: any[] = []
+    vi.mocked(prisma.$transaction).mockImplementation(async (fn: any) => {
+      const tx = baseTx()
+      tx.project.create = vi.fn().mockResolvedValue({ id: 'proj-clone-1' })
+      tx.projectOverhead.create = vi.fn(({ data }: any) => {
+        ohDataList.push(data)
+        return {}
+      })
+      return fn(tx)
+    })
+    await request(app).post('/api/projects/proj-1/clone').set('Authorization', authHeader)
+    expect(ohDataList[0].resourceTypeId).toBeNull()
+  })
+
+  // ── Discount RT remapping ──────────────────────────────────────────────
+
+  it('project discount with resourceTypeId is remapped to cloned RT', async () => {
+    const src = {
+      ...mockSource,
+      resourceTypes: [{ id: 'rt-1', namedResources: [] }],
+      discounts: [
+        { resourceTypeId: 'rt-1', type: 'PERCENTAGE', value: 10, label: 'Early adopter', order: 0 },
+      ],
+    }
+    vi.mocked(prisma.project.findFirst).mockResolvedValue(src as any)
+    const discDataList: any[] = []
+    vi.mocked(prisma.$transaction).mockImplementation(async (fn: any) => {
+      const tx = baseTx()
+      tx.project.create = vi.fn().mockResolvedValue({ id: 'proj-clone-1' })
+      tx.resourceType.create = vi.fn(() => ({ id: 'rt-c-1' }))
+      tx.projectDiscount.create = vi.fn(({ data }: any) => {
+        discDataList.push(data)
+        return {}
+      })
+      return fn(tx)
+    })
+    await request(app).post('/api/projects/proj-1/clone').set('Authorization', authHeader)
+    expect(discDataList).toHaveLength(1)
+    expect(discDataList[0].resourceTypeId).toBe('rt-c-1')
+    expect(discDataList[0].label).toBe('Early adopter')
+  })
+
+  it('project discount with null resourceTypeId passes null', async () => {
+    const src = {
+      ...mockSource,
+      discounts: [
+        { resourceTypeId: null, type: 'PERCENTAGE', value: 5, label: 'Loyalty', order: 0 },
+      ],
+    }
+    vi.mocked(prisma.project.findFirst).mockResolvedValue(src as any)
+    const discDataList: any[] = []
+    vi.mocked(prisma.$transaction).mockImplementation(async (fn: any) => {
+      const tx = baseTx()
+      tx.project.create = vi.fn().mockResolvedValue({ id: 'proj-clone-1' })
+      tx.projectDiscount.create = vi.fn(({ data }: any) => {
+        discDataList.push(data)
+        return {}
+      })
+      return fn(tx)
+    })
+    await request(app).post('/api/projects/proj-1/clone').set('Authorization', authHeader)
+    expect(discDataList[0].resourceTypeId).toBeNull()
   })
 })

--- a/server/src/test/projects.clone.test.ts
+++ b/server/src/test/projects.clone.test.ts
@@ -10,7 +10,6 @@ const userId = 'user-1'
 const token = jwt.sign({ userId }, 'test-secret')
 const authHeader = `Bearer ${token}`
 
-// Minimal source project returned by findFirst (includes all nested relations the clone route accesses)
 const mockSource = {
   id: 'proj-1',
   ownerId: userId,
@@ -21,9 +20,14 @@ const mockSource = {
   status: 'ACTIVE',
   hoursPerDay: 8,
   bufferWeeks: 0,
-  startDate: null,
+  onboardingWeeks: 2,
+  startDate: new Date('2026-06-01'),
   taxRate: null,
   taxLabel: null,
+  weeklyDemandCache: null,
+  timelineEntries: [],
+  storyTimelineEntries: [],
+  capacityPlans: [],
   resourceTypes: [],
   overheads: [],
   discounts: [],
@@ -38,88 +42,180 @@ const mockClonedProject = {
   _count: { epics: 0 },
 }
 
+function baseTx() {
+  return {
+    project: { create: vi.fn().mockResolvedValue({ id: 'proj-clone-1', name: 'Copy of Original Project' }), findFirst: vi.fn().mockResolvedValue(mockClonedProject), update: vi.fn() },
+    resourceType: { create: vi.fn() },
+    namedResource: { create: vi.fn() },
+    projectOverhead: { create: vi.fn() },
+    projectDiscount: { create: vi.fn() },
+    epic: { create: vi.fn() },
+    epicDependency: { create: vi.fn() },
+    feature: { create: vi.fn() },
+    featureDependency: { create: vi.fn() },
+    userStory: { create: vi.fn() },
+    storyDependency: { create: vi.fn() },
+    task: { create: vi.fn() },
+    timelineEntry: { create: vi.fn() },
+    storyTimelineEntry: { create: vi.fn() },
+    capacityPlan: { create: vi.fn() },
+    capacityPlanPeriod: { create: vi.fn() },
+    capacityPlanEntry: { create: vi.fn() },
+  }
+}
+
 beforeEach(() => vi.clearAllMocks())
 
 describe('POST /api/projects/:id/clone', () => {
   it('returns 201 with the cloned project on success', async () => {
     vi.mocked(prisma.project.findFirst).mockResolvedValue(mockSource as any)
     vi.mocked(prisma.$transaction).mockImplementation(async (fn: any) => {
-      // Provide a tx object that satisfies what the clone route creates
-      const tx = {
-        project: { create: vi.fn().mockResolvedValue({ id: 'proj-clone-1', name: 'Copy of Original Project' }), findFirst: vi.fn().mockResolvedValue(mockClonedProject) },
-        resourceType: { create: vi.fn() },
-        namedResource: { create: vi.fn() },
-        projectOverhead: { create: vi.fn() },
-        projectDiscount: { create: vi.fn() },
-        epic: { create: vi.fn() },
-        feature: { create: vi.fn() },
-        userStory: { create: vi.fn() },
-        task: { create: vi.fn() },
-      }
+      const tx = baseTx()
       return fn(tx)
     })
 
-    const res = await request(app)
-      .post('/api/projects/proj-1/clone')
-      .set('Authorization', authHeader)
-
+    const res = await request(app).post('/api/projects/proj-1/clone').set('Authorization', authHeader)
     expect(res.status).toBe(201)
     expect(res.body.name).toBe('Copy of Original Project')
   })
 
-  it('returns 404 when the source project does not exist or is not owned', async () => {
+  it('returns 404 when source project does not exist', async () => {
     vi.mocked(prisma.project.findFirst).mockResolvedValue(null)
-
-    const res = await request(app)
-      .post('/api/projects/nonexistent/clone')
-      .set('Authorization', authHeader)
-
+    const res = await request(app).post('/api/projects/nonexistent/clone').set('Authorization', authHeader)
     expect(res.status).toBe(404)
   })
 
-  it('returns 401 without an auth token', async () => {
+  it('returns 401 without auth token', async () => {
     const res = await request(app).post('/api/projects/proj-1/clone')
     expect(res.status).toBe(401)
   })
 
-  it('returns 500 and does NOT leave a partial project when the transaction throws', async () => {
+  it('rolls back on transaction failure', async () => {
     vi.mocked(prisma.project.findFirst).mockResolvedValue(mockSource as any)
-    vi.mocked(prisma.$transaction).mockRejectedValue(new Error('DB failure mid-clone'))
-
-    const res = await request(app)
-      .post('/api/projects/proj-1/clone')
-      .set('Authorization', authHeader)
-
+    vi.mocked(prisma.$transaction).mockRejectedValue(new Error('DB failure'))
+    const res = await request(app).post('/api/projects/proj-1/clone').set('Authorization', authHeader)
     expect(res.status).toBe(500)
-
-    // The transaction threw before committing — confirm no project.create was called outside the tx
     expect(vi.mocked(prisma.project.create)).not.toHaveBeenCalled()
   })
 
   it('passes timeout:30000 to $transaction', async () => {
     vi.mocked(prisma.project.findFirst).mockResolvedValue(mockSource as any)
     vi.mocked(prisma.$transaction).mockImplementation(async (fn: any) => {
-      const tx = {
-        project: { create: vi.fn().mockResolvedValue({ id: 'proj-clone-1' }), findFirst: vi.fn().mockResolvedValue(mockClonedProject) },
-        resourceType: { create: vi.fn() },
-        namedResource: { create: vi.fn() },
-        projectOverhead: { create: vi.fn() },
-        projectDiscount: { create: vi.fn() },
-        epic: { create: vi.fn() },
-        feature: { create: vi.fn() },
-        userStory: { create: vi.fn() },
-        task: { create: vi.fn() },
-      }
+      const tx = baseTx()
       return fn(tx)
     })
+    await request(app).post('/api/projects/proj-1/clone').set('Authorization', authHeader)
+    expect(vi.mocked(prisma.$transaction)).toHaveBeenCalledWith(expect.any(Function), expect.objectContaining({ timeout: 30000 }))
+  })
 
-    await request(app)
-      .post('/api/projects/proj-1/clone')
-      .set('Authorization', authHeader)
+  // ── Deep-copy regression tests (#298) ──────────────────────────────
 
-    expect(vi.mocked(prisma.$transaction)).toHaveBeenCalledWith(
-      expect.any(Function),
-      expect.objectContaining({ timeout: 30000 }),
-    )
+  it('preserves planning fields on cloned project', async () => {
+    const src = { ...mockSource, onboardingWeeks: 2, bufferWeeks: 3, startDate: new Date('2026-06-01'), hoursPerDay: 7.5, taxRate: 0.1, taxLabel: 'GST' }
+    vi.mocked(prisma.project.findFirst).mockResolvedValue(src as any)
+    let captured: Record<string, unknown> = {}
+    vi.mocked(prisma.$transaction).mockImplementation(async (fn: any) => {
+      const tx = baseTx()
+      tx.project.create = vi.fn(({ data }: any) => { captured = data; return { id: 'proj-clone-1' } })
+      return fn(tx)
+    })
+    await request(app).post('/api/projects/proj-1/clone').set('Authorization', authHeader)
+    expect(captured.onboardingWeeks).toBe(2)
+    expect(captured.bufferWeeks).toBe(3)
+    expect(captured.startDate).toEqual(new Date('2026-06-01'))
+    expect(captured.hoursPerDay).toBe(7.5)
+    expect(captured.taxRate).toBe(0.1)
+    expect(captured.taxLabel).toBe('GST')
+  })
+
+  it('preserves featureMode, timelineColour, timelineStartWeek on cloned features', async () => {
+    const src = { ...mockSource, epics: [{ id: 'epic-1', featureMode: 'parallel', scheduleMode: 'sequential', timelineStartWeek: null, epicDependencies: [], epicDependents: [], features: [{ id: 'feat-1', featureMode: 'parallel', timelineColour: '#ff0000', timelineStartWeek: 3, dependencies: [], dependents: [], timelineEntry: null, userStories: [] }] }] }
+    vi.mocked(prisma.project.findFirst).mockResolvedValue(src as any)
+    let captured: Record<string, unknown> = {}
+    vi.mocked(prisma.$transaction).mockImplementation(async (fn: any) => {
+      const tx = baseTx()
+      tx.project.create = vi.fn().mockResolvedValue({ id: 'proj-clone-1' })
+      tx.epic.create = vi.fn().mockResolvedValue({ id: 'epic-clone-1' })
+      tx.feature.create = vi.fn(({ data }: any) => { captured = data; return { id: 'feat-clone-1' } })
+      return fn(tx)
+    })
+    await request(app).post('/api/projects/proj-1/clone').set('Authorization', authHeader)
+    expect(captured.featureMode).toBe('parallel')
+    expect(captured.timelineColour).toBe('#ff0000')
+    expect(captured.timelineStartWeek).toBe(3)
+  })
+
+  it('recreates epic dependencies with remapped IDs', async () => {
+    const src = { ...mockSource, epics: [{ id: 'epic-a', featureMode: 'sequential', scheduleMode: 'sequential', timelineStartWeek: null, epicDependencies: [{ epicId: 'epic-a', dependsOnId: 'epic-b' }], epicDependents: [], features: [] }, { id: 'epic-b', featureMode: 'sequential', scheduleMode: 'sequential', timelineStartWeek: null, epicDependencies: [], epicDependents: [{ epicId: 'epic-a', dependsOnId: 'epic-b' }], features: [] }] }
+    vi.mocked(prisma.project.findFirst).mockResolvedValue(src as any)
+    const ids: string[] = []
+    let depCalled = false
+    vi.mocked(prisma.$transaction).mockImplementation(async (fn: any) => {
+      const tx = baseTx()
+      tx.project.create = vi.fn().mockResolvedValue({ id: 'proj-clone-1' })
+      tx.epic.create = vi.fn(() => { const id = `epic-c-${ids.length + 1}`; ids.push(id); return { id } })
+      tx.epicDependency.create = vi.fn(() => { depCalled = true; return {} })
+      return fn(tx)
+    })
+    await request(app).post('/api/projects/proj-1/clone').set('Authorization', authHeader)
+    expect(ids).toHaveLength(2)
+    expect(depCalled).toBe(true)
+  })
+
+  it('recreates feature deps and timeline entries', async () => {
+    const src = { ...mockSource, epics: [{ id: 'epic-1', featureMode: 'sequential', scheduleMode: 'sequential', timelineStartWeek: null, epicDependencies: [], epicDependents: [], features: [{ id: 'feat-1', featureMode: 'sequential', timelineColour: null, timelineStartWeek: null, dependencies: [{ featureId: 'feat-1', dependsOnId: 'feat-2' }], dependents: [], timelineEntry: { startWeek: 2, durationWeeks: 4, isManual: true }, userStories: [] }, { id: 'feat-2', featureMode: 'sequential', timelineColour: null, timelineStartWeek: null, dependencies: [], dependents: [{ featureId: 'feat-1', dependsOnId: 'feat-2' }], timelineEntry: null, userStories: [] }] }] }
+    vi.mocked(prisma.project.findFirst).mockResolvedValue(src as any)
+    let depCalled = false; let teCalled = false
+    vi.mocked(prisma.$transaction).mockImplementation(async (fn: any) => {
+      const tx = baseTx()
+      tx.project.create = vi.fn().mockResolvedValue({ id: 'proj-clone-1' })
+      tx.epic.create = vi.fn().mockResolvedValue({ id: 'epic-c-1' })
+      let fi = 0; tx.feature.create = vi.fn(() => { fi++; return { id: `feat-c-${fi}` } })
+      tx.featureDependency.create = vi.fn(() => { depCalled = true; return {} })
+      tx.timelineEntry.create = vi.fn(() => { teCalled = true; return {} })
+      return fn(tx)
+    })
+    await request(app).post('/api/projects/proj-1/clone').set('Authorization', authHeader)
+    expect(depCalled).toBe(true)
+    expect(teCalled).toBe(true)
+  })
+
+  it('recreates story deps and story timeline entries', async () => {
+    const src = { ...mockSource, epics: [{ id: 'epic-1', featureMode: 'sequential', scheduleMode: 'sequential', timelineStartWeek: null, epicDependencies: [], epicDependents: [], features: [{ id: 'feat-1', featureMode: 'sequential', timelineColour: null, timelineStartWeek: null, dependencies: [], dependents: [], timelineEntry: null, userStories: [{ id: 'story-1', dependencies: [{ storyId: 'story-1', dependsOnId: 'story-2' }], dependents: [], timelineEntry: { startWeek: 1, durationWeeks: 3, isManual: false }, tasks: [] }, { id: 'story-2', dependencies: [], dependents: [{ storyId: 'story-1', dependsOnId: 'story-2' }], timelineEntry: null, tasks: [] }] }] }] }
+    vi.mocked(prisma.project.findFirst).mockResolvedValue(src as any)
+    let depCalled = false; let steCalled = false
+    vi.mocked(prisma.$transaction).mockImplementation(async (fn: any) => {
+      const tx = baseTx()
+      tx.project.create = vi.fn().mockResolvedValue({ id: 'proj-clone-1' })
+      tx.epic.create = vi.fn().mockResolvedValue({ id: 'epic-c-1' })
+      tx.feature.create = vi.fn().mockResolvedValue({ id: 'feat-c-1' })
+      let si = 0; tx.userStory.create = vi.fn(() => { si++; return { id: `story-c-${si}` } })
+      tx.storyDependency.create = vi.fn(() => { depCalled = true; return {} })
+      tx.storyTimelineEntry.create = vi.fn(() => { steCalled = true; return {} })
+      return fn(tx)
+    })
+    await request(app).post('/api/projects/proj-1/clone').set('Authorization', authHeader)
+    expect(depCalled).toBe(true)
+    expect(steCalled).toBe(true)
+  })
+
+  it('recreates capacity plans with remapped resourceTypeId', async () => {
+    const src = { ...mockSource, resourceTypes: [{ id: 'rt-1', namedResources: [] }], capacityPlans: [{ id: 'cp-1', name: 'Monthly', targetWeeks: 12, periodWeeks: 4, maxDelta: 2, isActive: true, totalCost: 5000, deliveryWeeks: 10, periods: [{ id: 'per-1', periodIndex: 0, startWeek: 0, endWeek: 4, entries: [{ resourceTypeId: 'rt-1', headcount: 2, demandFTE: 1.5, utilisationPct: 0.75 }] }] }] }
+    vi.mocked(prisma.project.findFirst).mockResolvedValue(src as any)
+    let planC = false, periodC = false, entryC = false, entryData: any = {}
+    vi.mocked(prisma.$transaction).mockImplementation(async (fn: any) => {
+      const tx = baseTx()
+      tx.project.create = vi.fn().mockResolvedValue({ id: 'proj-clone-1' })
+      tx.resourceType.create = vi.fn(() => { return { id: 'rt-c-1' } })
+      tx.capacityPlan.create = vi.fn(() => { planC = true; return { id: 'cp-c-1' } })
+      tx.capacityPlanPeriod.create = vi.fn(() => { periodC = true; return { id: 'per-c-1' } })
+      tx.capacityPlanEntry.create = vi.fn(({ data }: any) => { entryC = true; entryData = data; return {} })
+      return fn(tx)
+    })
+    await request(app).post('/api/projects/proj-1/clone').set('Authorization', authHeader)
+    expect(planC).toBe(true)
+    expect(periodC).toBe(true)
+    expect(entryC).toBe(true)
+    expect(entryData.resourceTypeId).toBe('rt-c-1')
   })
 })


### PR DESCRIPTION
Closes #298

## Problem

Project clone omitted dependencies, timeline entries, story timeline entries, feature planning metadata, capacity plans, and `onboardingWeeks`. Cloned estimates lost all scheduling and resource planning state.

## Changes

### server/src/routes/projects.ts

**Source query** now includes all nested relations. **Clone logic** inside the existing transaction:

1. **ID maps**: rtIdMap, epicIdMap, featureIdMap, storyIdMap built during creation
2. **Project create**: copies onboardingWeeks (was missing)
3. **Feature create**: copies featureMode, timelineColour, timelineStartWeek (were missing)
4. **Capacity plans**: clones Plan → Periods → Entries; resourceTypeId is **fail-fast** — throws if the source RT ID is not found in rtIdMap (no silent fallback)
5. **Dependencies**: EpicDependency, FeatureDependency, StoryDependency recreated with remapped IDs
6. **Timeline entries**: TimelineEntry (per-feature), StoryTimelineEntry (per-story) with preserved startWeek, durationWeeks, isManual
7. **weeklyDemandCache**: left null (new project default, recomputed on next access)

### server/src/test/projects.clone.test.ts

17 tests (all passing):

| Area | Tests | Key assertions |
|------|-------|----------------|
| Basic smoke | 5 | 201, 404, 401, rollback, timeout |
| Planning fields | 1 | onboardingWeeks, bufferWeeks, startDate, hoursPerDay, tax fields |
| Feature metadata | 1 | featureMode, timelineColour, timelineStartWeek |
| Epic dependency | 1 | dep data uses **cloned epic IDs** not source IDs |
| Feature deps + timeline | 1 | dep uses cloned feature IDs; timeline uses cloned project + feature IDs, preserves values |
| Story deps + story timeline | 1 | dep uses cloned story IDs; story-timeline uses cloned project + story IDs, preserves values |
| Capacity plan RT remap | 1 | entry.resourceTypeId = cloned RT |
| Capacity plan fail-fast | 1 | missing RT returns 500 |
| Named resources | 1 | resourceTypeId = cloned RT |
| Overhead RT remap | 2 | with RT → cloned RT; null RT → null |
| Discount RT remap | 2 | with RT → cloned RT; null RT → null |

## Verification

```bash
cd server
npx vitest run                     # 386 passing (26 files, 0 failures)
npx tsc --noEmit                   # clean
npx vitest run src/test/projects.clone.test.ts  # 17 passing
```

## Do not merge

Draft — awaiting review.