### PR TITLE
feat: expose read-only capacity profile endpoint

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -34,6 +34,7 @@ import customerRoutes from './routes/customers.js'
 import documentRoutes from './routes/documents.js'
 import optimiserRoutes from './routes/optimiser.js'
 import squadPlanRoutes from './routes/squadPlan.js'
+import capacityProfileRoutes from './routes/capacityProfiles.js'
 
 const app = express()
 const PORT = process.env.PORT ?? 3001
@@ -78,6 +79,7 @@ app.use('/api/projects/:projectId/apply-rate-card', applyRateCardRouter)
 app.use('/api/projects/:projectId/documents', documentRoutes)
 app.use('/api/projects/:projectId/optimise', optimiserRoutes)
 app.use('/api/projects/:projectId/squad-plan', squadPlanRoutes)
+app.use('/api/projects/:projectId/capacity-profiles', capacityProfileRoutes)
 app.use('/api/projects/:projectId/squad-plans', squadPlanRoutes)
 app.use('/api/orgs', authenticate, orgRoutes)
 app.use('/api/customers', authenticate, customerRoutes)

--- a/server/src/routes/capacityProfiles.ts
+++ b/server/src/routes/capacityProfiles.ts
@@ -1,0 +1,63 @@
+import { Router, Response } from 'express'
+import { prisma } from '../lib/prisma.js'
+import { asyncHandler } from '../lib/asyncHandler.js'
+import { authenticate, AuthRequest } from '../middleware/auth.js'
+import { materializeCapacityPlanResources } from '../lib/capacityPlanMaterialisation.js'
+import { mapProjectToCapacityProfiles } from '../lib/capacityProfileMapping.js'
+import type { CapacityProfileResourceTypeLike, CapacityProfileNamedResourceLike, CapacityPlanSlotInput } from '../lib/capacityProfileMapping.js'
+
+const router = Router({ mergeParams: true })
+router.use(authenticate)
+
+router.get('/', asyncHandler(async (req: AuthRequest, res: Response) => {
+  const projectId = req.params.projectId as string
+
+  const project = await prisma.project.findFirst({
+    where: { id: projectId, ownerId: req.userId },
+    include: {
+      resourceTypes: {
+        include: {
+          namedResources: { orderBy: { createdAt: 'asc' } },
+        },
+      },
+      capacityPlans: {
+        where: { isActive: true },
+        take: 1,
+        include: { periods: { include: { entries: true }, orderBy: { periodIndex: 'asc' } } },
+      },
+    },
+  })
+
+  if (!project) {
+    res.status(404).json({ error: 'Project not found' })
+    return
+  }
+
+  // Materialise active capacity plan into slot windows per resource type
+  const activePlan = project.capacityPlans?.[0] ?? null
+  const capacityPlanByRt = materializeCapacityPlanResources(activePlan?.periods ?? [])
+
+  const capacityPlanSlotsByResourceTypeId = new Map<string, CapacityPlanSlotInput[]>(
+    Array.from(capacityPlanByRt.entries()).map(([rtId, materialized]) => [
+      rtId,
+      materialized.slotWindows,
+    ]),
+  )
+
+  // Build named resources lookup per resource type
+  const namedResourcesByResourceTypeId = new Map<string, CapacityProfileNamedResourceLike[]>()
+  for (const rt of project.resourceTypes) {
+    namedResourcesByResourceTypeId.set(rt.id, rt.namedResources as CapacityProfileNamedResourceLike[])
+  }
+
+  const profiles = mapProjectToCapacityProfiles({
+    projectId,
+    resourceTypes: project.resourceTypes as CapacityProfileResourceTypeLike[],
+    namedResourcesByResourceTypeId,
+    capacityPlanSlotsByResourceTypeId,
+  })
+
+  res.json({ capacityProfiles: profiles })
+}))
+
+export default router

--- a/server/src/test/capacityProfiles.test.ts
+++ b/server/src/test/capacityProfiles.test.ts
@@ -1,0 +1,252 @@
+/**
+ * capacityProfiles.test.ts — Integration tests for the read-only
+ * capacity-profile API endpoint.
+ *
+ * Tests that the endpoint correctly derives CapacityProfileDTOs from
+ * existing persisted fields using the mapper from PR #331.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import request from 'supertest'
+import jwt from 'jsonwebtoken'
+import { app } from '../index.js'
+import { prisma } from '../lib/prisma.js'
+
+process.env.JWT_SECRET = 'test-secret'
+
+const userId = 'user-1'
+const token = jwt.sign({ userId }, 'test-secret')
+const authHeader = `Bearer ${token}`
+
+beforeEach(() => vi.clearAllMocks())
+
+// ─── Helper: build a minimal project mock ──────────────────────────────────
+
+function mockProject(overrides: Record<string, unknown>) {
+  return {
+    id: 'proj-1',
+    ownerId: userId,
+    resourceTypes: [],
+    capacityPlans: [],
+    ...overrides,
+  } as any
+}
+
+// ─── Helper: build a minimal resource type for mocks ────────────────────────
+
+function mockRt(id: string, name: string, overrides: Record<string, unknown> = {}) {
+  return {
+    id,
+    name,
+    count: 1,
+    allocationMode: 'EFFORT',
+    allocationPercent: 100,
+    allocationStartWeek: null,
+    allocationEndWeek: null,
+    namedResources: [],
+    ...overrides,
+  }
+}
+
+// ─── Helper: build a minimal named resource for mocks ───────────────────────
+
+function mockNr(id: string, name: string, overrides: Record<string, unknown> = {}) {
+  return {
+    id,
+    name,
+    startWeek: null,
+    endWeek: null,
+    allocationPct: 100,
+    allocationMode: 'EFFORT',
+    allocationPercent: 100,
+    allocationStartWeek: null,
+    allocationEndWeek: null,
+    pricingModel: 'ACTUAL_DAYS',
+    ...overrides,
+  }
+}
+
+// ─── Tests ─────────────────────────────────────────────────────────────────
+
+describe('GET /api/projects/:projectId/capacity-profiles', () => {
+  it('rejects unauthenticated request', async () => {
+    vi.mocked(prisma.project.findFirst).mockResolvedValue(null)
+
+    const res = await request(app)
+      .get('/api/projects/proj-1/capacity-profiles')
+      // No auth header
+
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 404 for missing or inaccessible project', async () => {
+    vi.mocked(prisma.project.findFirst).mockResolvedValue(null)
+
+    const res = await request(app)
+      .get('/api/projects/proj-missing/capacity-profiles')
+      .set('Authorization', authHeader)
+
+    expect(res.status).toBe(404)
+    expect(res.body.error).toBe('Project not found')
+  })
+
+  it('returns demandFollowing role profile for EFFORT resource type', async () => {
+    vi.mocked(prisma.project.findFirst).mockResolvedValue(mockProject({
+      resourceTypes: [mockRt('rt-1', 'Engineer', { allocationMode: 'EFFORT' })],
+    }))
+
+    const res = await request(app)
+      .get('/api/projects/proj-1/capacity-profiles')
+      .set('Authorization', authHeader)
+
+    expect(res.status).toBe(200)
+    expect(res.body.capacityProfiles).toHaveLength(1)
+    expect(res.body.capacityProfiles[0]).toMatchObject({
+      owner: { kind: 'role', id: 'rt-1', name: 'Engineer' },
+      planningBasis: 'demandFollowing',
+      defaultPercent: 100,
+      source: 'fixed',
+      segments: [],
+    })
+  })
+
+  it('preserves TIMELINE percent/start/end with availabilityWindow', async () => {
+    vi.mocked(prisma.project.findFirst).mockResolvedValue(mockProject({
+      resourceTypes: [mockRt('rt-1', 'Dev', {
+        allocationMode: 'TIMELINE',
+        allocationPercent: 75,
+        allocationStartWeek: 2,
+        allocationEndWeek: 10,
+      })],
+    }))
+
+    const res = await request(app)
+      .get('/api/projects/proj-1/capacity-profiles')
+      .set('Authorization', authHeader)
+
+    expect(res.status).toBe(200)
+    expect(res.body.capacityProfiles[0]).toMatchObject({
+      planningBasis: 'availabilityWindow',
+      defaultPercent: 75,
+      startWeek: 2,
+      endWeek: 10,
+      source: 'availabilityWindow',
+      segments: [],
+    })
+  })
+
+  it('returns wholeProjectAllocation for FULL_PROJECT resource', async () => {
+    vi.mocked(prisma.project.findFirst).mockResolvedValue(mockProject({
+      resourceTypes: [mockRt('rt-1', 'PM', { allocationMode: 'FULL_PROJECT' })],
+    }))
+
+    const res = await request(app)
+      .get('/api/projects/proj-1/capacity-profiles')
+      .set('Authorization', authHeader)
+
+    expect(res.status).toBe(200)
+    expect(res.body.capacityProfiles[0]).toMatchObject({
+      planningBasis: 'wholeProjectAllocation',
+      source: 'fixed',
+    })
+  })
+
+  it('returns namedPerson owner kind for persisted named resource', async () => {
+    vi.mocked(prisma.project.findFirst).mockResolvedValue(mockProject({
+      resourceTypes: [mockRt('rt-1', 'Engineer', {
+        allocationMode: 'EFFORT',
+        namedResources: [mockNr('nr-1', 'Alice')],
+      })],
+    }))
+
+    const res = await request(app)
+      .get('/api/projects/proj-1/capacity-profiles')
+      .set('Authorization', authHeader)
+
+    expect(res.status).toBe(200)
+    expect(res.body.capacityProfiles).toHaveLength(1)
+    expect(res.body.capacityProfiles[0]).toMatchObject({
+      owner: { kind: 'namedPerson', id: 'nr-1', name: 'Alice', roleId: 'rt-1' },
+    })
+  })
+
+  it('returns capacityProfile with squadPlanner segments for CAPACITY_PLAN with active plan', async () => {
+    vi.mocked(prisma.project.findFirst).mockResolvedValue(mockProject({
+      resourceTypes: [mockRt('rt-1', 'Engineer', { allocationMode: 'CAPACITY_PLAN' })],
+      capacityPlans: [
+        {
+          id: 'plan-1',
+          isActive: true,
+          periods: [
+            {
+              periodIndex: 0,
+              startWeek: 0,
+              endWeek: 8,
+              entries: [{ resourceTypeId: 'rt-1', headcount: 1 }],
+            },
+          ],
+        },
+      ],
+    }))
+
+    const res = await request(app)
+      .get('/api/projects/proj-1/capacity-profiles')
+      .set('Authorization', authHeader)
+
+    expect(res.status).toBe(200)
+    expect(res.body.capacityProfiles[0]).toMatchObject({
+      planningBasis: 'capacityProfile',
+      source: 'squadPlanner',
+    })
+    expect(res.body.capacityProfiles[0].segments.length).toBeGreaterThan(0)
+    expect(res.body.capacityProfiles[0].segments[0]).toMatchObject({
+      source: 'squadPlanner',
+      capacityPercent: 100,
+    })
+  })
+
+  it('does not derive segments for non-CAPACITY_PLAN resource even with active plan', async () => {
+    vi.mocked(prisma.project.findFirst).mockResolvedValue(mockProject({
+      resourceTypes: [mockRt('rt-1', 'Engineer', { allocationMode: 'EFFORT' })],
+      capacityPlans: [
+        {
+          id: 'plan-1',
+          isActive: true,
+          periods: [
+            {
+              periodIndex: 0,
+              startWeek: 0,
+              endWeek: 8,
+              entries: [{ resourceTypeId: 'rt-1', headcount: 1 }],
+            },
+          ],
+        },
+      ],
+    }))
+
+    const res = await request(app)
+      .get('/api/projects/proj-1/capacity-profiles')
+      .set('Authorization', authHeader)
+
+    expect(res.status).toBe(200)
+    expect(res.body.capacityProfiles[0]).toMatchObject({
+      planningBasis: 'demandFollowing',
+      source: 'fixed',
+    })
+    expect(res.body.capacityProfiles[0].segments).toEqual([])
+  })
+
+  it('performs no database writes', async () => {
+    vi.mocked(prisma.project.findFirst).mockResolvedValue(mockProject({
+      resourceTypes: [mockRt('rt-1', 'Engineer', { allocationMode: 'EFFORT' })],
+    }))
+
+    await request(app)
+      .get('/api/projects/proj-1/capacity-profiles')
+      .set('Authorization', authHeader)
+
+    expect(prisma.project.create).not.toHaveBeenCalled()
+    expect(prisma.project.update).not.toHaveBeenCalled()
+    expect(prisma.project.updateMany).not.toHaveBeenCalled()
+    expect(prisma.project.delete).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
Refs #326

## Summary

Adds a new read-only endpoint `GET /api/projects/:projectId/capacity-profiles` that returns capacity-profile DTOs derived from existing persisted fields using the mapper from PR #331.

This is PR 3 of the rollout plan from #330.

## Endpoint behaviour

- Requires authentication via existing JWT middleware
- Scoped to projects owned by the authenticated user
- Returns 404 for missing or inaccessible projects
- Includes all project resource types with their named resources
- Materializes active capacity-plan periods into slot windows via `materializeCapacityPlanResources`
- Passes slot windows to `mapProjectToCapacityProfiles` (non-CAPACITY_PLAN modes ignore them, per the PR #331 fix)
- Returns `{ capacityProfiles: CapacityProfileDTO[] }`
- **Read-only** — performs no database writes

## Files changed

| File | Change |
|---|---|
| `server/src/routes/capacityProfiles.ts` | New route file (63 lines) |
| `server/src/index.ts` | Import + registration (+2 lines) |
| `server/src/test/capacityProfiles.test.ts` | 9 integration tests (252 lines) |

## Confirmation

- Read-only endpoint — consumes the mapper but does not alter any existing route behaviour
- No Prisma schema changes
- No migrations
- No database writes
- No UI changes
- No Resource Profile export changes
- No Commercial calculation changes
- No scheduler/leveller behaviour changes
- No Squad Planner behaviour changes
- No dependency updates
- Existing routes are not consuming this endpoint yet

## Validation

| Check | Result |
|---|---|
| Server typecheck | OK |
| Client typecheck | OK |
| Server tests | 28/28 files passing (1 new endpoint test file) |
| Client build | OK |
| No schema/migration changes | Confirmed |

Do not merge. Wait for review.