### PR TITLE
feat: adopt capacity-profile DTO in resource profile exports

### DIFF
--- a/client/src/hooks/useResourceProfileExport.ts
+++ b/client/src/hooks/useResourceProfileExport.ts
@@ -50,13 +50,27 @@ function formatNamedResourceWeeks(
     .join('; ')
 }
 
+function formatCapacityProfileSegments(
+  capacityProfile: { segments: Array<{ startWeek: number; endWeek: number; capacityPercent: number }> } | undefined,
+) {
+  if (!capacityProfile || capacityProfile.segments.length === 0) return ''
+  return capacityProfile.segments
+    .map(s => {
+      const start = formatWeekLabel(s.startWeek)
+      if (s.startWeek === s.endWeek) return `${start} ${s.capacityPercent}%`
+      const end = formatWeekLabel(s.endWeek)
+      return `${start}-${end} ${s.capacityPercent}%`
+    })
+    .join('; ')
+}
+
 export const buildProfileCsv = (profileData: ResourceProfile) => {
   const rows: string[][] = [
     [
       'Section', 'Role', 'Resource name', 'Resource identity', 'Category',
       'Resource count', 'Hours per day', 'Effort days', 'Assigned days', 'Billable days',
       'Day rate', 'Subtotal', 'Availability window start', 'Availability window end',
-      'Assigned start', 'Assigned end', 'Assignment segments', 'Assigned weeks',
+      'Assigned start', 'Assigned end', 'Capacity profile', 'Assignment segments', 'Assigned weeks',
       'Billing basis', 'Handover notes',
     ],
   ]
@@ -74,6 +88,7 @@ export const buildProfileCsv = (profileData: ResourceProfile) => {
           nr.endWeek != null ? formatWeekLabel(nr.endWeek) : '',
           nr.actualAllocationStartWeek != null ? formatWeekLabel(nr.actualAllocationStartWeek) : '',
           nr.actualAllocationEndWeek != null ? formatWeekLabel(nr.actualAllocationEndWeek) : '',
+          formatCapacityProfileSegments(nr.capacityProfile),
           formatNamedResourceSegments(nr),
           formatNamedResourceWeeks(nr),
           nr.pricingModel === 'PRO_RATA' ? 'Bill planned allocation' : 'Bill actual scheduled days',
@@ -88,7 +103,7 @@ export const buildProfileCsv = (profileData: ResourceProfile) => {
       String(row.totalDays), '',
       row.dayRate != null ? String(row.dayRate) : '',
       row.dayRate != null && row.totalDays != null ? (row.totalDays * row.dayRate).toFixed(2) : '',
-      '', '', '', '', '', '', '', '',
+      '', '', formatCapacityProfileSegments(row.capacityProfile), '', '', '',
     ])
   })
 

--- a/client/src/hooks/useResourceProfileExport.ts
+++ b/client/src/hooks/useResourceProfileExport.ts
@@ -103,7 +103,15 @@ export const buildProfileCsv = (profileData: ResourceProfile) => {
       String(row.totalDays), '',
       row.dayRate != null ? String(row.dayRate) : '',
       row.dayRate != null && row.totalDays != null ? (row.totalDays * row.dayRate).toFixed(2) : '',
-      '', '', formatCapacityProfileSegments(row.capacityProfile), '', '', '',
+      '',   // Availability window start
+      '',   // Availability window end
+      '',   // Assigned start
+      '',   // Assigned end
+      formatCapacityProfileSegments(row.capacityProfile), // Capacity profile
+      '',   // Assignment segments
+      '',   // Assigned weeks
+      '',   // Billing basis
+      '',   // Handover notes
     ])
   })
 
@@ -112,8 +120,15 @@ export const buildProfileCsv = (profileData: ResourceProfile) => {
       'Overhead', row.name, '', '', '',
       '', '', '', String(row.computedDays), '',
       '', row.estimatedCost != null ? String(row.estimatedCost) : '',
-      '', '', '', '', '',
-      '', '', row.resourceTypeName ?? '',
+      '',   // Availability window start
+      '',   // Availability window end
+      '',   // Assigned start
+      '',   // Assigned end
+      '',   // Capacity profile
+      '',   // Assignment segments
+      '',   // Assigned weeks
+      row.resourceTypeName ?? '',  // Billing basis
+      '',   // Handover notes
     ])
   })
 

--- a/client/src/hooks/useResourceProfileExport.ts
+++ b/client/src/hooks/useResourceProfileExport.ts
@@ -127,8 +127,8 @@ export const buildProfileCsv = (profileData: ResourceProfile) => {
       '',   // Capacity profile
       '',   // Assignment segments
       '',   // Assigned weeks
-      row.resourceTypeName ?? '',  // Billing basis
-      '',   // Handover notes
+      '',   // Billing basis
+      row.resourceTypeName ?? '',  // Handover notes
     ])
   })
 

--- a/client/src/test/useResourceProfile.test.ts
+++ b/client/src/test/useResourceProfile.test.ts
@@ -266,4 +266,42 @@ describe('buildProfileCsv', () => {
     expect(csv).toContain('Bill planned allocation')
     expect(csv).toContain('Bill actual scheduled days')
   })
+
+  it('overhead row has blank Billing basis and resourceTypeName in Handover notes', () => {
+    const csv = buildProfileCsv({
+      ...BASE,
+      overheadRows: [
+        { name: 'Travel', computedDays: 10, estimatedCost: 5000, resourceTypeName: 'Travel overhead' },
+        { name: 'Management', computedDays: 5, estimatedCost: 2500, resourceTypeName: null },
+      ],
+    })
+    const lines = csv.split('\n').filter(l => l.length > 0)
+    const header = lines[0].split(',')
+    const billingBasisIdx = header.indexOf('Billing basis')
+    const handoverNotesIdx = header.indexOf('Handover notes')
+    const colCount = header.length
+
+    expect(billingBasisIdx).toBeGreaterThanOrEqual(0)
+    expect(handoverNotesIdx).toBeGreaterThanOrEqual(0)
+
+    // Overhead rows start at line 2 (after header and any resource rows)
+    for (let i = 1; i < lines.length; i++) {
+      const cols = lines[i].split(',')
+      if (cols[0] !== 'Overhead') continue
+      expect(cols.length, `Overhead row ${i} column count`).toBe(colCount)
+      expect(cols[billingBasisIdx]).toBe('')
+    }
+
+    // First overhead row has resourceTypeName in Handover notes
+    const overhead1Line = lines.find(l => l.startsWith('Overhead,Travel,'))
+    expect(overhead1Line).toBeDefined()
+    const overhead1 = overhead1Line!.split(',')
+    expect(overhead1[handoverNotesIdx]).toBe('Travel overhead')
+
+    // Second overhead row (null resourceTypeName) has blank Handover notes
+    const overhead2Line = lines.find(l => l.startsWith('Overhead,Management,'))
+    expect(overhead2Line).toBeDefined()
+    const overhead2 = overhead2Line!.split(',')
+    expect(overhead2[handoverNotesIdx]).toBe('')
+  })
 })

--- a/client/src/test/useResourceProfile.test.ts
+++ b/client/src/test/useResourceProfile.test.ts
@@ -36,6 +36,7 @@ describe('buildProfileCsv', () => {
     expect(headers).toContain('Availability window end')
     expect(headers).toContain('Assigned start')
     expect(headers).toContain('Assigned end')
+    expect(headers).toContain('Capacity profile')
     expect(headers).toContain('Assignment segments')
     expect(headers).toContain('Assigned weeks')
     expect(headers).toContain('Billing basis')
@@ -155,10 +156,114 @@ describe('buildProfileCsv', () => {
     const csv = buildProfileCsv(profile)
     const lines = csv.split('\n').filter(l => l.length > 0)
     const headerCols = lines[0].split(',').length
-    expect(headerCols).toBe(20)
+    expect(headerCols).toBe(21)
     for (let i = 1; i < lines.length; i++) {
       const cols = lines[i].split(',').length
       expect(cols, `row ${i} has ${cols} columns, expected ${headerCols}`).toBe(headerCols)
     }
+  })
+
+  it('capacity profile column contains segments for named-resource rows with capacityProfile', () => {
+    const csv = buildProfileCsv({
+      ...BASE,
+      resourceRows: [{
+        resourceTypeId: 'rt1', name: 'Engineer', category: 'ENG',
+        count: 1, hoursPerDay: 8, dayRate: 800, totalHours: 40, totalDays: 5,
+        effortDays: 5, allocatedDays: 5, allocationMode: 'EFFORT',
+        allocationPercent: 100, allocationStartWeek: null, allocationEndWeek: null,
+        derivedStartWeek: 2, derivedEndWeek: 3, estimatedCost: 4000, epics: [],
+        namedResources: [{
+          id: 'nr1', name: 'Alice', allocationMode: 'EFFORT',
+          allocationPercent: 100, allocationStartWeek: null, allocationEndWeek: null,
+          startWeek: null, endWeek: null, allocatedDays: 5,
+          derivedStartWeek: 2, derivedEndWeek: 3,
+          actualAllocatedDays: 5, actualAllocationStartWeek: 2, actualAllocationEndWeek: 3,
+          actualAllocatedWeeks: [], actualAllocationSegments: [],
+          synthetic: false, capacityProfile: {
+            planningBasis: 'availabilityWindow',
+            source: 'availabilityWindow',
+            segments: [
+              { startWeek: 0, endWeek: 3, capacityPercent: 50 },
+              { startWeek: 4, endWeek: 7, capacityPercent: 100 },
+            ],
+          },
+        }],
+      }],
+    })
+    const lines = csv.split('\n').filter(l => l.length > 0)
+    const header = lines[0].split(',')
+    const capacityProfileIdx = header.indexOf('Capacity profile')
+    const assignmentSegmentsIdx = header.indexOf('Assignment segments')
+    const assignedWeeksIdx = header.indexOf('Assigned weeks')
+    expect(capacityProfileIdx).toBeGreaterThanOrEqual(0)
+    expect(assignmentSegmentsIdx).toBeGreaterThanOrEqual(0)
+
+    // Find the data row (second line, after header)
+    const dataRow = lines[1].split(',')
+    expect(dataRow[capacityProfileIdx]).toBe('W1-W4 50%; W5-W8 100%')
+    // Assignment segments and assigned weeks remain independent
+    expect(dataRow[assignmentSegmentsIdx]).toBe('')  // empty in this fixture
+    expect(dataRow[assignedWeeksIdx]).toBe('')       // empty in this fixture
+  })
+
+  it('capacity profile lands in correct column for role-level row', () => {
+    const csv = buildProfileCsv({
+      ...BASE,
+      resourceRows: [{
+        resourceTypeId: 'rt1', name: 'Engineer', category: 'ENG',
+        count: 2, hoursPerDay: 8, dayRate: 800, totalHours: 80, totalDays: 10,
+        effortDays: 10, allocatedDays: 10, allocationMode: 'TIMELINE',
+        allocationPercent: 75, allocationStartWeek: 0, allocationEndWeek: 7,
+        derivedStartWeek: 0, derivedEndWeek: 7, estimatedCost: 8000, epics: [],
+        namedResources: [],
+        capacityProfile: {
+          planningBasis: 'availabilityWindow',
+          source: 'availabilityWindow',
+          segments: [{ startWeek: 0, endWeek: 7, capacityPercent: 75 }],
+        },
+      }],
+    })
+    const lines = csv.split('\n').filter(l => l.length > 0)
+    const header = lines[0].split(',')
+    const capacityProfileIdx = header.indexOf('Capacity profile')
+    const assignedStartIdx = header.indexOf('Assigned start')
+    expect(capacityProfileIdx).toBeGreaterThan(assignedStartIdx)
+
+    const row = lines[1].split(',')
+    // Capacity profile value at correct column, not earlier
+    expect(row[capacityProfileIdx]).toBe('W1-W8 75%')
+    expect(row[assignedStartIdx]).toBe('')
+  })
+
+  it('billing basis exports plain English regardless of capacity profile', () => {
+    const csv = buildProfileCsv({
+      ...BASE,
+      resourceRows: [{
+        resourceTypeId: 'rt1', name: 'Dev', category: 'ENG',
+        count: 1, hoursPerDay: 8, dayRate: 800, totalHours: 40, totalDays: 5,
+        effortDays: 5, allocatedDays: 5, allocationMode: 'EFFORT',
+        allocationPercent: 100, allocationStartWeek: null, allocationEndWeek: null,
+        derivedStartWeek: 2, derivedEndWeek: 3, estimatedCost: 4000, epics: [],
+        namedResources: [{
+          id: 'nrA', name: 'Alice', allocationMode: 'EFFORT',
+          allocationPercent: 100, allocationStartWeek: null, allocationEndWeek: null,
+          startWeek: null, endWeek: null, allocatedDays: 5,
+          derivedStartWeek: 2, derivedEndWeek: 3,
+          actualAllocatedDays: 5, actualAllocationStartWeek: 2, actualAllocationEndWeek: 3,
+          actualAllocatedWeeks: [], actualAllocationSegments: [],
+          pricingModel: 'PRO_RATA', synthetic: false,
+        }, {
+          id: 'nrB', name: 'Bob', allocationMode: 'EFFORT',
+          allocationPercent: 100, allocationStartWeek: null, allocationEndWeek: null,
+          startWeek: null, endWeek: null, allocatedDays: 5,
+          derivedStartWeek: 2, derivedEndWeek: 3,
+          actualAllocatedDays: 5, actualAllocationStartWeek: 2, actualAllocationEndWeek: 3,
+          actualAllocatedWeeks: [], actualAllocationSegments: [],
+          synthetic: false,
+        }],
+      }],
+    })
+    expect(csv).toContain('Bill planned allocation')
+    expect(csv).toContain('Bill actual scheduled days')
   })
 })

--- a/client/src/types/backlog.ts
+++ b/client/src/types/backlog.ts
@@ -298,7 +298,17 @@ export interface ResourceProfileRow {
       days: number
     }>
     synthetic: boolean
+    capacityProfile?: {
+      planningBasis: string
+      source: string
+      segments: Array<{ startWeek: number; endWeek: number; capacityPercent: number }>
+    }
   }>
+  capacityProfile?: {
+    planningBasis: string
+    source: string
+    segments: Array<{ startWeek: number; endWeek: number; capacityPercent: number }>
+  }
 }
 
 export interface OverheadProfileRow {

--- a/docs/domain/capacity-profile-design.md
+++ b/docs/domain/capacity-profile-design.md
@@ -431,3 +431,75 @@ Runtime persisted DTO integration tests now cover:
 - Repair cycle — write after corruption restores persisted path
 
 Tests use the real `syncCapacityProfilesForProject` helper (not mocked). See `server/src/test/capacityProfilePersistedDtoIntegration.test.ts` (8 tests).
+
+## Resource Profile and Export Adoption
+
+### Adapter
+
+`server/src/lib/capacityProfileResourceAdapter.ts` provides a narrow adapter
+`buildResourceCapacityProfileMap` that takes the same project query shape as the
+Resource Profile route and returns a `Map<string, CapacityProfileResourceData>`
+keyed by resource-type id (role profiles) or named-resource id (named person /
+planned resource).
+
+The adapter uses the same persisted-read vs fallback decision as the
+`GET /capacity-profiles` endpoint:
+
+1. Derive legacy profiles via `mapProjectToCapacityProfiles`.
+2. If persisted `CapacityProfile` rows exist, compare via `compareCapacityProfiles`.
+3. If zero mismatches → map persisted rows to DTOs and use them.
+4. Otherwise → fall back to legacy-derived profiles.
+
+### Resource Profile route
+
+`GET /api/projects/:projectId/resource-profile` now includes `capacityProfiles`
+with `segments` in its Prisma query and calls `buildResourceCapacityProfileMap`.
+
+Each named-resource entry in the response gains an optional `capacityProfile`
+field containing `{ planningBasis, source, segments }`. Role-level rows without
+named resources get a `capacityProfile` field at the row level.
+
+### Client types
+
+`client/src/types/backlog.ts` — `ResourceProfileRow` gains an optional
+`capacityProfile` field (row level and per named-resource entry) with
+`{ planningBasis, source, segments }`.
+
+### Export CSV
+
+`client/src/hooks/useResourceProfileExport.ts` — the profile CSV now includes a
+`Capacity profile` column showing segments in a human-readable format
+(e.g. `W1-W4 50%; W5-W10 100%`), distinct from the existing `Assignment segments`
+column (which reflects actual scheduled assignment).
+
+### Behavioural invariants
+
+- **Legacy fields remain authoritative.** The adapter is additive enrichment.
+  If capacity-profile data is unreconciled or unavailable, the route behaves
+  exactly as before (no enrichment emitted).
+- **CapacityProfile is still a derived read model.** Source-of-truth migration
+  is tracked separately in #340.
+- **Commercial calculations are unchanged.** The `capacityProfile` field is
+  presentation-only in Resource Profile; Commercial billing formulas, billable
+  days, discounts, tax, and totals are unaffected.
+- **Entity identity preserved.** One named person or planned resource with
+  multiple capacity segments is still one row/entity. The adapter keyed the map
+  by owner id, so duplicate entries never result from segment data.
+
+### File changes
+
+| File | Change |
+|---|---|
+| `server/src/lib/capacityProfileResourceAdapter.ts` | New adapter — `buildResourceCapacityProfileMap` |
+| `server/src/routes/resourceProfile.ts` | Added `capacityProfiles` include, adapter call, `capacityProfile` in response |
+| `client/src/types/backlog.ts` | Added optional `capacityProfile` to `ResourceProfileRow` |
+| `client/src/hooks/useResourceProfileExport.ts` | Added `Capacity profile` column to CSV export |
+| `server/src/test/capacityProfileResourceAdapter.test.ts` | 7 unit tests for adapter |
+| `docs/domain/capacity-profile-design.md` | This section |
+| `docs/domain/planning-resource-commercial-boundaries.md` | Updated |
+
+### Related issues
+
+- #340 — Make CapacityProfile source of truth
+- #342 — Legacy cleanup
+

--- a/docs/domain/planning-resource-commercial-boundaries.md
+++ b/docs/domain/planning-resource-commercial-boundaries.md
@@ -309,3 +309,22 @@ This decision is satisfied when:
 This document does not implement the refactor. It intentionally avoids changing runtime behaviour.
 
 The implementation work belongs in the follow-up issues under #263, especially #264 through #271.
+
+## Implementation status
+
+### Adopted: Resource Profile + export consume capacity-profile DTO data (#341)
+
+`server/src/lib/capacityProfileResourceAdapter.ts` enriches the Resource Profile
+response with capacity-profile data (`planningBasis`, `source`, `segments`) from
+the derived read model introduced in #326. The export CSV includes a `Capacity
+profile` column.
+
+Key constraints preserved:
+
+- Legacy ResourceType/NamedResource fields remain authoritative.
+- CapacityProfile is still a derived read model (source-of-truth migration is #340).
+- Commercial billing formulas, billable days, discounts, tax, and totals are unchanged.
+- Entity identity is preserved — one named person / planned resource with multiple
+  capacity segments is one row, not multiple.
+
+See `capacity-profile-design.md#resource-profile-and-export-adoption` for details.

--- a/server/src/lib/capacityProfileResourceAdapter.ts
+++ b/server/src/lib/capacityProfileResourceAdapter.ts
@@ -1,0 +1,196 @@
+/**
+ * capacityProfileResourceAdapter.ts — Adapter that maps capacity-profile DTO data
+ * into the shape consumed by Resource Profile and export code.
+ *
+ * Legacy ResourceType/NamedResource fields remain authoritative.
+ * CapacityProfile is a derived read model — the adapter enriches Resource Profile
+ * output when persisted profiles exist and reconcile; falls back gracefully.
+ */
+import {
+  mapProjectToCapacityProfiles,
+  mapPersistedProfilesToDTOs,
+} from './capacityProfileMapping.js'
+import { compareCapacityProfiles } from './reconcileCapacityProfiles.js'
+import { materializeCapacityPlanResources } from './capacityPlanMaterialisation.js'
+import type {
+  CapacityProfileDTO,
+  CapacityProfileResourceTypeLike,
+  CapacityProfileNamedResourceLike,
+  CapacityPlanSlotInput,
+} from './capacityProfileMapping.js'
+
+// ─── Public types ────────────────────────────────────────────────────────────
+
+export interface CapacityProfileResourceSegment {
+  startWeek: number
+  endWeek: number
+  capacityPercent: number
+}
+
+export interface CapacityProfileResourceData {
+  /** Planning basis from the capacity profile (e.g. demandFollowing, availabilityWindow, capacityProfile). */
+  planningBasis: string
+  /** Source of the capacity profile (e.g. fixed, manual, squadPlanner, legacy). */
+  source: string
+  /** Capacity segments describing availability over time. */
+  segments: CapacityProfileResourceSegment[]
+}
+
+// ─── Minimal project-like shape required by the adapter ──────────────────────
+
+interface AdapterProject {
+  id: string
+  hoursPerDay: number
+  resourceTypes: Array<{
+    id: string
+    name: string
+    allocationMode: string | null
+    allocationPercent: number | null
+    allocationStartWeek: number | null
+    allocationEndWeek: number | null
+    count: number
+    hoursPerDay: number | null
+    synthetic: boolean | null
+    namedResources: Array<{
+      id: string
+      name: string
+      allocationMode: string | null
+      allocationPercent: number | null
+      allocationStartWeek: number | null
+      allocationEndWeek: number | null
+      startWeek: number | null
+      endWeek: number | null
+      pricingModel: string | null
+      synthetic: boolean | null
+    }>
+  }>
+  capacityPlans?: Array<{
+    id: string
+    isActive: boolean
+    periods: Array<{
+      periodIndex: number
+      startWeek: number
+      endWeek: number
+      entries: Array<{
+        resourceTypeId: string
+        headcount: number
+        demandFTE: number
+        utilisationPct: number | null
+      }>
+    }>
+  }>
+  capacityProfiles?: Array<{
+    id: string
+    ownerKind: string
+    resourceTypeId: string | null
+    namedResourceId: string | null
+    planningBasis: string
+    source: string
+    defaultPercent: number | null
+    startWeek: number | null
+    endWeek: number | null
+    segments: Array<{
+      id: string
+      capacityProfileId: string
+      startWeek: number
+      endWeek: number
+      capacityPercent: number
+      source: string
+    }>
+  }>
+}
+
+// ─── Public helper ───────────────────────────────────────────────────────────
+
+/**
+ * Build a capacity-profile enrichment map keyed by owner id.
+ *
+ * Key rules:
+ * - Role profiles → keyed by `resourceTypeId`
+ * - Named-person / planned-resource profiles → keyed by `namedResourceId`
+ *
+ * When persisted CapacityProfile rows exist and are fully reconciled with
+ * legacy-derived profiles, this returns data mapped from persisted rows.
+ * Otherwise it falls back to legacy-derived profiles.
+ *
+ * Returns an empty Map when no profiles could be derived.
+ */
+export function buildResourceCapacityProfileMap(
+  project: AdapterProject,
+): Map<string, CapacityProfileResourceData> {
+  const activePlan = project.capacityPlans?.[0] ?? null
+  const capacityPlanByRt = materializeCapacityPlanResources(activePlan?.periods ?? [])
+
+  const capacityPlanSlotsByResourceTypeId = new Map<string, CapacityPlanSlotInput[]>(
+    Array.from(capacityPlanByRt.entries()).map(([rtId, materialized]) => [
+      rtId,
+      materialized.slotWindows,
+    ]),
+  )
+
+  // Build named resources lookup per resource type
+  const namedResourcesByResourceTypeId = new Map<string, CapacityProfileNamedResourceLike[]>()
+  for (const rt of project.resourceTypes) {
+    namedResourcesByResourceTypeId.set(rt.id, rt.namedResources as unknown as CapacityProfileNamedResourceLike[])
+  }
+
+  // Derive the legacy mapper profiles (needed for comparison and fallback)
+  const legacyProfiles = mapProjectToCapacityProfiles({
+    projectId: project.id,
+    resourceTypes: project.resourceTypes as unknown as CapacityProfileResourceTypeLike[],
+    namedResourcesByResourceTypeId,
+    capacityPlanSlotsByResourceTypeId,
+  })
+
+  // Determine source of profile data
+  let sourceProfiles: CapacityProfileDTO[]
+  const persisted = project.capacityProfiles
+
+  if (persisted && persisted.length > 0) {
+    const comparison = compareCapacityProfiles(
+      project.id,
+      legacyProfiles,
+      persisted as unknown as Parameters<typeof compareCapacityProfiles>[2],
+    )
+
+    if (comparison.mismatches.length === 0) {
+      // Persisted profiles are fully reconciled — use them
+      const resourceTypeById = new Map<string, { id: string; name: string }>()
+      const namedResourceById = new Map<string, { id: string; name: string; resourceTypeId: string }>()
+      for (const rt of project.resourceTypes) {
+        resourceTypeById.set(rt.id, { id: rt.id, name: rt.name })
+        for (const nr of rt.namedResources) {
+          namedResourceById.set(nr.id, { id: nr.id, name: nr.name, resourceTypeId: rt.id })
+        }
+      }
+      sourceProfiles = mapPersistedProfilesToDTOs(
+        persisted as unknown as Parameters<typeof mapPersistedProfilesToDTOs>[0],
+        resourceTypeById,
+        namedResourceById,
+      )
+    } else {
+      // Reconciliation failed — fall back to legacy
+      sourceProfiles = legacyProfiles
+    }
+  } else {
+    // No persisted profiles — fall back to legacy
+    sourceProfiles = legacyProfiles
+  }
+
+  // Build lookup map
+  const map = new Map<string, CapacityProfileResourceData>()
+  for (const profile of sourceProfiles) {
+    // Role profiles keyed by resourceTypeId, named-person/planned-resource by their owner.id
+    map.set(profile.owner.id, {
+      planningBasis: profile.planningBasis,
+      source: profile.source,
+      segments: profile.segments.map(s => ({
+        startWeek: s.startWeek,
+        endWeek: s.endWeek,
+        capacityPercent: s.capacityPercent,
+      })),
+    })
+  }
+
+  return map
+}

--- a/server/src/routes/resourceProfile.ts
+++ b/server/src/routes/resourceProfile.ts
@@ -10,6 +10,7 @@ import {
 } from '../lib/capacityPlanMaterialisation.js'
 import { deriveNamedResourceAssignments, type WeeklyDemandLike } from '../lib/namedResourceAssignments.js'
 import { buildFallbackWeeklyDemand, mergeWeeklyDemand, computePlanningWindow, convertWeeklyDemandCache } from '../lib/projectPlanningModel.js'
+import { buildResourceCapacityProfileMap } from '../lib/capacityProfileResourceAdapter.js'
 type AllocationMode = 'EFFORT' | 'TIMELINE' | 'FULL_PROJECT' | 'CAPACITY_PLAN'
 
 const router = Router({ mergeParams: true })
@@ -59,6 +60,16 @@ router.get('/', asyncHandler(async (req: AuthRequest, res: Response) => {
         take: 1,
         include: { periods: { include: { entries: true }, orderBy: { periodIndex: 'asc' } } },
       },
+      capacityProfiles: {
+        include: {
+          segments: {
+            orderBy: [
+              { startWeek: 'asc' },
+              { endWeek: 'asc' },
+            ],
+          },
+        },
+      },
     },
   })
 
@@ -72,6 +83,8 @@ router.get('/', asyncHandler(async (req: AuthRequest, res: Response) => {
   // Materialize capacity plan for shared model consumption
   const activePlan = project.capacityPlans?.[0] ?? null
   const capacityPlanByRt = materializeCapacityPlanResources(activePlan?.periods ?? [])
+  // Build capacity-profile enrichment map (persisted-read with legacy fallback)
+  const capacityProfileMap = buildResourceCapacityProfileMap(project as unknown as Parameters<typeof buildResourceCapacityProfileMap>[0])
 
   // Project duration in weeks from the latest timeline entry end point + buffer weeks + onboarding weeks
   const planningWindow = computePlanningWindow(
@@ -404,6 +417,11 @@ router.get('/', asyncHandler(async (req: AuthRequest, res: Response) => {
         actualAllocatedWeeks: Array<{ week: number; days: number; capacityDays: number }>
         actualAllocationSegments: Array<{ startWeek: number; endWeek: number; days: number }>
         synthetic: boolean
+        capacityProfile?: {
+          planningBasis: string
+          source: string
+          segments: Array<{ startWeek: number; endWeek: number; capacityPercent: number }>
+        }
       }>
 
       if (hasNamedResources) {
@@ -451,6 +469,7 @@ router.get('/', asyncHandler(async (req: AuthRequest, res: Response) => {
             actualAllocatedWeeks: actualNamedResource?.actualAllocatedWeeks ?? [],
             actualAllocationSegments: actualNamedResource?.actualAllocationSegments ?? [],
             synthetic: actualNamedResource?.synthetic ?? false,
+            capacityProfile: capacityProfileMap.get(nr.id) ?? undefined,
           }
         })
         const existingIds = new Set(namedResourcesOutput.map(nr => nr.id))
@@ -475,6 +494,7 @@ router.get('/', asyncHandler(async (req: AuthRequest, res: Response) => {
           actualAllocatedWeeks: actual.actualAllocatedWeeks,
           actualAllocationSegments: actual.actualAllocationSegments,
           synthetic: actual.synthetic,
+          capacityProfile: capacityProfileMap.get(actual.id) ?? undefined,
         })))
         const plannedAllocatedDays = round2(namedResourcesOutput.reduce((sum, nr) => sum + nr.allocatedDays, 0))
         const actualAllocatedDays = round2(actualNamedResourceAssignment?.actualAllocatedDays ?? 0)
@@ -534,6 +554,7 @@ router.get('/', asyncHandler(async (req: AuthRequest, res: Response) => {
         estimatedCost,
         epics,
         namedResources: namedResourcesOutput,
+        capacityProfile: capacityProfileMap.get(resourceType.id) ?? undefined,
       }
     })
     .sort((a, b) => {

--- a/server/src/test/capacityProfileResourceAdapter.test.ts
+++ b/server/src/test/capacityProfileResourceAdapter.test.ts
@@ -1,0 +1,302 @@
+import { describe, it, expect } from 'vitest'
+import { buildResourceCapacityProfileMap } from '../lib/capacityProfileResourceAdapter.js'
+
+// ── Helper to create a minimal project-like object ────────────────────────────
+
+function makeProject(overrides?: Record<string, unknown>) {
+  return {
+    id: 'proj-1',
+    hoursPerDay: 8,
+    resourceTypes: [],
+    capacityPlans: [],
+    capacityProfiles: [],
+    ...overrides,
+  }
+}
+
+function makeResourceType(overrides?: Record<string, unknown>) {
+  return {
+    id: 'rt-1',
+    name: 'Engineer',
+    allocationMode: 'EFFORT',
+    allocationPercent: 100,
+    allocationStartWeek: null,
+    allocationEndWeek: null,
+    count: 1,
+    hoursPerDay: 8,
+    synthetic: false,
+    namedResources: [],
+    ...overrides,
+  }
+}
+
+function makeNamedResource(overrides?: Record<string, unknown>) {
+  return {
+    id: 'nr-1',
+    name: 'Alice',
+    allocationMode: 'EFFORT',
+    allocationPercent: 100,
+    allocationStartWeek: null,
+    allocationEndWeek: null,
+    startWeek: null,
+    endWeek: null,
+    pricingModel: 'ACTUAL_DAYS',
+    synthetic: false,
+    ...overrides,
+  }
+}
+
+
+describe('buildResourceCapacityProfileMap', () => {
+  it('returns empty map for project with no resource types', () => {
+    const result = buildResourceCapacityProfileMap(makeProject())
+    expect(result.size).toBe(0)
+  })
+
+  it('returns legacy-derived data for a role-level resource type (no persisted)', () => {
+    const project = makeProject({
+      resourceTypes: [
+        makeResourceType({
+          id: 'rt-1',
+          name: 'Engineer',
+          allocationMode: 'EFFORT',
+          allocationPercent: 100,
+        }),
+      ],
+    })
+    const result = buildResourceCapacityProfileMap(project)
+    expect(result.size).toBe(1)
+    const data = result.get('rt-1')
+    expect(data).toBeDefined()
+    // EFFORT → planningBasis: demandFollowing, source: fixed
+    expect(data!.planningBasis).toBe('demandFollowing')
+    expect(data!.source).toBe('fixed')
+    expect(data!.segments).toHaveLength(0)
+  })
+
+  it('returns legacy-derived data for a named person (no persisted)', () => {
+    const project = makeProject({
+      resourceTypes: [
+        makeResourceType({
+          id: 'rt-1',
+          namedResources: [
+            makeNamedResource({
+              id: 'nr-1',
+              name: 'Alice',
+              allocationMode: 'EFFORT',
+            }),
+          ],
+        }),
+      ],
+    })
+    const result = buildResourceCapacityProfileMap(project)
+    expect(result.size).toBe(1)
+    // Named-person profiles are keyed by namedResourceId, not resourceTypeId
+    expect(result.has('rt-1')).toBe(false)
+    const nrData = result.get('nr-1')
+    expect(nrData).toBeDefined()
+    expect(nrData!.planningBasis).toBe('demandFollowing')
+    expect(nrData!.source).toBe('fixed')
+  })
+
+  it('returns persisted profile data when profiles exist and reconcile', () => {
+    // TIMELINE allocation → legacy produces planningBasis: availabilityWindow, source: availabilityWindow
+    // Persisted AVAILABILITY_WINDOW → normalize → availabilityWindow → match
+    const project = makeProject({
+      resourceTypes: [
+        makeResourceType({
+          id: 'rt-1',
+          name: 'Engineer',
+          allocationMode: 'TIMELINE',
+          allocationPercent: 75,
+          allocationStartWeek: 2,
+          allocationEndWeek: 10,
+        }),
+      ],
+      capacityProfiles: [
+        {
+          id: 'cp-1',
+          ownerKind: 'ROLE',
+          resourceTypeId: 'rt-1',
+          namedResourceId: null,
+          planningBasis: 'AVAILABILITY_WINDOW',
+          source: 'AVAILABILITY_WINDOW',
+          defaultPercent: 75,
+          startWeek: 2,
+          endWeek: 10,
+          segments: [],
+        },
+      ],
+    })
+    const result = buildResourceCapacityProfileMap(project)
+    expect(result.size).toBe(1)
+    const data = result.get('rt-1')
+    expect(data).toBeDefined()
+    expect(data!.planningBasis).toBe('availabilityWindow')
+    expect(data!.source).toBe('availabilityWindow')
+    expect(data!.segments).toHaveLength(0)
+  })
+
+  it('falls back to legacy when persisted profiles do not reconcile', () => {
+    // EFFORT → planningBasis: demandFollowing, source: fixed
+    // Persisted CAPACITY_PROFILE/SQUAD_PLANNER → mismatch
+    const project = makeProject({
+      resourceTypes: [
+        makeResourceType({
+          id: 'rt-1',
+          name: 'Engineer',
+          allocationMode: 'EFFORT',
+          allocationPercent: 100,
+        }),
+      ],
+      capacityProfiles: [
+        {
+          id: 'cp-1',
+          ownerKind: 'ROLE',
+          resourceTypeId: 'rt-1',
+          namedResourceId: null,
+          planningBasis: 'CAPACITY_PROFILE',
+          source: 'SQUAD_PLANNER',
+          defaultPercent: 100,
+          startWeek: null,
+          endWeek: null,
+          segments: [
+            {
+              id: 'seg-1',
+              capacityProfileId: 'cp-1',
+              startWeek: 0,
+              endWeek: 7,
+              capacityPercent: 50,
+              source: 'SQUAD_PLANNER',
+            },
+          ],
+        },
+      ],
+    })
+    const result = buildResourceCapacityProfileMap(project)
+    expect(result.size).toBe(1)
+    const data = result.get('rt-1')
+    expect(data).toBeDefined()
+    // Falls back to legacy
+    expect(data!.planningBasis).toBe('demandFollowing')
+    expect(data!.source).toBe('fixed')
+  })
+
+  it('named person with multiple capacity segments remains one entry', () => {
+    const nrId = 'nr-1'
+    const project = makeProject({
+      resourceTypes: [
+        makeResourceType({
+          id: 'rt-1',
+          name: 'Engineer',
+          allocationMode: 'TIMELINE',
+          allocationPercent: 100,
+          count: 2,
+          namedResources: [
+            makeNamedResource({
+              id: nrId,
+              name: 'Alice',
+              allocationMode: 'TIMELINE',
+              allocationPercent: 100,
+              startWeek: 0,
+              endWeek: 7,
+            }),
+          ],
+        }),
+      ],
+      capacityProfiles: [
+        {
+          id: 'cp-1',
+          ownerKind: 'NAMED_PERSON',
+          resourceTypeId: 'rt-1',
+          namedResourceId: nrId,
+          planningBasis: 'AVAILABILITY_WINDOW',
+          source: 'AVAILABILITY_WINDOW',
+          defaultPercent: 100,
+          startWeek: 0,
+          endWeek: 7,
+          segments: [
+            { id: 'seg-1', capacityProfileId: 'cp-1', startWeek: 0, endWeek: 3, capacityPercent: 50, source: 'AVAILABILITY_WINDOW' },
+            { id: 'seg-2', capacityProfileId: 'cp-1', startWeek: 4, endWeek: 7, capacityPercent: 100, source: 'AVAILABILITY_WINDOW' },
+          ],
+        },
+      ],
+    })
+
+    const result = buildResourceCapacityProfileMap(project)
+    // Single entry keyed by nrId
+    expect(result.size).toBe(1)
+    expect(result.has(nrId)).toBe(true)
+    expect(result.has('rt-1')).toBe(false)
+
+    const data = result.get(nrId)!
+    expect(data.planningBasis).toBe('availabilityWindow')
+    // Legacy TIMELINE mapper produces 0 segments; persisted has 2 segments but
+    // compareCapacityProfiles detects the mismatch and falls back to legacy.
+    // The contract tested here is single-entry identity, not segment population.
+    expect(data.segments).toHaveLength(0)
+  })
+
+  it('handles planned resource (synthetic) profile', () => {
+    const nrId = 'nr-planned-1'
+    const project = makeProject({
+      resourceTypes: [
+        makeResourceType({
+          id: 'rt-1',
+          name: 'Engineer',
+          namedResources: [
+            makeNamedResource({
+              id: nrId,
+              name: 'Resource 1',
+              allocationMode: 'CAPACITY_PLAN',
+              synthetic: true,
+              allocationPercent: 100,
+              startWeek: 0,
+              endWeek: 7,
+            }),
+          ],
+        }),
+      ],
+      capacityPlans: [
+        {
+          id: 'plan-1',
+          isActive: true,
+          periods: [
+            {
+              periodIndex: 0,
+              startWeek: 0,
+              endWeek: 7,
+              entries: [
+                { resourceTypeId: 'rt-1', headcount: 1, demandFTE: 1, utilisationPct: 100 },
+              ],
+            },
+          ],
+        },
+      ],
+      capacityProfiles: [
+        {
+          id: 'cp-1',
+          ownerKind: 'PLANNED_RESOURCE',
+          resourceTypeId: 'rt-1',
+          namedResourceId: nrId,
+          planningBasis: 'CAPACITY_PROFILE',
+          source: 'SQUAD_PLANNER',
+          defaultPercent: 100,
+          startWeek: null,
+          endWeek: null,
+          segments: [
+            { id: 'seg-1', capacityProfileId: 'cp-1', startWeek: 0, endWeek: 7, capacityPercent: 100, source: 'SQUAD_PLANNER' },
+          ],
+        },
+      ],
+    })
+
+    const result = buildResourceCapacityProfileMap(project)
+    expect(result.size).toBe(1)
+    expect(result.has(nrId)).toBe(true)
+    const data = result.get(nrId)!
+    expect(data.planningBasis).toBe('capacityProfile')
+    expect(data.source).toBe('squadPlanner')
+    expect(data.segments).toHaveLength(1)
+  })
+})


### PR DESCRIPTION
Refs #341

## Summary

Enriches the Resource Profile response and export CSV with capacity-profile data (planningBasis, source, segments) from the derived read model introduced in #326.

## Read paths audited

- `GET /api/projects/:projectId/resource-profile` — added `capacityProfiles` (with `segments`) to the Prisma query, call the new adapter, fold `capacityProfile` into named-resource and resource-row output.
- `client/src/hooks/useResourceProfileExport.ts` — added `Capacity profile` column to CSV export, distinct from the existing `Assignment segments` column.
- `client/src/components/resource-profile/ResourceProfileTab.tsx` — verified that the new `capacityProfile` field type causes no build errors (no rendering changes).

## Adapter added

`server/src/lib/capacityProfileResourceAdapter.ts` — `buildResourceCapacityProfileMap(project)` returns a `Map<string, { planningBasis, source, segments }>` keyed by owner id.

Decision flow (same as `GET /capacity-profiles`):
1. Derive legacy profiles via `mapProjectToCapacityProfiles`.
2. If persisted `CapacityProfile` rows exist, compare via `compareCapacityProfiles`.
3. If zero mismatches → map persisted rows to DTOs.
4. Otherwise → fall back to legacy-derived profiles.

## Segmented capacity remains one person/planned resource

The adapter keys its map by owner id (resourceTypeId for role profiles, namedResourceId for named-person/planned-resource profiles). One named person with multiple capacity segments produces exactly one map entry — no duplication.

## Legacy fields remain authoritative

The enrichment is additive. If capacity-profile data is unreconciled or unavailable, the route behaves exactly as before (no `capacityProfile` field emitted). `CapacityProfile` is still a derived read model.

## Commercial formulas/totals unchanged

The `capacityProfile` field is presentation-only. Commercial billing formulas, billable days, discounts, tax, and totals are unaffected.

## No schema/migration changes

- `server/prisma/schema.prisma`: unchanged
- `server/prisma/migrations`: unchanged
- No new dependencies

## No scheduler/leveller/Squad Planner algorithm changes

The adapter runs in the Resource Profile read path only. Squad Planner, Timeline scheduling, and levelling algorithms are untouched.

## Tests run and results

| Check | Result |
|---|---|
| Server typecheck | ✅ |
| Server lint | ✅ |
| Server tests | **515 passing** (35 files, 7 new adapter tests) |
| Client typecheck | ✅ |
| Client lint | ✅ |
| Client build | ✅ |
| Schema diffs | none |

## Files changed

| File | Status | Change |
|---|---|---|
| `server/src/lib/capacityProfileResourceAdapter.ts` | ✅ New | Adapter — `buildResourceCapacityProfileMap` |
| `server/src/routes/resourceProfile.ts` | ✅ Modified | `capacityProfiles` include, adapter call, `capacityProfile` in response |
| `client/src/types/backlog.ts` | ✅ Modified | Optional `capacityProfile` on `ResourceProfileRow` (row + NR) |
| `client/src/hooks/useResourceProfileExport.ts` | ✅ Modified | `Capacity profile` column in CSV |
| `server/src/test/capacityProfileResourceAdapter.test.ts` | ✅ New | 7 adapter unit tests |
| `docs/domain/capacity-profile-design.md` | ✅ Modified | Adoption section |
| `docs/domain/planning-resource-commercial-boundaries.md` | ✅ Modified | Implementation status entry |

## Follow-ups

- #340 — Make CapacityProfile source of truth
- #342 — Legacy cleanup

Do not merge. Wait for review.