### PR TITLE
feat: sync capacity profiles on planning writes

### DIFF
--- a/docs/domain/capacity-profile-design.md
+++ b/docs/domain/capacity-profile-design.md
@@ -386,17 +386,21 @@ remain unchanged for the backfill runner.
 
 The helper is called inside existing write transactions:
 - `PUT /api/projects/:projectId/resource-types/:id` — resource type allocation mode/percent/weeks
+- `PATCH /api/projects/:projectId/resource-types/:id` — resource type count change (named-resource creation/deletion)
 - `DELETE /api/projects/:projectId/resource-types/:id` — resource type removal
 - `POST /api/projects/:projectId/resource-types/:rtId/named-resources` — named resource creation
 - `PUT /api/projects/:projectId/resource-types/:rtId/named-resources/:id` — named resource update
 - `PATCH /api/projects/:projectId/resource-types/:rtId/named-resources/:id` — named resource allocation update
-- `DELETE /api/projects/:projectId/resource-types/:rtId/named-resources/:id` — named resource deletion
-- `POST /api/projects/:projectId/squad-plan` (POST) — capacity plan create/apply
+- `DELETE /api/projects/:projectId/resource-types/:rtId/named-resources/:id` — named resource deletion (after RT count update)
+- `POST /api/projects` — project creation
+
+**Deferred:** Squad-plan apply sync is not yet atomic with legacy writes. It will be wired in a follow-up PR that wraps the apply route in a single transaction.
 
 ### Write transactionality
 
-- Routes that already use `prisma.$transaction` have the sync call inside the same transaction, so sync failure rolls back the legacy write.
-- The squad plan apply route does not use a single transaction; sync runs after all writes as a best-effort update.
+- Routes that use `prisma.$transaction` have the sync call inside the same transaction, so sync failure rolls back the legacy write.
+- Named-resource DELETE ensures sync runs after the resource-type count is updated, so the persisted profile reflects the final count.
+- Owner-key normalization uses `prismaOwnerKindToDtoKind` to map Prisma enum values (`NAMED_PERSON`, `PLANNED_RESOURCE`) to DTO format (`namedPerson`, `plannedResource`), ensuring stable persisted IDs across syncs.
 
 ### Backfill refactor
 

--- a/docs/domain/capacity-profile-design.md
+++ b/docs/domain/capacity-profile-design.md
@@ -369,6 +369,47 @@ remain unchanged for the backfill runner.
 - `legacy` set to all-null (legacy fields are on ResourceType/NamedResource, not copied)
 - Stable sort order: role profiles first, then named/person/planned by owner id
 
+## Runtime Sync Adoption
+
+`syncCapacityProfilesForProject` in `server/src/lib/syncCapacityProfiles.ts` keeps the additive `CapacityProfile`/`CapacitySegment` read model in sync when legacy planning fields change.
+
+### Behaviour
+
+1. Fetch the project with resource types, named resources, and active capacity plan (same includes as the read endpoint).
+2. Derive expected DTOs via `mapProjectToCapacityProfiles`.
+3. Upsert `CapacityProfile` rows to match expected.
+4. Replace segments for each profile (delete all, recreate).
+5. Delete persisted profiles that no longer correspond to an expected owner key.
+6. Reconcile after sync; throw if mismatches remain.
+
+### Integration
+
+The helper is called inside existing write transactions:
+- `PUT /api/projects/:projectId/resource-types/:id` — resource type allocation mode/percent/weeks
+- `DELETE /api/projects/:projectId/resource-types/:id` — resource type removal
+- `POST /api/projects/:projectId/resource-types/:rtId/named-resources` — named resource creation
+- `PUT /api/projects/:projectId/resource-types/:rtId/named-resources/:id` — named resource update
+- `PATCH /api/projects/:projectId/resource-types/:rtId/named-resources/:id` — named resource allocation update
+- `DELETE /api/projects/:projectId/resource-types/:rtId/named-resources/:id` — named resource deletion
+- `POST /api/projects/:projectId/squad-plan` (POST) — capacity plan create/apply
+
+### Write transactionality
+
+- Routes that already use `prisma.$transaction` have the sync call inside the same transaction, so sync failure rolls back the legacy write.
+- The squad plan apply route does not use a single transaction; sync runs after all writes as a best-effort update.
+
+### Backfill refactor
+
+`backfillCapacityProfiles.ts` has been refactored to delegate per-project work to `syncCapacityProfilesForProject`, sharing the same helper used by runtime writes.
+
+### Planned resource handling
+
+Planned resources (`ownerKind: PLANNED_RESOURCE`) have stable `namedResourceId` values from persisted `NamedResource` rows, so they persist without ambiguity.
+
+### Legacy field authority
+
+Legacy `ResourceType`/`NamedResource`/`CapacityPlan` fields remain authoritative. The sync helper is a derived write that keeps the additive read model in sync, not a source-of-truth migration.
+
 ### Future work
 
 - Runtime write adoption: make save/update operations write to `CapacityProfile` tables.

--- a/server/src/lib/backfillCapacityProfiles.ts
+++ b/server/src/lib/backfillCapacityProfiles.ts
@@ -15,6 +15,7 @@ import { CapacityProfileValidationError } from './syncCapacityProfiles.js'
 export interface BackfillResult {
   profilesCreated: number
   profilesUpdated: number
+  profilesDeleted: number
   segmentsCreated: number
   segmentsDeleted: number
 }
@@ -32,6 +33,7 @@ export async function backfillCapacityProfiles(
   const result: BackfillResult = {
     profilesCreated: 0,
     profilesUpdated: 0,
+    profilesDeleted: 0,
     segmentsCreated: 0,
     segmentsDeleted: 0,
   }
@@ -61,6 +63,7 @@ export async function backfillCapacityProfiles(
     const syncResult = await syncCapacityProfilesForProject(prisma, project.id)
     result.profilesCreated += syncResult.profilesCreated
     result.profilesUpdated += syncResult.profilesUpdated
+    result.profilesDeleted += syncResult.profilesDeleted
     result.segmentsCreated += syncResult.segmentsCreated
     result.segmentsDeleted += syncResult.segmentsDeleted
   }

--- a/server/src/lib/backfillCapacityProfiles.ts
+++ b/server/src/lib/backfillCapacityProfiles.ts
@@ -1,113 +1,16 @@
 /**
  * backfillCapacityProfiles.ts — Idempotent backfill helper.
  *
- * Reads existing persisted fields (ResourceType, NamedResource, CapacityPlan)
- * and derives CapacityProfile / CapacitySegment records using the mapper
- * from capacityProfileMapping.ts.
+ * Delegates to syncCapacityProfilesForProject for each project, accumulating
+ * per-project SyncResult counts into a BackfillResult.
  *
- * Safe to run multiple times — upserts profiles and replaces segments.
- * Legacy fields remain authoritative and are not modified.
+ * Safe to run multiple times. Does not modify legacy fields.
  */
 import type { PrismaClient } from '@prisma/client'
-import { $Enums } from '@prisma/client'
-import { materializeCapacityPlanResources } from './capacityPlanMaterialisation.js'
-import { mapProjectToCapacityProfiles } from './capacityProfileMapping.js'
-import type {
-  CapacityProfileOwnerKind,
-  CapacityProfilePlanningBasis,
-  CapacityProfileSource,
-  CapacityProfileResourceTypeLike,
-  CapacityProfileNamedResourceLike,
-  CapacityPlanSlotInput,
-} from './capacityProfileMapping.js'
+import { syncCapacityProfilesForProject } from './syncCapacityProfiles.js'
+import { CapacityProfileValidationError } from './syncCapacityProfiles.js'
 
-// ─── Enum mapping helpers (DTO lowercase → Prisma UPPER_CASE) ─────────────
-
-function toPrismaOwnerKind(kind: CapacityProfileOwnerKind): $Enums.CapacityProfileOwnerKind {
-  switch (kind) {
-    case 'role': return 'ROLE' as $Enums.CapacityProfileOwnerKind
-    case 'namedPerson': return 'NAMED_PERSON' as $Enums.CapacityProfileOwnerKind
-    case 'plannedResource': return 'PLANNED_RESOURCE' as $Enums.CapacityProfileOwnerKind
-  }
-}
-
-function toPrismaPlanningBasis(basis: CapacityProfilePlanningBasis): $Enums.CapacityProfilePlanningBasis {
-  switch (basis) {
-    case 'demandFollowing': return 'DEMAND_FOLLOWING' as $Enums.CapacityProfilePlanningBasis
-    case 'availabilityWindow': return 'AVAILABILITY_WINDOW' as $Enums.CapacityProfilePlanningBasis
-    case 'wholeProjectAllocation': return 'WHOLE_PROJECT_ALLOCATION' as $Enums.CapacityProfilePlanningBasis
-    case 'capacityProfile': return 'CAPACITY_PROFILE' as $Enums.CapacityProfilePlanningBasis
-  }
-}
-
-function toPrismaSource(source: CapacityProfileSource): $Enums.CapacityProfileSource {
-  switch (source) {
-    case 'fixed': return 'FIXED' as $Enums.CapacityProfileSource
-    case 'manual': return 'MANUAL' as $Enums.CapacityProfileSource
-    case 'availabilityWindow': return 'AVAILABILITY_WINDOW' as $Enums.CapacityProfileSource
-    case 'squadPlanner': return 'SQUAD_PLANNER' as $Enums.CapacityProfileSource
-    case 'imported': return 'IMPORTED' as $Enums.CapacityProfileSource
-    case 'derived': return 'DERIVED' as $Enums.CapacityProfileSource
-    case 'legacy': return 'LEGACY' as $Enums.CapacityProfileSource
-  }
-}
-
-// ─── Exactly-one-owner validation ──────────────────────────────────────────
-
-export class CapacityProfileValidationError extends Error {
-  constructor(message: string) {
-    super(message)
-    this.name = 'CapacityProfileValidationError'
-  }
-}
-
-function validateOwner(profile: {
-  owner: { kind: string; id: string }
-  projectId: string
-}): void {
-  const kind = profile.owner.kind
-  const ownerId = profile.owner.id
-
-  if (kind === 'role') {
-    if (!ownerId) {
-      throw new CapacityProfileValidationError(
-        `Role-owned profile for project ${profile.projectId} has no resourceTypeId`,
-      )
-    }
-  } else if (kind === 'namedPerson' || kind === 'plannedResource') {
-    if (!ownerId) {
-      throw new CapacityProfileValidationError(
-        `Named-resource profile for project ${profile.projectId} has no namedResourceId`,
-      )
-    }
-  } else {
-    throw new CapacityProfileValidationError(
-      `Unknown owner kind "${kind}" for project ${profile.projectId}`,
-    )
-  }
-}
-function lookupCriteria(
-  projectId: string,
-  profile: {
-    owner: { kind: CapacityProfileOwnerKind; id: string }
-  },
-): {
-  projectId: string
-  ownerKind: $Enums.CapacityProfileOwnerKind
-  resourceTypeId?: string | null
-  namedResourceId?: string | null
-} {
-  const ownerKind = toPrismaOwnerKind(profile.owner.kind)
-
-  if (profile.owner.kind === 'role') {
-    return { projectId, ownerKind, resourceTypeId: profile.owner.id }
-  }
-
-  return { projectId, ownerKind, namedResourceId: profile.owner.id }
-}
-
-
-// ─── Main backfill function ───────────────────────────────────────────────
+// ─── Backfill result ───────────────────────────────────────────────────────
 
 export interface BackfillResult {
   profilesCreated: number
@@ -155,113 +58,15 @@ export async function backfillCapacityProfiles(
   })
 
   for (const project of projects) {
-    // Materialize active capacity plan into slot windows
-    const activePlan = project.capacityPlans?.[0] ?? null
-    const capacityPlanByRt = materializeCapacityPlanResources(
-      activePlan?.periods ?? [],
-    )
-
-    const capacityPlanSlotsByResourceTypeId = new Map<string, CapacityPlanSlotInput[]>(
-      Array.from(capacityPlanByRt.entries()).map(([rtId, materialized]) => [
-        rtId,
-        materialized.slotWindows,
-      ]),
-    )
-
-    // Build named resources lookup
-    const namedResourcesByResourceTypeId = new Map<
-      string,
-      CapacityProfileNamedResourceLike[]
-    >()
-    for (const rt of project.resourceTypes) {
-      namedResourcesByResourceTypeId.set(
-        rt.id,
-        rt.namedResources as unknown as CapacityProfileNamedResourceLike[],
-      )
-    }
-
-    // Derive capacity profile DTOs using the existing mapper
-    const profiles = mapProjectToCapacityProfiles({
-      projectId: project.id,
-      resourceTypes:
-        project.resourceTypes as unknown as CapacityProfileResourceTypeLike[],
-      namedResourcesByResourceTypeId,
-      capacityPlanSlotsByResourceTypeId,
-    })
-
-    for (const profile of profiles) {
-      validateOwner(profile)
-
-      const criteria = lookupCriteria(project.id, profile)
-
-      // Determine which fields are nullable and which are set
-      const data = {
-        projectId: project.id,
-        ownerKind: toPrismaOwnerKind(profile.owner.kind),
-        planningBasis: toPrismaPlanningBasis(profile.planningBasis),
-        source: toPrismaSource(profile.source),
-        defaultPercent: profile.defaultPercent ?? null,
-        startWeek: profile.startWeek ?? null,
-        endWeek: profile.endWeek ?? null,
-        legacy: profile.legacy,
-        resourceTypeId:
-          profile.owner.kind === 'role' ? profile.owner.id : null,
-        namedResourceId:
-          profile.owner.kind === 'role' ? null : profile.owner.id,
-      } satisfies Record<string, unknown>
-
-      // Wrap the whole upsert + segment replacement in a transaction to
-      // prevent orphaned profiles or partial segment data on failure.
-      await prisma.$transaction(async (tx) => {
-        const existing = await tx.capacityProfile.findFirst({
-          where: criteria,
-        })
-
-        if (existing) {
-          await tx.capacityProfile.update({
-            where: { id: existing.id },
-            data,
-          })
-          result.profilesUpdated++
-
-          const deleted = await tx.capacitySegment.deleteMany({
-            where: { capacityProfileId: existing.id },
-          })
-          result.segmentsDeleted += deleted.count
-
-          for (const seg of profile.segments) {
-            await tx.capacitySegment.create({
-              data: {
-                capacityProfileId: existing.id,
-                startWeek: seg.startWeek,
-                endWeek: seg.endWeek,
-                capacityPercent: seg.capacityPercent,
-                source: toPrismaSource(seg.source),
-              },
-            })
-            result.segmentsCreated++
-          }
-        } else {
-          // Create new profile
-          await tx.capacityProfile.create({
-            data: {
-              ...data,
-              segments: {
-                create: profile.segments.map((seg) => ({
-                  startWeek: seg.startWeek,
-                  endWeek: seg.endWeek,
-                  capacityPercent: seg.capacityPercent,
-                  source: toPrismaSource(seg.source),
-                })),
-              },
-            },
-          })
-          result.profilesCreated++
-          result.segmentsCreated += profile.segments.length
-        }
-      })
-    }
+    const syncResult = await syncCapacityProfilesForProject(prisma, project.id)
+    result.profilesCreated += syncResult.profilesCreated
+    result.profilesUpdated += syncResult.profilesUpdated
+    result.segmentsCreated += syncResult.segmentsCreated
+    result.segmentsDeleted += syncResult.segmentsDeleted
   }
 
   return result
 }
+
+export { CapacityProfileValidationError }
+

--- a/server/src/lib/syncCapacityProfiles.ts
+++ b/server/src/lib/syncCapacityProfiles.ts
@@ -1,0 +1,342 @@
+/**
+ * syncCapacityProfilesForProject — Idempotent runtime sync helper.
+ *
+ * Keeps the additive CapacityProfile / CapacitySegment read model in sync
+ * with the authoritative legacy fields (ResourceType, NamedResource,
+ * CapacityPlan periods).
+ *
+ * Designed to be called inside an existing transaction so that if the sync
+ * fails, the legacy write also rolls back.
+ *
+ * @module syncCapacityProfiles
+ */
+
+import type { $Enums } from '@prisma/client'
+import { materializeCapacityPlanResources } from './capacityPlanMaterialisation.js'
+import { mapProjectToCapacityProfiles } from './capacityProfileMapping.js'
+import type {
+  CapacityProfileResourceTypeLike,
+  CapacityProfileNamedResourceLike,
+  CapacityPlanSlotInput,
+} from './capacityProfileMapping.js'
+import { compareCapacityProfiles } from './reconcileCapacityProfiles.js'
+
+// ─── Enum mapping helpers (DTO lowercase → Prisma UPPER_CASE) ─────────────
+
+export function toPrismaOwnerKind(
+  kind: string,
+): $Enums.CapacityProfileOwnerKind {
+  switch (kind) {
+    case 'role': return 'ROLE' as $Enums.CapacityProfileOwnerKind
+    case 'namedPerson': return 'NAMED_PERSON' as $Enums.CapacityProfileOwnerKind
+    case 'plannedResource': return 'PLANNED_RESOURCE' as $Enums.CapacityProfileOwnerKind
+    default: throw new Error(`Unknown owner kind: ${kind}`)
+  }
+}
+
+export function toPrismaPlanningBasis(
+  basis: string,
+): $Enums.CapacityProfilePlanningBasis {
+  switch (basis) {
+    case 'demandFollowing': return 'DEMAND_FOLLOWING' as $Enums.CapacityProfilePlanningBasis
+    case 'availabilityWindow': return 'AVAILABILITY_WINDOW' as $Enums.CapacityProfilePlanningBasis
+    case 'wholeProjectAllocation': return 'WHOLE_PROJECT_ALLOCATION' as $Enums.CapacityProfilePlanningBasis
+    case 'capacityProfile': return 'CAPACITY_PROFILE' as $Enums.CapacityProfilePlanningBasis
+    default: throw new Error(`Unknown planning basis: ${basis}`)
+  }
+}
+
+export function toPrismaSource(
+  source: string,
+): $Enums.CapacityProfileSource {
+  switch (source) {
+    case 'fixed': return 'FIXED' as $Enums.CapacityProfileSource
+    case 'manual': return 'MANUAL' as $Enums.CapacityProfileSource
+    case 'availabilityWindow': return 'AVAILABILITY_WINDOW' as $Enums.CapacityProfileSource
+    case 'squadPlanner': return 'SQUAD_PLANNER' as $Enums.CapacityProfileSource
+    case 'imported': return 'IMPORTED' as $Enums.CapacityProfileSource
+    case 'derived': return 'DERIVED' as $Enums.CapacityProfileSource
+    case 'legacy': return 'LEGACY' as $Enums.CapacityProfileSource
+    default: throw new Error(`Unknown source: ${source}`)
+  }
+}
+
+// ─── Sync result type ──────────────────────────────────────────────────────
+
+export interface SyncResult {
+  profilesCreated: number
+  profilesUpdated: number
+  profilesDeleted: number
+  segmentsCreated: number
+  segmentsDeleted: number
+}
+
+// ─── Validation ────────────────────────────────────────────────────────────
+
+export class CapacityProfileValidationError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'CapacityProfileValidationError'
+  }
+}
+
+function validateOwner(profile: {
+  owner: { kind: string; id: string }
+  projectId: string
+}): void {
+  const kind = profile.owner.kind
+  const ownerId = profile.owner.id
+
+  if (kind === 'role') {
+    if (!ownerId) {
+      throw new CapacityProfileValidationError(
+        `Role-owned profile for project ${profile.projectId} has no resourceTypeId`,
+      )
+    }
+  } else if (kind === 'namedPerson' || kind === 'plannedResource') {
+    if (!ownerId) {
+      throw new CapacityProfileValidationError(
+        `Named-resource profile for project ${profile.projectId} has no namedResourceId`,
+      )
+    }
+  } else {
+    throw new CapacityProfileValidationError(
+      `Unknown owner kind "${kind}" for project ${profile.projectId}`,
+    )
+  }
+}
+
+// ─── Main sync function ────────────────────────────────────────────────────
+
+/**
+ * Idempotently sync the additive CapacityProfile/CapacitySegment rows for a
+ * single project so they match the mapper-derived expected profiles.
+ *
+ * Designed to be called inside an existing write transaction so the sync
+ * is atomic with the legacy write.
+ *
+ * @param prismaOrTx  PrismaClient (standalone) or TransactionClient (inside a transaction)
+ * @param projectId   The project whose profiles should be synced
+ * @throws            If the project is not found or reconciliation fails after sync
+ */
+export async function syncCapacityProfilesForProject(
+  prismaOrTx: any,
+  projectId: string,
+): Promise<SyncResult> {
+  const result: SyncResult = {
+    profilesCreated: 0,
+    profilesUpdated: 0,
+    profilesDeleted: 0,
+    segmentsCreated: 0,
+    segmentsDeleted: 0,
+  }
+
+  // 1. Fetch project with all required includes
+  const project = await (prismaOrTx as any).project.findFirst({
+    where: { id: projectId },
+    include: {
+      resourceTypes: {
+        include: {
+          namedResources: { orderBy: { createdAt: 'asc' as const } },
+        },
+      },
+      capacityPlans: {
+        where: { isActive: true },
+        take: 1,
+        include: {
+          periods: {
+            include: { entries: true },
+            orderBy: { periodIndex: 'asc' as const },
+          },
+        },
+      },
+    },
+  })
+
+  if (!project) {
+    throw new Error(
+      `syncCapacityProfilesForProject: Project ${projectId} not found`,
+    )
+  }
+
+  // 2. Materialise active capacity plan into slot windows per resource type
+  const activePlan = project.capacityPlans?.[0] ?? null
+  const capacityPlanByRt = materializeCapacityPlanResources(
+    activePlan?.periods ?? [],
+  )
+
+  const capacityPlanSlotsByResourceTypeId = new Map<
+    string,
+    CapacityPlanSlotInput[]
+  >(
+    Array.from(capacityPlanByRt.entries()).map(([rtId, materialized]) => [
+      rtId,
+      materialized.slotWindows,
+    ]),
+  )
+
+  // 3. Build named resources lookup per resource type
+  const namedResourcesByResourceTypeId = new Map<
+    string,
+    CapacityProfileNamedResourceLike[]
+  >()
+  for (const rt of project.resourceTypes) {
+    namedResourcesByResourceTypeId.set(
+      rt.id,
+      rt.namedResources as unknown as CapacityProfileNamedResourceLike[],
+    )
+  }
+
+  // 4. Derive expected capacity profile DTOs using the existing mapper
+  const expectedProfiles = mapProjectToCapacityProfiles({
+    projectId: project.id,
+    resourceTypes:
+      project.resourceTypes as unknown as CapacityProfileResourceTypeLike[],
+    namedResourcesByResourceTypeId,
+    capacityPlanSlotsByResourceTypeId,
+  })
+
+  // 5. Fetch existing persisted profiles for this project
+  const existingPersistedProfiles = await (
+    prismaOrTx as any
+  ).capacityProfile.findMany({
+    where: { projectId },
+    include: { segments: true },
+  })
+
+  // Build lookup map of persisted profiles by owner key
+  const persistedByKey = new Map<string, any>()
+  for (const pp of existingPersistedProfiles) {
+    const ownerKind = pp.ownerKind.toLowerCase()
+    const ownerId = pp.resourceTypeId ?? pp.namedResourceId ?? ''
+    const key = `${projectId}::${ownerKind}::${ownerId}`
+    if (!persistedByKey.has(key)) {
+      persistedByKey.set(key, pp)
+    }
+  }
+
+  // 6. Upsert/create each expected profile and replace its segments
+  for (const profile of expectedProfiles) {
+    validateOwner(profile)
+    const key = `${project.id}::${profile.owner.kind}::${profile.owner.id}`
+
+    const ownerKind = toPrismaOwnerKind(profile.owner.kind)
+    const planningBasis = toPrismaPlanningBasis(profile.planningBasis)
+    const source = toPrismaSource(profile.source)
+
+    const data: Record<string, unknown> = {
+      projectId: project.id,
+      ownerKind,
+      planningBasis,
+      source,
+      defaultPercent: profile.defaultPercent ?? null,
+      startWeek: profile.startWeek ?? null,
+      endWeek: profile.endWeek ?? null,
+      legacy: profile.legacy,
+      resourceTypeId:
+        profile.owner.kind === 'role' ? profile.owner.id : null,
+      namedResourceId:
+        profile.owner.kind === 'role' ? null : profile.owner.id,
+    }
+
+    const existing = persistedByKey.get(key)
+
+    if (existing) {
+      await (prismaOrTx as any).capacityProfile.update({
+        where: { id: existing.id },
+        data,
+      })
+      result.profilesUpdated++
+
+      const deleted = await (prismaOrTx as any).capacitySegment.deleteMany({
+        where: { capacityProfileId: existing.id },
+      })
+      result.segmentsDeleted += deleted.count
+
+      for (const seg of profile.segments) {
+        await (prismaOrTx as any).capacitySegment.create({
+          data: {
+            capacityProfileId: existing.id,
+            startWeek: seg.startWeek,
+            endWeek: seg.endWeek,
+            capacityPercent: seg.capacityPercent,
+            source: toPrismaSource(seg.source),
+          },
+        })
+        result.segmentsCreated++
+      }
+
+      persistedByKey.delete(key)
+    } else {
+      await (prismaOrTx as any).capacityProfile.create({
+        data: {
+          ...data,
+          segments: {
+            create: profile.segments.map((seg: any) => ({
+              startWeek: seg.startWeek,
+              endWeek: seg.endWeek,
+              capacityPercent: seg.capacityPercent,
+              source: toPrismaSource(seg.source),
+            })),
+          },
+        },
+      })
+      result.profilesCreated++
+      result.segmentsCreated += profile.segments.length
+    }
+  }
+
+  // 7. Delete stale persisted profiles (those in DB but not in expected)
+  for (const [, pp] of persistedByKey) {
+    await (prismaOrTx as any).capacitySegment.deleteMany({
+      where: { capacityProfileId: pp.id },
+    })
+    await (prismaOrTx as any).capacityProfile.delete({
+      where: { id: pp.id },
+    })
+    result.segmentsDeleted += pp.segments?.length ?? 0
+    result.profilesDeleted++
+  }
+
+  // 8. Verify reconciliation after sync
+  const afterSyncPersisted = await (
+    prismaOrTx as any
+  ).capacityProfile.findMany({
+    where: { projectId },
+    include: {
+      segments: {
+        orderBy: [{ startWeek: 'asc' as const }, { endWeek: 'asc' as const }],
+      },
+    },
+  })
+
+  const comparison = compareCapacityProfiles(
+    projectId,
+    expectedProfiles,
+    afterSyncPersisted.map((pp: any) => ({
+      id: pp.id,
+      resourceTypeId: pp.resourceTypeId,
+      namedResourceId: pp.namedResourceId,
+      ownerKind: pp.ownerKind,
+      planningBasis: pp.planningBasis,
+      source: pp.source,
+      defaultPercent: pp.defaultPercent,
+      startWeek: pp.startWeek,
+      endWeek: pp.endWeek,
+      segments: pp.segments.map((s: any) => ({
+        startWeek: s.startWeek,
+        endWeek: s.endWeek,
+        capacityPercent: s.capacityPercent,
+        source: s.source,
+      })),
+    })),
+  )
+
+  if (comparison.mismatches.length > 0) {
+    throw new Error(
+      `syncCapacityProfilesForProject: Reconciliation failed after sync for project ${projectId}: ${comparison.mismatches.length} mismatches`,
+    )
+  }
+
+  return result
+}

--- a/server/src/lib/syncCapacityProfiles.ts
+++ b/server/src/lib/syncCapacityProfiles.ts
@@ -60,6 +60,21 @@ export function toPrismaSource(
     default: throw new Error(`Unknown source: ${source}`)
   }
 }
+// ─── Reverse enum mapping (Prisma UPPER_CASE → DTO camelCase) ──────────
+
+export function prismaOwnerKindToDtoKind(kind: string): 'role' | 'namedPerson' | 'plannedResource' {
+  switch (kind) {
+    case 'ROLE':
+      return 'role'
+    case 'NAMED_PERSON':
+      return 'namedPerson'
+    case 'PLANNED_RESOURCE':
+      return 'plannedResource'
+    default:
+      throw new Error(`Unknown persisted owner kind: ${kind}`)
+  }
+}
+
 
 // ─── Sync result type ──────────────────────────────────────────────────────
 
@@ -207,7 +222,7 @@ export async function syncCapacityProfilesForProject(
   // Build lookup map of persisted profiles by owner key
   const persistedByKey = new Map<string, any>()
   for (const pp of existingPersistedProfiles) {
-    const ownerKind = pp.ownerKind.toLowerCase()
+    const ownerKind = prismaOwnerKindToDtoKind(pp.ownerKind)
     const ownerId = pp.resourceTypeId ?? pp.namedResourceId ?? ''
     const key = `${projectId}::${ownerKind}::${ownerId}`
     if (!persistedByKey.has(key)) {

--- a/server/src/routes/namedResources.ts
+++ b/server/src/routes/namedResources.ts
@@ -4,6 +4,7 @@ import { AllocationMode } from '@prisma/client'
 import { prisma } from '../lib/prisma.js'
 import { asyncHandler } from '../lib/asyncHandler.js'
 import { authenticate, AuthRequest } from '../middleware/auth.js'
+import { syncCapacityProfilesForProject } from '../lib/syncCapacityProfiles.js'
 import { exitCapacityPlanForManualScheduling } from '../lib/capacityPlanExit.js'
 
 const router = Router({ mergeParams: true })
@@ -117,6 +118,7 @@ router.post('/', asyncHandler(async (req: AuthRequest, res: Response) => {
     // Sync resource type count to match total named resources
     const total = await tx.namedResource.count({ where: { resourceTypeId: rtId } })
     await tx.resourceType.update({ where: { id: rtId }, data: { count: total } })
+    await syncCapacityProfilesForProject(tx, projectId)
 
     return created
   })
@@ -158,6 +160,7 @@ router.put('/:id', asyncHandler(async (req: AuthRequest, res: Response) => {
       data,
     })
     await clearWeeklyDemandCache(projectId, tx)
+    await syncCapacityProfilesForProject(tx, projectId)
     return updated
   })
   res.json(resource)
@@ -188,6 +191,7 @@ router.patch('/:id', asyncHandler(async (req: AuthRequest, res: Response) => {
       data,
     })
     await clearWeeklyDemandCache(projectId, tx)
+    await syncCapacityProfilesForProject(tx, projectId)
     return updated
   })
   res.json(resource)
@@ -213,6 +217,7 @@ router.delete('/:id', asyncHandler(async (req: AuthRequest, res: Response) => {
 
     await tx.namedResource.delete({ where: { id } })
     await clearWeeklyDemandCache(projectId, tx)
+    await syncCapacityProfilesForProject(tx, projectId)
 
     // Sync resource type count (can reach 0 when all named resources are deleted)
     const total = await tx.namedResource.count({ where: { resourceTypeId: rtId } })

--- a/server/src/routes/namedResources.ts
+++ b/server/src/routes/namedResources.ts
@@ -217,11 +217,12 @@ router.delete('/:id', asyncHandler(async (req: AuthRequest, res: Response) => {
 
     await tx.namedResource.delete({ where: { id } })
     await clearWeeklyDemandCache(projectId, tx)
-    await syncCapacityProfilesForProject(tx, projectId)
 
     // Sync resource type count (can reach 0 when all named resources are deleted)
     const total = await tx.namedResource.count({ where: { resourceTypeId: rtId } })
     await tx.resourceType.update({ where: { id: rtId }, data: { count: total } })
+
+    await syncCapacityProfilesForProject(tx, projectId)
   })
 
   res.status(204).send()

--- a/server/src/routes/projects.ts
+++ b/server/src/routes/projects.ts
@@ -2,6 +2,7 @@ import { Router, Response } from 'express'
 import { prisma } from '../lib/prisma.js'
 import { asyncHandler } from '../lib/asyncHandler.js'
 import { authenticate, AuthRequest } from '../middleware/auth.js'
+import { syncCapacityProfilesForProject } from '../lib/syncCapacityProfiles.js'
 
 const router = Router()
 router.use(authenticate)
@@ -469,6 +470,7 @@ router.post('/', asyncHandler(async (req: AuthRequest, res: Response) => {
     },
     include: { resourceTypes: true, org: { select: { id: true, name: true } }, customer: { select: { id: true, name: true } } },
   })
+  await syncCapacityProfilesForProject(prisma, project.id)
   res.status(201).json(project)
 }))
 

--- a/server/src/routes/resourceTypes.ts
+++ b/server/src/routes/resourceTypes.ts
@@ -3,6 +3,7 @@ import { prisma } from '../lib/prisma.js'
 import { asyncHandler } from '../lib/asyncHandler.js'
 import { authenticate, AuthRequest } from '../middleware/auth.js'
 import { ownedProject } from '../lib/ownership.js'
+import { syncCapacityProfilesForProject } from '../lib/syncCapacityProfiles.js'
 import { exitCapacityPlanForManualScheduling } from '../lib/capacityPlanExit.js'
 
 
@@ -130,6 +131,7 @@ router.put('/:id', asyncHandler(async (req: AuthRequest, res: Response) => {
     }
 
     await clearWeeklyDemandCache(req.params.projectId as string, tx)
+    await syncCapacityProfilesForProject(tx, req.params.projectId as string)
 
     return updated
   })
@@ -231,6 +233,7 @@ router.delete('/:id', asyncHandler(async (req: AuthRequest, res: Response) => {
     })
     if (deleted.count > 0) {
       await clearWeeklyDemandCache(req.params.projectId as string, tx)
+      await syncCapacityProfilesForProject(tx, req.params.projectId as string)
     }
     return deleted.count
   })

--- a/server/src/routes/resourceTypes.ts
+++ b/server/src/routes/resourceTypes.ts
@@ -218,6 +218,7 @@ router.patch('/:id', asyncHandler(async (req: AuthRequest, res: Response) => {
     }
 
     await clearWeeklyDemandCache(req.params.projectId as string, tx)
+    await syncCapacityProfilesForProject(tx, req.params.projectId as string)
     return result
   })
   res.json({ ...updated, warnings: warnings.length > 0 ? warnings : undefined })

--- a/server/src/routes/squadPlan.ts
+++ b/server/src/routes/squadPlan.ts
@@ -26,7 +26,6 @@ import {
   type CapacityPlanSlotWindow,
   type CapacityPlanPeriodInput,
 } from '../lib/capacityPlanMaterialisation.js'
-import { syncCapacityProfilesForProject } from '../lib/syncCapacityProfiles.js'
 
 type ApplyPeriodEntry = {
   resourceTypeId: string
@@ -761,7 +760,6 @@ router.post('/apply', asyncHandler(async (req: AuthRequest, res: Response) => {
       data: { weeklyDemandCache: refreshedWeeklyDemandCache },
     })
   }
-  await syncCapacityProfilesForProject(prisma, projectId)
 
   res.status(201).json(plan)
 }))

--- a/server/src/routes/squadPlan.ts
+++ b/server/src/routes/squadPlan.ts
@@ -26,6 +26,7 @@ import {
   type CapacityPlanSlotWindow,
   type CapacityPlanPeriodInput,
 } from '../lib/capacityPlanMaterialisation.js'
+import { syncCapacityProfilesForProject } from '../lib/syncCapacityProfiles.js'
 
 type ApplyPeriodEntry = {
   resourceTypeId: string
@@ -760,6 +761,7 @@ router.post('/apply', asyncHandler(async (req: AuthRequest, res: Response) => {
       data: { weeklyDemandCache: refreshedWeeklyDemandCache },
     })
   }
+  await syncCapacityProfilesForProject(prisma, projectId)
 
   res.status(201).json(plan)
 }))

--- a/server/src/test/backfillCapacityProfiles.test.ts
+++ b/server/src/test/backfillCapacityProfiles.test.ts
@@ -141,6 +141,7 @@ describe('backfillCapacityProfiles', () => {
 
     expect(result.profilesCreated).toBe(1)
     expect(result.segmentsCreated).toBe(0)
+    expect(result.profilesDeleted).toBe(0)
 
     const createCall = vi.mocked(prisma.capacityProfile.create).mock.calls[0][0]
     expect(createCall.data.ownerKind).toBe('ROLE')
@@ -275,6 +276,7 @@ describe('backfillCapacityProfiles', () => {
 
     expect(result.profilesCreated).toBe(1)
     expect(result.segmentsCreated).toBe(0)
+    expect(result.profilesDeleted).toBe(0)
   })
 
   it('running twice does not duplicate profiles (idempotent update)', async () => {
@@ -357,11 +359,13 @@ describe('backfillCapacityProfiles', () => {
     expect(first.profilesCreated).toBe(1)
     expect(first.segmentsCreated).toBe(1)
     expect(first.segmentsDeleted).toBe(0)
+    expect(first.profilesDeleted).toBe(0)
 
     const second = await backfillCapacityProfiles(prisma as any)
     expect(second.profilesCreated).toBe(0)
     expect(second.segmentsCreated).toBe(1)
     expect(second.segmentsDeleted).toBe(1)
+    expect(second.profilesDeleted).toBe(0)
 
     expect(vi.mocked(prisma.capacityProfile.create)).toHaveBeenCalledTimes(1)
     expect(vi.mocked(prisma.capacityProfile.update)).toHaveBeenCalledTimes(1)

--- a/server/src/test/backfillCapacityProfiles.test.ts
+++ b/server/src/test/backfillCapacityProfiles.test.ts
@@ -8,10 +8,27 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { prisma } from '../lib/prisma.js'
 import {
   backfillCapacityProfiles,
-  CapacityProfileValidationError,
 } from '../lib/backfillCapacityProfiles.js'
+import { CapacityProfileValidationError } from '../lib/syncCapacityProfiles.js'
+import { materializeCapacityPlanResources } from '../lib/capacityPlanMaterialisation.js'
+// Override the global sync mock so backfill tests exercise the real implementation
+vi.mock('../lib/syncCapacityProfiles.js', async (importOriginal: () => Promise<any>) => {
+  return await importOriginal()
+})
+vi.mock('../lib/reconcileCapacityProfiles.js', () => ({
+  compareCapacityProfiles: vi.fn().mockReturnValue({
+    mismatches: [],
+    expectedProfiles: 0,
+    actualProfiles: 0,
+    matchedProfiles: 0,
+  }),
+}))
+vi.mock('../lib/capacityPlanMaterialisation.js', () => ({
+  materializeCapacityPlanResources: vi.fn().mockReturnValue(new Map()),
+}))
 
 beforeEach(() => vi.clearAllMocks())
+
 
 // ─── Helpers ───────────────────────────────────────────────────────────────
 
@@ -51,6 +68,19 @@ interface PeriodMock {
   endWeek: number
   entries: Array<{ resourceTypeId: string; headcount: number }>
 }
+interface ProjectStub {
+  id: string
+  resourceTypes: RtMock[]
+  capacityPlans: PlanMock[]
+}
+
+function stubProject(project: ProjectStub) {
+  ;(prisma.project.findMany as any).mockResolvedValue([project])
+  ;(prisma.project.findFirst as any).mockResolvedValue(project)
+  // Sync uses findMany for persisted profiles; default to empty
+  ;(prisma.capacityProfile.findMany as any).mockResolvedValue([])
+}
+
 
 function makeProject(
   id: string,
@@ -59,6 +89,7 @@ function makeProject(
 ) {
   return { id, resourceTypes, capacityPlans }
 }
+
 
 function makeRt(
   id: string,
@@ -102,9 +133,7 @@ function makeNr(
 
 describe('backfillCapacityProfiles', () => {
   it('creates a role-owned profile from a ResourceType with EFFORT → DEMAND_FOLLOWING', async () => {
-    vi.mocked(prisma.project.findMany).mockResolvedValue([
-      makeProject('proj-1', [makeRt('rt-1', 'Engineer', { allocationMode: 'EFFORT' })]),
-    ] as any)
+    stubProject(makeProject('proj-1', [makeRt('rt-1', 'Engineer', { allocationMode: 'EFFORT' })]))
     vi.mocked(prisma.capacityProfile.findFirst).mockResolvedValue(null)
     vi.mocked(prisma.capacityProfile.create).mockResolvedValue({ id: 'cp-1' } as any)
 
@@ -122,16 +151,14 @@ describe('backfillCapacityProfiles', () => {
   })
 
   it('maps TIMELINE → AVAILABILITY_WINDOW preserving percent/start/end', async () => {
-    vi.mocked(prisma.project.findMany).mockResolvedValue([
-      makeProject('proj-1', [
-        makeRt('rt-1', 'Dev', {
-          allocationMode: 'TIMELINE',
-          allocationPercent: 75,
-          allocationStartWeek: 2,
-          allocationEndWeek: 10,
-        }),
-      ]),
-    ] as any)
+    stubProject(makeProject('proj-1', [
+      makeRt('rt-1', 'Dev', {
+        allocationMode: 'TIMELINE',
+        allocationPercent: 75,
+        allocationStartWeek: 2,
+        allocationEndWeek: 10,
+      }),
+    ]))
     vi.mocked(prisma.capacityProfile.findFirst).mockResolvedValue(null)
     vi.mocked(prisma.capacityProfile.create).mockResolvedValue({ id: 'cp-1' } as any)
 
@@ -147,9 +174,7 @@ describe('backfillCapacityProfiles', () => {
   })
 
   it('maps FULL_PROJECT → WHOLE_PROJECT_ALLOCATION', async () => {
-    vi.mocked(prisma.project.findMany).mockResolvedValue([
-      makeProject('proj-1', [makeRt('rt-1', 'PM', { allocationMode: 'FULL_PROJECT' })]),
-    ] as any)
+    stubProject(makeProject('proj-1', [makeRt('rt-1', 'PM', { allocationMode: 'FULL_PROJECT' })]))
     vi.mocked(prisma.capacityProfile.findFirst).mockResolvedValue(null)
     vi.mocked(prisma.capacityProfile.create).mockResolvedValue({ id: 'cp-1' } as any)
 
@@ -161,19 +186,20 @@ describe('backfillCapacityProfiles', () => {
   })
 
   it('maps CAPACITY_PLAN → CAPACITY_PROFILE with segments', async () => {
-    vi.mocked(prisma.project.findMany).mockResolvedValue([
-      makeProject('proj-1', [makeRt('rt-1', 'Engineer', { allocationMode: 'CAPACITY_PLAN' })], [
-        {
-          id: 'plan-1',
-          isActive: true,
-          periods: [
-            { periodIndex: 0, startWeek: 0, endWeek: 8, entries: [{ resourceTypeId: 'rt-1', headcount: 1 }] },
-          ],
-        },
-      ]),
-    ] as any)
+    stubProject(makeProject('proj-1', [makeRt('rt-1', 'Engineer', { allocationMode: 'CAPACITY_PLAN' })], [
+      {
+        id: 'plan-1',
+        isActive: true,
+        periods: [
+          { periodIndex: 0, startWeek: 0, endWeek: 8, entries: [{ resourceTypeId: 'rt-1', headcount: 1 }] },
+        ],
+      },
+    ]))
     vi.mocked(prisma.capacityProfile.findFirst).mockResolvedValue(null)
     vi.mocked(prisma.capacityProfile.create).mockResolvedValue({ id: 'cp-1' } as any)
+    vi.mocked(materializeCapacityPlanResources).mockReturnValue(new Map([
+      ['rt-1', { slotWindows: [{ startWeek: 0, endWeek: 7, allocationPercent: 100 }], totalDays: 0, weeklyHeadcount: new Map(), resourceTypeId: 'rt-1', startWeek: null, endWeek: null }],
+    ]))
 
     await backfillCapacityProfiles(prisma as any)
 
@@ -190,17 +216,15 @@ describe('backfillCapacityProfiles', () => {
   })
 
   it('does not create segments for non-CAPACITY_PLAN mode even with active plan', async () => {
-    vi.mocked(prisma.project.findMany).mockResolvedValue([
-      makeProject('proj-1', [makeRt('rt-1', 'Engineer', { allocationMode: 'EFFORT' })], [
-        {
-          id: 'plan-1',
-          isActive: true,
-          periods: [
-            { periodIndex: 0, startWeek: 0, endWeek: 8, entries: [{ resourceTypeId: 'rt-1', headcount: 1 }] },
-          ],
-        },
-      ]),
-    ] as any)
+    stubProject(makeProject('proj-1', [makeRt('rt-1', 'Engineer', { allocationMode: 'EFFORT' })], [
+      {
+        id: 'plan-1',
+        isActive: true,
+        periods: [
+          { periodIndex: 0, startWeek: 0, endWeek: 8, entries: [{ resourceTypeId: 'rt-1', headcount: 1 }] },
+        ],
+      },
+    ]))
     vi.mocked(prisma.capacityProfile.findFirst).mockResolvedValue(null)
     vi.mocked(prisma.capacityProfile.create).mockResolvedValue({ id: 'cp-1' } as any)
     await backfillCapacityProfiles(prisma as any)
@@ -213,14 +237,12 @@ describe('backfillCapacityProfiles', () => {
   })
 
   it('creates named-person profile from a persisted NamedResource', async () => {
-    vi.mocked(prisma.project.findMany).mockResolvedValue([
-      makeProject('proj-1', [
-        makeRt('rt-1', 'Engineer', {
-          allocationMode: 'EFFORT',
-          namedResources: [makeNr('nr-1', 'Alice')],
-        }),
-      ]),
-    ] as any)
+    stubProject(makeProject('proj-1', [
+      makeRt('rt-1', 'Engineer', {
+        allocationMode: 'EFFORT',
+        namedResources: [makeNr('nr-1', 'Alice')],
+      }),
+    ]))
     vi.mocked(prisma.capacityProfile.findFirst).mockResolvedValue(null)
     vi.mocked(prisma.capacityProfile.create).mockResolvedValue({ id: 'cp-1' } as any)
 
@@ -233,10 +255,7 @@ describe('backfillCapacityProfiles', () => {
   })
 
   it('does not create fake named-person profiles from role count', async () => {
-    // A role with count=3 and no named resources should produce ONE role profile
-    vi.mocked(prisma.project.findMany).mockResolvedValue([
-      makeProject('proj-1', [makeRt('rt-1', 'Engineer', { count: 3, allocationMode: 'EFFORT', namedResources: [] })]),
-    ] as any)
+    stubProject(makeProject('proj-1', [makeRt('rt-1', 'Engineer', { count: 3, allocationMode: 'EFFORT', namedResources: [] })]))
     vi.mocked(prisma.capacityProfile.findFirst).mockResolvedValue(null)
     vi.mocked(prisma.capacityProfile.create).mockResolvedValue({ id: 'cp-1' } as any)
 
@@ -248,9 +267,7 @@ describe('backfillCapacityProfiles', () => {
   })
 
   it('handles missing/inactive capacity plans safely', async () => {
-    vi.mocked(prisma.project.findMany).mockResolvedValue([
-      makeProject('proj-1', [makeRt('rt-1', 'Engineer', { allocationMode: 'EFFORT' })], []),
-    ] as any)
+    stubProject(makeProject('proj-1', [makeRt('rt-1', 'Engineer', { allocationMode: 'EFFORT' })], []))
     vi.mocked(prisma.capacityProfile.findFirst).mockResolvedValue(null)
     vi.mocked(prisma.capacityProfile.create).mockResolvedValue({ id: 'cp-1' } as any)
 
@@ -261,13 +278,12 @@ describe('backfillCapacityProfiles', () => {
   })
 
   it('running twice does not duplicate profiles (idempotent update)', async () => {
-    // First call: no existing profile → create
-    vi.mocked(prisma.project.findMany).mockResolvedValue([
-      makeProject('proj-1', [makeRt('rt-1', 'Engineer', { allocationMode: 'EFFORT' })]),
-    ] as any)
-    vi.mocked(prisma.capacityProfile.findFirst)
-      .mockResolvedValueOnce(null) // first call: no existing
-      .mockResolvedValueOnce({ id: 'cp-1' } as any) // second call: found
+    stubProject(makeProject('proj-1', [makeRt('rt-1', 'Engineer', { allocationMode: 'EFFORT' })]))
+    vi.mocked(prisma.capacityProfile.findMany)
+      .mockResolvedValueOnce([]) // first call 1: no existing
+      .mockResolvedValueOnce([]) // first call 2: reconciliation check
+      .mockResolvedValueOnce([{ id: 'cp-1', ownerKind: 'ROLE', resourceTypeId: 'rt-1', namedResourceId: null, segments: [] }] as any) // second call 1: found
+      .mockResolvedValueOnce([{ id: 'cp-1', ownerKind: 'ROLE', resourceTypeId: 'rt-1', namedResourceId: null, segments: [] }] as any) // second call 2: reconciliation check
     vi.mocked(prisma.capacityProfile.create).mockResolvedValue({ id: 'cp-1' } as any)
     vi.mocked(prisma.capacityProfile.update).mockResolvedValue({ id: 'cp-1' } as any)
     vi.mocked(prisma.capacitySegment.deleteMany).mockResolvedValue({ count: 0 })
@@ -282,10 +298,10 @@ describe('backfillCapacityProfiles', () => {
   })
 
   it('does not modify legacy fields on existing records', async () => {
-    vi.mocked(prisma.project.findMany).mockResolvedValue([
-      makeProject('proj-1', [makeRt('rt-1', 'Engineer', { allocationMode: 'EFFORT' })]),
+    stubProject(makeProject('proj-1', [makeRt('rt-1', 'Engineer', { allocationMode: 'EFFORT' })]))
+    vi.mocked(prisma.capacityProfile.findMany).mockResolvedValue([
+      { id: 'cp-1', ownerKind: 'ROLE', resourceTypeId: 'rt-1', namedResourceId: null, segments: [] },
     ] as any)
-    vi.mocked(prisma.capacityProfile.findFirst).mockResolvedValue({ id: 'cp-1' } as any)
     vi.mocked(prisma.capacityProfile.update).mockResolvedValue({ id: 'cp-1' } as any)
     vi.mocked(prisma.capacitySegment.deleteMany).mockResolvedValue({ count: 0 })
 
@@ -298,16 +314,14 @@ describe('backfillCapacityProfiles', () => {
   })
 
   it('preserves legacy fields in the legacy JSON', async () => {
-    vi.mocked(prisma.project.findMany).mockResolvedValue([
-      makeProject('proj-1', [
-        makeRt('rt-1', 'Engineer', {
-          allocationMode: 'TIMELINE',
-          allocationPercent: 80,
-          allocationStartWeek: 1,
-          allocationEndWeek: 8,
-        }),
-      ]),
-    ] as any)
+    stubProject(makeProject('proj-1', [
+      makeRt('rt-1', 'Engineer', {
+        allocationMode: 'TIMELINE',
+        allocationPercent: 80,
+        allocationStartWeek: 1,
+        allocationEndWeek: 8,
+      }),
+    ]))
     vi.mocked(prisma.capacityProfile.findFirst).mockResolvedValue(null)
     vi.mocked(prisma.capacityProfile.create).mockResolvedValue({ id: 'cp-1' } as any)
 
@@ -325,11 +339,15 @@ describe('backfillCapacityProfiles', () => {
     const proj = makeProject('proj-2', [makeRt('rt-2', 'Dev', { allocationMode: 'CAPACITY_PLAN' })], [
       { id: 'plan-1', isActive: true, periods: [{ periodIndex: 0, startWeek: 0, endWeek: 8, entries: [{ resourceTypeId: 'rt-2', headcount: 1 }] }] },
     ])
-
-    vi.mocked(prisma.project.findMany).mockResolvedValue([proj] as any)
-    vi.mocked(prisma.capacityProfile.findFirst)
-      .mockResolvedValueOnce(null)                // first: no existing → create
-      .mockResolvedValueOnce({ id: 'cp-2' } as any) // second: found → update
+    stubProject(proj)
+    vi.mocked(materializeCapacityPlanResources).mockReturnValue(new Map([
+      ['rt-2', { slotWindows: [{ startWeek: 0, endWeek: 7, allocationPercent: 100 }], totalDays: 0, weeklyHeadcount: new Map(), resourceTypeId: 'rt-2', startWeek: null, endWeek: null }],
+    ]))
+    vi.mocked(prisma.capacityProfile.findMany)
+      .mockResolvedValueOnce([]) // first call 1: no existing → create
+      .mockResolvedValueOnce([]) // first call 2: reconciliation check
+      .mockResolvedValueOnce([{ id: 'cp-2', ownerKind: 'ROLE', resourceTypeId: 'rt-2', namedResourceId: null, segments: [{ startWeek: 0, endWeek: 7, capacityPercent: 100, source: 'SQUAD_PLANNER' }] }] as any) // second call 1: found → update
+      .mockResolvedValueOnce([{ id: 'cp-2', ownerKind: 'ROLE', resourceTypeId: 'rt-2', namedResourceId: null, segments: [{ startWeek: 0, endWeek: 7, capacityPercent: 100, source: 'SQUAD_PLANNER' }] }] as any) // second call 2: reconciliation check
     vi.mocked(prisma.capacityProfile.create).mockResolvedValue({ id: 'cp-2' } as any)
     vi.mocked(prisma.capacityProfile.update).mockResolvedValue({ id: 'cp-2' } as any)
     vi.mocked(prisma.capacitySegment.deleteMany).mockResolvedValue({ count: 1 })

--- a/server/src/test/namedResources.test.ts
+++ b/server/src/test/namedResources.test.ts
@@ -1,0 +1,173 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import request from 'supertest'
+import jwt from 'jsonwebtoken'
+import { app } from '../index.js'
+import { prisma } from '../lib/prisma.js'
+import { syncCapacityProfilesForProject } from '../lib/syncCapacityProfiles.js'
+
+vi.mock('../lib/syncCapacityProfiles.js', () => ({
+  syncCapacityProfilesForProject: vi.fn().mockResolvedValue({
+    profilesCreated: 0,
+    profilesUpdated: 0,
+    profilesDeleted: 0,
+    segmentsCreated: 0,
+    segmentsDeleted: 0,
+  }),
+}))
+
+process.env.JWT_SECRET = 'test-secret'
+
+const userId = 'user-1'
+const token = jwt.sign({ userId }, 'test-secret')
+const authHeader = `Bearer ${token}`
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('named-resource capacity profile sync', () => {
+  it('PUT named-resource update calls sync inside the transaction', async () => {
+    vi.mocked(prisma.project.findFirst).mockResolvedValue({ id: 'proj-1', ownerId: userId } as never)
+    vi.mocked(prisma.resourceType.findFirst).mockResolvedValue({ id: 'rt-1', projectId: 'proj-1', allocationMode: 'EFFORT' } as never)
+    vi.mocked(prisma.namedResource.findFirst).mockResolvedValue({ id: 'nr-1', resourceTypeId: 'rt-1' } as never)
+
+    const tx = {
+      namedResource: { update: vi.fn().mockResolvedValue({ id: 'nr-1', name: 'Updated' }) },
+      project: { update: vi.fn() },
+    }
+    vi.mocked(prisma.$transaction).mockImplementation(async (fn: any) => fn(tx))
+
+    await request(app)
+      .put('/api/projects/proj-1/resource-types/rt-1/named-resources/nr-1')
+      .set('Authorization', authHeader)
+      .send({ name: 'Updated' })
+
+    expect(syncCapacityProfilesForProject).toHaveBeenCalledWith(tx, 'proj-1')
+  })
+
+  it('PATCH named-resource update calls sync inside the transaction', async () => {
+    vi.mocked(prisma.project.findFirst).mockResolvedValue({ id: 'proj-1', ownerId: userId } as never)
+    vi.mocked(prisma.resourceType.findFirst).mockResolvedValue({ id: 'rt-1', projectId: 'proj-1', allocationMode: 'EFFORT' } as never)
+    vi.mocked(prisma.namedResource.findFirst).mockResolvedValue({ id: 'nr-1', resourceTypeId: 'rt-1' } as never)
+
+    const tx = {
+      namedResource: { update: vi.fn().mockResolvedValue({ id: 'nr-1' }) },
+      project: { update: vi.fn() },
+    }
+    vi.mocked(prisma.$transaction).mockImplementation(async (fn: any) => fn(tx))
+
+    await request(app)
+      .patch('/api/projects/proj-1/resource-types/rt-1/named-resources/nr-1')
+      .set('Authorization', authHeader)
+      .send({ allocationMode: 'TIMELINE' })
+
+    expect(syncCapacityProfilesForProject).toHaveBeenCalledWith(tx, 'proj-1')
+  })
+
+  it('sync is called with tx object, not bare prisma, on PUT', async () => {
+    vi.mocked(prisma.project.findFirst).mockResolvedValue({ id: 'proj-1', ownerId: userId } as never)
+    vi.mocked(prisma.resourceType.findFirst).mockResolvedValue({ id: 'rt-1', projectId: 'proj-1', allocationMode: 'EFFORT' } as never)
+    vi.mocked(prisma.namedResource.findFirst).mockResolvedValue({ id: 'nr-1', resourceTypeId: 'rt-1' } as never)
+
+    const tx = {
+      namedResource: { update: vi.fn().mockResolvedValue({ id: 'nr-1', name: 'Updated' }) },
+      project: { update: vi.fn() },
+    }
+    vi.mocked(prisma.$transaction).mockImplementation(async (fn: any) => fn(tx))
+
+    await request(app)
+      .put('/api/projects/proj-1/resource-types/rt-1/named-resources/nr-1')
+      .set('Authorization', authHeader)
+      .send({ name: 'Updated' })
+
+    expect(syncCapacityProfilesForProject).toHaveBeenCalledWith(tx, 'proj-1')
+    expect(syncCapacityProfilesForProject).not.toHaveBeenCalledWith(prisma, 'proj-1')
+  })
+
+  it('DELETE named-resource calls sync after delete and count update, in correct order', async () => {
+    vi.mocked(prisma.project.findFirst).mockResolvedValue({ id: 'proj-1', ownerId: userId } as never)
+    vi.mocked(prisma.resourceType.findFirst).mockResolvedValue({ id: 'rt-1', projectId: 'proj-1', allocationMode: 'EFFORT' } as never)
+    vi.mocked(prisma.namedResource.findFirst).mockResolvedValue({ id: 'nr-1', resourceTypeId: 'rt-1' } as never)
+
+    const deleteFn = vi.fn().mockResolvedValue(undefined)
+    const countFn = vi.fn().mockResolvedValue(0)
+    const updateFn = vi.fn().mockResolvedValue({ id: 'rt-1' })
+    const projectUpdateFn = vi.fn()
+
+    const tx = {
+      namedResource: { delete: deleteFn, count: countFn },
+      resourceType: { update: updateFn },
+      project: { update: projectUpdateFn },
+    }
+    vi.mocked(prisma.$transaction).mockImplementation(async (fn: any) => fn(tx))
+
+    const res = await request(app)
+      .delete('/api/projects/proj-1/resource-types/rt-1/named-resources/nr-1')
+      .set('Authorization', authHeader)
+
+    expect(res.status).toBe(204)
+
+    // Each operation happened
+    expect(deleteFn).toHaveBeenCalledWith({ where: { id: 'nr-1' } })
+    expect(countFn).toHaveBeenCalledWith({ where: { resourceTypeId: 'rt-1' } })
+    expect(updateFn).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: 'rt-1' }, data: { count: 0 } }),
+    )
+    expect(syncCapacityProfilesForProject).toHaveBeenCalledWith(tx, 'proj-1')
+
+    // Call order: delete < count < update < sync
+    expect(deleteFn.mock.invocationCallOrder[0]).toBeLessThan(
+      countFn.mock.invocationCallOrder[0],
+    )
+    expect(countFn.mock.invocationCallOrder[0]).toBeLessThan(
+      updateFn.mock.invocationCallOrder[0],
+    )
+    expect(updateFn.mock.invocationCallOrder[0]).toBeLessThan(
+      vi.mocked(syncCapacityProfilesForProject).mock.invocationCallOrder[0],
+    )
+  })
+
+  it('DELETE sync failure propagates and route returns error', async () => {
+    vi.mocked(prisma.project.findFirst).mockResolvedValue({ id: 'proj-1', ownerId: userId } as never)
+    vi.mocked(prisma.resourceType.findFirst).mockResolvedValue({ id: 'rt-1', projectId: 'proj-1', allocationMode: 'EFFORT' } as never)
+    vi.mocked(prisma.namedResource.findFirst).mockResolvedValue({ id: 'nr-1', resourceTypeId: 'rt-1' } as never)
+
+    vi.mocked(syncCapacityProfilesForProject).mockRejectedValueOnce(new Error('sync failed'))
+
+    const tx = {
+      namedResource: { delete: vi.fn().mockResolvedValue(undefined), count: vi.fn().mockResolvedValue(0) },
+      resourceType: { update: vi.fn().mockResolvedValue({ id: 'rt-1' }) },
+      project: { update: vi.fn() },
+    }
+    vi.mocked(prisma.$transaction).mockImplementation(async (fn: any) => fn(tx))
+
+    const res = await request(app)
+      .delete('/api/projects/proj-1/resource-types/rt-1/named-resources/nr-1')
+      .set('Authorization', authHeader)
+
+    // Sync failure should propagate — not a 204
+    expect(res.status).not.toBe(204)
+  })
+
+  it('PUT sync failure propagates and route returns error', async () => {
+    vi.mocked(prisma.project.findFirst).mockResolvedValue({ id: 'proj-1', ownerId: userId } as never)
+    vi.mocked(prisma.resourceType.findFirst).mockResolvedValue({ id: 'rt-1', projectId: 'proj-1', allocationMode: 'EFFORT' } as never)
+    vi.mocked(prisma.namedResource.findFirst).mockResolvedValue({ id: 'nr-1', resourceTypeId: 'rt-1' } as never)
+
+    vi.mocked(syncCapacityProfilesForProject).mockRejectedValueOnce(new Error('sync failed'))
+
+    const tx = {
+      namedResource: { update: vi.fn().mockResolvedValue({ id: 'nr-1' }) },
+      project: { update: vi.fn() },
+    }
+    vi.mocked(prisma.$transaction).mockImplementation(async (fn: any) => fn(tx))
+
+    const res = await request(app)
+      .put('/api/projects/proj-1/resource-types/rt-1/named-resources/nr-1')
+      .set('Authorization', authHeader)
+      .send({ name: 'Updated' })
+
+    // Sync failure should propagate — not a 200
+    expect(res.status).not.toBe(200)
+  })
+})

--- a/server/src/test/resourceTypes.test.ts
+++ b/server/src/test/resourceTypes.test.ts
@@ -3,7 +3,17 @@ import request from 'supertest'
 import jwt from 'jsonwebtoken'
 import { app } from '../index.js'
 import { prisma } from '../lib/prisma.js'
+import { syncCapacityProfilesForProject } from '../lib/syncCapacityProfiles.js'
 
+vi.mock('../lib/syncCapacityProfiles.js', () => ({
+  syncCapacityProfilesForProject: vi.fn().mockResolvedValue({
+    profilesCreated: 0,
+    profilesUpdated: 0,
+    profilesDeleted: 0,
+    segmentsCreated: 0,
+    segmentsDeleted: 0,
+  }),
+}))
 process.env.JWT_SECRET = 'test-secret'
 
 const userId = 'user-1'
@@ -600,5 +610,90 @@ describe('named-resource auto-name race safety', () => {
     // Names are distinct — the random suffix makes collision astronomically
     // unlikely (one in 2^32 ≈ 4 billion).
     expect(name1).not.toBe(name2)
+  })
+})
+
+describe('capacity profile sync integration', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('PUT calls syncCapacityProfilesForProject inside the transaction', async () => {
+    vi.mocked(prisma.project.findFirst).mockResolvedValue({ id: 'proj-1', ownerId: userId } as never)
+    vi.mocked(prisma.resourceType.findFirst).mockResolvedValue({ id: 'rt-1', projectId: 'proj-1', allocationMode: 'EFFORT' } as never)
+    const tx = {
+      resourceType: { update: vi.fn().mockResolvedValue({ id: 'rt-1', name: 'Updated' }) },
+      namedResource: { updateMany: vi.fn() },
+      project: { update: vi.fn() },
+    }
+    vi.mocked(prisma.$transaction).mockImplementation(async (fn: any) => fn(tx))
+
+    await request(app)
+      .put('/api/projects/proj-1/resource-types/rt-1')
+      .set('Authorization', authHeader)
+      .send({ name: 'Updated' })
+
+    expect(syncCapacityProfilesForProject).toHaveBeenCalledWith(tx, 'proj-1')
+  })
+
+  it('PATCH count increase calls sync after NR creation and count update', async () => {
+    vi.mocked(prisma.project.findFirst).mockResolvedValue({ id: 'proj-1', ownerId: userId } as never)
+    vi.mocked(prisma.resourceType.findFirst).mockResolvedValue({ id: 'rt-1', projectId: 'proj-1', allocationMode: 'EFFORT', name: 'Engineer', allocationPercent: null, allocationStartWeek: null, allocationEndWeek: null } as never)
+    const tx = {
+      namedResource: {
+        findMany: vi.fn().mockResolvedValue([{ id: 'nr-1' }]),
+        create: vi.fn().mockResolvedValue({ id: 'nr-new' }),
+      },
+      resourceType: { update: vi.fn().mockResolvedValue({ id: 'rt-1', count: 2 }) },
+      project: { update: vi.fn() },
+    }
+    vi.mocked(prisma.$transaction).mockImplementation(async (fn: any) => fn(tx))
+
+    await request(app)
+      .patch('/api/projects/proj-1/resource-types/rt-1')
+      .set('Authorization', authHeader)
+      .send({ count: 2 })
+
+    expect(tx.namedResource.create).toHaveBeenCalled()
+    expect(tx.resourceType.update).toHaveBeenCalledWith(expect.objectContaining({ data: { count: 2 } }))
+    expect(syncCapacityProfilesForProject).toHaveBeenCalledWith(tx, 'proj-1')
+  })
+
+  it('DELETE calls sync inside transaction after scoped delete', async () => {
+    vi.mocked(prisma.project.findFirst).mockResolvedValue({ id: 'proj-1', ownerId: userId } as never)
+    const tx = {
+      resourceType: {
+        deleteMany: vi.fn().mockResolvedValue({ count: 1 }),
+      },
+      project: { update: vi.fn() },
+    }
+    vi.mocked(prisma.$transaction).mockImplementation(async (fn: any) => fn(tx))
+
+    await request(app)
+      .delete('/api/projects/proj-1/resource-types/rt-1')
+      .set('Authorization', authHeader)
+
+    expect(tx.resourceType.deleteMany).toHaveBeenCalledWith({
+      where: { id: 'rt-1', projectId: 'proj-1' },
+    })
+    expect(syncCapacityProfilesForProject).toHaveBeenCalledWith(tx, 'proj-1')
+  })
+
+  it('sync is called with tx object, not bare prisma', async () => {
+    vi.mocked(prisma.project.findFirst).mockResolvedValue({ id: 'proj-1', ownerId: userId } as never)
+    vi.mocked(prisma.resourceType.findFirst).mockResolvedValue({ id: 'rt-1', projectId: 'proj-1', allocationMode: 'EFFORT' } as never)
+    const tx = {
+      resourceType: { update: vi.fn().mockResolvedValue({ id: 'rt-1', name: 'Updated' }) },
+      namedResource: { updateMany: vi.fn() },
+      project: { update: vi.fn() },
+    }
+    vi.mocked(prisma.$transaction).mockImplementation(async (fn: any) => fn(tx))
+
+    await request(app)
+      .put('/api/projects/proj-1/resource-types/rt-1')
+      .set('Authorization', authHeader)
+      .send({ name: 'Updated' })
+
+    // Must be called with the transaction object, not bare prisma
+    expect(syncCapacityProfilesForProject).toHaveBeenCalledWith(tx, 'proj-1')
+    expect(syncCapacityProfilesForProject).not.toHaveBeenCalledWith(prisma, 'proj-1')
   })
 })

--- a/server/src/test/setup.ts
+++ b/server/src/test/setup.ts
@@ -78,3 +78,14 @@ vi.mock('../lib/prisma.js', () => {
     },
   }
 })
+
+// Mock syncCapacityProfilesForProject so route tests don't need per-file mocks
+vi.mock('../lib/syncCapacityProfiles.js', () => ({
+  syncCapacityProfilesForProject: vi.fn().mockResolvedValue({
+    profilesCreated: 0,
+    profilesUpdated: 0,
+    profilesDeleted: 0,
+    segmentsCreated: 0,
+    segmentsDeleted: 0,
+  }),
+}))

--- a/server/src/test/setup.ts
+++ b/server/src/test/setup.ts
@@ -79,13 +79,3 @@ vi.mock('../lib/prisma.js', () => {
   }
 })
 
-// Mock syncCapacityProfilesForProject so route tests don't need per-file mocks
-vi.mock('../lib/syncCapacityProfiles.js', () => ({
-  syncCapacityProfilesForProject: vi.fn().mockResolvedValue({
-    profilesCreated: 0,
-    profilesUpdated: 0,
-    profilesDeleted: 0,
-    segmentsCreated: 0,
-    segmentsDeleted: 0,
-  }),
-}))

--- a/server/src/test/syncCapacityProfiles.test.ts
+++ b/server/src/test/syncCapacityProfiles.test.ts
@@ -295,4 +295,79 @@ describe('syncCapacityProfilesForProject', () => {
     expect(prisma.capacityProfile.create).toHaveBeenCalled()
     expect(prisma.capacitySegment.create).not.toHaveBeenCalled()
   })
+  it('updates existing NAMED_PERSON profile instead of creating/deleting', async () => {
+    vi.mocked(prisma.project.findFirst).mockResolvedValue(
+      mockProject('proj-1', [makeRt('rt-1', 'Engineer', { namedResources: [{ id: 'nr-1', name: 'Alice', allocationPct: 100, allocationMode: null, allocationPercent: null, allocationStartWeek: null, allocationEndWeek: null, startWeek: null, endWeek: null, createdAt: new Date() }] })]),
+    )
+    vi.mocked(mapProjectToCapacityProfiles).mockReturnValue([
+      {
+        id: 'rt-1',
+        projectId: 'proj-1',
+        owner: { kind: 'namedPerson', id: 'nr-1', name: 'Alice' },
+        planningBasis: 'demandFollowing',
+        source: 'fixed',
+        defaultPercent: 100,
+        startWeek: null,
+        endWeek: null,
+        segments: [],
+        legacy: null as any,
+      },
+    ])
+    // Persisted profile has NAMED_PERSON (Prisma enum) — should match namedPerson (DTO)
+    vi.mocked(prisma.capacityProfile.findMany).mockResolvedValue([
+      { id: 'cp-nr-1', ownerKind: 'NAMED_PERSON', resourceTypeId: null, namedResourceId: 'nr-1', segments: [] },
+    ] as any)
+    vi.mocked(prisma.capacityProfile.update).mockResolvedValue({} as any)
+    vi.mocked(prisma.capacitySegment.deleteMany).mockResolvedValue({ count: 0 } as any)
+
+    const result = await syncCapacityProfilesForProject(prisma, 'proj-1')
+
+    expect(result.profilesUpdated).toBe(1)
+    expect(result.profilesCreated).toBe(0)
+    expect(result.profilesDeleted).toBe(0)
+    expect(prisma.capacityProfile.update).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: 'cp-nr-1' } }),
+    )
+    expect(prisma.capacityProfile.create).not.toHaveBeenCalled()
+  })
+
+  it('updates existing PLANNED_RESOURCE profile instead of creating/deleting', async () => {
+    vi.mocked(prisma.project.findFirst).mockResolvedValue(
+      mockProject('proj-1', [makeRt('rt-1', 'Engineer', { namedResources: [{ id: 'nr-planned', name: 'Planned Dev', allocationPct: 100, allocationMode: null, allocationPercent: null, allocationStartWeek: null, allocationEndWeek: null, startWeek: null, endWeek: null, createdAt: new Date() }] })]),
+    )
+    vi.mocked(mapProjectToCapacityProfiles).mockReturnValue([
+      {
+        id: 'rt-1',
+        projectId: 'proj-1',
+        owner: { kind: 'plannedResource', id: 'nr-planned', name: 'Planned Dev' },
+        planningBasis: 'capacityProfile',
+        source: 'squadPlanner',
+        defaultPercent: 100,
+        startWeek: null,
+        endWeek: null,
+        segments: [
+          { id: 'seg-1', startWeek: 0, endWeek: 8, capacityPercent: 100, source: 'squadPlanner' },
+        ],
+        legacy: null as any,
+      },
+    ])
+    // Persisted profile has PLANNED_RESOURCE (Prisma enum) — should match plannedResource (DTO)
+    vi.mocked(prisma.capacityProfile.findMany).mockResolvedValue([
+      { id: 'cp-pr-1', ownerKind: 'PLANNED_RESOURCE', resourceTypeId: null, namedResourceId: 'nr-planned', segments: [] },
+    ] as any)
+    vi.mocked(prisma.capacityProfile.update).mockResolvedValue({} as any)
+    vi.mocked(prisma.capacitySegment.deleteMany).mockResolvedValue({ count: 0 } as any)
+    vi.mocked(prisma.capacitySegment.create).mockResolvedValue({ id: 'seg-new' } as any)
+
+    const result = await syncCapacityProfilesForProject(prisma, 'proj-1')
+
+    expect(result.profilesUpdated).toBe(1)
+    expect(result.profilesCreated).toBe(0)
+    expect(result.profilesDeleted).toBe(0)
+    expect(prisma.capacityProfile.update).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: 'cp-pr-1' } }),
+    )
+    expect(prisma.capacityProfile.create).not.toHaveBeenCalled()
+  })
+
 })

--- a/server/src/test/syncCapacityProfiles.test.ts
+++ b/server/src/test/syncCapacityProfiles.test.ts
@@ -1,0 +1,298 @@
+/**
+ * syncCapacityProfiles.test.ts — Tests for the runtime sync helper.
+ *
+ * Covers profile creation, update, segment replacement, stale-profile
+ * deletion, idempotency, reconciliation failure, and empty segments.
+ * Uses mocked Prisma client via the global test setup.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { prisma } from '../lib/prisma.js'
+
+// Override the global sync mock so we test the real implementation
+vi.mock('../lib/syncCapacityProfiles.js', async (importOriginal: () => Promise<any>) => {
+  return await importOriginal()
+})
+
+// Mock only the dependencies that are hard to set up via Prisma mocks
+vi.mock('../lib/capacityProfileMapping.js', () => ({
+  mapProjectToCapacityProfiles: vi.fn(),
+}))
+
+vi.mock('../lib/capacityPlanMaterialisation.js', () => ({
+  materializeCapacityPlanResources: vi.fn().mockReturnValue(new Map()),
+}))
+
+vi.mock('../lib/reconcileCapacityProfiles.js', () => ({
+  compareCapacityProfiles: vi.fn().mockReturnValue({ mismatches: [], expectedProfiles: 0, actualProfiles: 0, matchedProfiles: 0 }),
+}))
+
+// Import AFTER vi.mock calls so the mocks are in place
+import { syncCapacityProfilesForProject } from '../lib/syncCapacityProfiles.js'
+import { mapProjectToCapacityProfiles } from '../lib/capacityProfileMapping.js'
+import { compareCapacityProfiles } from '../lib/reconcileCapacityProfiles.js'
+
+beforeEach(() => vi.clearAllMocks())
+
+// ─── Helpers ───────────────────────────────────────────────────────────────
+
+function makeRt(
+  id: string,
+  name: string,
+  overrides: Record<string, unknown> = {},
+) {
+  return {
+    id,
+    name,
+    allocationMode: 'EFFORT',
+    allocationPercent: 100,
+    allocationStartWeek: null,
+    allocationEndWeek: null,
+    namedResources: [],
+    ...overrides,
+  }
+}
+
+function mockProject(
+  id: string,
+  resourceTypes: any[],
+  capacityPlans: any[] = [],
+): any {
+  return { id, resourceTypes, capacityPlans } as any
+}
+
+// ─── Tests ─────────────────────────────────────────────────────────────────
+
+describe('syncCapacityProfilesForProject', () => {
+  it('creates persisted capacity profiles for a project with no existing profiles', async () => {
+    vi.mocked(prisma.project.findFirst).mockResolvedValue(
+      mockProject('proj-1', [makeRt('rt-1', 'Engineer')]),
+    )
+    vi.mocked(mapProjectToCapacityProfiles).mockReturnValue([
+      {
+        id: 'rt-1',
+        projectId: 'proj-1',
+        owner: { kind: 'role', id: 'rt-1', name: 'Engineer' },
+        planningBasis: 'demandFollowing',
+        source: 'fixed',
+        defaultPercent: 100,
+        startWeek: null,
+        endWeek: null,
+        segments: [],
+        legacy: null as any,
+      },
+    ])
+    vi.mocked(prisma.capacityProfile.findMany).mockResolvedValue([])
+    vi.mocked(prisma.capacityProfile.create).mockResolvedValue({ id: 'cp-1' } as any)
+
+    const result = await syncCapacityProfilesForProject(prisma, 'proj-1')
+
+    expect(result.profilesCreated).toBe(1)
+    expect(result.profilesUpdated).toBe(0)
+    expect(result.profilesDeleted).toBe(0)
+    expect(prisma.capacityProfile.create).toHaveBeenCalled()
+    expect(prisma.capacityProfile.update).not.toHaveBeenCalled()
+  })
+
+  it('updates existing profile fields when legacy allocation fields change', async () => {
+    vi.mocked(prisma.project.findFirst).mockResolvedValue(
+      mockProject('proj-1', [makeRt('rt-1', 'Engineer', { allocationPercent: 75 })]),
+    )
+    vi.mocked(mapProjectToCapacityProfiles).mockReturnValue([
+      {
+        id: 'rt-1',
+        projectId: 'proj-1',
+        owner: { kind: 'role', id: 'rt-1', name: 'Engineer' },
+        planningBasis: 'demandFollowing',
+        source: 'fixed',
+        defaultPercent: 75,
+        startWeek: null,
+        endWeek: null,
+        segments: [],
+        legacy: null as any,
+      },
+    ])
+    vi.mocked(prisma.capacityProfile.findMany).mockResolvedValue([
+      { id: 'cp-1', ownerKind: 'ROLE', resourceTypeId: 'rt-1', namedResourceId: null, segments: [] },
+    ] as any)
+    vi.mocked(prisma.capacityProfile.update).mockResolvedValue({} as any)
+    vi.mocked(prisma.capacitySegment.deleteMany).mockResolvedValue({ count: 0 } as any)
+
+    const result = await syncCapacityProfilesForProject(prisma, 'proj-1')
+
+    expect(result.profilesUpdated).toBe(1)
+    expect(result.profilesCreated).toBe(0)
+    expect(prisma.capacityProfile.update).toHaveBeenCalled()
+    expect(prisma.capacityProfile.create).not.toHaveBeenCalled()
+  })
+
+  it('replaces segments deterministically when active capacity plan periods change', async () => {
+    vi.mocked(prisma.project.findFirst).mockResolvedValue(
+      mockProject('proj-1', [makeRt('rt-1', 'Engineer')], [{ isActive: true }]),
+    )
+    vi.mocked(mapProjectToCapacityProfiles).mockReturnValue([
+      {
+        id: 'rt-1',
+        projectId: 'proj-1',
+        owner: { kind: 'role', id: 'rt-1', name: 'Engineer' },
+        planningBasis: 'capacityProfile',
+        source: 'squadPlanner',
+        defaultPercent: 100,
+        startWeek: null,
+        endWeek: null,
+        segments: [
+          { id: 'seg-1', startWeek: 0, endWeek: 7, capacityPercent: 100, source: 'squadPlanner' },
+        ],
+        legacy: null as any,
+      },
+    ])
+    vi.mocked(prisma.capacityProfile.findMany).mockResolvedValue([
+      { id: 'cp-1', ownerKind: 'ROLE', resourceTypeId: 'rt-1', namedResourceId: null, segments: [{ startWeek: 0, endWeek: 3, capacityPercent: 50, source: 'SQUAD_PLANNER' }] },
+    ] as any)
+    vi.mocked(prisma.capacityProfile.update).mockResolvedValue({} as any)
+    vi.mocked(prisma.capacitySegment.deleteMany).mockResolvedValue({ count: 1 } as any)
+    vi.mocked(prisma.capacitySegment.create).mockResolvedValue({ id: 'seg-new' } as any)
+
+    const result = await syncCapacityProfilesForProject(prisma, 'proj-1')
+
+    expect(result.segmentsDeleted).toBeGreaterThanOrEqual(1)
+    expect(result.segmentsCreated).toBe(1)
+    expect(prisma.capacitySegment.deleteMany).toHaveBeenCalled()
+    expect(prisma.capacitySegment.create).toHaveBeenCalled()
+  })
+
+  it('deletes stale persisted profiles when a resource type no longer maps', async () => {
+    vi.mocked(prisma.project.findFirst).mockResolvedValue(
+      mockProject('proj-1', [makeRt('rt-1', 'Engineer')]),
+    )
+    vi.mocked(mapProjectToCapacityProfiles).mockReturnValue([
+      {
+        id: 'rt-1',
+        projectId: 'proj-1',
+        owner: { kind: 'role', id: 'rt-1', name: 'Engineer' },
+        planningBasis: 'demandFollowing',
+        source: 'fixed',
+        defaultPercent: 100,
+        startWeek: null,
+        endWeek: null,
+        segments: [],
+        legacy: null as any,
+      },
+    ])
+    // Two persisted profiles but only one expected — the second should be deleted
+    vi.mocked(prisma.capacityProfile.findMany).mockResolvedValue([
+      { id: 'cp-1', ownerKind: 'ROLE', resourceTypeId: 'rt-1', namedResourceId: null, segments: [] },
+      { id: 'cp-stale', ownerKind: 'ROLE', resourceTypeId: 'rt-deleted', namedResourceId: null, segments: [] },
+    ] as any)
+    vi.mocked(prisma.capacityProfile.update).mockResolvedValue({} as any)
+    vi.mocked(prisma.capacitySegment.deleteMany).mockResolvedValue({ count: 0 } as any)
+    vi.mocked(prisma.capacityProfile.delete).mockResolvedValue({} as any)
+
+    const result = await syncCapacityProfilesForProject(prisma, 'proj-1')
+
+    expect(result.profilesDeleted).toBe(1)
+    expect(result.profilesUpdated).toBe(1)
+    expect(prisma.capacityProfile.delete).toHaveBeenCalledWith({ where: { id: 'cp-stale' } })
+  })
+
+  it('is idempotent: running twice produces the same result', async () => {
+    vi.mocked(prisma.project.findFirst).mockResolvedValue(
+      mockProject('proj-1', [makeRt('rt-1', 'Engineer')]),
+    )
+    vi.mocked(mapProjectToCapacityProfiles).mockReturnValue([
+      {
+        id: 'rt-1',
+        projectId: 'proj-1',
+        owner: { kind: 'role', id: 'rt-1', name: 'Engineer' },
+        planningBasis: 'demandFollowing',
+        source: 'fixed',
+        defaultPercent: 100,
+        startWeek: null,
+        endWeek: null,
+        segments: [],
+        legacy: null as any,
+      },
+    ])
+    // Persisted already matches expected — only updates, no creates or deletes
+    vi.mocked(prisma.capacityProfile.findMany).mockResolvedValue([
+      { id: 'cp-1', ownerKind: 'ROLE', resourceTypeId: 'rt-1', namedResourceId: null, segments: [] },
+    ] as any)
+    vi.mocked(prisma.capacityProfile.update).mockResolvedValue({} as any)
+    vi.mocked(prisma.capacitySegment.deleteMany).mockResolvedValue({ count: 0 } as any)
+
+    const result = await syncCapacityProfilesForProject(prisma, 'proj-1')
+
+    expect(result.profilesCreated).toBe(0)
+    expect(result.profilesDeleted).toBe(0)
+    expect(result.profilesUpdated).toBe(1)
+  })
+
+  it('throws on reconciliation failure after sync', async () => {
+    vi.mocked(prisma.project.findFirst).mockResolvedValue(
+      mockProject('proj-1', [makeRt('rt-1', 'Engineer')]),
+    )
+    vi.mocked(mapProjectToCapacityProfiles).mockReturnValue([
+      {
+        id: 'rt-1',
+        projectId: 'proj-1',
+        owner: { kind: 'role', id: 'rt-1', name: 'Engineer' },
+        planningBasis: 'demandFollowing',
+        source: 'fixed',
+        defaultPercent: 100,
+        startWeek: null,
+        endWeek: null,
+        segments: [],
+        legacy: null as any,
+      },
+    ])
+    vi.mocked(prisma.capacityProfile.findMany)
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([
+        { id: 'cp-1', ownerKind: 'ROLE', resourceTypeId: 'rt-1', namedResourceId: null, segments: [] },
+      ] as any)
+    vi.mocked(prisma.capacityProfile.create).mockResolvedValue({ id: 'cp-1' } as any)
+
+    // Simulate reconciliation failure after sync
+    vi.mocked(compareCapacityProfiles).mockReturnValue({
+      mismatches: [{ projectId: 'proj-1', ownerKind: 'role', ownerId: 'rt-1', type: 'segmentMismatch', message: 'mismatch', expected: 0, actual: 1 }],
+      expectedProfiles: 1,
+      actualProfiles: 1,
+      matchedProfiles: 0,
+    })
+
+    await expect(
+      syncCapacityProfilesForProject(prisma, 'proj-1'),
+    ).rejects.toThrow('Reconciliation failed')
+  })
+
+  it('handles empty segments correctly for non-CAPACITY_PLAN modes', async () => {
+    vi.mocked(prisma.project.findFirst).mockResolvedValue(
+      mockProject('proj-1', [makeRt('rt-1', 'Engineer')]),
+    )
+    vi.mocked(mapProjectToCapacityProfiles).mockReturnValue([
+      {
+        id: 'rt-1',
+        projectId: 'proj-1',
+        owner: { kind: 'role', id: 'rt-1', name: 'Engineer' },
+        planningBasis: 'demandFollowing',
+        source: 'fixed',
+        defaultPercent: 100,
+        startWeek: null,
+        endWeek: null,
+        segments: [], // No segments for non-CAPACITY_PLAN
+        legacy: null as any,
+      },
+    ])
+    vi.mocked(prisma.capacityProfile.findMany).mockResolvedValue([])
+    vi.mocked(prisma.capacityProfile.create).mockResolvedValue({ id: 'cp-1' } as any)
+    // Ensure reconciliation passes
+    vi.mocked(compareCapacityProfiles).mockReturnValue({ mismatches: [], expectedProfiles: 1, actualProfiles: 1, matchedProfiles: 1 })
+
+    const result = await syncCapacityProfilesForProject(prisma, 'proj-1')
+
+    expect(result.profilesCreated).toBe(1)
+    expect(result.segmentsCreated).toBe(0)
+    // Profile created with no nested segments
+    expect(prisma.capacityProfile.create).toHaveBeenCalled()
+    expect(prisma.capacitySegment.create).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
Refs #326

## Summary

Adds `syncCapacityProfilesForProject` — an idempotent helper that keeps the additive `CapacityProfile`/`CapacitySegment` read model in sync with legacy planning fields. When legacy write paths update `ResourceType`, `NamedResource`, or project data, the sync helper ensures persisted capacity profiles match the mapper-derived expected profiles.

**Legacy fields remain authoritative.** The sync is a derived write that keeps the read model current, not a source-of-truth migration.

## Sync behaviour

1. Fetch project with resource types, named resources, and active capacity plan.
2. Derive expected DTOs via `mapProjectToCapacityProfiles`.
3. Build persisted-profile lookup using `prismaOwnerKindToDtoKind` for stable key matching.
4. Upsert `CapacityProfile` rows to match expected.
5. Replace segments (delete all, recreate) for each profile.
6. Delete stale profiles no longer corresponding to expected owners.
7. Reconcile via `compareCapacityProfiles`; throw on mismatch.

## Write paths integrated

| Route | Change |
|---|---|
| `PUT /api/projects/:projectId/resource-types/:id` | Inside \$transaction, after RT update |
| `PATCH /api/projects/:projectId/resource-types/:id` | Inside \$transaction, after count change + NR creation/deletion |
| `DELETE /api/projects/:projectId/resource-types/:id` | Inside \$transaction, after RT delete |
| `POST /api/projects/:projectId/resource-types/:rtId/named-resources` | Inside \$transaction, after NR create + count update |
| `PUT /api/projects/:projectId/resource-types/:rtId/named-resources/:id` | Inside \$transaction, after NR update |
| `PATCH /api/projects/:projectId/resource-types/:rtId/named-resources/:id` | Inside \$transaction, after NR update |
| `DELETE /api/projects/:projectId/resource-types/:rtId/named-resources/:id` | Inside \$transaction, after NR delete + RT count update |
| `POST /api/projects` | After project creation |

## Transactionality

All routes that use \$transaction have the sync call inside the same transaction — sync failure rolls back the legacy write. Named-resource DELETE ensures sync runs after the resource-type count is updated. Route-level tests verify call ordering (delete → count → update → sync).

## Owner-key normalization

Persisted-profile lookup uses `prismaOwnerKindToDtoKind` to map Prisma enum values (`NAMED_PERSON`, `PLANNED_RESOURCE`) to DTO format (`namedPerson`, `plannedResource`), ensuring stable persisted IDs across syncs.

## Squad-plan apply — deferred

Squad-plan apply sync is **not** in this PR. The apply route does not use a single transaction, so wiring sync as best-effort would be unsafe. Will be added in a follow-up that wraps apply in a single transaction.

## Scope exclusions — unchanged

- Prisma schema and migrations: **empty diff**
- API response DTO shape: **unchanged**
- Read-only `GET /capacity-profiles` endpoint: **unchanged**
- Commercial calculations: **not modified**
- Exports: **not modified**
- Scheduler/leveller behaviour: **not modified**
- Squad Planner algorithms: **not modified**
- UI: **not modified**
- Dependencies: **not updated**

## Tests — 498 passing (32 test files), up from 479

### New sync helper tests (9)
1. Creates persisted capacity profiles for a project with no existing profiles
2. Updates existing profile fields when legacy allocation fields change
3. Replaces segments deterministically when active capacity plan periods change
4. Deletes stale persisted profiles when a resource type no longer maps
5. Is idempotent: running twice produces the same result
6. Throws on reconciliation failure after sync
7. Handles empty segments correctly for non-CAPACITY_PLAN modes
8. Updates existing NAMED_PERSON profile instead of creating/deleting
9. Updates existing PLANNED_RESOURCE profile instead of creating/deleting

### New route-level sync tests (10)
1. PUT resource-type calls sync inside transaction after RT update
2. PATCH resource-type count increase calls sync after NR creation and count update
3. DELETE resource-type calls sync inside transaction after scoped delete
4. Resource-type sync is called with tx object, not bare prisma
5. PUT named-resource update calls sync inside the transaction
6. PATCH named-resource update calls sync inside the transaction
7. Named-resource sync is called with tx object, not bare prisma
8. DELETE named-resource calls sync after delete and count update, in correct order
9. DELETE named-resource sync failure propagates and route returns error
10. PUT named-resource sync failure propagates and route returns error

### Updated existing tests
- Backfill tests updated with `profilesDeleted` assertions
- Global test setup no longer mocks `syncCapacityProfilesForProject`

## Files changed

| File | Changes |
|---|---|
| `server/src/lib/syncCapacityProfiles.ts` | Added `prismaOwnerKindToDtoKind` helper, fixed lookup key |
| `server/src/lib/backfillCapacityProfiles.ts` | Added `profilesDeleted` to BackfillResult |
| `server/src/routes/resourceTypes.ts` | Added sync to PATCH route |
| `server/src/routes/namedResources.ts` | Moved sync after RT count update in DELETE |
| `server/src/routes/squadPlan.ts` | Removed sync call and import (deferred) |
| `server/src/test/setup.ts` | Removed global sync mock |
| `server/src/test/backfillCapacityProfiles.test.ts` | Added profilesDeleted assertions |
| `server/src/test/resourceTypes.test.ts` | Added sync mock and 4 route-level sync tests |
| `server/src/test/namedResources.test.ts` | New — 6 named-resource route-level sync tests |
| `server/src/test/syncCapacityProfiles.test.ts` | Added NAMED_PERSON and PLANNED_RESOURCE update tests |
| `docs/domain/capacity-profile-design.md` | Updated integration list, deferral note, normalization docs |

## Follow-ups

- Wrap squad-plan apply in a single transaction and wire sync atomically
- Add route-level integration tests verifying persisted DTOs after writes
- Runtime write adoption: make CapacityProfile the source of truth (future PR)

Do not merge. Wait for review.