### PR TITLE
feat: add read-only capacity profile mapping helpers

### DIFF
--- a/server/src/lib/capacityProfileMapping.ts
+++ b/server/src/lib/capacityProfileMapping.ts
@@ -1,0 +1,335 @@
+/**
+ * capacityProfileMapping.ts — Pure read-only mapping helpers.
+ *
+ * Converts existing implicit capacity/profile fields (ResourceType, NamedResource)
+ * into a first-class CapacityProfileDTO shape.
+ *
+ * Read-only. Not consumed by any route yet.
+ *
+ * Mapping rules:
+ *   EFFORT        → demandFollowing
+ *   TIMELINE      → availabilityWindow
+ *   FULL_PROJECT  → wholeProjectAllocation
+ *   CAPACITY_PLAN → capacityProfile
+ *
+ * Owner kinds:
+ *   ResourceType without named resources → role
+ *   NamedResource (persisted)            → namedPerson
+ *   NamedResource (synthetic/derived)    → plannedResource
+ *
+ * Field precedence (matching current app behaviour):
+ *   allocationPercent > allocationPct for NamedResource
+ *   allocationStartWeek > startWeek / allocationEndWeek > endWeek
+ */
+
+// ─── Public DTO types ───────────────────────────────────────────────────────
+
+export type CapacityProfileOwnerKind = 'role' | 'namedPerson' | 'plannedResource'
+
+export type CapacityProfilePlanningBasis =
+  | 'demandFollowing'
+  | 'availabilityWindow'
+  | 'wholeProjectAllocation'
+  | 'capacityProfile'
+
+export type CapacityProfileSource =
+  | 'fixed'
+  | 'manual'
+  | 'availabilityWindow'
+  | 'squadPlanner'
+  | 'imported'
+  | 'derived'
+  | 'legacy'
+
+export type CapacitySegmentDTO = {
+  id: string
+  startWeek: number
+  endWeek: number
+  capacityPercent: number
+  source: CapacityProfileSource
+}
+
+export type CapacityProfileDTO = {
+  id: string
+  projectId: string
+  owner: {
+    kind: CapacityProfileOwnerKind
+    id: string
+    name: string
+    roleId?: string
+    roleName?: string
+  }
+  planningBasis: CapacityProfilePlanningBasis
+  defaultPercent?: number | null
+  startWeek?: number | null
+  endWeek?: number | null
+  segments: CapacitySegmentDTO[]
+  source: CapacityProfileSource
+  legacy: {
+    allocationMode?: string | null
+    allocationPercent?: number | null
+    allocationPct?: number | null
+    allocationStartWeek?: number | null
+    allocationEndWeek?: number | null
+    startWeek?: number | null
+    endWeek?: number | null
+  }
+}
+
+// ─── Input "Like" types (minimal shape, no Prisma dependency) ───────────────
+
+export type CapacityProfileResourceTypeLike = {
+  id: string
+  name: string
+  allocationMode?: string | null
+  allocationPercent?: number | null
+  allocationStartWeek?: number | null
+  allocationEndWeek?: number | null
+  count?: number | null
+}
+
+export type CapacityProfileNamedResourceLike = {
+  id: string
+  name: string
+  startWeek?: number | null
+  endWeek?: number | null
+  allocationPct?: number | null
+  allocationMode?: string | null
+  allocationPercent?: number | null
+  allocationStartWeek?: number | null
+  allocationEndWeek?: number | null
+  pricingModel?: string | null
+  synthetic?: boolean | null
+}
+
+/** Pre-derived capacity plan slot windows (produced by materializeCapacityPlanResources). */
+export type CapacityPlanSlotInput = {
+  startWeek: number
+  endWeek: number
+  allocationPercent: number
+}
+
+// ─── Allocation mode → planning basis mapping ───────────────────────────────
+
+const ALLOCATION_MODE_TO_PLANNING_BASIS: Record<string, CapacityProfilePlanningBasis> = {
+  EFFORT: 'demandFollowing',
+  TIMELINE: 'availabilityWindow',
+  FULL_PROJECT: 'wholeProjectAllocation',
+  CAPACITY_PLAN: 'capacityProfile',
+}
+
+export function allocationModeToPlanningBasis(
+  mode: string | null | undefined,
+): CapacityProfilePlanningBasis {
+  if (mode && mode in ALLOCATION_MODE_TO_PLANNING_BASIS) {
+    return ALLOCATION_MODE_TO_PLANNING_BASIS[mode]!
+  }
+  return 'demandFollowing'
+}
+
+// ─── Source derivation ──────────────────────────────────────────────────────
+
+function deriveSource(
+  mode: string | null | undefined,
+  hasActivePlanSlots: boolean,
+): CapacityProfileSource {
+  if (mode === 'CAPACITY_PLAN' && hasActivePlanSlots) return 'squadPlanner'
+  if (mode === 'TIMELINE') return 'availabilityWindow'
+  if (mode === 'EFFORT') return 'fixed'
+  if (mode === 'FULL_PROJECT') return 'fixed'
+  return 'legacy'
+}
+
+// ─── Field precedence helpers ───────────────────────────────────────────────
+
+export function resolveNamedResourcePercent(
+  nr: CapacityProfileNamedResourceLike,
+): number {
+  return nr.allocationPercent ?? nr.allocationPct ?? 100
+}
+
+export function resolveNamedResourceStartWeek(
+  nr: CapacityProfileNamedResourceLike,
+): number | null {
+  return nr.allocationStartWeek ?? nr.startWeek ?? null
+}
+
+export function resolveNamedResourceEndWeek(
+  nr: CapacityProfileNamedResourceLike,
+): number | null {
+  return nr.allocationEndWeek ?? nr.endWeek ?? null
+}
+
+// ─── Owner kind resolution ──────────────────────────────────────────────────
+
+function ownerKindFromSynthetic(synthetic?: boolean | null): CapacityProfileOwnerKind {
+  return synthetic ? 'plannedResource' : 'namedPerson'
+}
+
+// ─── Segment derivation from slot windows ───────────────────────────────────
+
+function deriveSegmentsFromSlotWindows(
+  resourceTypeId: string,
+  slotWindows: CapacityPlanSlotInput[],
+): CapacitySegmentDTO[] {
+  return slotWindows.map((window, idx) => ({
+    id: `segment-${resourceTypeId}-${idx + 1}`,
+    startWeek: window.startWeek,
+    endWeek: window.endWeek,
+    capacityPercent: window.allocationPercent,
+    source: 'squadPlanner' as CapacityProfileSource,
+  }))
+}
+
+// ─── Legacy snapshot helper ─────────────────────────────────────────────────
+
+function buildLegacyFields(
+  fields: {
+    allocationMode?: string | null
+    allocationPercent?: number | null
+    allocationPct?: number | null
+    allocationStartWeek?: number | null
+    allocationEndWeek?: number | null
+    startWeek?: number | null
+    endWeek?: number | null
+  },
+): CapacityProfileDTO['legacy'] {
+  return {
+    allocationMode: fields.allocationMode ?? null,
+    allocationPercent: fields.allocationPercent ?? null,
+    allocationPct: fields.allocationPct ?? null,
+    allocationStartWeek: fields.allocationStartWeek ?? null,
+    allocationEndWeek: fields.allocationEndWeek ?? null,
+    startWeek: fields.startWeek ?? null,
+    endWeek: fields.endWeek ?? null,
+  }
+}
+
+// ─── Map single ResourceType (role-level) ───────────────────────────────────
+
+export function mapResourceTypeToCapacityProfile(input: {
+  projectId: string
+  resourceType: CapacityProfileResourceTypeLike
+  capacityPlanSlots?: CapacityPlanSlotInput[]
+}): CapacityProfileDTO {
+  const { projectId, resourceType, capacityPlanSlots } = input
+  const mode = resourceType.allocationMode ?? null
+  const hasActivePlanSlots = capacityPlanSlots !== undefined && capacityPlanSlots.length > 0
+  const planningBasis = allocationModeToPlanningBasis(mode)
+  const segments = hasActivePlanSlots
+    ? deriveSegmentsFromSlotWindows(resourceType.id, capacityPlanSlots!)
+    : []
+
+  return {
+    id: resourceType.id,
+    projectId,
+    owner: {
+      kind: 'role',
+      id: resourceType.id,
+      name: resourceType.name,
+    },
+    planningBasis,
+    defaultPercent: resourceType.allocationPercent ?? null,
+    startWeek: resourceType.allocationStartWeek ?? null,
+    endWeek: resourceType.allocationEndWeek ?? null,
+    segments,
+    source: deriveSource(mode, hasActivePlanSlots),
+    legacy: buildLegacyFields({
+      allocationMode: mode,
+      allocationPercent: resourceType.allocationPercent,
+      allocationStartWeek: resourceType.allocationStartWeek,
+      allocationEndWeek: resourceType.allocationEndWeek,
+    }),
+  }
+}
+
+// ─── Map single NamedResource within a ResourceType ─────────────────────────
+
+export function mapNamedResourceToCapacityProfile(input: {
+  projectId: string
+  resourceType: CapacityProfileResourceTypeLike
+  namedResource: CapacityProfileNamedResourceLike
+  capacityPlanSlots?: CapacityPlanSlotInput[]
+}): CapacityProfileDTO {
+  const { projectId, resourceType, namedResource, capacityPlanSlots } = input
+  const mode = namedResource.allocationMode ?? resourceType.allocationMode ?? null
+  const hasActivePlanSlots = capacityPlanSlots !== undefined && capacityPlanSlots.length > 0
+  const planningBasis = allocationModeToPlanningBasis(mode)
+  const segments = hasActivePlanSlots
+    ? deriveSegmentsFromSlotWindows(resourceType.id, capacityPlanSlots!)
+    : []
+
+  const resolvedPct = resolveNamedResourcePercent(namedResource)
+  const resolvedStartWeek = resolveNamedResourceStartWeek(namedResource)
+  const resolvedEndWeek = resolveNamedResourceEndWeek(namedResource)
+
+  return {
+    id: namedResource.id,
+    projectId,
+    owner: {
+      kind: ownerKindFromSynthetic(namedResource.synthetic),
+      id: namedResource.id,
+      name: namedResource.name,
+      roleId: resourceType.id,
+      roleName: resourceType.name,
+    },
+    planningBasis,
+    defaultPercent: resolvedPct,
+    startWeek: resolvedStartWeek,
+    endWeek: resolvedEndWeek,
+    segments,
+    source: deriveSource(mode, hasActivePlanSlots),
+    legacy: buildLegacyFields({
+      allocationMode: mode,
+      allocationPercent: namedResource.allocationPercent,
+      allocationPct: namedResource.allocationPct,
+      allocationStartWeek: namedResource.allocationStartWeek,
+      allocationEndWeek: namedResource.allocationEndWeek,
+      startWeek: namedResource.startWeek,
+      endWeek: namedResource.endWeek,
+    }),
+  }
+}
+
+// ─── Map a full project's worth of capacity profiles ───────────────────────
+
+export function mapProjectToCapacityProfiles(input: {
+  projectId: string
+  resourceTypes: CapacityProfileResourceTypeLike[]
+  namedResourcesByResourceTypeId?: Map<string, CapacityProfileNamedResourceLike[]>
+  capacityPlanSlotsByResourceTypeId?: Map<string, CapacityPlanSlotInput[]>
+}): CapacityProfileDTO[] {
+  const {
+    projectId,
+    resourceTypes,
+    namedResourcesByResourceTypeId,
+    capacityPlanSlotsByResourceTypeId,
+  } = input
+
+  const profiles: CapacityProfileDTO[] = []
+
+  for (const rt of resourceTypes) {
+    const nrList = namedResourcesByResourceTypeId?.get(rt.id) ?? []
+
+    if (nrList.length === 0) {
+      // Role-level profile only — no named resources
+      profiles.push(mapResourceTypeToCapacityProfile({
+        projectId,
+        resourceType: rt,
+        capacityPlanSlots: capacityPlanSlotsByResourceTypeId?.get(rt.id),
+      }))
+    } else {
+      // One profile per named resource
+      for (const nr of nrList) {
+        profiles.push(mapNamedResourceToCapacityProfile({
+          projectId,
+          resourceType: rt,
+          namedResource: nr,
+          capacityPlanSlots: capacityPlanSlotsByResourceTypeId?.get(rt.id),
+        }))
+      }
+    }
+  }
+
+  return profiles
+}

--- a/server/src/lib/capacityProfileMapping.ts
+++ b/server/src/lib/capacityProfileMapping.ts
@@ -214,9 +214,12 @@ export function mapResourceTypeToCapacityProfile(input: {
 }): CapacityProfileDTO {
   const { projectId, resourceType, capacityPlanSlots } = input
   const mode = resourceType.allocationMode ?? null
-  const hasActivePlanSlots = capacityPlanSlots !== undefined && capacityPlanSlots.length > 0
+  const usesCapacityPlanSegments =
+    mode === 'CAPACITY_PLAN' &&
+    capacityPlanSlots !== undefined &&
+    capacityPlanSlots.length > 0
   const planningBasis = allocationModeToPlanningBasis(mode)
-  const segments = hasActivePlanSlots
+  const segments = usesCapacityPlanSegments
     ? deriveSegmentsFromSlotWindows(resourceType.id, capacityPlanSlots!)
     : []
 
@@ -233,7 +236,7 @@ export function mapResourceTypeToCapacityProfile(input: {
     startWeek: resourceType.allocationStartWeek ?? null,
     endWeek: resourceType.allocationEndWeek ?? null,
     segments,
-    source: deriveSource(mode, hasActivePlanSlots),
+    source: deriveSource(mode, usesCapacityPlanSegments),
     legacy: buildLegacyFields({
       allocationMode: mode,
       allocationPercent: resourceType.allocationPercent,
@@ -253,9 +256,12 @@ export function mapNamedResourceToCapacityProfile(input: {
 }): CapacityProfileDTO {
   const { projectId, resourceType, namedResource, capacityPlanSlots } = input
   const mode = namedResource.allocationMode ?? resourceType.allocationMode ?? null
-  const hasActivePlanSlots = capacityPlanSlots !== undefined && capacityPlanSlots.length > 0
+  const usesCapacityPlanSegments =
+    mode === 'CAPACITY_PLAN' &&
+    capacityPlanSlots !== undefined &&
+    capacityPlanSlots.length > 0
   const planningBasis = allocationModeToPlanningBasis(mode)
-  const segments = hasActivePlanSlots
+  const segments = usesCapacityPlanSegments
     ? deriveSegmentsFromSlotWindows(resourceType.id, capacityPlanSlots!)
     : []
 
@@ -278,7 +284,7 @@ export function mapNamedResourceToCapacityProfile(input: {
     startWeek: resolvedStartWeek,
     endWeek: resolvedEndWeek,
     segments,
-    source: deriveSource(mode, hasActivePlanSlots),
+    source: deriveSource(mode, usesCapacityPlanSegments),
     legacy: buildLegacyFields({
       allocationMode: mode,
       allocationPercent: namedResource.allocationPercent,

--- a/server/src/test/capacityProfileMapping.test.ts
+++ b/server/src/test/capacityProfileMapping.test.ts
@@ -1,0 +1,473 @@
+/**
+ * capacityProfileMapping.test.ts — Parity tests for read-only mapping helpers.
+ *
+ * Validates that the mapping preserves current behaviour for all allocation
+ * modes, field precedence rules, owner kinds, and capacity plan integration.
+ *
+ * Pure unit tests — no database required.
+ */
+import { describe, it, expect } from 'vitest'
+import {
+  allocationModeToPlanningBasis,
+  mapResourceTypeToCapacityProfile,
+  mapNamedResourceToCapacityProfile,
+  mapProjectToCapacityProfiles,
+  resolveNamedResourcePercent,
+  resolveNamedResourceStartWeek,
+  resolveNamedResourceEndWeek,
+} from '../lib/capacityProfileMapping.js'
+import type {
+  CapacityProfileResourceTypeLike,
+  CapacityProfileNamedResourceLike,
+  CapacityPlanSlotInput,
+} from '../lib/capacityProfileMapping.js'
+
+// ─── Helper: build minimal RT with defaults ─────────────────────────────────
+const defaultRt = (
+  overrides: Partial<CapacityProfileResourceTypeLike> = {},
+): CapacityProfileResourceTypeLike => ({
+  id: 'rt-1',
+  name: 'Engineer',
+  count: 1,
+  allocationMode: 'EFFORT',
+  allocationPercent: 100,
+  allocationStartWeek: null,
+  allocationEndWeek: null,
+  ...overrides,
+})
+
+// ─── Helper: build minimal NR with defaults ─────────────────────────────────
+const defaultNr = (
+  overrides: Partial<CapacityProfileNamedResourceLike> = {},
+): CapacityProfileNamedResourceLike => ({
+  id: 'nr-1',
+  name: 'Alice',
+  startWeek: null,
+  endWeek: null,
+  allocationPct: 100,
+  allocationMode: 'EFFORT',
+  allocationPercent: 100,
+  allocationStartWeek: null,
+  allocationEndWeek: null,
+  synthetic: false,
+  ...overrides,
+})
+
+// ─── allocationModeToPlanningBasis ─────────────────────────────────────────
+
+describe('allocationModeToPlanningBasis', () => {
+  it('maps EFFORT to demandFollowing', () => {
+    expect(allocationModeToPlanningBasis('EFFORT')).toBe('demandFollowing')
+  })
+
+  it('maps TIMELINE to availabilityWindow', () => {
+    expect(allocationModeToPlanningBasis('TIMELINE')).toBe('availabilityWindow')
+  })
+
+  it('maps FULL_PROJECT to wholeProjectAllocation', () => {
+    expect(allocationModeToPlanningBasis('FULL_PROJECT')).toBe('wholeProjectAllocation')
+  })
+
+  it('maps CAPACITY_PLAN to capacityProfile', () => {
+    expect(allocationModeToPlanningBasis('CAPACITY_PLAN')).toBe('capacityProfile')
+  })
+
+  it('falls back to demandFollowing for null/undefined/unknown', () => {
+    expect(allocationModeToPlanningBasis(null)).toBe('demandFollowing')
+    expect(allocationModeToPlanningBasis(undefined)).toBe('demandFollowing')
+    expect(allocationModeToPlanningBasis('OLD_MODE')).toBe('demandFollowing')
+  })
+})
+
+// ─── resolveNamedResourcePercent (field precedence) ────────────────────────
+
+describe('resolveNamedResourcePercent', () => {
+  it('returns allocationPercent when allocationPercent is set', () => {
+    const nr = defaultNr({ allocationPercent: 75, allocationPct: 50 })
+    expect(resolveNamedResourcePercent(nr)).toBe(75)
+  })
+
+  it('falls back to allocationPct when allocationPercent is null', () => {
+    const nr = defaultNr({ allocationPercent: null, allocationPct: 60 })
+    expect(resolveNamedResourcePercent(nr)).toBe(60)
+  })
+
+  it('defaults to 100 when both are null', () => {
+    const nr = defaultNr({ allocationPercent: null, allocationPct: null })
+    expect(resolveNamedResourcePercent(nr)).toBe(100)
+  })
+
+  it('defaults to 100 when both are undefined', () => {
+    const nr = defaultNr({ allocationPercent: undefined, allocationPct: undefined })
+    expect(resolveNamedResourcePercent(nr)).toBe(100)
+  })
+})
+
+// ─── resolveNamedResourceStartWeek/EndWeek (field precedence) ──────────────
+
+describe('resolveNamedResourceStartWeek', () => {
+  it('returns allocationStartWeek when set', () => {
+    const nr = defaultNr({ allocationStartWeek: 3, startWeek: 1 })
+    expect(resolveNamedResourceStartWeek(nr)).toBe(3)
+  })
+
+  it('falls back to startWeek when allocationStartWeek is null', () => {
+    const nr = defaultNr({ allocationStartWeek: null, startWeek: 5 })
+    expect(resolveNamedResourceStartWeek(nr)).toBe(5)
+  })
+
+  it('returns null when both are null', () => {
+    const nr = defaultNr({ allocationStartWeek: null, startWeek: null })
+    expect(resolveNamedResourceStartWeek(nr)).toBeNull()
+  })
+})
+
+describe('resolveNamedResourceEndWeek', () => {
+  it('returns allocationEndWeek when set', () => {
+    const nr = defaultNr({ allocationEndWeek: 10, endWeek: 8 })
+    expect(resolveNamedResourceEndWeek(nr)).toBe(10)
+  })
+
+  it('falls back to endWeek when allocationEndWeek is null', () => {
+    const nr = defaultNr({ allocationEndWeek: null, endWeek: 12 })
+    expect(resolveNamedResourceEndWeek(nr)).toBe(12)
+  })
+
+  it('returns null when both are null', () => {
+    const nr = defaultNr({ allocationEndWeek: null, endWeek: null })
+    expect(resolveNamedResourceEndWeek(nr)).toBeNull()
+  })
+})
+
+// ─── mapResourceTypeToCapacityProfile ──────────────────────────────────────
+
+describe('mapResourceTypeToCapacityProfile', () => {
+  it('maps EFFORT to demandFollowing with defaultPercent=100', () => {
+    const rt = defaultRt({ allocationMode: 'EFFORT', allocationPercent: 100 })
+    const result = mapResourceTypeToCapacityProfile({ projectId: 'p1', resourceType: rt })
+
+    expect(result.planningBasis).toBe('demandFollowing')
+    expect(result.defaultPercent).toBe(100)
+    expect(result.source).toBe('fixed')
+    expect(result.owner.kind).toBe('role')
+    expect(result.owner.id).toBe(rt.id)
+    expect(result.owner.name).toBe(rt.name)
+  })
+
+  it('maps TIMELINE preserving percent/start/end', () => {
+    const rt = defaultRt({
+      allocationMode: 'TIMELINE',
+      allocationPercent: 75,
+      allocationStartWeek: 2,
+      allocationEndWeek: 10,
+    })
+    const result = mapResourceTypeToCapacityProfile({ projectId: 'p1', resourceType: rt })
+
+    expect(result.planningBasis).toBe('availabilityWindow')
+    expect(result.defaultPercent).toBe(75)
+    expect(result.startWeek).toBe(2)
+    expect(result.endWeek).toBe(10)
+    expect(result.source).toBe('availabilityWindow')
+  })
+
+  it('maps FULL_PROJECT to wholeProjectAllocation', () => {
+    const rt = defaultRt({ allocationMode: 'FULL_PROJECT' })
+    const result = mapResourceTypeToCapacityProfile({ projectId: 'p1', resourceType: rt })
+
+    expect(result.planningBasis).toBe('wholeProjectAllocation')
+    expect(result.source).toBe('fixed')
+  })
+
+  it('maps CAPACITY_PLAN to capacityProfile without plan slots → source=legacy', () => {
+    const rt = defaultRt({ allocationMode: 'CAPACITY_PLAN' })
+    const result = mapResourceTypeToCapacityProfile({ projectId: 'p1', resourceType: rt })
+
+    expect(result.planningBasis).toBe('capacityProfile')
+    expect(result.segments).toEqual([])
+    expect(result.source).toBe('legacy')
+  })
+
+  it('maps CAPACITY_PLAN with slot windows → source=squadPlanner with segments', () => {
+    const rt = defaultRt({ allocationMode: 'CAPACITY_PLAN' })
+    const slots: CapacityPlanSlotInput[] = [
+      { startWeek: 0, endWeek: 3, allocationPercent: 100 },
+      { startWeek: 4, endWeek: 9, allocationPercent: 50 },
+    ]
+    const result = mapResourceTypeToCapacityProfile({
+      projectId: 'p1',
+      resourceType: rt,
+      capacityPlanSlots: slots,
+    })
+
+    expect(result.planningBasis).toBe('capacityProfile')
+    expect(result.segments).toHaveLength(2)
+    expect(result.source).toBe('squadPlanner')
+    expect(result.segments[0]).toMatchObject({
+      startWeek: 0,
+      endWeek: 3,
+      capacityPercent: 100,
+      source: 'squadPlanner',
+    })
+    expect(result.segments[1]).toMatchObject({
+      startWeek: 4,
+      endWeek: 9,
+      capacityPercent: 50,
+      source: 'squadPlanner',
+    })
+  })
+
+  it('preserves legacy fields in the legacy snapshot', () => {
+    const rt = defaultRt({
+      allocationMode: 'TIMELINE',
+      allocationPercent: 80,
+      allocationStartWeek: 1,
+      allocationEndWeek: 8,
+    })
+    const result = mapResourceTypeToCapacityProfile({ projectId: 'p1', resourceType: rt })
+
+    expect(result.legacy.allocationMode).toBe('TIMELINE')
+    expect(result.legacy.allocationPercent).toBe(80)
+    expect(result.legacy.allocationStartWeek).toBe(1)
+    expect(result.legacy.allocationEndWeek).toBe(8)
+    expect(result.legacy.allocationPct).toBeNull()
+    expect(result.legacy.startWeek).toBeNull()
+    expect(result.legacy.endWeek).toBeNull()
+  })
+
+  it('uses null fallback when RT fields are null/missing', () => {
+    const rt = defaultRt({
+      allocationMode: null,
+      allocationPercent: null,
+      allocationStartWeek: null,
+      allocationEndWeek: null,
+    })
+    const result = mapResourceTypeToCapacityProfile({ projectId: 'p1', resourceType: rt })
+
+    expect(result.planningBasis).toBe('demandFollowing')
+    expect(result.defaultPercent).toBeNull()
+    expect(result.startWeek).toBeNull()
+    expect(result.endWeek).toBeNull()
+    expect(result.source).toBe('legacy')
+  })
+})
+
+// ─── mapNamedResourceToCapacityProfile ─────────────────────────────────────
+
+describe('mapNamedResourceToCapacityProfile', () => {
+  it('maps persisted named resource to owner kind namedPerson', () => {
+    const rt = defaultRt()
+    const nr = defaultNr({ synthetic: false })
+    const result = mapNamedResourceToCapacityProfile({
+      projectId: 'p1',
+      resourceType: rt,
+      namedResource: nr,
+    })
+
+    expect(result.owner.kind).toBe('namedPerson')
+    expect(result.owner.id).toBe(nr.id)
+    expect(result.owner.name).toBe(nr.name)
+    expect(result.owner.roleId).toBe(rt.id)
+    expect(result.owner.roleName).toBe(rt.name)
+  })
+
+  it('maps synthetic (planned) resource to owner kind plannedResource', () => {
+    const rt = defaultRt()
+    const nr = defaultNr({ synthetic: true })
+    const result = mapNamedResourceToCapacityProfile({
+      projectId: 'p1',
+      resourceType: rt,
+      namedResource: nr,
+    })
+
+    expect(result.owner.kind).toBe('plannedResource')
+  })
+
+  it('falls back to RT allocationMode when NR mode is null', () => {
+    const rt = defaultRt({ allocationMode: 'FULL_PROJECT' })
+    const nr = defaultNr({ allocationMode: null })
+    const result = mapNamedResourceToCapacityProfile({
+      projectId: 'p1',
+      resourceType: rt,
+      namedResource: nr,
+    })
+
+    expect(result.planningBasis).toBe('wholeProjectAllocation')
+  })
+
+  it('uses NR allocationMode when set (overrides RT mode)', () => {
+    const rt = defaultRt({ allocationMode: 'TIMELINE' })
+    const nr = defaultNr({ allocationMode: 'EFFORT' })
+    const result = mapNamedResourceToCapacityProfile({
+      projectId: 'p1',
+      resourceType: rt,
+      namedResource: nr,
+    })
+
+    expect(result.planningBasis).toBe('demandFollowing')
+  })
+
+  it('preserves NR allocationPercent over allocationPct', () => {
+    const rt = defaultRt()
+    const nr = defaultNr({ allocationPercent: 85, allocationPct: 70 })
+    const result = mapNamedResourceToCapacityProfile({
+      projectId: 'p1',
+      resourceType: rt,
+      namedResource: nr,
+    })
+
+    expect(result.defaultPercent).toBe(85)
+  })
+
+  it('preserves allocationStartWeek over startWeek', () => {
+    const rt = defaultRt()
+    const nr = defaultNr({ allocationStartWeek: 3, startWeek: 1 })
+    const result = mapNamedResourceToCapacityProfile({
+      projectId: 'p1',
+      resourceType: rt,
+      namedResource: nr,
+    })
+
+    expect(result.startWeek).toBe(3)
+  })
+
+  it('preserves allocationEndWeek over endWeek', () => {
+    const rt = defaultRt()
+    const nr = defaultNr({ allocationEndWeek: 10, endWeek: 8 })
+    const result = mapNamedResourceToCapacityProfile({
+      projectId: 'p1',
+      resourceType: rt,
+      namedResource: nr,
+    })
+
+    expect(result.endWeek).toBe(10)
+  })
+
+  it('includes all legacy source fields on a named resource', () => {
+    const rt = defaultRt()
+    const nr = defaultNr({
+      allocationMode: 'TIMELINE',
+      allocationPercent: 90,
+      allocationPct: 80,
+      allocationStartWeek: 2,
+      allocationEndWeek: 9,
+      startWeek: 1,
+      endWeek: 10,
+    })
+    const result = mapNamedResourceToCapacityProfile({
+      projectId: 'p1',
+      resourceType: rt,
+      namedResource: nr,
+    })
+
+    expect(result.legacy.allocationMode).toBe('TIMELINE')
+    expect(result.legacy.allocationPercent).toBe(90)
+    expect(result.legacy.allocationPct).toBe(80)
+    expect(result.legacy.allocationStartWeek).toBe(2)
+    expect(result.legacy.allocationEndWeek).toBe(9)
+    expect(result.legacy.startWeek).toBe(1)
+    expect(result.legacy.endWeek).toBe(10)
+  })
+
+  it('handles null/missing fields with same fallback as current app', () => {
+    const rt = defaultRt({ allocationMode: null })
+    const nr = defaultNr({
+      allocationMode: null,
+      allocationPercent: null,
+      allocationPct: null,
+      startWeek: null,
+      endWeek: null,
+      allocationStartWeek: null,
+      allocationEndWeek: null,
+    })
+    const result = mapNamedResourceToCapacityProfile({
+      projectId: 'p1',
+      resourceType: rt,
+      namedResource: nr,
+    })
+
+    expect(result.planningBasis).toBe('demandFollowing')
+    expect(result.defaultPercent).toBe(100)
+    expect(result.startWeek).toBeNull()
+    expect(result.endWeek).toBeNull()
+  })
+})
+
+// ─── mapProjectToCapacityProfiles ─────────────────────────────────────────
+
+describe('mapProjectToCapacityProfiles', () => {
+  it('returns role-level profiles when resource type has no named resources', () => {
+    const rts: CapacityProfileResourceTypeLike[] = [
+      defaultRt({ id: 'rt-1', name: 'Engineer', allocationMode: 'EFFORT' }),
+      defaultRt({ id: 'rt-2', name: 'PM', allocationMode: 'FULL_PROJECT' }),
+    ]
+    const results = mapProjectToCapacityProfiles({ projectId: 'p1', resourceTypes: rts })
+
+    expect(results).toHaveLength(2)
+    expect(results[0].owner.kind).toBe('role')
+    expect(results[0].owner.id).toBe('rt-1')
+    expect(results[1].owner.kind).toBe('role')
+    expect(results[1].owner.id).toBe('rt-2')
+  })
+
+  it('returns one profile per named resource when NRs exist', () => {
+    const rt = defaultRt({ id: 'rt-1', name: 'Engineer' })
+    const nrs: CapacityProfileNamedResourceLike[] = [
+      defaultNr({ id: 'nr-1', name: 'Alice' }),
+      defaultNr({ id: 'nr-2', name: 'Bob' }),
+    ]
+    const nrMap = new Map<string, CapacityProfileNamedResourceLike[]>([['rt-1', nrs]])
+    const results = mapProjectToCapacityProfiles({
+      projectId: 'p1',
+      resourceTypes: [rt],
+      namedResourcesByResourceTypeId: nrMap,
+    })
+
+    expect(results).toHaveLength(2)
+    expect(results[0].owner.id).toBe('nr-1')
+    expect(results[0].owner.name).toBe('Alice')
+    expect(results[1].owner.id).toBe('nr-2')
+    expect(results[1].owner.name).toBe('Bob')
+  })
+
+  it('does NOT create fake named people for count > 1 without NRs', () => {
+    // A role with count=3 and no named resources should produce ONE role-level profile
+    const rt = defaultRt({ id: 'rt-1', name: 'Engineer', count: 3 })
+    const results = mapProjectToCapacityProfiles({
+      projectId: 'p1',
+      resourceTypes: [rt],
+    })
+
+    expect(results).toHaveLength(1)
+    expect(results[0].owner.kind).toBe('role')
+    expect(results[0].owner.id).toBe('rt-1')
+  })
+
+  it('passes capacityPlanSlots through to NR and RT profiles', () => {
+    const rt = defaultRt({ id: 'rt-1', name: 'Engineer', allocationMode: 'CAPACITY_PLAN' })
+    const nr = defaultNr({ id: 'nr-1', name: 'Alice', allocationMode: 'CAPACITY_PLAN' })
+    const nrMap = new Map<string, CapacityProfileNamedResourceLike[]>([['rt-1', [nr]]])
+    const slots: CapacityPlanSlotInput[] = [
+      { startWeek: 0, endWeek: 3, allocationPercent: 100 },
+    ]
+    const slotsMap = new Map<string, CapacityPlanSlotInput[]>([['rt-1', slots]])
+    const results = mapProjectToCapacityProfiles({
+      projectId: 'p1',
+      resourceTypes: [rt],
+      namedResourcesByResourceTypeId: nrMap,
+      capacityPlanSlotsByResourceTypeId: slotsMap,
+    })
+
+    expect(results).toHaveLength(1)
+    expect(results[0].segments).toHaveLength(1)
+    expect(results[0].segments[0].capacityPercent).toBe(100)
+    expect(results[0].source).toBe('squadPlanner')
+  })
+
+  it('returns empty array for empty resource type list', () => {
+    const results = mapProjectToCapacityProfiles({
+      projectId: 'p1',
+      resourceTypes: [],
+    })
+    expect(results).toEqual([])
+  })
+})

--- a/server/src/test/capacityProfileMapping.test.ts
+++ b/server/src/test/capacityProfileMapping.test.ts
@@ -216,6 +216,54 @@ describe('mapResourceTypeToCapacityProfile', () => {
     })
   })
 
+  it('EFFORT with supplied capacityPlanSlots produces no segments and source=fixed', () => {
+    const rt = defaultRt({ allocationMode: 'EFFORT' })
+    const slots: CapacityPlanSlotInput[] = [
+      { startWeek: 0, endWeek: 3, allocationPercent: 100 },
+    ]
+    const result = mapResourceTypeToCapacityProfile({
+      projectId: 'p1',
+      resourceType: rt,
+      capacityPlanSlots: slots,
+    })
+
+    expect(result.planningBasis).toBe('demandFollowing')
+    expect(result.segments).toEqual([])
+    expect(result.source).toBe('fixed')
+  })
+
+  it('TIMELINE with supplied capacityPlanSlots produces no segments and source=availabilityWindow', () => {
+    const rt = defaultRt({ allocationMode: 'TIMELINE', allocationPercent: 75, allocationStartWeek: 2, allocationEndWeek: 10 })
+    const slots: CapacityPlanSlotInput[] = [
+      { startWeek: 0, endWeek: 3, allocationPercent: 100 },
+    ]
+    const result = mapResourceTypeToCapacityProfile({
+      projectId: 'p1',
+      resourceType: rt,
+      capacityPlanSlots: slots,
+    })
+
+    expect(result.planningBasis).toBe('availabilityWindow')
+    expect(result.segments).toEqual([])
+    expect(result.source).toBe('availabilityWindow')
+  })
+
+  it('FULL_PROJECT with supplied capacityPlanSlots produces no segments and source=fixed', () => {
+    const rt = defaultRt({ allocationMode: 'FULL_PROJECT' })
+    const slots: CapacityPlanSlotInput[] = [
+      { startWeek: 0, endWeek: 3, allocationPercent: 100 },
+    ]
+    const result = mapResourceTypeToCapacityProfile({
+      projectId: 'p1',
+      resourceType: rt,
+      capacityPlanSlots: slots,
+    })
+
+    expect(result.planningBasis).toBe('wholeProjectAllocation')
+    expect(result.segments).toEqual([])
+    expect(result.source).toBe('fixed')
+  })
+
   it('preserves legacy fields in the legacy snapshot', () => {
     const rt = defaultRt({
       allocationMode: 'TIMELINE',
@@ -304,6 +352,64 @@ describe('mapNamedResourceToCapacityProfile', () => {
     })
 
     expect(result.planningBasis).toBe('demandFollowing')
+  })
+
+  it('inherits CAPACITY_PLAN from RT when NR mode is null, uses supplied slots → segments', () => {
+    const rt = defaultRt({ allocationMode: 'CAPACITY_PLAN' })
+    const nr = defaultNr({ allocationMode: null })
+    const slots: CapacityPlanSlotInput[] = [
+      { startWeek: 0, endWeek: 3, allocationPercent: 100 },
+    ]
+    const result = mapNamedResourceToCapacityProfile({
+      projectId: 'p1',
+      resourceType: rt,
+      namedResource: nr,
+      capacityPlanSlots: slots,
+    })
+
+    expect(result.planningBasis).toBe('capacityProfile')
+    expect(result.segments).toHaveLength(1)
+    expect(result.segments[0].capacityPercent).toBe(100)
+    expect(result.source).toBe('squadPlanner')
+  })
+
+  it('overrides RT CAPACITY_PLAN to EFFORT, ignores supplied slots → no segments', () => {
+    const rt = defaultRt({ allocationMode: 'CAPACITY_PLAN' })
+    const nr = defaultNr({ allocationMode: 'EFFORT' })
+    const slots: CapacityPlanSlotInput[] = [
+      { startWeek: 0, endWeek: 3, allocationPercent: 100 },
+    ]
+    const result = mapNamedResourceToCapacityProfile({
+      projectId: 'p1',
+      resourceType: rt,
+      namedResource: nr,
+      capacityPlanSlots: slots,
+    })
+
+    expect(result.planningBasis).toBe('demandFollowing')
+    expect(result.segments).toEqual([])
+    expect(result.source).toBe('fixed')
+  })
+
+  it('overrides RT CAPACITY_PLAN to TIMELINE, ignores supplied slots → no segments', () => {
+    const rt = defaultRt({ allocationMode: 'CAPACITY_PLAN' })
+    const nr = defaultNr({ allocationMode: 'TIMELINE', allocationPercent: 50, allocationStartWeek: 5, allocationEndWeek: 12 })
+    const slots: CapacityPlanSlotInput[] = [
+      { startWeek: 0, endWeek: 3, allocationPercent: 100 },
+    ]
+    const result = mapNamedResourceToCapacityProfile({
+      projectId: 'p1',
+      resourceType: rt,
+      namedResource: nr,
+      capacityPlanSlots: slots,
+    })
+
+    expect(result.planningBasis).toBe('availabilityWindow')
+    expect(result.segments).toEqual([])
+    expect(result.source).toBe('availabilityWindow')
+    expect(result.defaultPercent).toBe(50)
+    expect(result.startWeek).toBe(5)
+    expect(result.endWeek).toBe(12)
   })
 
   it('preserves NR allocationPercent over allocationPct', () => {


### PR DESCRIPTION
Refs #326

## Summary

Adds pure, read-only mapping helpers that convert existing implicit capacity/profile fields (ResourceType, NamedResource) into a **CapacityProfileDTO** shape. This is PR 2 of the rollout plan from #330.

## Helper functions added

- `allocationModeToPlanningBasis(mode)` — maps legacy AllocationMode enum to CapacityProfilePlanningBasis
- `resolveNamedResourcePercent(nr)` — resolves allocationPercent → allocationPct → 100 precedence
- `resolveNamedResourceStartWeek(nr)` — resolves allocationStartWeek → startWeek → null precedence
- `resolveNamedResourceEndWeek(nr)` — resolves allocationEndWeek → endWeek → null precedence
- `mapResourceTypeToCapacityProfile(input)` — maps a single ResourceType to a role-level CapacityProfileDTO
- `mapNamedResourceToCapacityProfile(input)` — maps a single NamedResource within a ResourceType
- `mapProjectToCapacityProfiles(input)` — maps a full project's resource types (optionally with named resources)

## Mapping rules

| Legacy AllocationMode | PlanningBasis |
|---|---|
| EFFORT | demandFollowing |
| TIMELINE | availabilityWindow |
| FULL_PROJECT | wholeProjectAllocation |
| CAPACITY_PLAN | capacityProfile |

**Owner kinds:** ResourceType → `role`, persisted NamedResource → `namedPerson`, synthetic/derived NamedResource → `plannedResource`

**Field precedence:** allocationPercent > allocationPct for percent; allocationStartWeek > startWeek for start; allocationEndWeek > endWeek for end.

**Capacity plan integration:** accepts pre-derived slot windows (`{startWeek, endWeek, allocationPercent}[]`) as input. When present and mode is CAPACITY_PLAN, produces segments with source `squadPlanner`.

## Confirmation

- Read-only helpers — NOT consumed by any route yet
- No Prisma schema changes
- No migrations
- No database writes
- No API route changes
- No UI changes
- No Resource Profile export changes
- No Commercial calculation changes
- No scheduler/leveller behaviour changes
- No Squad Planner behaviour changes
- No dependency updates

## New files

- `server/src/lib/capacityProfileMapping.ts` — types + mapping helpers
- `server/src/test/capacityProfileMapping.test.ts` — 36 unit tests

## Validation

| Check | Result |
|---|---|
| Server typecheck | OK |
| Client typecheck | OK |
| Server tests | 422/422 passed (36 new) |
| Client build | OK |
| No schema/migration changes | Confirmed |

Do not merge. Wait for review.