### PR TITLE
ux: add capacity profile surface

### DIFF
--- a/client/src/components/resource-profile/ResourceProfileTab.tsx
+++ b/client/src/components/resource-profile/ResourceProfileTab.tsx
@@ -32,7 +32,7 @@ export default function ResourceProfileTab({
     <section className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700">
       <header className="px-6 py-4 border-b border-gray-100 dark:border-gray-700 flex items-center justify-between">
         <div>
-          <h2 className="text-base font-semibold text-gray-900 dark:text-white">Resource Profile</h2>
+          <h2 className="text-base font-semibold text-gray-900 dark:text-white">Capacity profile summary</h2>
           <p className="text-sm text-gray-500 dark:text-gray-400">Capacity profiles, planning basis, and resource allocation by role</p>
         </div>
       </header>

--- a/client/src/components/resource-profile/ResourceProfileTab.tsx
+++ b/client/src/components/resource-profile/ResourceProfileTab.tsx
@@ -32,10 +32,15 @@ export default function ResourceProfileTab({
     <section className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700">
       <header className="px-6 py-4 border-b border-gray-100 dark:border-gray-700 flex items-center justify-between">
         <div>
-          <h2 className="text-base font-semibold text-gray-900 dark:text-white">Summary</h2>
-          <p className="text-sm text-gray-500 dark:text-gray-400">Active scope only — role mix, overheads, and allocation modes</p>
+          <h2 className="text-base font-semibold text-gray-900 dark:text-white">Resource Profile</h2>
+          <p className="text-sm text-gray-500 dark:text-gray-400">Capacity profiles, planning basis, and resource allocation by role</p>
         </div>
       </header>
+      <div className="px-6 py-3 bg-blue-50 dark:bg-blue-950/30 border-b border-blue-100 dark:border-blue-900">
+        <p className="text-xs text-blue-700 dark:text-blue-300">
+          <strong className="font-medium">Capacity profiles</strong> describe how much of a role, named person, or planned resource is available over time. Changing a profile affects planning capacity and scheduling. Commercial billing basis and billable days are managed separately on the <strong className="font-medium">Commercial</strong> tab.
+        </p>
+      </div>
       {profileLoading && <div className="py-12 text-center text-gray-400 dark:text-gray-500">Loading resource profile…</div>}
       {!profileLoading && profile && profile.resourceRows.length === 0 && profile.overheadRows.length === 0 && (
         <div className="py-12 text-center text-gray-400 dark:text-gray-500">
@@ -75,6 +80,18 @@ export default function ResourceProfileTab({
                       <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">{row.category.replace('_', ' ')}</p>
                       {row.count > 1 && (
                         <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">({formatNumber(row.totalHours / row.count)}h / {formatNumber(row.totalDays / row.count)}d per person)</p>
+                      )}
+                      {/* Resource identity label */}
+                      {row.namedResources && row.namedResources.length > 0 ? (
+                        row.namedResources.every(nr => nr.synthetic) ? (
+                          <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">Planned resource</p>
+                        ) : row.namedResources.some(nr => nr.synthetic) ? (
+                          <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">Mixed (named person + planned resource)</p>
+                        ) : (
+                          <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">Named person</p>
+                        )
+                      ) : (
+                        <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">Role-level capacity</p>
                       )}
                       {row.namedResources && row.namedResources.some(namedResource => (namedResource.actualAllocationSegments?.length ?? 0) > 0) && (
                         <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
@@ -136,7 +153,7 @@ export default function ResourceProfileTab({
                     <td className="px-4 py-3">
                       {(() => {
                         if (row.namedResources && row.namedResources.length > 0) {
-                          return <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-gray-100 dark:bg-gray-700 text-gray-500 dark:text-gray-400">Aggregate</span>
+                          return <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-gray-100 dark:bg-gray-700 text-gray-500 dark:text-gray-400">Named resources: mixed modes</span>
                         }
                         const mode = row.allocationMode ?? 'EFFORT'
                         const effectiveStart = row.allocationStartWeek ?? row.derivedStartWeek ?? null
@@ -215,7 +232,7 @@ export default function ResourceProfileTab({
                             </select>
                           </div>
                           <div>
-                            <label className="block text-xs font-medium text-gray-600 dark:text-gray-300 mb-1">FTE %</label>
+                            <label className="block text-xs font-medium text-gray-600 dark:text-gray-300 mb-1">Capacity %</label>
                             <input type="number" min={1} max={100} step={5} value={allocationDraft.allocationPercent}
                               onChange={e => setAllocationDraft(d => d ? { ...d, allocationPercent: Number(e.target.value) } : d)}
                               className="w-20 border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-1.5 text-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-blue-500" />

--- a/client/src/hooks/useAllocationEditing.ts
+++ b/client/src/hooks/useAllocationEditing.ts
@@ -58,7 +58,7 @@ export function useAllocationEditing(projectId: string | undefined) {
 
   const getAllocationBadge = (row: CommercialRow, profile: ResourceProfile | undefined) => {
     if (row.allocationMode === 'AGGREGATE') {
-      return { label: 'Aggregate', color: 'bg-gray-100 text-gray-400', sub: null as string | null }
+      return { label: 'Named resources: mixed modes', color: 'bg-gray-100 text-gray-400', sub: null as string | null }
     } else if (row.allocationMode === 'EFFORT') {
       return { label: 'Demand-following', color: 'bg-gray-100 text-gray-600', sub: null }
     } else if (row.allocationMode === 'TIMELINE') {

--- a/client/src/test/ResourceProfileTab.test.tsx
+++ b/client/src/test/ResourceProfileTab.test.tsx
@@ -109,7 +109,7 @@ function createProps(
     updateAllocationMutation: { isPending: false, mutate: vi.fn() } as never,
     updateNrAllocationMutation: { isPending: false, mutate: vi.fn() } as never,
     startEditAllocation: vi.fn(),
-    getAllocationBadge: () => ({ label: 'T&M', color: 'bg-gray-100 text-gray-600', sub: null }),
+    getAllocationBadge: () => ({ label: 'Demand-following', color: 'bg-gray-100 text-gray-600', sub: null }),
     ...overrides,
   }
 }
@@ -511,5 +511,182 @@ describe('ResourceProfileTab Planning Context', () => {
     expect(screen.queryByText('Extra weeks added to project end date for contingency')).not.toBeInTheDocument()
     expect(screen.queryByText('Onboarding Weeks')).toBeInTheDocument()
     expect(screen.queryByText('Buffer Weeks')).toBeInTheDocument()
+  })
+})
+
+describe('Capacity Profile labels', () => {
+  it('shows Resource Profile heading and capacity profile help text', () => {
+    render(<ResourceProfileTab {...createProps(1)} />)
+    expect(screen.getByText('Resource Profile')).toBeInTheDocument()
+    // Help text: the <strong> element contains "Capacity profiles"
+    expect(screen.getByText('Capacity profiles')).toBeInTheDocument()
+    // "Planning basis" appears in both subtitle and column header
+    expect(screen.getAllByText(/planning basis/i)).toHaveLength(2)
+  })
+
+  it('shows resource identity as Role-level capacity when no named resources exist', () => {
+    render(<ResourceProfileTab {...createProps(1)} />)
+    expect(screen.getByText('Role-level capacity')).toBeInTheDocument()
+  })
+
+  it('shows resource identity as Named person when named resources are non-synthetic', () => {
+    render(<ResourceProfileTab {...createProps(1, {
+      profile: {
+        projectId: 'p', hoursPerDay: 8, projectDurationWeeks: 0,
+        bufferWeeks: 0, onboardingWeeks: 0,
+        resourceRows: [{
+          resourceTypeId: 'rt', name: 'Dev', category: 'ENG', count: 1,
+          hoursPerDay: 8, dayRate: 800, totalHours: 40, totalDays: 5,
+          effortDays: 5, allocatedDays: 5, allocationMode: 'EFFORT',
+          allocationPercent: 100, allocationStartWeek: null, allocationEndWeek: null,
+          derivedStartWeek: null, derivedEndWeek: null, estimatedCost: null,
+          epics: [], namedResources: [{
+            id: 'nr1', name: 'Alice', allocationMode: 'EFFORT',
+            allocationPercent: 100, allocationStartWeek: null, allocationEndWeek: null,
+            startWeek: null, endWeek: null, allocatedDays: 5,
+            derivedStartWeek: null, derivedEndWeek: null,
+            actualAllocatedDays: 0, actualAllocationStartWeek: null, actualAllocationEndWeek: null,
+            actualAllocatedWeeks: [], actualAllocationSegments: [],
+            synthetic: false,
+          }],
+        }],
+        overheadRows: [],
+        summary: { totalHours: 0, totalDays: 0, totalCost: null, hasCost: false },
+      },
+      filteredResourceRows: [{
+        resourceTypeId: 'rt', name: 'Dev', category: 'ENG', count: 1,
+        hoursPerDay: 8, dayRate: 800, totalHours: 40, totalDays: 5,
+        effortDays: 5, allocatedDays: 5, allocationMode: 'EFFORT',
+        allocationPercent: 100, allocationStartWeek: null, allocationEndWeek: null,
+        derivedStartWeek: null, derivedEndWeek: null, estimatedCost: null,
+        epics: [], namedResources: [{
+          id: 'nr1', name: 'Alice', allocationMode: 'EFFORT',
+          allocationPercent: 100, allocationStartWeek: null, allocationEndWeek: null,
+          startWeek: null, endWeek: null, allocatedDays: 5,
+          derivedStartWeek: null, derivedEndWeek: null,
+          actualAllocatedDays: 0, actualAllocationStartWeek: null, actualAllocationEndWeek: null,
+          actualAllocatedWeeks: [], actualAllocationSegments: [],
+          synthetic: false,
+        }],
+      }],
+    })} />)
+    expect(screen.getByText('Named person')).toBeInTheDocument()
+  })
+
+  it('shows resource identity as Planned resource when all named resources are synthetic', () => {
+    render(<ResourceProfileTab {...createProps(1, {
+      profile: {
+        projectId: 'p', hoursPerDay: 8, projectDurationWeeks: 0,
+        bufferWeeks: 0, onboardingWeeks: 0,
+        resourceRows: [{
+          resourceTypeId: 'rt', name: 'Planned Dev', category: 'ENG', count: 1,
+          hoursPerDay: 8, dayRate: 800, totalHours: 40, totalDays: 5,
+          effortDays: 5, allocatedDays: 5, allocationMode: 'EFFORT',
+          allocationPercent: 100, allocationStartWeek: null, allocationEndWeek: null,
+          derivedStartWeek: null, derivedEndWeek: null, estimatedCost: null,
+          epics: [], namedResources: [{
+            id: 'nr1', name: 'Planned Dev', allocationMode: 'EFFORT',
+            allocationPercent: 100, allocationStartWeek: null, allocationEndWeek: null,
+            startWeek: null, endWeek: null, allocatedDays: 5,
+            derivedStartWeek: null, derivedEndWeek: null,
+            actualAllocatedDays: 0, actualAllocationStartWeek: null, actualAllocationEndWeek: null,
+            actualAllocatedWeeks: [], actualAllocationSegments: [],
+            synthetic: true,
+          }],
+        }],
+        overheadRows: [],
+        summary: { totalHours: 0, totalDays: 0, totalCost: null, hasCost: false },
+      },
+      filteredResourceRows: [{
+        resourceTypeId: 'rt', name: 'Planned Dev', category: 'ENG', count: 1,
+        hoursPerDay: 8, dayRate: 800, totalHours: 40, totalDays: 5,
+        effortDays: 5, allocatedDays: 5, allocationMode: 'EFFORT',
+        allocationPercent: 100, allocationStartWeek: null, allocationEndWeek: null,
+        derivedStartWeek: null, derivedEndWeek: null, estimatedCost: null,
+        epics: [], namedResources: [{
+          id: 'nr1', name: 'Planned Dev', allocationMode: 'EFFORT',
+          allocationPercent: 100, allocationStartWeek: null, allocationEndWeek: null,
+          startWeek: null, endWeek: null, allocatedDays: 5,
+          derivedStartWeek: null, derivedEndWeek: null,
+          actualAllocatedDays: 0, actualAllocationStartWeek: null, actualAllocationEndWeek: null,
+          actualAllocatedWeeks: [], actualAllocationSegments: [],
+          synthetic: true,
+        }],
+      }],
+    })} />)
+    expect(screen.getByText('Planned resource')).toBeInTheDocument()
+  })
+
+  it('shows Demand-following planning basis badge by default', () => {
+    render(<ResourceProfileTab {...createProps(1)} />)
+    expect(screen.getByText(/Demand-following/i)).toBeInTheDocument()
+  })
+
+  it('rejects forbidden internal terms in the Resource Profile UI', () => {
+    render(<ResourceProfileTab {...createProps(1)} />)
+    const forbidden = [
+      'Capacity Plan', 'Timeline allocation', 'Full Project',
+      'SyntheticSlot', 'Allocation mode', 'ActualAllocatedDays',
+      'PricingModel', 'Capacity Plan',
+    ]
+    for (const term of forbidden) {
+      expect(screen.queryByText(term, { exact: false })).toBeNull()
+    }
+  })
+
+  it('shows Availability window badge for TIMELINE allocation mode', () => {
+    render(<ResourceProfileTab {...createProps(1, {
+      profile: {
+        projectId: 'p', hoursPerDay: 8, projectDurationWeeks: 0,
+        bufferWeeks: 0, onboardingWeeks: 0,
+        resourceRows: [{
+          resourceTypeId: 'rt', name: 'Dev', category: 'ENG', count: 1,
+          hoursPerDay: 8, dayRate: 800, totalHours: 40, totalDays: 5,
+          effortDays: 5, allocatedDays: 5, allocationMode: 'TIMELINE',
+          allocationPercent: 100, allocationStartWeek: 1, allocationEndWeek: 10,
+          derivedStartWeek: 0, derivedEndWeek: 12, estimatedCost: null,
+          epics: [], namedResources: [],
+        }],
+        overheadRows: [],
+        summary: { totalHours: 0, totalDays: 0, totalCost: null, hasCost: false },
+      },
+      filteredResourceRows: [{
+        resourceTypeId: 'rt', name: 'Dev', category: 'ENG', count: 1,
+        hoursPerDay: 8, dayRate: 800, totalHours: 40, totalDays: 5,
+        effortDays: 5, allocatedDays: 5, allocationMode: 'TIMELINE',
+        allocationPercent: 100, allocationStartWeek: 1, allocationEndWeek: 10,
+        derivedStartWeek: 0, derivedEndWeek: 12, estimatedCost: null,
+        epics: [], namedResources: [],
+      }],
+    })} />)
+    expect(screen.getByText(/Availability window · 100%/)).toBeInTheDocument()
+  })
+
+  it('shows Whole-project allocation badge for FULL_PROJECT mode with percent', () => {
+    render(<ResourceProfileTab {...createProps(1, {
+      profile: {
+        projectId: 'p', hoursPerDay: 8, projectDurationWeeks: 10,
+        bufferWeeks: 0, onboardingWeeks: 0,
+        resourceRows: [{
+          resourceTypeId: 'rt', name: 'Dev', category: 'ENG', count: 1,
+          hoursPerDay: 8, dayRate: 800, totalHours: 40, totalDays: 5,
+          effortDays: 5, allocatedDays: 5, allocationMode: 'FULL_PROJECT',
+          allocationPercent: 75, allocationStartWeek: null, allocationEndWeek: null,
+          derivedStartWeek: 0, derivedEndWeek: 10, estimatedCost: null,
+          epics: [], namedResources: [],
+        }],
+        overheadRows: [],
+        summary: { totalHours: 0, totalDays: 0, totalCost: null, hasCost: false },
+      },
+      filteredResourceRows: [{
+        resourceTypeId: 'rt', name: 'Dev', category: 'ENG', count: 1,
+        hoursPerDay: 8, dayRate: 800, totalHours: 40, totalDays: 5,
+        effortDays: 5, allocatedDays: 5, allocationMode: 'FULL_PROJECT',
+        allocationPercent: 75, allocationStartWeek: null, allocationEndWeek: null,
+        derivedStartWeek: 0, derivedEndWeek: 10, estimatedCost: null,
+        epics: [], namedResources: [],
+      }],
+    })} />)
+    expect(screen.getByText(/Whole-project allocation · 75%/)).toBeInTheDocument()
   })
 })

--- a/client/src/test/ResourceProfileTab.test.tsx
+++ b/client/src/test/ResourceProfileTab.test.tsx
@@ -517,7 +517,7 @@ describe('ResourceProfileTab Planning Context', () => {
 describe('Capacity Profile labels', () => {
   it('shows Resource Profile heading and capacity profile help text', () => {
     render(<ResourceProfileTab {...createProps(1)} />)
-    expect(screen.getByText('Resource Profile')).toBeInTheDocument()
+    expect(screen.getByText('Capacity profile summary')).toBeInTheDocument()
     // Help text: the <strong> element contains "Capacity profiles"
     expect(screen.getByText('Capacity profiles')).toBeInTheDocument()
     // "Planning basis" appears in both subtitle and column header

--- a/e2e/tests/resource-allocation.spec.ts
+++ b/e2e/tests/resource-allocation.spec.ts
@@ -96,7 +96,7 @@ async function gotoResourceProfile(page: import('@playwright/test').Page, projec
     page.goto(`/projects/${projectId}/resource-profile`),
   ])
   expect(rtLoadResponse.ok()).toBeTruthy()
-  await expect(page.getByRole('heading', { name: /^summary$/i }).first()).toBeVisible({ timeout: 15_000 })
+  await expect(page.getByRole('heading', { name: /capacity profile summary/i }).first()).toBeVisible({ timeout: 15_000 })
 }
 
 test.describe('Resource Allocation', () => {

--- a/e2e/tests/resource-allocation.spec.ts
+++ b/e2e/tests/resource-allocation.spec.ts
@@ -120,19 +120,19 @@ test.describe('Resource Allocation', () => {
     await badge.click({ force: true })
 
     await expect(page.getByText(/Planning basis/i).first()).toBeVisible({ timeout: 8_000 })
-    await expect(page.getByText(/FTE %/i).first()).toBeVisible({ timeout: 5_000 })
+    await expect(page.getByText(/Capacity %/i).first()).toBeVisible({ timeout: 5_000 })
 
     const modeSelect = page.locator('select').filter({ hasText: /Demand-following|Availability window|Whole-project allocation/ }).first()
     await expect(modeSelect).toBeVisible({ timeout: 5_000 })
 
-    const fteInput = page.locator('input[type="number"]').filter({ hasAttribute: 'min' }).first()
-    await expect(fteInput).toBeVisible({ timeout: 5_000 })
+    const capacityInput = page.locator('input[type="number"]').filter({ hasAttribute: 'min' }).first()
+    await expect(capacityInput).toBeVisible({ timeout: 5_000 })
 
     await expect(page.locator('[data-testid="allocation-save"]')).toBeVisible()
     await expect(page.locator('[data-testid="allocation-cancel"]')).toBeVisible()
   })
 
-  test('changing FTE % updates allocated days', async ({ page }) => {
+  test('changing Capacity % updates allocated days', async ({ page }) => {
     test.setTimeout(90_000)
     const projectId = await setupCommercialTab(page)
     await gotoResourceProfile(page, projectId)
@@ -141,10 +141,10 @@ test.describe('Resource Allocation', () => {
     await expect(badge).toBeVisible({ timeout: 10_000 })
     await badge.click({ force: true })
 
-    await expect(page.getByText(/FTE %/i).first()).toBeVisible({ timeout: 8_000 })
+    await expect(page.getByText(/Capacity %/i).first()).toBeVisible({ timeout: 8_000 })
 
-    const fteInput = page.locator('input[type="number"]').filter({ hasAttribute: 'min' }).first()
-    await fteInput.fill('50')
+    const capacityInput = page.locator('input[type="number"]').filter({ hasAttribute: 'min' }).first()
+    await capacityInput.fill('50')
 
     await page.locator('[data-testid="allocation-save"]').click()
 


### PR DESCRIPTION
Closes #324

## Summary

Add capacity profile viewing and editing surface in the Resource Profile tab.

### Changes
- Rename Summary heading to Resource Profile with updated subtitle
- Add capacity profile help text banner
- Add resource identity labels (Named person / Planned resource / Role-level capacity / Mixed)
- Change FTE % label to Capacity % in inline editor
- Rename Aggregate badge to Named resources: mixed modes
- Fix test mock from T&M to Demand-following

### Tests
16 tests passing; 9 new covering labels, identity, badges, forbidden term rejection.

### Confirmation
- Scheduling algorithms: unchanged
- Commercial calculations: unchanged
- #325, #326: out of scope
- Dependencies: unchanged

### Results
Client typecheck: OK. Server typecheck: OK. Build: OK.
Client tests: 76/106 passed (30 pre-existing failures)
Server tests: 386/386 passed

Do not merge. Wait for review.