### PR TITLE
docs: plan capacity profile source-of-truth migration

### DIFF
--- a/docs/domain/capacity-profile-design.md
+++ b/docs/domain/capacity-profile-design.md
@@ -500,6 +500,9 @@ column (which reflects actual scheduled assignment).
 
 ### Related issues
 
-- #340 — Make CapacityProfile source of truth
-- #342 — Legacy cleanup
+- [#340 — Make CapacityProfile source of truth](../..issues/340)
+- [#342 — Legacy cleanup](../..issues/342)
 
+### Source-of-truth migration plan
+
+See the separate [`capacity-profile-source-of-truth-migration-plan.md`](capacity-profile-source-of-truth-migration-plan.md) for the staged migration plan, field audit, regression matrix, and open decisions.

--- a/docs/domain/capacity-profile-design.md
+++ b/docs/domain/capacity-profile-design.md
@@ -500,8 +500,8 @@ column (which reflects actual scheduled assignment).
 
 ### Related issues
 
-- [#340 — Make CapacityProfile source of truth](../..issues/340)
-- [#342 — Legacy cleanup](../..issues/342)
+- #340 — Make CapacityProfile source of truth
+- #342 — Legacy cleanup
 
 ### Source-of-truth migration plan
 

--- a/docs/domain/capacity-profile-source-of-truth-migration-plan.md
+++ b/docs/domain/capacity-profile-source-of-truth-migration-plan.md
@@ -1,0 +1,325 @@
+# Capacity Profile — Source-of-Truth Migration Plan
+
+**Epic:** #340  
+**Status:** Plan / audit only — not yet implemented  
+**PR:** <!--link to this PR-->
+
+## Overview
+
+Issues [#326](../..issues/326), [#336](../..issues/336), [#337](../..issues/337), [#338](../..issues/338), [#339](../..issues/339), and [#341](../..issues/341) delivered `CapacityProfile` / `CapacitySegment` as an **additive derived read model**. Legacy `ResourceType`, `NamedResource`, and `CapacityPlan` fields remain authoritative. The adapter in `capacityProfileResourceAdapter.ts` reads profiles and falls back to legacy-derived values when persisted data does not match.
+
+Issue [#340](../..issues/340) is the larger migration where capacity profiles become the **actual source of truth** for allocation data.
+
+## Principles
+
+1. **Read adoption before write migration.** Read paths were migrated first (#336, #341). No write path is authoritative on capacity profiles yet.
+2. **Migrate one authoritative write path at a time.** Each phase flips one write path to produce capacity profiles as source of truth and project legacy fields as compatibility.
+3. **Keep legacy fields as compatibility projections** until all consumers have migrated. Do not remove them until [#342](../..issues/342).
+4. **Commercial remains billing-only.** Capacity profiles describe availability, not billing.
+5. **Reconcile after each migrated write path.** `compareCapacityProfiles` validates that persisted profiles match expected state. Once writes are flipped, reconciliation direction must invert.
+6. **Keep rollback possible** while legacy projections remain current. The fallback in `capacityProfileResourceAdapter.ts` is the safety net.
+
+## Audit
+
+### Field classification
+
+#### Future CapacityProfile source-of-truth fields
+
+| Table | Field | Maps to |
+|-------|-------|---------|
+| `ResourceType` | `allocationMode` | `CapacityProfile.planningBasis` (role level) |
+| `ResourceType` | `allocationPercent` | default segment `capacityPercent` or role fixed FTE |
+| `ResourceType` | `allocationStartWeek` | role availability-window segment start |
+| `ResourceType` | `allocationEndWeek` | role availability-window segment end |
+| `NamedResource` | `allocationMode` | `CapacityProfile.planningBasis` (per-named-resource) |
+| `NamedResource` | `allocationPercent` / `allocationPct` | default segment `capacityPercent` (field precedence: `allocationPercent > allocationPct`) |
+| `NamedResource` | `allocationStartWeek` | per-nr availability-window segment start |
+| `NamedResource` | `allocationEndWeek` | per-nr availability-window segment end |
+| `NamedResource` | `startWeek` / `endWeek` | segment windows (actual assignment) |
+| `CapacityPlan` | all periods/entries | Squad Planner generated profiles |
+
+#### Legacy compatibility projections
+
+Once source of truth flips, the same fields above become **read-only compatibility projections** that must be kept in sync with the `CapacityProfile` table. The `syncCapacityProfilesForProject` helper is currently derived → profile. After migration it must become profile → derived.
+
+#### Independent metadata (not capacity-profile-owned)
+
+| Table | Field | Reason |
+|-------|-------|--------|
+| `ResourceType` | `count` | Role metadata. Affects phantom slot count (`count - namedResources.length`) in scheduler. Stays role-level metadata. |
+| `NamedResource` | `synthetic` | Flags planned resource vs named person. Maps to `ownerKind` in capacity profile. Independent identity metadata. |
+| `NamedResource` | `pricingModel` | Commercial / billing basis. **Not** capacity-profile data. |
+
+### Key risks
+
+1. **Multi-segment → single start/end projection is inherently lossy.** A profile with segments `{W1-W4: 50%, W5-W10: 100%, W11-W14: 25%}` cannot be represented in a single `(startWeek, endWeek)` pair without losing information. Compatibility projections will need a strategy for truncation or the first/last segment.
+2. **Planned-resource identity instability.** Preview paths generate IDs like `capacity-plan-${rt.id}-${idx}`. Actual persisted NRs get stable IDs from the DB, but fallback paths from the adapter use IDs like `synthetic-{rt.id}-{N}`. Stable identity is a prerequisite for `PLANNED_RESOURCE` becoming authoritative.
+3. **`allocationPct` vs `allocationPercent` duality.** `NamedResource` has both. The model uses `allocationPercent` over `allocationPct` when both are set (`resourceProfile.ts` line ~196 and `mappers.ts`). Migration must preserve this precedence and consider dropping one.
+4. **`CAPACITY_PLAN` mode is a special case.** When `allocationMode === 'CAPACITY_PLAN'`, allocation fields are meaningless — capacity is derived from the active `CapacityPlan`. The mapping function (`capacityProfileMapping.ts`) already handles this by constructing segments from plan entries. Source-of-truth migration must preserve this derivation or make it explicit.
+5. **Squad Planner generates non-deterministic preview IDs.** Preview resources (`capacity-plan-*`) are not stable across sessions. Stable identity requires writing actual DB rows during planning, not just in "apply".
+6. **`shouldFallbackToActiveCapacityPlan` logic is scattered.** The function lives in `mappers.ts` but similar fallback logic exists in `resourceProfile.ts`, `timeline.ts`, and `projectPlanningModel.ts`. These must converge before or during migration.
+7. **`phantomSlots` in scheduler.** `scheduler.ts` computes `phantomSlots = resourceType.count - namedResources.length`, implicitly depending on `ResourceType.count`. This ties role-level count to scheduling behaviour independently of capacity profiles.
+
+### Files audited
+
+**Server routes:**
+- `server/src/routes/resourceProfile.ts` — reads all legacy allocation fields, produces DTO with optional `capacityProfile`
+- `server/src/routes/resourceTypes.ts` — CRUD on `ResourceType.allocationMode/Percent/StartWeek/EndWeek`, triggers sync
+- `server/src/routes/namedResources.ts` — CRUD on `NamedResource.allocationMode/Percent(Pct)/StartWeek/EndWeek/StartWeek/EndWeek/PricingModel/Synthetic`, triggers sync
+- `server/src/routes/capacityProfiles.ts` — GET persisted profiles (read-side endpoint)
+- `server/src/routes/squadPlan.ts` — generates plans, applies with sync
+- `server/src/routes/projects.ts` — POST creates project with initial RTs, triggers sync
+- `server/src/routes/timeline.ts` — reads RT/NR allocation for scheduling, consumes `shouldFallbackToActiveCapacityPlan`
+
+**Server lib:**
+- `server/src/lib/capacityProfileMapping.ts` — core mapper: `mapProjectToCapacityProfiles` derives profiles from legacy fields
+- `server/src/lib/syncCapacityProfiles.ts` — `syncCapacityProfilesForProject` upserts/deletes segments to match mapped profiles
+- `server/src/lib/reconcileCapacityProfiles.ts` — `compareCapacityProfiles` compares mapped vs persisted
+- `server/src/lib/backfillCapacityProfiles.ts` — iterates projects calling sync
+- `server/src/lib/capacityProfileResourceAdapter.ts` — new adapter for #341, reads persisted or falls back to legacy
+- `server/src/lib/projectPlanningModel.ts` — reads RT/NR allocation fields for resource-demand calculation
+- `server/src/lib/namedResourceAssignments.ts` — reads NR allocation fields for assignment logic
+- `server/src/lib/scheduler.ts` — consumes allocation fields, `phantomSlots` uses `count`
+- `server/src/lib/leveller.ts` — reads resource availability for levelling
+- `server/src/lib/capacityPlanMaterialisation.ts` — materialises capacity plans into segments
+- `server/src/lib/capacity-planning/` — Squad Planner helpers
+
+**Client:**
+- `client/src/components/resource-profile/ResourceProfileTab.tsx` — displays resource rows, reads `capacityProfile` if present
+- `client/src/components/resource-profile/CommercialTab.tsx` — billing UI, consumes `pricingModel`, `allocationPercent`, etc.
+- `client/src/hooks/useResourceProfileExport.ts` — CSV export, consumes `capacityProfile`, legacy fields
+- `client/src/pages/TimelinePage.tsx` — timeline UI, reads allocation fields via DTO
+
+## Phase plan
+
+### Phase 0 — Audit and decision record ✅ (this document)
+
+The audit above classifies all fields. Remaining decisions:
+
+| Decision | Options | Recommendation |
+|----------|---------|----------------|
+| `pricingModel` ownership | (a) stays Commercial metadata; (b) moves into CapacityProfile | **(a)** — Commercial field, not capacity data |
+| `ResourceType.count` relation to profile | (a) stays role metadata; (b) becomes capacity-profile property | **(a)** — `count` is headcount target, not per-person capacity |
+| Planned-resource identity | (a) stable IDs from DB on apply; (b) UUID-based stable IDs that survive preview | **(a)** simplest; preview never needs stable identity |
+| Multi-segment backward projection | (a) truncate to first/last segment start/end; (b) leave empty; (c) emit contiguous merged range | **(c)** — merged range is safest for backward compat but semantically lossy — document limitation |
+| `allocationPct` removal | (a) keep both forever; (b) normalise to `allocationPercent` only in migration | **(b)** — source-of-truth migration is the right moment |
+
+### Phase 1 — Harden read-side contracts
+
+Before flipping writes, add or identify tests proving:
+
+- **Resource Profile** can read capacity-profile DTOs safely (existing: `capacityProfileResourceAdapter.test.ts`).
+- **Exports** keep capacity profile, assigned work, and billing basis separate (existing: `useResourceProfile.test.ts`).
+- **One named person with multiple segments** remains one row (existing adapter tests).
+- **One planned resource with multiple segments** remains one row (existing adapter tests).
+- **Commercial totals** remain unchanged (check: `CommercialTab.tsx`, server commercial tests).
+- **Legacy fallback** still works when persisted profiles are empty or mismatched (existing: `capacityProfilePersistedDtoIntegration.test.ts`).
+
+Gap: No test explicitly verifies that multi-segment profiles roundtrip through export CSV → parsed spreadsheet columns. Consider adding if CSV parser roundtrip is a requirement.
+
+### Phase 2 — Compatibility projection helpers
+
+Add pure helpers that project `CapacityProfile` state back into legacy field shapes *without* writing to legacy tables. These are the inverse of `mapProjectToCapacityProfiles`.
+
+```typescript
+// Project a CapacityProfile into legacy ResourceType/NamedResource allocation shape
+function projectProfileToLegacyAllocation(profile: CapacityProfileDTO): {
+  allocationMode: string;
+  allocationPercent: number | null;
+  allocationStartWeek: number | null;
+  allocationEndWeek: number | null;
+} { /* ... */ }
+```
+
+**Lossy cases (documented):**
+
+| Profile shape | Legacy projection |
+|---|---|
+| Fixed FTE (single percent, no segments) | `allocationPercent = percent`, `startWeek/endWeek = null` |
+| Availability window (single segment) | `allocationPercent = seg.capacityPercent`, `startWeek = seg.startWeek`, `endWeek = seg.endWeek` |
+| Multi-segment | Cannot be losslessly represented. Project as merged range `(min(startWeek), max(endWeek))` with overall average percent. **Semantic loss warning.** |
+| CAPACITY_PLAN derived | Remains special: legacy fields stay as-is (or become explicit profile ref) |
+
+### Phase 3 — First source-of-truth write path: NamedResource capacity/profile editing
+
+**Recommended first migration target:** NamedResource allocation editing (`PUT /named-resources/:id`).
+
+#### Current behaviour
+
+`PUT /named-resources/:id` writes legacy fields directly to `NamedResource`, then calls `syncCapacityProfilesForProject` as a post-write sync.
+
+#### Migrated behaviour
+
+1. Write to `CapacityProfile` / `CapacitySegment` as authoritative.
+2. Compute legacy compatibility fields from the new profile via `projectProfileToLegacyAllocation`.
+3. Write compatibility fields to `NamedResource` in the same transaction.
+4. Run reconciliation after write (now comparing legacy projection vs profile, not the reverse).
+5. Response shape unchanged (existing `NamedResource` DTO).
+
+#### Transaction boundaries
+
+```
+$transaction([
+  // 1. Authoritative profile write
+  prisma.capacityProfile.upsert({ ... }),
+  prisma.capacitySegment.deleteMany({ where: { profileId } }),
+  prisma.capacitySegment.createMany({ data: newSegments }),
+  // 2. Legacy compatibility projection
+  prisma.namedResource.update({ data: { allocationMode, allocationPercent, allocationStartWeek, allocationEndWeek } }),
+])
+```
+
+#### Rollback safety
+
+- Legacy compatibility fields are written in the same transaction. If the transaction fails, nothing changes.
+- If only profile is correct and legacy projection is wrong (bug in helper), the mismatch is detected by the existing reconciliation report.
+- `capacityProfileResourceAdapter.ts` falls back to legacy fields when reconciliation mismatch is detected. So even a buggy projection keeps existing reads working via fallback.
+
+#### Non-goal
+
+Do not change the request/response shape of `PUT /named-resources/:id` in this phase. The client still sends legacy fields; the server projects them into profile as source of truth. The client can be migrated in a follow-up.
+
+### Phase 4 — Role-level / ResourceType capacity writes
+
+Migrate role-level capacity editing (`PATCH /resource-types/:id`).
+
+#### Additional concerns
+
+- **`ResourceType.count` interaction:** Role-level capacity updates should not change `count`. If count is adjusted separately, the capacity profile for the role must remain distinct from slot count.
+- **Role-level profile with named resources:** If a role has named resources with their own profiles, does the role-level profile act as a default/template, or is it independent? Recommend: role-level profile is the **default** for new named resources; existing NRs keep their own profiles.
+- **Interaction with planned resources:** Planned resources at the role level should inherit the role's capacity profile when created. Changing the role profile later should not retroactively change existing planned resources.
+
+#### Graduated approach
+
+1. `PATCH /resource-types/:id` writes `CapacityProfile` for the role.
+2. Live named resources without explicit profiles inherit from role profile at read time (adapter already does this via fallback).
+3. Named resources with explicit profiles are unaffected.
+4. New named resources created after role profile change get the current role profile as their default.
+
+### Phase 5 — Squad Planner apply
+
+Only migrate after Phases 3 and 4 are proven in production.
+
+#### Required prerequisites
+
+- **Stable planned-resource identity.** The `apply` endpoint currently generates NRs with predictable IDs (`capacity-plan-*`). Need actual DB persistence before capacity profiles can reference them.
+- **Repeated apply semantics defined.** What happens when Squad Planner is re-run and re-applied? Delete and recreate profiles? Merge? Version? The current sync-based approach deletes stale segments and recreates. Similar semantics: delete all capacity profiles for `CAPACITY_PLAN`-sourced NRs and recreate from new plan.
+- **Transaction boundaries.** Capacity-profile-affecting writes (NR creation, capacity profile creation) inside transaction. Timeline and weekly-demand cache outside, as currently done.
+
+#### Flow after migration
+
+```
+1. Squad Planner generates plan (unchanged — still reads legacy fields)
+2. Apply:
+   a. Create/update named resources (currently does this)
+   b. Write CapacityProfile/CapacitySegment as authoritative (new)
+   c. Sync legacy compatibility projections from profile (replaces current reverse sync)
+   d. Reconcile (now profile → legacy)
+   e. Materialise timeline (outside transaction)
+```
+
+### Phase 6 — Reverse reconciliation direction
+
+Once writes are profile-first:
+
+- `syncCapacityProfilesForProject` no longer means "derive profiles from legacy fields". It becomes a **compatibility projection** function that writes legacy fields from profile state.
+- Rename or restructure to reflect new direction: `projectLegacyFromProfiles` or similar.
+- `reconcileCapacityProfiles` should compare profile source of truth to legacy projections, not the reverse.
+- The `compareCapacityProfiles` helper may need a mode flag until both directions are proven.
+
+### Phase 7 — Legacy cleanup (#342)
+
+Tracked separately by [#342](../..issues/342).
+
+#### Preconditions
+
+1. All read paths consume profile DTO directly (not legacy fields).
+2. All write paths produce profile as source of truth.
+3. Compatibility projections run and reconcile cleanly in production.
+4. No consumer depends on legacy `allocationMode`, `allocationPercent`, `allocationStartWeek`, `allocationEndWeek` fields for correctness.
+5. Backfill/reconcile evidence is clean for at least one release cycle.
+
+#### Cleanup steps
+
+1. Remove `allocationPct` (normalise to `allocationPercent`).
+2. Make `allocationMode`, `allocationPercent`, `allocationStartWeek`, `allocationEndWeek` computed/generated columns or remove them from the Prisma schema.
+3. Update all read paths to use profile DTO only.
+4. Remove `syncCapacityProfilesForProject` — no longer needed when profiles are always source-of-truth.
+5. Remove `capacityProfileResourceAdapter.ts` fallback — no longer needed.
+6. Remove `mapProjectToCapacityProfiles` — no longer needed.
+7. Archive `capacityProfileMapping.ts`.
+
+#### Non-goals for cleanup
+
+- Do not remove `ResourceType.count` — role metadata, not profile data.
+- Do not remove `NamedResource.synthetic` — maps to `ownerKind`, independent identity metadata.
+- Do not remove `NamedResource.pricingModel` — Commercial metadata, not profile data.
+
+## Regression matrix
+
+### Commercial
+
+| Test | What to assert |
+|------|----------------|
+| Billing basis unchanged | `pricingModel` values preserved through migration |
+| Billable days unchanged | Total billable days same before/after profile write |
+| Discounts/tax/totals unchanged | Commercial aggregate calculations preserved |
+| PRO_RATA → "Bill planned allocation" export | CSV export text stable |
+
+### Resource Profile / Export
+
+| Test | What to assert |
+|------|----------------|
+| One person with multiple segments remains one row | NR row not duplicated per segment |
+| One planned resource with multiple segments remains one row | Planned resource not duplicated per segment |
+| Capacity profile, assigned work, billing basis are separate columns | CSV column independence |
+| Legacy fallback works | Adapter falls back when profiles missing or mismatched |
+| CSV roundtrip | Multi-segment profiles survive export → parse → compare |
+
+### Scheduler / Leveller / Timeline
+
+| Test | What to assert |
+|------|----------------|
+| Effective capacity unchanged for legacy-equivalent projects | Same schedule output when profiles match legacy fields |
+| Segmented capacity affects schedule only where intended | Multi-segment profiles produce correct per-week availability |
+| Resource levelling respects segmented capacity | Leveller reads per-week availability from profiles |
+| Phantom slots unaffected | `count - namedResources.length` stays same when count unchanged |
+
+### Squad Planner
+
+| Test | What to assert |
+|------|----------------|
+| Deterministic generated profiles | Same inputs → same profile output |
+| Stable planned-resource identity | NR IDs stable across repeated applies |
+| Repeated apply behaviour defined | Second apply does not duplicate or corrupt |
+| Preview (non-apply) unchanged | Preview does not write to DB, uses temporary IDs |
+
+### Operational
+
+| Test | What to assert |
+|------|----------------|
+| Backfill passes | `npm run capacity-profiles:backfill` exits 0 |
+| Reconciliation passes | `npm run capacity-profiles:reconcile` exits 0 |
+| Source-of-truth writes are transactional | Partial write failure rolls back both profile and legacy fields |
+| Stale profile deletion is safe | Deleting a capacity profile with no legacy counterpart does nothing harmful |
+
+## Open questions
+
+1. **Should capacity profiles always affect scheduling, or only when selected as the capacity source?** The answer changes how `scheduler.ts` and `leveller.ts` consume profiles. Current: only via `shouldFallbackToActiveCapacityPlan` logic. Target: always, once profiles are source of truth.
+2. **Should role-level capacity profiles be allowed without planned resources?** Yes — a role with `count: 3` but no named resources still has role-level capacity (phantom slots). The profile should represent that.
+3. **Should Squad Planner generate role-level profiles first, then let users map them to planned resources?** Possibly a future UX improvement, but the data model should support it.
+4. **Should billing basis be editable only in Commercial?** Yes — Commercial is the billing owner. The profile describes availability, not billing.
+5. **Do we need a legacy resource-profile export during transition?** Yes — the current export already works with profile DTO as additive enrichment. No separate legacy export needed.
+6. **How should NamedResource.allocationMode === 'CAPACITY_PLAN' be handled in source-of-truth mode?** Options: (a) reject editing allocation fields when mode is CAPACITY_PLAN, (b) treat CAPACITY_PLAN as "profile is derived from capacity plan" flag, (c) convert CAPACITY_PLAN into an explicit profile on first edit. Recommend (b) — the mode flag remains the indicator that profile comes from Squad Planner, and direct edits convert to an explicit profile.
+
+## Follow-up issues to consider
+
+| Issue | Description |
+|-------|-------------|
+| Normalise `allocationPct` → `allocationPercent` | Remove the dual field before or during source-of-truth migration |
+| Stable planned-resource identity | Make Squad Planner "Apply" produce stable DB-persisted NR IDs before migration |
+| Converge `shouldFallbackToActiveCapacityPlan` | Unify scattered fallback logic into one place |
+| CSV roundtrip test | Test multi-segment profile → CSV → parse → compare |
+| Phase 3 implementation | NamedResource capacity/profile editing as source of truth |
+| Phase 4 implementation | ResourceType capacity writes as source of truth |
+| Phase 5 implementation | Squad Planner apply as source of truth |

--- a/docs/domain/capacity-profile-source-of-truth-migration-plan.md
+++ b/docs/domain/capacity-profile-source-of-truth-migration-plan.md
@@ -2,19 +2,19 @@
 
 **Epic:** #340  
 **Status:** Plan / audit only — not yet implemented  
-**PR:** <!--link to this PR-->
+**PR:** #344
 
 ## Overview
 
-Issues [#326](../..issues/326), [#336](../..issues/336), [#337](../..issues/337), [#338](../..issues/338), [#339](../..issues/339), and [#341](../..issues/341) delivered `CapacityProfile` / `CapacitySegment` as an **additive derived read model**. Legacy `ResourceType`, `NamedResource`, and `CapacityPlan` fields remain authoritative. The adapter in `capacityProfileResourceAdapter.ts` reads profiles and falls back to legacy-derived values when persisted data does not match.
+Issues #326, #336, #337, #338, #339, and #341 delivered `CapacityProfile` / `CapacitySegment` as an **additive derived read model**. Legacy `ResourceType`, `NamedResource`, and `CapacityPlan` fields remain authoritative. The adapter in `capacityProfileResourceAdapter.ts` reads profiles and falls back to legacy-derived values when persisted data does not match.
 
-Issue [#340](../..issues/340) is the larger migration where capacity profiles become the **actual source of truth** for allocation data.
+Issue #340 is the larger migration where capacity profiles become the **actual source of truth** for allocation data.
 
 ## Principles
 
 1. **Read adoption before write migration.** Read paths were migrated first (#336, #341). No write path is authoritative on capacity profiles yet.
 2. **Migrate one authoritative write path at a time.** Each phase flips one write path to produce capacity profiles as source of truth and project legacy fields as compatibility.
-3. **Keep legacy fields as compatibility projections** until all consumers have migrated. Do not remove them until [#342](../..issues/342).
+3. **Keep legacy fields as compatibility projections** until all consumers have migrated. Do not remove them until #342.
 4. **Commercial remains billing-only.** Capacity profiles describe availability, not billing.
 5. **Reconcile after each migrated write path.** `compareCapacityProfiles` validates that persisted profiles match expected state. Once writes are flipped, reconciliation direction must invert.
 6. **Keep rollback possible** while legacy projections remain current. The fallback in `capacityProfileResourceAdapter.ts` is the safety net.
@@ -33,14 +33,26 @@ Issue [#340](../..issues/340) is the larger migration where capacity profiles be
 | `ResourceType` | `allocationEndWeek` | role availability-window segment end |
 | `NamedResource` | `allocationMode` | `CapacityProfile.planningBasis` (per-named-resource) |
 | `NamedResource` | `allocationPercent` / `allocationPct` | default segment `capacityPercent` (field precedence: `allocationPercent > allocationPct`) |
-| `NamedResource` | `allocationStartWeek` | per-nr availability-window segment start |
-| `NamedResource` | `allocationEndWeek` | per-nr availability-window segment end |
-| `NamedResource` | `startWeek` / `endWeek` | segment windows (actual assignment) |
 | `CapacityPlan` | all periods/entries | Squad Planner generated profiles |
 
 #### Legacy compatibility projections
 
-Once source of truth flips, the same fields above become **read-only compatibility projections** that must be kept in sync with the `CapacityProfile` table. The `syncCapacityProfilesForProject` helper is currently derived → profile. After migration it must become profile → derived.
+Once source of truth flips, fields above under **Future CapacityProfile source-of-truth fields** become **read-only compatibility projections** that must be kept in sync with the `CapacityProfile` table. The `syncCapacityProfilesForProject` helper is currently derived → profile. After migration it must become profile → derived.
+
+Additional NamedResource fields that serve as legacy availability-window compatibility fields:
+
+| Table | Field | Role |
+|-------|-------|------|
+| `NamedResource` | `allocationStartWeek` | explicit legacy availability-window compatibility field |
+| `NamedResource` | `allocationEndWeek` | explicit legacy availability-window compatibility field |
+| `NamedResource` | `startWeek` / `endWeek` | legacy fallback availability-window fields used by older paths; not actual scheduled assignment source of truth |
+
+> **Capacity vs assignment separation:** `CapacityProfile` / `CapacitySegment` describe **availability/capacity over time**. Actual assignment windows, weeks, and segments produced by the scheduler/planning model are not CapacityProfile-owned. The profile describes what *could* be assigned; the scheduler decides what *is* assigned. Commercial billing basis is independent metadata owned by the Commercial domain.
+
+This means:
+- Capacity profile = what capacity exists (W1–W4: 50%, W5–W8: 100%)
+- Assigned work = what the scheduler allocated (actual demand consumed)
+- Billing basis = what Commercial charges for (bill planned allocation, bill actual scheduled days, etc.)
 
 #### Independent metadata (not capacity-profile-owned)
 
@@ -229,7 +241,7 @@ Once writes are profile-first:
 
 ### Phase 7 — Legacy cleanup (#342)
 
-Tracked separately by [#342](../..issues/342).
+Tracked separately by #342.
 
 #### Preconditions
 


### PR DESCRIPTION
Refs #340

## Summary

This PR introduces `docs/domain/capacity-profile-source-of-truth-migration-plan.md` — a reviewable plan for migrating `CapacityProfile` / `CapacitySegment` from a derived read model to the authoritative source of truth for allocation data.

## What's in the plan

- **Principles** — 6 rules for staged migration with rollback safety
- **Field audit** — classification of every legacy allocation field (ResourceType, NamedResource, CapacityPlan) as future SOT, legacy compatibility projection, or independent metadata
- **Key risks** — 7 documented risks including multi-segment lossy projection, planned-resource identity instability, allocationPct duality, and CAPACITY_PLAN special case
- **Phased approach** — 7 phases from audit → read-side hardening → compatibility helpers → NamedResource writes → ResourceType writes → Squad Planner → reconciliation reversal → legacy cleanup
- **Regression matrix** — tests required across Commercial, Resource Profile/export, scheduler/leveller, Squad Planner, and operational
- **Open questions** — 6 unresolved decisions flagged for discussion
- **Follow-up issues** — 8 suggested issues to split off

## Files changed

| File | Change |
|---|---|
| `docs/domain/capacity-profile-source-of-truth-migration-plan.md` | **New** — full migration plan (325 lines) |
| `docs/domain/capacity-profile-design.md` | **Updated** — added link to migration plan at end |

## Validation

| Check | Result |
|---|---|
| Server typecheck | ✅ |
| Server lint | ✅ |
| Client typecheck | ✅ |
| Client lint | ✅ |
| Schema diffs | none |

No production code changed. Docs only.

## Next steps

- Review and refine the plan
- Challenge weak assumptions and risky migration points
- Split follow-up issues where appropriate
- Do not merge until the plan is reviewed