### PR TITLE
fix: use cross-platform lockfile for native CI deps

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -52,21 +52,6 @@ jobs:
       - name: Install all dependencies
         run: npm ci
 
-      # ── Fix platform-native binaries (npm/cli#4828) ────────────
-      # macOS-generated lockfile omits Linux-specific optional native packages.
-      # After npm ci, surgically install the Linux x64 bindings that Vite 8
-      # (rolldown, lightningcss), Rollup 4, and Tailwind CSS (oxide) need.
-      # Versions are read from the installed packages so they stay in sync.
-      # Note: some packages don't export ./package.json so we use fs.readFileSync.
-      - name: Install missing Linux native binaries
-        run: |
-          get_ver() { node -p "JSON.parse(require('fs').readFileSync('node_modules/$1/package.json','utf8')).version"; }
-          npm install --no-save --ignore-scripts \
-            "@rolldown/binding-linux-x64-gnu@$(get_ver rolldown)" \
-            "@rollup/rollup-linux-x64-gnu@$(get_ver rollup)" \
-            "lightningcss-linux-x64-gnu@$(get_ver lightningcss)" \
-            "@tailwindcss/oxide-linux-x64-gnu@$(get_ver @tailwindcss/oxide)"
-
       # ── TypeScript type-checking ──────────────────────────────────
       - name: TypeScript check (client)
         working-directory: client

--- a/package-lock.json
+++ b/package-lock.json
@@ -1676,6 +1676,21 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.13.tgz",
+      "integrity": "sha512-eRrPvat2YaVQcwwKi/JzOP6MKf1WRnOCr+VaI3cTWz3ZoLcP/654z90lVCJ4dAuMEpPdke0n+qyAqXDZdIC4rA==",
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "cpu": [
+        "x64"
+      ]
+    },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.59.0",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.59.0.tgz",
@@ -2054,6 +2069,21 @@
       "engines": {
         "node": ">= 20"
       }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.2.1.tgz",
+      "integrity": "sha512-qMFzxI2YlBOLW5PhblzuSWlWfwLHaneBE0xHzLrBgNtqN6mWfs+qYbhryGSXQjFYB1Dzf5w+LN5qbUTPhW7Y5g==",
+      "engines": {
+        "node": ">= 20"
+      },
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "cpu": [
+        "x64"
+      ]
     },
     "node_modules/@tailwindcss/vite": {
       "version": "4.2.1",
@@ -5876,6 +5906,21 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.31.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.31.1.tgz",
+      "integrity": "sha512-xGlFWRMl+0KvUhgySdIaReQdB4FNudfUTARn7q0hh/V67PVGCs3ADFjw+6++kG1RNd0zdGRlEKa+T13/tQjPMA==",
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "cpu": [
+        "x64"
+      ]
+    },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "license": "MIT"
@@ -7873,17 +7918,6 @@
         "text-decoder": "^1.1.0"
       }
     },
-    "node_modules/string_decoder": {
-      "version": "1.1.1",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
-    "node_modules/string_decoder/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "license": "MIT"
-    },
     "node_modules/string-width": {
       "version": "4.2.3",
       "license": "MIT",
@@ -7895,6 +7929,17 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/string_decoder/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "license": "MIT"
     },
     "node_modules/strip-ansi": {
       "version": "6.0.1",
@@ -8736,6 +8781,7 @@
         "express": "^5.2.1",
         "express-rate-limit": "^7.5.1",
         "helmet": "^8.1.0",
+        "ipaddr.js": "^1.9.1",
         "jsonwebtoken": "^9.0.3",
         "multer": "^2.1.1",
         "nodemailer": "^8.0.5",


### PR DESCRIPTION
Closes #216

## Problem
The CI workflow had a brittle workaround that manually installed Linux native optional packages via `npm install --no-save`:

- `@rolldown/binding-linux-x64-gnu`
- `@rollup/rollup-linux-x64-gnu`
- `lightningcss-linux-x64-gnu`
- `@tailwindcss/oxide-linux-x64-gnu`

This was fragile because any new dependency with Linux-native binaries could silently break CI until manually patched. Root cause: macOS-generated `package-lock.json` omits Linux-specific optional packages.

## Solution
Rather than switching package managers, this PR regenerates the lockfile to include the missing Linux native optional dependency entries. The lockfile was generated from a Linux environment, which resolved the platform-specific packages that macOS skips.

**Native optional dependency entries now present in the lockfile:**
- `node_modules/@rolldown/binding-linux-x64-gnu` @ `1.0.0-rc.13`
- `node_modules/lightningcss-linux-x64-gnu` @ `1.31.1`
- `node_modules/@tailwindcss/oxide-linux-x64-gnu` @ `4.2.1`

(Note: `@rollup/rollup-linux-x64-gnu` was already present in the lockfile as a nested dependency of rollup.)

**CI workflow change:**
- Removed the "Install missing Linux native binaries" step (the entire `# ── Fix platform-native binaries (npm/cli#4828) ────` block)

## Validation
All verified on Linux (local environment):

| Check | Result |
|---|---|
| `npm ci` | 797 packages installed successfully — no workaround needed |
| `npm run typecheck` (client) | Passed |
| `npm run typecheck` (server) | Passed |
| `npm test` (server) | 26 files, 386 tests passed |
| `npm run build` (client) | Built successfully |

## Out of scope
- No package manager migration (still npm)
- No dependency updates beyond lockfile completeness
- No application code changes
- No Timeline, Resource Profile, Commercial, or export changes