### PR TITLE
feat: add capacity profile legacy projection helpers

### DIFF
--- a/server/src/lib/capacityProfileLegacyProjection.ts
+++ b/server/src/lib/capacityProfileLegacyProjection.ts
@@ -1,0 +1,150 @@
+/**
+ * capacityProfileLegacyProjection.ts — Pure projection helpers that convert
+ * CapacityProfile / CapacitySegment state back into legacy allocation field shapes.
+ *
+ * This is the inverse of mapProjectToCapacityProfiles in capacityProfileMapping.ts.
+ * It prepares for Phase 3 (source-of-truth write migration) by providing
+ * lossy-aware projection logic without writing to any table.
+ *
+ * @see docs/domain/capacity-profile-source-of-truth-migration-plan.md#phase-2
+ */
+
+// ─── Public types ────────────────────────────────────────────────────────────
+
+export type LegacyAllocationMode = 'EFFORT' | 'TIMELINE' | 'FULL_PROJECT' | 'CAPACITY_PLAN'
+
+export interface LegacyAllocationProjection {
+  allocationMode: LegacyAllocationMode
+  allocationPercent: number | null
+  allocationStartWeek: number | null
+  allocationEndWeek: number | null
+  /** True when the projection is semantically lossy (e.g. multi-segment → single range). */
+  lossy: boolean
+  /** Human-readable explanation of why the projection is lossy, if applicable. */
+  lossReason?: string
+}
+
+/** Minimal segment shape consumed by the projection helper. */
+export interface SegmentLike {
+  startWeek: number
+  endWeek: number
+  capacityPercent: number
+}
+
+/** Minimal profile shape consumed by the projection helper. */
+export interface CapacityProfileLike {
+  planningBasis: string
+  source: string
+  defaultPercent?: number | null
+  segments: SegmentLike[]
+}
+
+// ─── Mapping table: planning basis → allocation mode ─────────────────────────
+
+const PLANNING_BASIS_TO_ALLOCATION_MODE: Record<string, LegacyAllocationMode> = {
+  demandFollowing: 'EFFORT',
+  availabilityWindow: 'TIMELINE',
+  wholeProjectAllocation: 'FULL_PROJECT',
+  capacityProfile: 'CAPACITY_PLAN',
+}
+
+function planningBasisToAllocationMode(basis: string): LegacyAllocationMode {
+  return PLANNING_BASIS_TO_ALLOCATION_MODE[basis] ?? 'EFFORT'
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+/**
+ * Compute the duration (in weeks) of an inclusive-week segment.
+ * Duration = endWeek - startWeek + 1  (both ends inclusive).
+ */
+function segmentDuration(seg: SegmentLike): number {
+  return Math.max(0, seg.endWeek - seg.startWeek + 1)
+}
+
+/**
+ * Compute a duration-weighted average capacity percent across segments.
+ * Weight = segment duration (inclusive weeks).
+ */
+function weightedAveragePercent(segments: SegmentLike[]): number {
+  if (segments.length === 0) return 100
+  let totalWeight = 0
+  let weightedSum = 0
+  for (const seg of segments) {
+    const w = segmentDuration(seg)
+    totalWeight += w
+    weightedSum += w * seg.capacityPercent
+  }
+  if (totalWeight === 0) return 100
+  return Math.round((weightedSum / totalWeight) * 100) / 100
+}
+
+// ─── Main projection function ────────────────────────────────────────────────
+
+/**
+ * Project a CapacityProfile back into legacy allocation field values.
+ *
+ * This is a pure, lossy-aware helper. It does NOT read or write any database.
+ *
+ * ## Projection rules
+ *
+ * | Profile shape | Legacy projection |
+ * |---|---|
+ * | `null` / `undefined` profile | Returns `null` — caller preserves existing legacy fields |
+ * | Demand-following (no segments) | `EFFORT`, `defaultPercent`, no window |
+ * | Single availability-window segment | `TIMELINE`, segment `capacityPercent`, `startWeek`/`endWeek` |
+ * | Multi-segment | Merged range: `min(startWeek)`–`max(endWeek)`, duration-weighted avg `capacityPercent`, **lossy: true** |
+ * | CAPACITY_PLAN / Squad Planner | `CAPACITY_PLAN`, merged range if multi-segment, **lossy: true** when lossy |
+ *
+ * @param profile - The capacity profile to project, or null/undefined.
+ * @returns A `LegacyAllocationProjection` describing the best-effort legacy representation,
+ *          or `null` if no projection is meaningful (caller should preserve existing fields).
+ */
+export function projectCapacityProfileToLegacyAllocation(
+  profile: CapacityProfileLike | null | undefined,
+): LegacyAllocationProjection | null {
+  if (!profile) return null
+
+  const allocationMode = planningBasisToAllocationMode(profile.planningBasis)
+  const segments = profile.segments ?? []
+  const defaultPercent = profile.defaultPercent ?? 100
+
+  // ── No segments → effort / fixed-FTE projection ─────────────────────────
+  if (segments.length === 0) {
+    return {
+      allocationMode,
+      allocationPercent: defaultPercent,
+      allocationStartWeek: null,
+      allocationEndWeek: null,
+      lossy: false,
+    }
+  }
+
+  // ── Single segment → lossless projection ────────────────────────────────
+  if (segments.length === 1) {
+    const seg = segments[0]
+    return {
+      allocationMode: allocationMode === 'EFFORT' ? 'TIMELINE' : allocationMode,
+      allocationPercent: seg.capacityPercent,
+      allocationStartWeek: seg.startWeek,
+      allocationEndWeek: seg.endWeek,
+      lossy: false,
+    }
+  }
+
+  // ── Multi-segment → lossy merged-range projection ───────────────────────
+  const startWeek = Math.min(...segments.map(s => s.startWeek))
+  const endWeek = Math.max(...segments.map(s => s.endWeek))
+  const avgPercent = weightedAveragePercent(segments)
+
+  const result: LegacyAllocationProjection = {
+    allocationMode,
+    allocationPercent: avgPercent,
+    allocationStartWeek: startWeek,
+    allocationEndWeek: endWeek,
+    lossy: true,
+    lossReason: `Multi-segment profile projected to merged range W${startWeek}–W${endWeek} at ${avgPercent}% (duration-weighted average). Individual segment granularity is lost.`,
+  }
+
+  return result
+}

--- a/server/src/test/capacityProfileLegacyProjection.test.ts
+++ b/server/src/test/capacityProfileLegacyProjection.test.ts
@@ -1,0 +1,206 @@
+/**
+ * capacityProfileLegacyProjection.test.ts — Unit tests for the legacy
+ * allocation projection helper.
+ *
+ * These tests verify that CapacityProfile → legacy field conversion is
+ * correct, lossy-aware, and does not mutate inputs.
+ *
+ * @see server/src/lib/capacityProfileLegacyProjection.ts
+ */
+
+import { describe, expect, it } from 'vitest'
+import {
+  projectCapacityProfileToLegacyAllocation,
+  type CapacityProfileLike,
+} from '../lib/capacityProfileLegacyProjection.js'
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function profile(overrides: Partial<CapacityProfileLike> = {}): CapacityProfileLike {
+  return {
+    planningBasis: 'demandFollowing',
+    source: 'fixed',
+    defaultPercent: 100,
+    segments: [],
+    ...overrides,
+  }
+}
+
+function seg(startWeek: number, endWeek: number, capacityPercent: number) {
+  return { startWeek, endWeek, capacityPercent }
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe('projectCapacityProfileToLegacyAllocation', () => {
+  it('returns null for a null/undefined profile', () => {
+    expect(projectCapacityProfileToLegacyAllocation(null)).toBeNull()
+    expect(projectCapacityProfileToLegacyAllocation(undefined)).toBeNull()
+  })
+
+  it('projects demand-following profile to EFFORT with defaultPercent', () => {
+    const result = projectCapacityProfileToLegacyAllocation(
+      profile({ planningBasis: 'demandFollowing', source: 'fixed', defaultPercent: 100 }),
+    )
+
+    expect(result).not.toBeNull()
+    expect(result!.allocationMode).toBe('EFFORT')
+    expect(result!.allocationPercent).toBe(100)
+    expect(result!.allocationStartWeek).toBeNull()
+    expect(result!.allocationEndWeek).toBeNull()
+    expect(result!.lossy).toBe(false)
+  })
+
+  it('projects demand-following with non-default percent', () => {
+    const result = projectCapacityProfileToLegacyAllocation(
+      profile({ planningBasis: 'demandFollowing', source: 'fixed', defaultPercent: 75 }),
+    )
+
+    expect(result!.allocationMode).toBe('EFFORT')
+    expect(result!.allocationPercent).toBe(75)
+    expect(result!.lossy).toBe(false)
+  })
+
+  it('projects legacy-sourced demand-following profile to EFFORT', () => {
+    // Legacy source is a valid demand-following variant that maps to EFFORT
+    const result = projectCapacityProfileToLegacyAllocation(
+      profile({ planningBasis: 'demandFollowing', source: 'legacy', defaultPercent: 100 }),
+    )
+
+    expect(result!.allocationMode).toBe('EFFORT')
+    expect(result!.allocationPercent).toBe(100)
+    expect(result!.lossy).toBe(false)
+  })
+
+  it('projects single availability-window segment losslessly', () => {
+    const result = projectCapacityProfileToLegacyAllocation(
+      profile({
+        planningBasis: 'availabilityWindow',
+        source: 'availabilityWindow',
+        segments: [seg(2, 10, 75)],
+      }),
+    )
+
+    expect(result).not.toBeNull()
+    expect(result!.allocationMode).toBe('TIMELINE')
+    expect(result!.allocationPercent).toBe(75)
+    expect(result!.allocationStartWeek).toBe(2)
+    expect(result!.allocationEndWeek).toBe(10)
+    expect(result!.lossy).toBe(false)
+  })
+
+  it('projects single demand-following segment as TIMELINE (segment presence overrides EFFORT)', () => {
+    // When a demand-following profile has a segment, it behaves like an
+    // availability window — projection uses TIMELINE mode.
+    const result = projectCapacityProfileToLegacyAllocation(
+      profile({
+        planningBasis: 'demandFollowing',
+        source: 'fixed',
+        segments: [seg(0, 4, 100)],
+      }),
+    )
+
+    expect(result!.allocationMode).toBe('TIMELINE')
+    expect(result!.allocationPercent).toBe(100)
+    expect(result!.allocationStartWeek).toBe(0)
+    expect(result!.allocationEndWeek).toBe(4)
+    expect(result!.lossy).toBe(false)
+  })
+
+  it('projects multi-segment profile to merged range and marks lossy', () => {
+    const result = projectCapacityProfileToLegacyAllocation(
+      profile({
+        planningBasis: 'availabilityWindow',
+        source: 'fixed',
+        segments: [seg(0, 3, 50), seg(4, 7, 100)],
+      }),
+    )
+
+    expect(result).not.toBeNull()
+    expect(result!.allocationMode).toBe('TIMELINE')
+    expect(result!.allocationStartWeek).toBe(0)
+    expect(result!.allocationEndWeek).toBe(7)
+    expect(result!.lossy).toBe(true)
+    expect(result!.lossReason).toBeDefined()
+    expect(result!.lossReason).toContain('merged range')
+  })
+
+  it('computes duration-weighted average percent for unequal segment durations', () => {
+    // Segment A: W1-W4 (4 weeks) at 50%  → weight = 4
+    // Segment B: W5-W10 (6 weeks) at 100% → weight = 6
+    // Weighted avg: (4*50 + 6*100) / (4 + 6) = (200 + 600) / 10 = 80%
+    const result = projectCapacityProfileToLegacyAllocation(
+      profile({
+        planningBasis: 'availabilityWindow',
+        segments: [seg(1, 4, 50), seg(5, 10, 100)],
+      }),
+    )
+
+    expect(result!.allocationPercent).toBe(80)
+    expect(result!.lossy).toBe(true)
+  })
+
+  it('projects CAPACITY_PLAN / squadPlanner profile preserving CAPACITY_PLAN mode', () => {
+    const result = projectCapacityProfileToLegacyAllocation(
+      profile({
+        planningBasis: 'capacityProfile',
+        source: 'squadPlanner',
+        defaultPercent: 100,
+        segments: [],
+      }),
+    )
+
+    expect(result).not.toBeNull()
+    expect(result!.allocationMode).toBe('CAPACITY_PLAN')
+    expect(result!.allocationPercent).toBe(100)
+    expect(result!.allocationStartWeek).toBeNull()
+    expect(result!.allocationEndWeek).toBeNull()
+    expect(result!.lossy).toBe(false)
+  })
+
+  it('projects multi-segment CAPACITY_PLAN profile as lossy', () => {
+    const result = projectCapacityProfileToLegacyAllocation(
+      profile({
+        planningBasis: 'capacityProfile',
+        source: 'squadPlanner',
+        segments: [seg(0, 7, 50), seg(8, 15, 100)],
+      }),
+    )
+
+    expect(result!.allocationMode).toBe('CAPACITY_PLAN')
+    expect(result!.allocationStartWeek).toBe(0)
+    expect(result!.allocationEndWeek).toBe(15)
+    expect(result!.lossy).toBe(true)
+    expect(result!.lossReason).toBeDefined()
+  })
+
+  it('does not mutate the input profile or segment array', () => {
+    const input: CapacityProfileLike = {
+      planningBasis: 'availabilityWindow',
+      source: 'fixed',
+      defaultPercent: 100,
+      segments: [
+        { startWeek: 0, endWeek: 3, capacityPercent: 50 },
+        { startWeek: 4, endWeek: 7, capacityPercent: 100 },
+      ],
+    }
+    const frozenSegments = [...input.segments]
+
+    projectCapacityProfileToLegacyAllocation(input)
+
+    expect(input.segments).toHaveLength(2)
+    expect(input.segments[0]).toEqual(frozenSegments[0])
+    expect(input.segments[1]).toEqual(frozenSegments[1])
+    expect(input.planningBasis).toBe('availabilityWindow')
+  })
+
+  it('projects wholeProjectAllocation to FULL_PROJECT', () => {
+    const result = projectCapacityProfileToLegacyAllocation(
+      profile({ planningBasis: 'wholeProjectAllocation', source: 'fixed' }),
+    )
+
+    expect(result!.allocationMode).toBe('FULL_PROJECT')
+    expect(result!.allocationPercent).toBe(100)
+    expect(result!.lossy).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary

Add pure, well-tested helper(s) that project `CapacityProfile` / `CapacitySegment` state back into legacy allocation field shapes.

Refs #340 — Phase 2 of the capacity profile source-of-truth migration plan.

## New files

### `server/src/lib/capacityProfileLegacyProjection.ts`

New pure helper with:

- **`projectCapacityProfileToLegacyAllocation(profile)`** — projects a `CapacityProfile` back into legacy `(allocationMode, allocationPercent, allocationStartWeek, allocationEndWeek)` shape.

### Projection rules

| Profile shape | Legacy projection | Lossy? |
|---|---|---|
| `null` / `undefined` | Returns `null` — caller preserves existing fields | — |
| Demand-following, no segments (`demandFollowing` / `fixed` / `legacy`) | `EFFORT`, `defaultPercent`, no window | No |
| Single segment (`availabilityWindow` or any basis with 1 segment) | `TIMELINE`, segment's `capacityPercent`, `startWeek`/ `endWeek` | No |
| Multi-segment (2+ segments) | Merged range: `min(startWeek)`–`max(endWeek)`, duration-weighted average `capacityPercent` | **Yes** |
| `capacityProfile` / `squadPlanner` | `CAPACITY_PLAN`, merged range when multi-segment | **Yes** when multi-segment |
| `wholeProjectAllocation` / `fixed` | `FULL_PROJECT`, `defaultPercent`, no window | No |

- **Duration-weighted average:** Each segment's contribution to the average is proportional to its inclusive-week span (`endWeek - startWeek + 1`).
- **Lossy projections** include a `lossReason` string explaining why individual segment granularity is lost.

### `server/src/test/capacityProfileLegacyProjection.test.ts`

12 tests covering:

1. `null` / `undefined` returns `null`
2. Demand-following with `defaultPercent: 100` → `EFFORT`, 100%, no window
3. Demand-following with non-default percent
4. Legacy-sourced demand-following → `EFFORT`
5. Single availability-window segment → `TIMELINE`, lossless
6. Single demand-following segment → `TIMELINE` (segment overrides mode)
7. Multi-segment → merged range, marks `lossy: true`
8. Duration-weighted average correct for unequal segment durations
9. `CAPACITY_PLAN` / `squadPlanner` preserves `CAPACITY_PLAN` mode
10. Multi-segment `CAPACITY_PLAN` → lossy
11. No mutation of input profile/segments
12. `wholeProjectAllocation` → `FULL_PROJECT`

## Guardrails

- ✅ No source-of-truth write migration
- ✅ No `server/prisma/schema.prisma` changes
- ✅ No `server/prisma/migrations` changes
- ✅ No route behaviour changes
- ✅ No `syncCapacityProfilesForProject` direction change
- ✅ No `reconcileCapacityProfiles` direction change
- ✅ No API response shape changes
- ✅ No client UI changes
- ✅ No Commercial formulas/totals changes
- ✅ No scheduler/leveller/Squad Planner algorithm changes

## Validation

```
npm run typecheck --workspace=server       # PASS
npm run lint --workspace=server            # PASS
npm test --workspace=server                # PASS (all 535 tests)
npm run typecheck --workspace=client       # PASS
npm run lint --workspace=client            # PASS
npm run build --workspace=client           # PASS
```

```
git diff --name-only origin/main...HEAD
> server/src/lib/capacityProfileLegacyProjection.ts
> server/src/test/capacityProfileLegacyProjection.test.ts

git diff origin/main...HEAD -- server/prisma/schema.prisma
> (empty)

git diff origin/main...HEAD -- server/prisma/migrations
> (empty)
```

2 new files, 357 lines total. Zero production behaviour changes.