### PR TITLE
fix: remove deprecated client baseUrl config

### DIFF
--- a/client/tsconfig.app.json
+++ b/client/tsconfig.app.json
@@ -15,13 +15,11 @@
     "moduleDetection": "force",
     "noEmit": true,
     "jsx": "react-jsx",
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
     },
 
     /* Linting */
-    "ignoreDeprecations": "6.0",
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,


### PR DESCRIPTION
Closes #214

## Problem
`client/tsconfig.app.json` had two deprecated/legacy settings:

1. `"baseUrl": "."` — deprecated in TypeScript 6 when used without a `paths`-only configuration. TS requires migrating to paths-only resolution.
2. `"ignoreDeprecations": "6.0"` — a temporary suppression that allowed the deprecated `baseUrl` to coexist with TS 6.

## Solution
Removed both settings. `@/*` imports continue to work through three independent resolution paths:

| Layer | Mechanism | Config file |
|---|---|---|
| **TypeScript** | `"paths": {"@/*": ["./src/*"]}` resolves relative to the tsconfig directory — same behaviour as before since the default `baseUrl` was already `"."` | `tsconfig.app.json` |
| **Vite** | `resolve.alias: { '@': path.resolve(__dirname, './src') }` | `vite.config.ts` (unchanged) |
| **Vitest** | `resolve.alias: { '@': resolve(__dirname, './src') }` | `vitest.config.ts` (unchanged) |

## Validation

| Check | Result |
|---|---|
| `npx tsc --noEmit -p tsconfig.app.json` (client) | Passed |
| `npm run typecheck` (full repo, client + server) | Passed |
| `npm run build` (client, rolldown) | Passed |
| `npx vitest run` (client) | Same 30 pre-existing failures as `main` — no regressions |

## Out of scope
- No application code changes
- No dependency updates
- No server-side changes
- No Timeline, Resource Profile, Commercial, or export changes