### PR TITLE
feat: sync capacity profiles during squad plan apply

### DIFF
--- a/docs/domain/capacity-profile-design.md
+++ b/docs/domain/capacity-profile-design.md
@@ -393,14 +393,14 @@ The helper is called inside existing write transactions:
 - `PATCH /api/projects/:projectId/resource-types/:rtId/named-resources/:id` — named resource allocation update
 - `DELETE /api/projects/:projectId/resource-types/:rtId/named-resources/:id` — named resource deletion (after RT count update)
 - `POST /api/projects` — project creation
-
-**Deferred:** Squad-plan apply sync is not yet atomic with legacy writes. It will be wired in a follow-up PR that wraps the apply route in a single transaction.
+- `POST /api/projects/:projectId/squad-plan/apply` — squad plan apply (transactional, inside same transaction as RT/NR writes)
 
 ### Write transactionality
 
 - Routes that use `prisma.$transaction` have the sync call inside the same transaction, so sync failure rolls back the legacy write.
 - Named-resource DELETE ensures sync runs after the resource-type count is updated, so the persisted profile reflects the final count.
 - Owner-key normalization uses `prismaOwnerKindToDtoKind` to map Prisma enum values (`NAMED_PERSON`, `PLANNED_RESOURCE`) to DTO format (`namedPerson`, `plannedResource`), ensuring stable persisted IDs across syncs.
+- Squad-plan apply wraps plan creation, RT/NR updates, and sync in a single `$transaction`. Timeline materialisation (epic start weeks, timeline entries, weekly demand cache) runs after the transaction — these downstream writes do not affect capacity profile output.
 
 ### Backfill refactor
 

--- a/server/src/routes/squadPlan.ts
+++ b/server/src/routes/squadPlan.ts
@@ -26,6 +26,7 @@ import {
   type CapacityPlanSlotWindow,
   type CapacityPlanPeriodInput,
 } from '../lib/capacityPlanMaterialisation.js'
+import { syncCapacityProfilesForProject } from '../lib/syncCapacityProfiles.js'
 
 type ApplyPeriodEntry = {
   resourceTypeId: string
@@ -434,137 +435,145 @@ router.post('/apply', asyncHandler(async (req: AuthRequest, res: Response) => {
   })
   await pruneSnapshots(prisma, projectId)
 
-  // ── 2. Deactivate existing active plans ─────────────────────────────────
+
+  // ── 2. Compute planner-derived values from request data (no DB) ──────────
+  let maxHeadcountByRt: Map<string, number> | undefined
+  let slotWindowsByRt: Map<string, CapacityPlanSlotWindow[]> | undefined
   if (shouldActivate) {
-    await prisma.capacityPlan.updateMany({
-      where: { projectId, isActive: true },
-      data: { isActive: false },
-    })
-  }
-
-  // ── 3. Create the new plan with nested periods & entries ────────────────
-  const plan = await prisma.capacityPlan.create({
-    data: {
-      projectId,
-      name,
-      targetWeeks,
-      periodWeeks,
-      maxDelta,
-      isActive: shouldActivate,
-      totalCost,
-      deliveryWeeks,
-      periods: {
-        create: normalisedPeriods.map(p => ({
-          periodIndex: p.periodIndex,
-          startWeek: p.startWeek,
-          endWeek: p.endWeek,
-          entries: {
-            create: p.entries.map(e => ({
-              resourceTypeId: e.resourceTypeId,
-              headcount: e.headcount,
-              demandFTE: e.demandFTE,
-              utilisationPct: e.utilisationPct,
-            })),
-          },
-        })),
-      },
-    },
-    include: { periods: { include: { entries: true } } },
-  })
-
-  // ── 4. Update RT counts + allocation mode, re-run scheduler ─────────────
-  if (shouldActivate) {
-    let refreshedWeeklyDemandCache: Record<string, number>
-
-    // Compute max headcount per RT across all periods
-    const maxHeadcountByRt = new Map<string, number>()
+    maxHeadcountByRt = new Map<string, number>()
     for (const p of normalisedPeriods) {
       for (const e of p.entries) {
         const current = maxHeadcountByRt.get(e.resourceTypeId) ?? 0
         maxHeadcountByRt.set(e.resourceTypeId, Math.max(current, e.headcount))
       }
     }
+    slotWindowsByRt = deriveSlotWindowsByResourceType(normalisedPeriods)
+  }
 
-    // Update RT counts and allocation mode for demand RTs
-    for (const [rtId, count] of maxHeadcountByRt) {
-      await prisma.resourceType.update({
-        where: { id: rtId },
-        data: { count: Math.max(1, Math.ceil(count)), allocationMode: 'CAPACITY_PLAN' },
+  // ── 3. Transaction: plan + capacity-profile-affecting writes + sync ──────
+  const plan = await prisma.$transaction(async tx => {
+    // Deactivate existing active plans
+    if (shouldActivate) {
+      await tx.capacityPlan.updateMany({
+        where: { projectId, isActive: true },
+        data: { isActive: false },
       })
     }
 
-    // Also set ALL other project RTs to CAPACITY_PLAN (overhead RTs keep their count)
-    await prisma.resourceType.updateMany({
-      where: { projectId, id: { notIn: [...maxHeadcountByRt.keys()] } },
-      data: { allocationMode: 'CAPACITY_PLAN' },
+    // Create the new plan with nested periods & entries
+    const createdPlan = await tx.capacityPlan.create({
+      data: {
+        projectId,
+        name,
+        targetWeeks,
+        periodWeeks,
+        maxDelta,
+        isActive: shouldActivate,
+        totalCost,
+        deliveryWeeks,
+        periods: {
+          create: normalisedPeriods.map(p => ({
+            periodIndex: p.periodIndex,
+            startWeek: p.startWeek,
+            endWeek: p.endWeek,
+            entries: {
+              create: p.entries.map(e => ({
+                resourceTypeId: e.resourceTypeId,
+                headcount: e.headcount,
+                demandFTE: e.demandFTE,
+                utilisationPct: e.utilisationPct,
+              })),
+            },
+          })),
+        },
+      },
+      include: { periods: { include: { entries: true } } },
     })
 
-    // Update ALL named resources allocation mode
-    await prisma.namedResource.updateMany({
-      where: { resourceType: { projectId } },
-      data: { allocationMode: 'CAPACITY_PLAN' },
-    })
-
-    // ── Compute fractional-aware slot windows per RT ──────────────────────────
-    // Uses the shared materialisation library so fractional headcount (e.g. 0.25,
-    // 1.25) produces the correct number of NR windows with the right
-    // allocationPercent values (e.g. 0.25 HC → one window at 25%).
-    const slotWindowsByRt = deriveSlotWindowsByResourceType(normalisedPeriods)
-
-    // ── Auto-create missing NRs then assign slot windows ────────────────────
-    for (const [rtId] of maxHeadcountByRt) {
-      const slotWindows = slotWindowsByRt.get(rtId) ?? []
-
-      // Fetch existing NRs with stable ordering (oldest first = lowest id)
-      const existingNRs = await prisma.namedResource.findMany({
-        where: { resourceTypeId: rtId },
-        orderBy: { id: 'asc' },
-        select: { id: true },
-      })
-
-      const missing = Math.max(0, slotWindows.length - existingNRs.length)
-      if (missing > 0) {
-        const rt = await prisma.resourceType.findUnique({
+    // Update RT counts + allocation mode + NR assignments (capacity-profile-affecting)
+    if (shouldActivate && maxHeadcountByRt && slotWindowsByRt) {
+      // Update RT counts and allocation mode for demand RTs
+      for (const [rtId, count] of maxHeadcountByRt) {
+        await tx.resourceType.update({
           where: { id: rtId },
-          select: { name: true },
+          data: { count: Math.max(1, Math.ceil(count)), allocationMode: 'CAPACITY_PLAN' },
         })
-        const baseName = rt?.name ?? 'Resource'
-        const startIndex = existingNRs.length + 1
-        const newNRs = Array.from({ length: missing }, (_, i) => ({
-          resourceTypeId: rtId,
-          name: `${baseName} ${startIndex + i}`,
-          allocationMode: 'CAPACITY_PLAN' as const,
-          startWeek: 0,   // placeholder; updated immediately below
-        }))
-        await prisma.namedResource.createMany({ data: newNRs })
       }
 
-      // Re-fetch all NRs (including any just created) with stable ordering
-      const allNRs = await prisma.namedResource.findMany({
-        where: { resourceTypeId: rtId },
-        orderBy: { id: 'asc' },
-        select: { id: true },
+      // Also set ALL other project RTs to CAPACITY_PLAN
+      await tx.resourceType.updateMany({
+        where: { projectId, id: { notIn: [...maxHeadcountByRt.keys()] } },
+        data: { allocationMode: 'CAPACITY_PLAN' },
       })
 
-      // Assign each NR one slot window (startWeek, endWeek, allocationPercent).
-      // Surplus NRs become inactive (startWeek=-1, endWeek=-1, allocationPercent=100).
-      await Promise.all(
-        allNRs.map((nr, idx) => {
-          const win = slotWindows[idx] ?? { startWeek: -1, endWeek: -1, allocationPercent: 100 }
-          return prisma.namedResource.update({
-            where: { id: nr.id },
-            data: {
-              startWeek: win.startWeek,
-              endWeek: win.endWeek,
-              allocationPercent: win.allocationPercent,
-              allocationMode: 'CAPACITY_PLAN',
-            },
-          })
+      // Update ALL named resources allocation mode
+      await tx.namedResource.updateMany({
+        where: { resourceType: { projectId } },
+        data: { allocationMode: 'CAPACITY_PLAN' },
+      })
+
+      // Auto-create missing NRs then assign slot windows
+      for (const [rtId] of maxHeadcountByRt) {
+        const slotWindows = slotWindowsByRt.get(rtId) ?? []
+
+        // Fetch existing NRs with stable ordering
+        const existingNRs = await tx.namedResource.findMany({
+          where: { resourceTypeId: rtId },
+          orderBy: { id: 'asc' },
+          select: { id: true },
         })
-      )
+
+        const missing = Math.max(0, slotWindows.length - existingNRs.length)
+        if (missing > 0) {
+          const rt = await tx.resourceType.findUnique({
+            where: { id: rtId },
+            select: { name: true },
+          })
+          const baseName = rt?.name ?? 'Resource'
+          const startIndex = existingNRs.length + 1
+          const newNRs = Array.from({ length: missing }, (_, i) => ({
+            resourceTypeId: rtId,
+            name: `${baseName} ${startIndex + i}`,
+            allocationMode: 'CAPACITY_PLAN' as const,
+            startWeek: 0,
+          }))
+          await tx.namedResource.createMany({ data: newNRs })
+        }
+
+        // Re-fetch all NRs (including any just created) with stable ordering
+        const allNRs = await tx.namedResource.findMany({
+          where: { resourceTypeId: rtId },
+          orderBy: { id: 'asc' },
+          select: { id: true },
+        })
+
+        // Assign each NR one slot window
+        await Promise.all(
+          allNRs.map((nr, idx) => {
+            const win = slotWindows[idx] ?? { startWeek: -1, endWeek: -1, allocationPercent: 100 }
+            return tx.namedResource.update({
+              where: { id: nr.id },
+              data: {
+                startWeek: win.startWeek,
+                endWeek: win.endWeek,
+                allocationPercent: win.allocationPercent,
+                allocationMode: 'CAPACITY_PLAN',
+              },
+            })
+          })
+        )
+      }
+
+      // Sync capacity profiles after all authoritative legacy writes
+      await syncCapacityProfilesForProject(tx, projectId)
     }
 
-    // ── 5. Materialise timeline using the projected schedule ───────────────
+    return createdPlan
+  })
+
+  // ── 4. Materialise timeline using the projected schedule ─────────────────
+  if (shouldActivate && maxHeadcountByRt && slotWindowsByRt) {
+    let refreshedWeeklyDemandCache: Record<string, number>
 
     if (clientLevellingResult?.featureStartWeeks && Object.keys(clientLevellingResult.featureStartWeeks).length > 0) {
       // ── Direct persistence path: derive spans from planner allocations ───
@@ -615,7 +624,6 @@ router.post('/apply', asyncHandler(async (req: AuthRequest, res: Response) => {
 
       const hpd = project.hoursPerDay
 
-      // Compute feature spans from actual weekly allocations produced by planner
       const featureStartWeeks = clientLevellingResult.featureStartWeeks
       const featureRows: Array<{
         projectId: string; featureId: string; startWeek: number; durationWeeks: number; isManual: false
@@ -637,7 +645,6 @@ router.post('/apply', asyncHandler(async (req: AuthRequest, res: Response) => {
             fallbackStartWeek,
           )
 
-          // Compute demand per RT (same as sa-planner.ts lines 104-112)
           const demandByRt = new Map<string, number>()
           const activeStories = feature.userStories.filter(s => s.isActive !== false)
           for (const story of activeStories) {
@@ -657,8 +664,6 @@ router.post('/apply', asyncHandler(async (req: AuthRequest, res: Response) => {
             isManual: false as const,
           })
 
-          // Create story-level entries: each story starts at parent feature's start
-          // with proportional duration based on its share of total effort
           const totalFeatureDays = Array.from(demandByRt.values()).reduce((sum, d) => sum + d, 0)
           for (const story of activeStories) {
             let storyDays = 0
@@ -710,13 +715,11 @@ router.post('/apply', asyncHandler(async (req: AuthRequest, res: Response) => {
         )
       )
 
-      // Prepare levelled epics for scheduler
       const levelledEpics = schedulerInput.epics.map(e => ({
         ...e,
         timelineStartWeek: epicStartWeeks.get(e.id) ?? e.timelineStartWeek,
       }))
 
-      // Run scheduler with levelled start weeks
       const { featureSchedule, storySchedule, weeklyConsumptionMap } = runScheduler({
         ...schedulerInput,
         epics: levelledEpics,

--- a/server/src/test/squadPlan.test.ts
+++ b/server/src/test/squadPlan.test.ts
@@ -26,6 +26,16 @@ import {
 } from '../routes/squadPlan.js'
 import type { SchedulerResourceType } from '../lib/scheduler.js'
 
+
+vi.mock('../lib/syncCapacityProfiles.js', () => ({
+  syncCapacityProfilesForProject: vi.fn().mockResolvedValue({
+    profilesCreated: 0,
+    profilesUpdated: 0,
+    profilesDeleted: 0,
+    segmentsCreated: 0,
+    segmentsDeleted: 0,
+  }),
+}))
 process.env.JWT_SECRET = 'test-secret'
 
 const userId = 'user-1'
@@ -247,6 +257,21 @@ describe('POST /api/projects/:projectId/squad-plan/apply', () => {
         ],
       })
 
+    // Mock $transaction once for the sync-wrapped plan+RT+NR writes
+    vi.mocked(prisma.$transaction).mockImplementationOnce(async (fn: any) => fn({
+      capacityPlan: { updateMany: vi.fn().mockResolvedValue({ count: 0 }), create: vi.fn().mockResolvedValue({ id: 'plan-1', projectId: 'proj-1', isActive: true, periods: [] }) },
+      resourceType: { update: vi.fn().mockResolvedValue({}), updateMany: vi.fn().mockResolvedValue({ count: 0 }), findUnique: vi.fn().mockResolvedValue({ name: 'Developer' }) },
+      namedResource: { updateMany: vi.fn().mockResolvedValue({ count: 1 }), findMany: vi.fn().mockResolvedValue([{ id: 'nr-dev' }]), createMany: vi.fn().mockResolvedValue({ count: 0 }), update: vi.fn().mockResolvedValue({}), delete: vi.fn(), count: vi.fn().mockResolvedValue(0) },
+      capacityProfile: { findMany: vi.fn().mockResolvedValue([]), create: vi.fn().mockResolvedValue({ id: 'cp-1' }), update: vi.fn(), deleteMany: vi.fn() },
+      capacitySegment: { deleteMany: vi.fn().mockResolvedValue({ count: 0 }), create: vi.fn() },
+      project: { findFirst: vi.fn().mockResolvedValue({ id: 'proj-1', resourceTypes: [], capacityPlans: [] }), update: vi.fn() },
+      timelineEntry: { deleteMany: vi.fn(), createMany: vi.fn() },
+      storyTimelineEntry: { deleteMany: vi.fn(), createMany: vi.fn() },
+      epic: { update: vi.fn(), findMany: vi.fn() },
+      epicDependency: { findMany: vi.fn() },
+      storyDependency: { findMany: vi.fn() },
+    }))
+
     expect(res.status).toBe(400)
     expect(res.body.error).toContain('Unknown resourceTypeId')
     expect(prisma.backlogSnapshot.create).not.toHaveBeenCalled()
@@ -337,6 +362,21 @@ describe('POST /api/projects/:projectId/squad-plan/apply', () => {
       ...mockProject,
       weeklyDemandCache: { 'rt-dev|0': 2 },
     } as never)
+
+    // Mock $transaction once for the sync-wrapped plan+RT+NR writes
+    vi.mocked(prisma.$transaction).mockImplementationOnce(async (fn: any) => fn({
+      capacityPlan: { updateMany: vi.fn().mockResolvedValue({ count: 0 }), create: vi.fn().mockResolvedValue({ id: 'plan-1', projectId: 'proj-1', isActive: true, periods: [] }) },
+      resourceType: { update: vi.fn().mockResolvedValue({}), updateMany: vi.fn().mockResolvedValue({ count: 0 }), findUnique: vi.fn().mockResolvedValue({ name: 'Developer' }) },
+      namedResource: { updateMany: vi.fn().mockResolvedValue({ count: 1 }), findMany: vi.fn().mockResolvedValue([{ id: 'nr-dev' }]), createMany: vi.fn().mockResolvedValue({ count: 0 }), update: vi.fn().mockResolvedValue({}), delete: vi.fn(), count: vi.fn().mockResolvedValue(0) },
+      capacityProfile: { findMany: vi.fn().mockResolvedValue([]), create: vi.fn().mockResolvedValue({ id: 'cp-1' }), update: vi.fn(), deleteMany: vi.fn() },
+      capacitySegment: { deleteMany: vi.fn().mockResolvedValue({ count: 0 }), create: vi.fn() },
+      project: { findFirst: vi.fn().mockResolvedValue({ id: 'proj-1', resourceTypes: [], capacityPlans: [] }), update: vi.fn() },
+      timelineEntry: { deleteMany: vi.fn(), createMany: vi.fn() },
+      storyTimelineEntry: { deleteMany: vi.fn(), createMany: vi.fn() },
+      epic: { update: vi.fn(), findMany: vi.fn() },
+      epicDependency: { findMany: vi.fn() },
+      storyDependency: { findMany: vi.fn() },
+    }))
 
     const res = await request(app)
       .post('/api/projects/proj-1/squad-plan/apply')
@@ -464,6 +504,21 @@ describe('POST /api/projects/:projectId/squad-plan/apply', () => {
       ...mockProject,
       weeklyDemandCache: {},
     } as never)
+
+    // Mock $transaction once for the sync-wrapped plan+RT+NR writes
+    vi.mocked(prisma.$transaction).mockImplementationOnce(async (fn: any) => fn({
+      capacityPlan: { updateMany: vi.fn().mockResolvedValue({ count: 0 }), create: vi.fn().mockResolvedValue({ id: 'plan-1', projectId: 'proj-1', isActive: true, periods: [] }) },
+      resourceType: { update: vi.fn().mockResolvedValue({}), updateMany: vi.fn().mockResolvedValue({ count: 0 }), findUnique: vi.fn().mockResolvedValue({ name: 'Developer' }) },
+      namedResource: { updateMany: vi.fn().mockResolvedValue({ count: 1 }), findMany: vi.fn().mockResolvedValue([{ id: 'nr-dev-1' }, { id: 'nr-dev-2' }]), createMany: vi.fn().mockResolvedValue({ count: 0 }), update: vi.fn().mockResolvedValue({}), delete: vi.fn(), count: vi.fn().mockResolvedValue(0) },
+      capacityProfile: { findMany: vi.fn().mockResolvedValue([]), create: vi.fn().mockResolvedValue({ id: 'cp-1' }), update: vi.fn(), deleteMany: vi.fn() },
+      capacitySegment: { deleteMany: vi.fn().mockResolvedValue({ count: 0 }), create: vi.fn() },
+      project: { findFirst: vi.fn().mockResolvedValue({ id: 'proj-1', resourceTypes: [], capacityPlans: [] }), update: vi.fn() },
+      timelineEntry: { deleteMany: vi.fn(), createMany: vi.fn() },
+      storyTimelineEntry: { deleteMany: vi.fn(), createMany: vi.fn() },
+      epic: { update: vi.fn(), findMany: vi.fn() },
+      epicDependency: { findMany: vi.fn() },
+      storyDependency: { findMany: vi.fn() },
+    }))
 
     const res = await request(app)
       .post('/api/projects/proj-1/squad-plan/apply')

--- a/server/src/test/squadPlanCapacityProfileSync.test.ts
+++ b/server/src/test/squadPlanCapacityProfileSync.test.ts
@@ -1,0 +1,278 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import request from 'supertest'
+import jwt from 'jsonwebtoken'
+import { app } from '../index.js'
+import { prisma } from '../lib/prisma.js'
+import { syncCapacityProfilesForProject } from '../lib/syncCapacityProfiles.js'
+
+vi.mock('../routes/snapshots.js', async (importOriginal: () => Promise<any>) => {
+  const actual = await importOriginal()
+  return {
+    ...actual,
+    buildSnapshot: vi.fn().mockResolvedValue({}),
+  }
+})
+
+vi.mock('../lib/snapshotUtils.js', () => ({
+  pruneSnapshots: vi.fn().mockResolvedValue(undefined),
+}))
+
+vi.mock('../lib/syncCapacityProfiles.js', () => ({
+  syncCapacityProfilesForProject: vi.fn().mockResolvedValue({
+    profilesCreated: 0,
+    profilesUpdated: 0,
+    profilesDeleted: 0,
+    segmentsCreated: 0,
+    segmentsDeleted: 0,
+  }),
+}))
+
+process.env.JWT_SECRET = 'test-secret'
+
+const userId = 'user-1'
+const token = jwt.sign({ userId }, 'test-secret')
+const authHeader = `Bearer ${token}`
+
+// Minimal project stub for squad-plan apply route
+const mockProject = {
+  id: 'proj-1',
+  ownerId: userId,
+  name: 'Test Project',
+  hoursPerDay: 8,
+  weeklyDemandCache: {},
+} as never
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+function validPeriod() {
+  return [
+    {
+      periodIndex: 0,
+      startWeek: 0,
+      endWeek: 4,
+      entries: [
+        { resourceTypeId: 'rt-dev', headcount: 1, demandFTE: 0.5, utilisationPct: 50 },
+      ],
+    },
+  ]
+}
+
+function makeValidRequest(overrides: Record<string, unknown> = {}) {
+  return {
+    name: 'Plan',
+    targetWeeks: 4,
+    periodWeeks: 4,
+    maxDelta: 1,
+    setActive: true,
+    periods: validPeriod(),
+    ...overrides,
+  }
+}
+
+describe('squad-plan apply capacity profile sync', () => {
+  it('calls syncCapacityProfilesForProject(tx, projectId) with transaction object', async () => {
+    vi.mocked(prisma.project.findFirst).mockResolvedValue(mockProject)
+    vi.mocked(prisma.resourceType.findMany).mockResolvedValue([{ id: 'rt-dev' }] as never)
+
+    // Mock the main transaction so sync receives the tx object
+    const tx = {
+      capacityPlan: { updateMany: vi.fn().mockResolvedValue({ count: 0 }), create: vi.fn().mockResolvedValue({ id: 'plan-1', projectId: 'proj-1', isActive: true, periods: [] }) },
+      resourceType: { update: vi.fn().mockResolvedValue({}), updateMany: vi.fn().mockResolvedValue({ count: 0 }), findUnique: vi.fn().mockResolvedValue({ name: 'Developer' }) },
+      namedResource: { updateMany: vi.fn().mockResolvedValue({ count: 1 }), findMany: vi.fn().mockResolvedValue([{ id: 'nr-dev' }]), createMany: vi.fn().mockResolvedValue({ count: 0 }), update: vi.fn().mockResolvedValue({}), delete: vi.fn(), count: vi.fn().mockResolvedValue(0) },
+      capacityProfile: { findMany: vi.fn().mockResolvedValue([]), create: vi.fn().mockResolvedValue({ id: 'cp-1' }), update: vi.fn(), deleteMany: vi.fn() },
+      capacitySegment: { deleteMany: vi.fn().mockResolvedValue({ count: 0 }), create: vi.fn() },
+      project: { findFirst: vi.fn().mockResolvedValue({ id: 'proj-1', resourceTypes: [], capacityPlans: [] }), update: vi.fn() },
+      timelineEntry: { deleteMany: vi.fn(), createMany: vi.fn() },
+      storyTimelineEntry: { deleteMany: vi.fn(), createMany: vi.fn() },
+      epic: { update: vi.fn(), findMany: vi.fn() },
+      epicDependency: { findMany: vi.fn() },
+      storyDependency: { findMany: vi.fn() },
+    }
+    vi.mocked(prisma.$transaction).mockImplementationOnce(async (fn: any) => fn(tx))
+
+    await request(app)
+      .post('/api/projects/proj-1/squad-plan/apply')
+      .set('Authorization', authHeader)
+      .send(makeValidRequest())
+
+    // Must be called with tx object, not bare prisma
+    expect(syncCapacityProfilesForProject).toHaveBeenCalledWith(tx, 'proj-1')
+    expect(syncCapacityProfilesForProject).not.toHaveBeenCalledWith(prisma, 'proj-1')
+  })
+
+  it('does not call sync with bare prisma (best-effort path absent)', async () => {
+    vi.mocked(prisma.project.findFirst).mockResolvedValue(mockProject)
+    vi.mocked(prisma.resourceType.findMany).mockResolvedValue([{ id: 'rt-dev' }] as never)
+    const tx = {
+      capacityPlan: { updateMany: vi.fn().mockResolvedValue({ count: 0 }), create: vi.fn().mockResolvedValue({ id: 'plan-1', projectId: 'proj-1', isActive: true, periods: [] }) },
+      resourceType: { update: vi.fn().mockResolvedValue({}), updateMany: vi.fn().mockResolvedValue({ count: 0 }), findUnique: vi.fn().mockResolvedValue({ name: 'Developer' }) },
+      namedResource: { updateMany: vi.fn().mockResolvedValue({ count: 1 }), findMany: vi.fn().mockResolvedValue([{ id: 'nr-dev' }]), createMany: vi.fn().mockResolvedValue({ count: 0 }), update: vi.fn().mockResolvedValue({}), delete: vi.fn(), count: vi.fn().mockResolvedValue(0) },
+      capacityProfile: { findMany: vi.fn().mockResolvedValue([]), create: vi.fn().mockResolvedValue({ id: 'cp-1' }), update: vi.fn(), deleteMany: vi.fn() },
+      capacitySegment: { deleteMany: vi.fn().mockResolvedValue({ count: 0 }), create: vi.fn() },
+      project: { findFirst: vi.fn().mockResolvedValue({ id: 'proj-1', resourceTypes: [], capacityPlans: [] }), update: vi.fn() },
+      timelineEntry: { deleteMany: vi.fn(), createMany: vi.fn() },
+      storyTimelineEntry: { deleteMany: vi.fn(), createMany: vi.fn() },
+      epic: { update: vi.fn(), findMany: vi.fn() },
+      epicDependency: { findMany: vi.fn() },
+      storyDependency: { findMany: vi.fn() },
+    }
+    vi.mocked(prisma.$transaction).mockImplementationOnce(async (fn: any) => fn(tx))
+
+    await request(app)
+      .post('/api/projects/proj-1/squad-plan/apply')
+      .set('Authorization', authHeader)
+      .send(makeValidRequest())
+
+    expect(syncCapacityProfilesForProject).toHaveBeenCalledWith(tx, 'proj-1')
+    expect(syncCapacityProfilesForProject).not.toHaveBeenCalledWith(prisma, 'proj-1')
+  })
+
+  it('returns 201 on successful apply with sync', async () => {
+    vi.mocked(prisma.project.findFirst).mockResolvedValue(mockProject)
+    vi.mocked(prisma.resourceType.findMany)
+      .mockResolvedValueOnce([{ id: 'rt-dev' }] as never)
+      .mockResolvedValueOnce([
+        { id: 'rt-dev', name: 'Developer', count: 1, hoursPerDay: 8, allocationMode: 'CAPACITY_PLAN', namedResources: [] },
+      ] as never)
+    vi.mocked(prisma.epic.findMany).mockResolvedValue([] as never)
+    vi.mocked(prisma.timelineEntry.findMany).mockResolvedValue([] as never)
+    vi.mocked(prisma.storyTimelineEntry.findMany).mockResolvedValue([] as never)
+    vi.mocked(prisma.epicDependency.findMany).mockResolvedValue([] as never)
+    vi.mocked(prisma.backlogSnapshot.create).mockResolvedValue({ id: 'snap-1' } as never)
+    vi.mocked(prisma.project.update).mockResolvedValue(mockProject)
+
+    const tx = {
+      capacityPlan: { updateMany: vi.fn().mockResolvedValue({ count: 0 }), create: vi.fn().mockResolvedValue({ id: 'plan-1', projectId: 'proj-1', isActive: true, periods: [] }) },
+      resourceType: { update: vi.fn().mockResolvedValue({}), updateMany: vi.fn().mockResolvedValue({ count: 0 }), findUnique: vi.fn().mockResolvedValue({ name: 'Developer' }) },
+      namedResource: { updateMany: vi.fn().mockResolvedValue({ count: 1 }), findMany: vi.fn().mockResolvedValue([{ id: 'nr-dev' }]), createMany: vi.fn().mockResolvedValue({ count: 0 }), update: vi.fn().mockResolvedValue({}), delete: vi.fn(), count: vi.fn().mockResolvedValue(0) },
+      capacityProfile: { findMany: vi.fn().mockResolvedValue([]), create: vi.fn().mockResolvedValue({ id: 'cp-1' }), update: vi.fn(), deleteMany: vi.fn() },
+      capacitySegment: { deleteMany: vi.fn().mockResolvedValue({ count: 0 }), create: vi.fn() },
+      project: { findFirst: vi.fn().mockResolvedValue({ id: 'proj-1', resourceTypes: [], capacityPlans: [] }), update: vi.fn() },
+      timelineEntry: { deleteMany: vi.fn(), createMany: vi.fn() },
+      storyTimelineEntry: { deleteMany: vi.fn(), createMany: vi.fn() },
+      epic: { update: vi.fn(), findMany: vi.fn() },
+      epicDependency: { findMany: vi.fn() },
+      storyDependency: { findMany: vi.fn() },
+    }
+    vi.mocked(prisma.$transaction).mockImplementationOnce(async (fn: any) => fn(tx))
+
+    const res = await request(app)
+      .post('/api/projects/proj-1/squad-plan/apply')
+      .set('Authorization', authHeader)
+      .send(makeValidRequest())
+
+    expect(res.status).toBe(201)
+    expect(res.body).toMatchObject({ id: 'plan-1' })
+  })
+
+  it('returns error when sync fails (sync failure propagates)', async () => {
+    vi.mocked(syncCapacityProfilesForProject).mockRejectedValueOnce(new Error('sync failed'))
+    vi.mocked(prisma.project.findFirst).mockResolvedValue(mockProject)
+    vi.mocked(prisma.resourceType.findMany).mockResolvedValue([{ id: 'rt-dev' }] as never)
+
+    const tx = {
+      capacityPlan: { updateMany: vi.fn().mockResolvedValue({ count: 0 }), create: vi.fn().mockResolvedValue({ id: 'plan-1', projectId: 'proj-1', isActive: true, periods: [] }) },
+      resourceType: { update: vi.fn().mockResolvedValue({}), updateMany: vi.fn().mockResolvedValue({ count: 0 }), findUnique: vi.fn().mockResolvedValue({ name: 'Developer' }) },
+      namedResource: { updateMany: vi.fn().mockResolvedValue({ count: 1 }), findMany: vi.fn().mockResolvedValue([{ id: 'nr-dev' }]), createMany: vi.fn().mockResolvedValue({ count: 0 }), update: vi.fn().mockResolvedValue({}), delete: vi.fn(), count: vi.fn().mockResolvedValue(0) },
+      capacityProfile: { findMany: vi.fn().mockResolvedValue([]), create: vi.fn().mockResolvedValue({ id: 'cp-1' }), update: vi.fn(), deleteMany: vi.fn() },
+      capacitySegment: { deleteMany: vi.fn().mockResolvedValue({ count: 0 }), create: vi.fn() },
+      project: { findFirst: vi.fn().mockResolvedValue({ id: 'proj-1', resourceTypes: [], capacityPlans: [] }), update: vi.fn() },
+      timelineEntry: { deleteMany: vi.fn(), createMany: vi.fn() },
+      storyTimelineEntry: { deleteMany: vi.fn(), createMany: vi.fn() },
+      epic: { update: vi.fn(), findMany: vi.fn() },
+      epicDependency: { findMany: vi.fn() },
+      storyDependency: { findMany: vi.fn() },
+    }
+    vi.mocked(prisma.$transaction).mockImplementationOnce(async (fn: any) => fn(tx))
+
+    const res = await request(app)
+      .post('/api/projects/proj-1/squad-plan/apply')
+      .set('Authorization', authHeader)
+      .send(makeValidRequest())
+
+    // Sync failure should propagate — not a 201
+    expect(res.status).not.toBe(201)
+  })
+
+  it('sync runs after capacity-plan and named-resource writes', async () => {
+    vi.mocked(prisma.project.findFirst).mockResolvedValue(mockProject)
+    vi.mocked(prisma.resourceType.findMany).mockResolvedValue([{ id: 'rt-dev' }] as never)
+
+    const capacityPlanCreateFn = vi.fn().mockResolvedValue({ id: 'plan-1', projectId: 'proj-1', isActive: true, periods: [] })
+    const resourceTypeUpdateFn = vi.fn().mockResolvedValue({})
+    const namedResourceUpdateFn = vi.fn().mockResolvedValue({})
+
+    const tx = {
+      capacityPlan: { updateMany: vi.fn().mockResolvedValue({ count: 0 }), create: capacityPlanCreateFn },
+      resourceType: { update: resourceTypeUpdateFn, updateMany: vi.fn().mockResolvedValue({ count: 0 }), findUnique: vi.fn().mockResolvedValue({ name: 'Developer' }) },
+      namedResource: { updateMany: vi.fn().mockResolvedValue({ count: 1 }), findMany: vi.fn().mockResolvedValue([{ id: 'nr-dev' }]), createMany: vi.fn().mockResolvedValue({ count: 0 }), update: namedResourceUpdateFn, delete: vi.fn(), count: vi.fn().mockResolvedValue(0) },
+      capacityProfile: { findMany: vi.fn().mockResolvedValue([]), create: vi.fn().mockResolvedValue({ id: 'cp-1' }), update: vi.fn(), deleteMany: vi.fn() },
+      capacitySegment: { deleteMany: vi.fn().mockResolvedValue({ count: 0 }), create: vi.fn() },
+      project: { findFirst: vi.fn().mockResolvedValue({ id: 'proj-1', resourceTypes: [], capacityPlans: [] }), update: vi.fn() },
+      timelineEntry: { deleteMany: vi.fn(), createMany: vi.fn() },
+      storyTimelineEntry: { deleteMany: vi.fn(), createMany: vi.fn() },
+      epic: { update: vi.fn(), findMany: vi.fn() },
+      epicDependency: { findMany: vi.fn() },
+      storyDependency: { findMany: vi.fn() },
+    }
+    vi.mocked(prisma.$transaction).mockImplementationOnce(async (fn: any) => fn(tx))
+
+    await request(app)
+      .post('/api/projects/proj-1/squad-plan/apply')
+      .set('Authorization', authHeader)
+      .send(makeValidRequest())
+
+    // Plan creation and resource updates happen before sync
+    expect(capacityPlanCreateFn.mock.invocationCallOrder[0]).toBeLessThan(
+      vi.mocked(syncCapacityProfilesForProject).mock.invocationCallOrder[0],
+    )
+    expect(resourceTypeUpdateFn.mock.invocationCallOrder[0]).toBeLessThan(
+      vi.mocked(syncCapacityProfilesForProject).mock.invocationCallOrder[0],
+    )
+    expect(namedResourceUpdateFn.mock.invocationCallOrder[0]).toBeLessThan(
+      vi.mocked(syncCapacityProfilesForProject).mock.invocationCallOrder[0],
+    )
+  })
+
+  it('existing apply behaviour and response shape are preserved', async () => {
+    vi.mocked(prisma.project.findFirst).mockResolvedValue(mockProject)
+    vi.mocked(prisma.resourceType.findMany)
+      .mockResolvedValueOnce([{ id: 'rt-dev' }] as never)
+      .mockResolvedValueOnce([
+        { id: 'rt-dev', name: 'Developer', count: 1, hoursPerDay: 8, allocationMode: 'CAPACITY_PLAN', namedResources: [] },
+      ] as never)
+    vi.mocked(prisma.epic.findMany).mockResolvedValue([] as never)
+    vi.mocked(prisma.timelineEntry.findMany).mockResolvedValue([] as never)
+    vi.mocked(prisma.storyTimelineEntry.findMany).mockResolvedValue([] as never)
+    vi.mocked(prisma.epicDependency.findMany).mockResolvedValue([] as never)
+    vi.mocked(prisma.backlogSnapshot.create).mockResolvedValue({ id: 'snap-1' } as never)
+    vi.mocked(prisma.project.update).mockResolvedValue(mockProject)
+
+    const tx = {
+      capacityPlan: { updateMany: vi.fn().mockResolvedValue({ count: 0 }), create: vi.fn().mockResolvedValue({ id: 'plan-1', projectId: 'proj-1', isActive: true, periods: [] }) },
+      resourceType: { update: vi.fn().mockResolvedValue({}), updateMany: vi.fn().mockResolvedValue({ count: 0 }), findUnique: vi.fn().mockResolvedValue({ name: 'Developer' }) },
+      namedResource: { updateMany: vi.fn().mockResolvedValue({ count: 1 }), findMany: vi.fn().mockResolvedValue([{ id: 'nr-dev' }]), createMany: vi.fn().mockResolvedValue({ count: 0 }), update: vi.fn().mockResolvedValue({}), delete: vi.fn(), count: vi.fn().mockResolvedValue(0) },
+      capacityProfile: { findMany: vi.fn().mockResolvedValue([]), create: vi.fn().mockResolvedValue({ id: 'cp-1' }), update: vi.fn(), deleteMany: vi.fn() },
+      capacitySegment: { deleteMany: vi.fn().mockResolvedValue({ count: 0 }), create: vi.fn() },
+      project: { findFirst: vi.fn().mockResolvedValue({ id: 'proj-1', resourceTypes: [], capacityPlans: [] }), update: vi.fn() },
+      timelineEntry: { deleteMany: vi.fn(), createMany: vi.fn() },
+      storyTimelineEntry: { deleteMany: vi.fn(), createMany: vi.fn() },
+      epic: { update: vi.fn(), findMany: vi.fn() },
+      epicDependency: { findMany: vi.fn() },
+      storyDependency: { findMany: vi.fn() },
+    }
+    vi.mocked(prisma.$transaction).mockImplementationOnce(async (fn: any) => fn(tx))
+
+    const res = await request(app)
+      .post('/api/projects/proj-1/squad-plan/apply')
+      .set('Authorization', authHeader)
+      .send(makeValidRequest())
+
+    // Response shape preserved: plan object with id
+    expect(res.status).toBe(201)
+    expect(res.body).toHaveProperty('id')
+    expect(res.body).toHaveProperty('projectId', 'proj-1')
+  })
+})


### PR DESCRIPTION
Refs #326

## Summary

Wires Squad Planner apply (`POST /api/projects/:projectId/squad-plan/apply`) into runtime capacity-profile sync atomically. All capacity-profile-affecting writes (plan creation, resource type updates, named resource creation/assignment) now happen inside a single `$transaction` with `syncCapacityProfilesForProject(tx, projectId)` called at the end — not as a separate best-effort call with bare `prisma`.

**Legacy fields remain authoritative.** The sync is a derived write, not a source-of-truth migration.

## Transaction design

The apply route now follows this order:

1. Snapshot creation — outside transaction (pre-apply state capture, independent)
2. **Transaction** (`$transaction` with sync):
   a. Deactivate existing active capacity plans
   b. Create the new capacity plan with nested periods and entries
   c. Update resource type counts and allocation modes for all project RTs
   d. Update all named resources allocation mode to `CAPACITY_PLAN`
   e. Auto-create missing named resources for slot windows, assign slot windows
   f. `syncCapacityProfilesForProject(tx, projectId)` — after all authoritative writes
3. Timeline materialisation — outside transaction (epic start weeks, timeline entries, story timeline entries, weekly demand cache)
   - These downstream writes do **not** affect capacity profile output
   - If they fail, the capacity profile state is still consistent

## Sync failure behaviour

Sync failure inside the transaction propagates, rolling back all plan/RT/NR writes. The route does not return `201` when sync fails.

## What was changed

| File | Change |
|---|---|
| `server/src/routes/squadPlan.ts` | Refactored apply route: plan+RT+NR writes + sync in single `$transaction`; timeline materialisation after transaction |
| `server/src/test/squadPlan.test.ts` | Added sync mock and `$transaction` mocks for existing tests |
| `server/src/test/squadPlanCapacityProfileSync.test.ts` | New — 6 focused tests for squad-plan sync wiring |
| `docs/domain/capacity-profile-design.md` | Updated integration list, removed deferral note |

## Scope exclusions — unchanged

- Prisma schema and migrations: **empty diff**
- API response DTO shape: **unchanged**
- Read-only `GET /capacity-profiles` endpoint: **unchanged**
- Commercial calculations: **not modified**
- Exports: **not modified**
- Scheduler/leveller/Squad Planner algorithms: **not modified** (only persistence layer restructured)
- UI: **not modified**
- Dependencies: **not updated**

## Tests — 506 passing (33 test files)

### New squad-plan sync tests (6)
1. Calls `syncCapacityProfilesForProject(tx, projectId)` with transaction object
2. No bare-prisma sync call (best-effort path absent)
3. Returns 201 on successful apply with sync
4. Returns error when sync fails (sync failure propagates)
5. Sync runs after capacity-plan and named-resource writes (call order verified)
6. Existing apply behaviour and response shape preserved

### Updated tests
- Existing squad-plan apply tests updated with `$transaction` mocks and sync mock

## Follow-ups

- None for this slice. All capacity-profile-affecting writes are now wired transactionally.

Do not merge. Wait for review.