### PR TITLE
feat: write named-resource capacity profiles first

### DIFF
--- a/server/src/lib/capacityProfileLegacyProjection.ts
+++ b/server/src/lib/capacityProfileLegacyProjection.ts
@@ -36,6 +36,10 @@ export interface CapacityProfileLike {
   planningBasis: string
   source: string
   defaultPercent?: number | null
+  /** Legacy fallback availability-window start week (e.g. TIMELINE without explicit segments). */
+  startWeek?: number | null
+  /** Legacy fallback availability-window end week. */
+  endWeek?: number | null
   segments: SegmentLike[]
 }
 
@@ -108,9 +112,21 @@ export function projectCapacityProfileToLegacyAllocation(
   const allocationMode = planningBasisToAllocationMode(profile.planningBasis)
   const segments = profile.segments ?? []
   const defaultPercent = profile.defaultPercent ?? 100
+  const profileStartWeek = profile.startWeek ?? null
+  const profileEndWeek = profile.endWeek ?? null
 
-  // ── No segments → effort / fixed-FTE projection ─────────────────────────
+  // ── No segments → effort / availability-window projection ────────────
   if (segments.length === 0) {
+    // For availability-window / TIMELINE profiles, preserve the start/end range
+    if (profileStartWeek != null || profileEndWeek != null) {
+      return {
+        allocationMode: 'TIMELINE',
+        allocationPercent: defaultPercent,
+        allocationStartWeek: profileStartWeek,
+        allocationEndWeek: profileEndWeek,
+        lossy: false,
+      }
+    }
     return {
       allocationMode,
       allocationPercent: defaultPercent,

--- a/server/src/lib/namedResourceCapacityProfileWrites.ts
+++ b/server/src/lib/namedResourceCapacityProfileWrites.ts
@@ -75,13 +75,20 @@ export async function upsertNRProfileAndProjectLegacy(
   options: NRProfileWriteOptions = {},
 ): Promise<LegacyAllocationProjection> {
   // ── 1. Normalise incoming fields ───────────────────────────────────────
-  const mode = payload.allocationMode ?? 'EFFORT'
-  const percent = payload.allocationPercent ?? payload.allocationPct ?? 100
   const allocationStartWeek = payload.allocationStartWeek ?? payload.startWeek ?? null
   const allocationEndWeek = payload.allocationEndWeek ?? payload.endWeek ?? null
 
-  const planningBasis = ALLOCATION_MODE_TO_PLANNING_BASIS[mode] ?? 'DEMAND_FOLLOWING'
-  const source = deriveProfileSource(mode)
+  // Normalise mode: explicit allocationMode wins; if window fields are present, infer TIMELINE
+  let mode: string | null | undefined = payload.allocationMode
+  const hasAllocationMode = mode !== undefined && mode !== null
+  const hasWindow = allocationStartWeek != null || allocationEndWeek != null
+  if (!hasAllocationMode) {
+    mode = hasWindow ? 'TIMELINE' : 'EFFORT'
+  }
+  const percent = payload.allocationPercent ?? payload.allocationPct ?? 100
+
+  const planningBasis = ALLOCATION_MODE_TO_PLANNING_BASIS[mode as string] ?? 'DEMAND_FOLLOWING'
+  const source = deriveProfileSource(mode as string)
 
   // Build the in-memory profile shape (camelCase for the projection helper).
   const profile = {
@@ -90,19 +97,32 @@ export async function upsertNRProfileAndProjectLegacy(
     defaultPercent: percent,
     // For simple legacy fields there are no explicit segments.
     // The projection helper uses startWeek/endWeek when segments are empty.
-    startWeek: planningBasis === 'AVAILABILITY_WINDOW' ? allocationStartWeek : null,
-    endWeek: planningBasis === 'AVAILABILITY_WINDOW' ? allocationEndWeek : null,
+    // Always include window values if present, regardless of planning basis.
+    // This ensures explicit startWeek/endWeek inputs are preserved through
+    // the projection cycle even when allocationMode was omitted/defaulted.
+    startWeek: allocationStartWeek,
+    endWeek: allocationEndWeek,
     segments: [] as Array<{ startWeek: number; endWeek: number; capacityPercent: number; source: string }>,
   }
 
   // ── 2. Persist CapacityProfile ─────────────────────────────────────────
   // Delete any existing profile + segments for this NR first.
-  await tx.capacitySegment.deleteMany({
-    where: { capacityProfile: { namedResourceId: nrId, projectId } },
-  })
-  await tx.capacityProfile.deleteMany({
+  // Use explicit profile lookup + ID-based delete for compatibility with
+  // both Prisma's nested relation filters and the integration test store.
+  const existingProfiles = await tx.capacityProfile.findMany({
     where: { namedResourceId: nrId, projectId },
+    select: { id: true },
   })
+  const existingProfileIds = existingProfiles.map((p: { id: string }) => p.id)
+
+  if (existingProfileIds.length > 0) {
+    await tx.capacitySegment.deleteMany({
+      where: { capacityProfileId: { in: existingProfileIds } },
+    })
+    await tx.capacityProfile.deleteMany({
+      where: { id: { in: existingProfileIds } },
+    })
+  }
 
   await tx.capacityProfile.create({
     data: {

--- a/server/src/lib/namedResourceCapacityProfileWrites.ts
+++ b/server/src/lib/namedResourceCapacityProfileWrites.ts
@@ -75,8 +75,8 @@ export async function upsertNRProfileAndProjectLegacy(
   options: NRProfileWriteOptions = {},
 ): Promise<LegacyAllocationProjection> {
   // ── 1. Normalise incoming fields ───────────────────────────────────────
-  const allocationStartWeek = payload.allocationStartWeek ?? payload.startWeek ?? null
-  const allocationEndWeek = payload.allocationEndWeek ?? payload.endWeek ?? null
+  let allocationStartWeek = payload.allocationStartWeek !== undefined ? payload.allocationStartWeek : payload.startWeek ?? null
+  let allocationEndWeek = payload.allocationEndWeek !== undefined ? payload.allocationEndWeek : payload.endWeek ?? null
 
   // Normalise mode: explicit allocationMode wins; if window fields are present, infer TIMELINE
   let mode: string | null | undefined = payload.allocationMode
@@ -84,6 +84,12 @@ export async function upsertNRProfileAndProjectLegacy(
   const hasWindow = allocationStartWeek != null || allocationEndWeek != null
   if (!hasAllocationMode) {
     mode = hasWindow ? 'TIMELINE' : 'EFFORT'
+  } else if (mode === 'EFFORT' || mode === 'FULL_PROJECT' || mode === 'CAPACITY_PLAN') {
+    // Non-window mode explicitly set — suppress window fields to prevent
+    // the projection helper from returning TIMELINE due to stale window values.
+    // This ensures explicit non-window mode always projects back correctly.
+    allocationStartWeek = null
+    allocationEndWeek = null
   }
   const percent = payload.allocationPercent ?? payload.allocationPct ?? 100
 

--- a/server/src/lib/namedResourceCapacityProfileWrites.ts
+++ b/server/src/lib/namedResourceCapacityProfileWrites.ts
@@ -1,0 +1,135 @@
+/**
+ * namedResourceCapacityProfileWrites.ts — Profile-first write helper for
+ * named-resource capacity/allocation updates.
+ *
+ * This is the first source-of-truth migration step (Phase 3 of #340).
+ * Incoming legacy-style payload fields are converted to CapacityProfile /
+ * CapacitySegment rows, persisted transactionally, then projected back
+ * into legacy NamedResource fields for compatibility.
+ *
+ * @see docs/domain/capacity-profile-source-of-truth-migration-plan.md#phase-3
+ */
+
+import { projectCapacityProfileToLegacyAllocation } from './capacityProfileLegacyProjection.js'
+import type { LegacyAllocationProjection } from './capacityProfileLegacyProjection.js'
+
+// ─── Mapping tables (legacy → profile) ───────────────────────────────────────
+
+const ALLOCATION_MODE_TO_PLANNING_BASIS: Record<string, string> = {
+  EFFORT: 'DEMAND_FOLLOWING',
+  TIMELINE: 'AVAILABILITY_WINDOW',
+  FULL_PROJECT: 'WHOLE_PROJECT_ALLOCATION',
+  CAPACITY_PLAN: 'CAPACITY_PROFILE',
+}
+
+function deriveProfileSource(mode: string | null | undefined): string {
+  if (mode === 'CAPACITY_PLAN') return 'SQUAD_PLANNER'
+  if (mode === 'TIMELINE') return 'AVAILABILITY_WINDOW'
+  if (mode === 'EFFORT' || mode === 'FULL_PROJECT') return 'FIXED'
+  return 'LEGACY'
+}
+
+// ─── Input type ──────────────────────────────────────────────────────────────
+
+export interface NamedResourceCapacityPayload {
+  allocationMode?: string | null
+  allocationPercent?: number | null
+  allocationPct?: number | null
+  allocationStartWeek?: number | null
+  allocationEndWeek?: number | null
+  startWeek?: number | null
+  endWeek?: number | null
+}
+/**
+ * ## Flow
+ *
+ * 1. Normalise incoming fields → profile shape (planningBasis, source, percent, etc.)
+ * 2. Upsert `CapacityProfile` row (delete existing for this NR, create new)
+ * 3. Replace `CapacitySegment` rows
+ * 4. Call `projectCapacityProfileToLegacyAllocation` for backward projection
+ * 5. Return projected legacy-allocation values the caller writes to NamedResource
+ *
+ * ## Transactionality
+ *
+ * This function MUST be called inside a Prisma `$transaction` callback.
+ * All DB writes use the provided `tx` client.
+ *
+ * @param tx         Prisma transaction client
+ * @param projectId  Project ID
+ * @param nrId       NamedResource ID
+ * @param rtId       ResourceType ID the NR belongs to
+ * @param payload    Incoming capacity/allocation fields from the request
+ * @returns LegacyAllocationProjection for the caller to write to NamedResource
+ */
+export async function upsertNRProfileAndProjectLegacy(
+  tx: any,
+  projectId: string,
+  nrId: string,
+  rtId: string,
+  payload: NamedResourceCapacityPayload,
+): Promise<LegacyAllocationProjection> {
+  // ── 1. Normalise incoming fields ───────────────────────────────────────
+  const mode = payload.allocationMode ?? 'EFFORT'
+  const percent = payload.allocationPercent ?? payload.allocationPct ?? 100
+  const allocationStartWeek = payload.allocationStartWeek ?? payload.startWeek ?? null
+  const allocationEndWeek = payload.allocationEndWeek ?? payload.endWeek ?? null
+
+  const planningBasis = ALLOCATION_MODE_TO_PLANNING_BASIS[mode] ?? 'DEMAND_FOLLOWING'
+  const source = deriveProfileSource(mode)
+
+  // Build the in-memory profile shape (camelCase for the projection helper).
+  const profile = {
+    planningBasis: planningBasisToCamel(planningBasis),
+    source: sourceToCamel(source),
+    defaultPercent: percent,
+    // For simple legacy fields there are no explicit segments.
+    // The projection helper uses startWeek/endWeek when segments are empty.
+    startWeek: planningBasis === 'AVAILABILITY_WINDOW' ? allocationStartWeek : null,
+    endWeek: planningBasis === 'AVAILABILITY_WINDOW' ? allocationEndWeek : null,
+    segments: [] as Array<{ startWeek: number; endWeek: number; capacityPercent: number; source: string }>,
+  }
+
+  // ── 2. Persist CapacityProfile ─────────────────────────────────────────
+  // Delete any existing profile + segments for this NR first.
+  await tx.capacitySegment.deleteMany({
+    where: { capacityProfile: { namedResourceId: nrId, projectId } },
+  })
+  await tx.capacityProfile.deleteMany({
+    where: { namedResourceId: nrId, projectId },
+  })
+
+  await tx.capacityProfile.create({
+    data: {
+      projectId,
+      resourceTypeId: rtId,
+      namedResourceId: nrId,
+      ownerKind: 'NAMED_PERSON',
+      planningBasis,
+      source,
+      defaultPercent: percent,
+      startWeek: allocationStartWeek,
+      endWeek: allocationEndWeek,
+    },
+  })
+
+  // ── 3. Replace segments ────────────────────────────────────────────────
+  // For simple legacy-style payloads there are no segments to create.
+  // When segment arrays are added to the public API in a future phase,
+  // they will be created here.
+
+  // ── 4. Project back to legacy ──────────────────────────────────────────
+  const projection = projectCapacityProfileToLegacyAllocation(profile)
+
+  // The projection is always non-null because we always have a profile here.
+  return projection!
+}
+
+// ─── Internal helpers ────────────────────────────────────────────────────────
+
+function planningBasisToCamel(value: string): string {
+  return value.toLowerCase().replace(/_([a-z])/g, (_, c: string) => c.toUpperCase())
+}
+
+function sourceToCamel(value: string): string {
+  return value.toLowerCase().replace(/_([a-z])/g, (_, c: string) => c.toUpperCase())
+}

--- a/server/src/lib/namedResourceCapacityProfileWrites.ts
+++ b/server/src/lib/namedResourceCapacityProfileWrites.ts
@@ -40,6 +40,11 @@ export interface NamedResourceCapacityPayload {
   startWeek?: number | null
   endWeek?: number | null
 }
+
+export interface NRProfileWriteOptions {
+  /** Whether the named resource is a synthetic/planned resource (true) or a named person (false/null/undefined). */
+  synthetic?: boolean | null
+}
 /**
  * ## Flow
  *
@@ -59,14 +64,15 @@ export interface NamedResourceCapacityPayload {
  * @param nrId       NamedResource ID
  * @param rtId       ResourceType ID the NR belongs to
  * @param payload    Incoming capacity/allocation fields from the request
- * @returns LegacyAllocationProjection for the caller to write to NamedResource
+ * @param options    Optional: { synthetic } to control owner kind. Default { synthetic: false } → NAMED_PERSON.
  */
 export async function upsertNRProfileAndProjectLegacy(
   tx: any,
   projectId: string,
   nrId: string,
-  rtId: string,
+  _rtId: string,
   payload: NamedResourceCapacityPayload,
+  options: NRProfileWriteOptions = {},
 ): Promise<LegacyAllocationProjection> {
   // ── 1. Normalise incoming fields ───────────────────────────────────────
   const mode = payload.allocationMode ?? 'EFFORT'
@@ -100,10 +106,10 @@ export async function upsertNRProfileAndProjectLegacy(
 
   await tx.capacityProfile.create({
     data: {
+      ownerKind: options.synthetic ? 'PLANNED_RESOURCE' : 'NAMED_PERSON',
       projectId,
-      resourceTypeId: rtId,
+      resourceTypeId: null,
       namedResourceId: nrId,
-      ownerKind: 'NAMED_PERSON',
       planningBasis,
       source,
       defaultPercent: percent,

--- a/server/src/lib/syncCapacityProfiles.ts
+++ b/server/src/lib/syncCapacityProfiles.ts
@@ -86,6 +86,11 @@ export interface SyncResult {
   segmentsDeleted: number
 }
 
+export interface SyncOptions {
+  /** Named resource IDs whose capacity profiles should not be overwritten by the legacy-derived sync. */
+  preserveNamedResourceIds?: string[]
+}
+
 // ─── Validation ────────────────────────────────────────────────────────────
 
 export class CapacityProfileValidationError extends Error {
@@ -131,12 +136,13 @@ function validateOwner(profile: {
  * is atomic with the legacy write.
  *
  * @param prismaOrTx  PrismaClient (standalone) or TransactionClient (inside a transaction)
- * @param projectId   The project whose profiles should be synced
+ * @param options     Optional: SyncOptions (preserveNamedResourceIds, etc.)
  * @throws            If the project is not found or reconciliation fails after sync
  */
 export async function syncCapacityProfilesForProject(
   prismaOrTx: any,
   projectId: string,
+  options?: SyncOptions,
 ): Promise<SyncResult> {
   const result: SyncResult = {
     profilesCreated: 0,
@@ -230,9 +236,26 @@ export async function syncCapacityProfilesForProject(
     }
   }
 
+  // Remove preserved NR profiles from persistedByKey so sync won't touch them
+  const preserveIds = new Set(options?.preserveNamedResourceIds ?? [])
+  if (preserveIds.size > 0) {
+    for (const [key, pp] of persistedByKey) {
+      if (pp.namedResourceId && preserveIds.has(pp.namedResourceId)) {
+        persistedByKey.delete(key)
+      }
+    }
+  }
+
   // 6. Upsert/create each expected profile and replace its segments
   for (const profile of expectedProfiles) {
     validateOwner(profile)
+    // Skip expected profiles for NRs preserved by profile-first writes
+    if (profile.owner.kind !== 'role' && preserveIds.has(profile.owner.id)) {
+      const skipKey = `${project.id}::${profile.owner.kind}::${profile.owner.id}`
+      persistedByKey.delete(skipKey)
+      continue
+    }
+
     const key = `${project.id}::${profile.owner.kind}::${profile.owner.id}`
 
     const ownerKind = toPrismaOwnerKind(profile.owner.kind)
@@ -313,7 +336,7 @@ export async function syncCapacityProfilesForProject(
     result.profilesDeleted++
   }
 
-  // 8. Verify reconciliation after sync
+  // 8. Verify reconciliation after sync (exclude preserved NRs)
   const afterSyncPersisted = await (
     prismaOrTx as any
   ).capacityProfile.findMany({
@@ -325,10 +348,17 @@ export async function syncCapacityProfilesForProject(
     },
   })
 
+  const filterPreserved = (p: any) =>
+    preserveIds.size === 0 || !('namedResourceId' in p) || !p.namedResourceId || !preserveIds.has(p.namedResourceId)
+  const filteredExpected = expectedProfiles.filter(
+    (p: any) => preserveIds.size === 0 || p.owner.kind === 'role' || !preserveIds.has(p.owner.id),
+  )
+  const filteredPersisted = afterSyncPersisted.filter(filterPreserved)
+
   const comparison = compareCapacityProfiles(
     projectId,
-    expectedProfiles,
-    afterSyncPersisted.map((pp: any) => ({
+    filteredExpected,
+    filteredPersisted.map((pp: any) => ({
       id: pp.id,
       resourceTypeId: pp.resourceTypeId,
       namedResourceId: pp.namedResourceId,

--- a/server/src/routes/namedResources.ts
+++ b/server/src/routes/namedResources.ts
@@ -111,15 +111,28 @@ router.post('/', asyncHandler(async (req: AuthRequest, res: Response) => {
       },
     })
 
-    // Build capacity payload from request + inherited RT allocation defaults
+    // Build capacity payload: explicit request fields win, fall back to inherited RT defaults
+    const hasPost = (k: string) => Object.prototype.hasOwnProperty.call(req.body, k)
     const capacityPayload: NamedResourceCapacityPayload = {
-      allocationMode: req.body.allocationMode ?? (inheritAllocation ? rtAllocationMode : undefined),
-      allocationPercent: req.body.allocationPercent ?? (inheritAllocation ? rtAllocationPercent : undefined),
-      allocationPct: req.body.allocationPct,
-      allocationStartWeek: req.body.allocationStartWeek ?? (inheritAllocation ? rtAllocationStartWeek : undefined),
-      allocationEndWeek: req.body.allocationEndWeek ?? (inheritAllocation ? rtAllocationEndWeek : undefined),
-      startWeek: req.body.startWeek,
-      endWeek: req.body.endWeek,
+      allocationMode: hasPost('allocationMode') ? req.body.allocationMode : (inheritAllocation ? rtAllocationMode : undefined),
+      allocationPercent: hasPost('allocationPercent')
+        ? req.body.allocationPercent
+        : hasPost('allocationPct')
+          ? undefined
+          : (inheritAllocation ? rtAllocationPercent : undefined),
+      allocationPct: hasPost('allocationPct') ? req.body.allocationPct : undefined,
+      allocationStartWeek: hasPost('allocationStartWeek')
+        ? req.body.allocationStartWeek
+        : hasPost('startWeek')
+          ? undefined
+          : (inheritAllocation ? rtAllocationStartWeek : undefined),
+      allocationEndWeek: hasPost('allocationEndWeek')
+        ? req.body.allocationEndWeek
+        : hasPost('endWeek')
+          ? undefined
+          : (inheritAllocation ? rtAllocationEndWeek : undefined),
+      startWeek: hasPost('startWeek') ? req.body.startWeek : undefined,
+      endWeek: hasPost('endWeek') ? req.body.endWeek : undefined,
     }
 
     // Profile-first write + project back to legacy
@@ -179,15 +192,29 @@ router.put('/:id', asyncHandler(async (req: AuthRequest, res: Response) => {
   Object.keys(nrData).forEach(key => {
     if (nrData[key] === undefined) delete nrData[key]
   })
-  // Capacity payload: request fields take precedence, fall back to existing NR
+
+  // Capacity payload: explicit request fields win, fall back to existing NR
+  const has = (k: string) => Object.prototype.hasOwnProperty.call(req.body, k)
   const capacityPayload: NamedResourceCapacityPayload = {
-    allocationMode: allocationMode ?? existing.allocationMode,
-    allocationPercent: allocationPercent ?? existing.allocationPercent,
-    allocationPct: allocationPct ?? existing.allocationPct,
-    allocationStartWeek: allocationStartWeek ?? existing.allocationStartWeek,
-    allocationEndWeek: allocationEndWeek ?? existing.allocationEndWeek,
-    startWeek: startWeek ?? existing.startWeek,
-    endWeek: endWeek ?? existing.endWeek,
+    allocationMode: has('allocationMode') ? allocationMode : undefined,
+    allocationPercent: has('allocationPercent')
+      ? allocationPercent
+      : has('allocationPct')
+        ? undefined
+        : existing.allocationPercent,
+    allocationPct: has('allocationPct') ? allocationPct : existing.allocationPct,
+    allocationStartWeek: has('allocationStartWeek')
+      ? allocationStartWeek
+      : has('startWeek')
+        ? undefined
+        : existing.allocationStartWeek,
+    allocationEndWeek: has('allocationEndWeek')
+      ? allocationEndWeek
+      : has('endWeek')
+        ? undefined
+        : existing.allocationEndWeek,
+    startWeek: has('startWeek') ? startWeek : existing.startWeek,
+    endWeek: has('endWeek') ? endWeek : existing.endWeek,
   }
 
   const resource = await prisma.$transaction(async tx => {

--- a/server/src/routes/namedResources.ts
+++ b/server/src/routes/namedResources.ts
@@ -131,8 +131,11 @@ router.post('/', asyncHandler(async (req: AuthRequest, res: Response) => {
       data: {
         allocationMode: projection.allocationMode,
         allocationPercent: projection.allocationPercent ?? 100,
+        allocationPct: projection.allocationPercent ?? 100,
         allocationStartWeek: projection.allocationStartWeek,
         allocationEndWeek: projection.allocationEndWeek,
+        startWeek: projection.allocationStartWeek,
+        endWeek: projection.allocationEndWeek,
       },
     })
 
@@ -140,7 +143,7 @@ router.post('/', asyncHandler(async (req: AuthRequest, res: Response) => {
     const total = await tx.namedResource.count({ where: { resourceTypeId: rtId } })
     await tx.resourceType.update({ where: { id: rtId }, data: { count: total } })
     // Sync remaining profiles (role-level, other NRs) for full project reconciliation
-    await syncCapacityProfilesForProject(tx, projectId)
+    await syncCapacityProfilesForProject(tx, projectId, { preserveNamedResourceIds: [created.id] })
 
 
     return updated
@@ -198,12 +201,15 @@ router.put('/:id', asyncHandler(async (req: AuthRequest, res: Response) => {
       data: {
         allocationMode: projection.allocationMode,
         allocationPercent: projection.allocationPercent ?? 100,
+        allocationPct: projection.allocationPercent ?? 100,
         allocationStartWeek: projection.allocationStartWeek,
         allocationEndWeek: projection.allocationEndWeek,
+        startWeek: projection.allocationStartWeek,
+        endWeek: projection.allocationEndWeek,
       },
     })
     // Sync remaining profiles (role-level, other NRs) for full project reconciliation
-    await syncCapacityProfilesForProject(tx, projectId)
+    await syncCapacityProfilesForProject(tx, projectId, { preserveNamedResourceIds: [id] })
 
     await clearWeeklyDemandCache(projectId, tx)
     return updated
@@ -242,12 +248,15 @@ router.patch('/:id', asyncHandler(async (req: AuthRequest, res: Response) => {
       data: {
         allocationMode: projection.allocationMode,
         allocationPercent: projection.allocationPercent ?? 100,
+        allocationPct: projection.allocationPercent ?? 100,
         allocationStartWeek: projection.allocationStartWeek,
         allocationEndWeek: projection.allocationEndWeek,
+        startWeek: projection.allocationStartWeek,
+        endWeek: projection.allocationEndWeek,
       },
     })
     // Sync remaining profiles (role-level, other NRs) for full project reconciliation
-    await syncCapacityProfilesForProject(tx, projectId)
+    await syncCapacityProfilesForProject(tx, projectId, { preserveNamedResourceIds: [id] })
 
     await clearWeeklyDemandCache(projectId, tx)
     return updated

--- a/server/src/routes/namedResources.ts
+++ b/server/src/routes/namedResources.ts
@@ -193,26 +193,47 @@ router.put('/:id', asyncHandler(async (req: AuthRequest, res: Response) => {
     if (nrData[key] === undefined) delete nrData[key]
   })
 
-  // Capacity payload: explicit request fields win, fall back to existing NR
+  // Capacity payload: distinguish explicit capacity input from non-capacity-only changes.
+  // When no capacity fields are provided, preserve existing capacity state.
+  // When capacity fields are provided but allocationMode is omitted, pass undefined
+  // so the helper can infer TIMELINE from explicit startWeek/endWeek presence.
   const has = (k: string) => Object.prototype.hasOwnProperty.call(req.body, k)
+  const hasCapacityInput =
+    has('allocationMode') ||
+    has('allocationPercent') ||
+    has('allocationPct') ||
+    has('allocationStartWeek') ||
+    has('allocationEndWeek') ||
+    has('startWeek') ||
+    has('endWeek')
+
   const capacityPayload: NamedResourceCapacityPayload = {
-    allocationMode: has('allocationMode') ? allocationMode : undefined,
+    allocationMode: has('allocationMode')
+      ? allocationMode
+      : hasCapacityInput
+        ? undefined          // let helper infer TIMELINE from startWeek/endWeek
+        : existing.allocationMode,  // preserve existing mode
+
     allocationPercent: has('allocationPercent')
       ? allocationPercent
       : has('allocationPct')
         ? undefined
         : existing.allocationPercent,
+
     allocationPct: has('allocationPct') ? allocationPct : existing.allocationPct,
+
     allocationStartWeek: has('allocationStartWeek')
       ? allocationStartWeek
       : has('startWeek')
         ? undefined
         : existing.allocationStartWeek,
+
     allocationEndWeek: has('allocationEndWeek')
       ? allocationEndWeek
       : has('endWeek')
         ? undefined
         : existing.allocationEndWeek,
+
     startWeek: has('startWeek') ? startWeek : existing.startWeek,
     endWeek: has('endWeek') ? endWeek : existing.endWeek,
   }
@@ -220,21 +241,41 @@ router.put('/:id', asyncHandler(async (req: AuthRequest, res: Response) => {
   const resource = await prisma.$transaction(async tx => {
     // Write non-capacity fields first
     await tx.namedResource.update({ where: { id }, data: nrData })
-    // Profile-first write + project back to legacy
-    const projection = await upsertNRProfileAndProjectLegacy(tx, projectId, id, rtId, capacityPayload)
-    // Write projected legacy fields as compatibility
-    const updated = await tx.namedResource.update({
-      where: { id },
-      data: {
-        allocationMode: projection.allocationMode,
-        allocationPercent: projection.allocationPercent ?? 100,
-        allocationPct: projection.allocationPercent ?? 100,
-        allocationStartWeek: projection.allocationStartWeek,
-        allocationEndWeek: projection.allocationEndWeek,
-        startWeek: projection.allocationStartWeek,
-        endWeek: projection.allocationEndWeek,
-      },
-    })
+
+    let updated
+    if (hasCapacityInput) {
+      // Capacity fields provided — profile-first write + project back to legacy
+      const projection = await upsertNRProfileAndProjectLegacy(tx, projectId, id, rtId, capacityPayload)
+      updated = await tx.namedResource.update({
+        where: { id },
+        data: {
+          allocationMode: projection.allocationMode,
+          allocationPercent: projection.allocationPercent ?? 100,
+          allocationPct: projection.allocationPercent ?? 100,
+          allocationStartWeek: projection.allocationStartWeek,
+          allocationEndWeek: projection.allocationEndWeek,
+          startWeek: projection.allocationStartWeek,
+          endWeek: projection.allocationEndWeek,
+        },
+      })
+    } else {
+      // No capacity changes — ensure a profile exists without changing legacy fields.
+      // Suppress window fields so an EFFORT-mode NR with historical window values
+      // does not have its projection silently changed to TIMELINE.
+      await upsertNRProfileAndProjectLegacy(tx, projectId, id, rtId, {
+        allocationMode: existing.allocationMode,
+        allocationPercent: existing.allocationPercent,
+        allocationPct: existing.allocationPct,
+        allocationStartWeek: null,
+        allocationEndWeek: null,
+        startWeek: null,
+        endWeek: null,
+      })
+      // Don't touch legacy fields — existing values remain intact
+      updated = await tx.namedResource.findFirst({ where: { id } })
+      if (!updated) throw new Error('NamedResource not found after update')
+    }
+
     // Sync remaining profiles (role-level, other NRs) for full project reconciliation
     await syncCapacityProfilesForProject(tx, projectId, { preserveNamedResourceIds: [id] })
 

--- a/server/src/routes/namedResources.ts
+++ b/server/src/routes/namedResources.ts
@@ -5,6 +5,8 @@ import { prisma } from '../lib/prisma.js'
 import { asyncHandler } from '../lib/asyncHandler.js'
 import { authenticate, AuthRequest } from '../middleware/auth.js'
 import { syncCapacityProfilesForProject } from '../lib/syncCapacityProfiles.js'
+import { upsertNRProfileAndProjectLegacy } from '../lib/namedResourceCapacityProfileWrites.js'
+import type { NamedResourceCapacityPayload } from '../lib/namedResourceCapacityProfileWrites.js'
 import { exitCapacityPlanForManualScheduling } from '../lib/capacityPlanExit.js'
 
 const router = Router({ mergeParams: true })
@@ -98,35 +100,55 @@ router.post('/', asyncHandler(async (req: AuthRequest, res: Response) => {
       await exitCapacityPlanForManualScheduling(rt.id, tx)
     }
 
+    // Create NR with non-capacity fields first
     const created = await tx.namedResource.create({
       data: {
         name,
         resourceTypeId: rtId,
         ...(startWeek !== undefined && { startWeek }),
         ...(endWeek !== undefined && { endWeek }),
-        ...(allocationPct !== undefined && { allocationPct }),
         ...(pricingModel !== undefined && { pricingModel }),
-        ...(inheritAllocation && {
-          allocationMode: rtAllocationMode,
-          allocationPercent: rtAllocationPercent,
-          allocationStartWeek: rtAllocationStartWeek,
-          allocationEndWeek: rtAllocationEndWeek,
-        }),
+      },
+    })
+
+    // Build capacity payload from request + inherited RT allocation defaults
+    const capacityPayload: NamedResourceCapacityPayload = {
+      allocationMode: req.body.allocationMode ?? (inheritAllocation ? rtAllocationMode : undefined),
+      allocationPercent: req.body.allocationPercent ?? (inheritAllocation ? rtAllocationPercent : undefined),
+      allocationPct: req.body.allocationPct,
+      allocationStartWeek: req.body.allocationStartWeek ?? (inheritAllocation ? rtAllocationStartWeek : undefined),
+      allocationEndWeek: req.body.allocationEndWeek ?? (inheritAllocation ? rtAllocationEndWeek : undefined),
+      startWeek: req.body.startWeek,
+      endWeek: req.body.endWeek,
+    }
+
+    // Profile-first write + project back to legacy
+    const projection = await upsertNRProfileAndProjectLegacy(tx, projectId, created.id, rtId, capacityPayload)
+
+    // Write projected legacy fields as compatibility
+    const updated = await tx.namedResource.update({
+      where: { id: created.id },
+      data: {
+        allocationMode: projection.allocationMode,
+        allocationPercent: projection.allocationPercent ?? 100,
+        allocationStartWeek: projection.allocationStartWeek,
+        allocationEndWeek: projection.allocationEndWeek,
       },
     })
 
     // Sync resource type count to match total named resources
     const total = await tx.namedResource.count({ where: { resourceTypeId: rtId } })
     await tx.resourceType.update({ where: { id: rtId }, data: { count: total } })
+    // Sync remaining profiles (role-level, other NRs) for full project reconciliation
     await syncCapacityProfilesForProject(tx, projectId)
 
-    return created
+
+    return updated
   })
 
   res.status(201).json(resource)
 }))
 
-// PUT /projects/:projectId/resource-types/:rtId/named-resources/:id
 router.put('/:id', asyncHandler(async (req: AuthRequest, res: Response) => {
   const { projectId, rtId, id } = req.params as { projectId: string; rtId: string; id: string }
   const project = await ownedProject(projectId, req.userId!)
@@ -149,23 +171,45 @@ router.put('/:id', asyncHandler(async (req: AuthRequest, res: Response) => {
     res.status(400).json({ error: `pricingModel must be one of: ${VALID_PRICING_MODELS.join(', ')}` }); return
   }
 
-  const data: Record<string, unknown> = { name, startWeek, endWeek, allocationPct, pricingModel, allocationMode, allocationPercent, allocationStartWeek, allocationEndWeek }
-  Object.keys(data).forEach(key => {
-    if (data[key] === undefined) delete data[key]
+  // Non-capacity fields written directly to NamedResource
+  const nrData: Record<string, unknown> = { name, pricingModel }
+  Object.keys(nrData).forEach(key => {
+    if (nrData[key] === undefined) delete nrData[key]
   })
+  // Capacity payload: request fields take precedence, fall back to existing NR
+  const capacityPayload: NamedResourceCapacityPayload = {
+    allocationMode: allocationMode ?? existing.allocationMode,
+    allocationPercent: allocationPercent ?? existing.allocationPercent,
+    allocationPct: allocationPct ?? existing.allocationPct,
+    allocationStartWeek: allocationStartWeek ?? existing.allocationStartWeek,
+    allocationEndWeek: allocationEndWeek ?? existing.allocationEndWeek,
+    startWeek: startWeek ?? existing.startWeek,
+    endWeek: endWeek ?? existing.endWeek,
+  }
 
   const resource = await prisma.$transaction(async tx => {
+    // Write non-capacity fields first
+    await tx.namedResource.update({ where: { id }, data: nrData })
+    // Profile-first write + project back to legacy
+    const projection = await upsertNRProfileAndProjectLegacy(tx, projectId, id, rtId, capacityPayload)
+    // Write projected legacy fields as compatibility
     const updated = await tx.namedResource.update({
       where: { id },
-      data,
+      data: {
+        allocationMode: projection.allocationMode,
+        allocationPercent: projection.allocationPercent ?? 100,
+        allocationStartWeek: projection.allocationStartWeek,
+        allocationEndWeek: projection.allocationEndWeek,
+      },
     })
-    await clearWeeklyDemandCache(projectId, tx)
+    // Sync remaining profiles (role-level, other NRs) for full project reconciliation
     await syncCapacityProfilesForProject(tx, projectId)
+
+    await clearWeeklyDemandCache(projectId, tx)
     return updated
   })
   res.json(resource)
 }))
-
 // PATCH /projects/:projectId/resource-types/:rtId/named-resources/:id
 router.patch('/:id', asyncHandler(async (req: AuthRequest, res: Response) => {
   const { projectId, rtId, id } = req.params as { projectId: string; rtId: string; id: string }
@@ -177,21 +221,35 @@ router.patch('/:id', asyncHandler(async (req: AuthRequest, res: Response) => {
 
   const existing = await prisma.namedResource.findFirst({ where: { id, resourceTypeId: rtId } })
   if (!existing) { res.status(404).json({ error: 'Named resource not found' }); return }
-
   const { allocationMode, allocationPercent, allocationStartWeek, allocationEndWeek } = req.body
 
-  const data: Record<string, unknown> = { allocationMode, allocationPercent, allocationStartWeek, allocationEndWeek }
-  Object.keys(data).forEach(key => {
-    if (data[key] === undefined) delete data[key]
-  })
+  const capacityPayload: NamedResourceCapacityPayload = {
+    allocationMode: allocationMode ?? existing.allocationMode,
+    allocationPercent: allocationPercent ?? existing.allocationPercent,
+    allocationStartWeek: allocationStartWeek ?? existing.allocationStartWeek,
+    allocationEndWeek: allocationEndWeek ?? existing.allocationEndWeek,
+    allocationPct: existing.allocationPct,
+    startWeek: existing.startWeek,
+    endWeek: existing.endWeek,
+  }
 
   const resource = await prisma.$transaction(async tx => {
+    // Profile-first write + project back to legacy
+    const projection = await upsertNRProfileAndProjectLegacy(tx, projectId, id, rtId, capacityPayload)
+    // Write projected legacy fields as compatibility
     const updated = await tx.namedResource.update({
       where: { id },
-      data,
+      data: {
+        allocationMode: projection.allocationMode,
+        allocationPercent: projection.allocationPercent ?? 100,
+        allocationStartWeek: projection.allocationStartWeek,
+        allocationEndWeek: projection.allocationEndWeek,
+      },
     })
-    await clearWeeklyDemandCache(projectId, tx)
+    // Sync remaining profiles (role-level, other NRs) for full project reconciliation
     await syncCapacityProfilesForProject(tx, projectId)
+
+    await clearWeeklyDemandCache(projectId, tx)
     return updated
   })
   res.json(resource)

--- a/server/src/routes/namedResources.ts
+++ b/server/src/routes/namedResources.ts
@@ -193,10 +193,6 @@ router.put('/:id', asyncHandler(async (req: AuthRequest, res: Response) => {
     if (nrData[key] === undefined) delete nrData[key]
   })
 
-  // Capacity payload: distinguish explicit capacity input from non-capacity-only changes.
-  // When no capacity fields are provided, preserve existing capacity state.
-  // When capacity fields are provided but allocationMode is omitted, pass undefined
-  // so the helper can infer TIMELINE from explicit startWeek/endWeek presence.
   const has = (k: string) => Object.prototype.hasOwnProperty.call(req.body, k)
   const hasCapacityInput =
     has('allocationMode') ||
@@ -206,6 +202,10 @@ router.put('/:id', asyncHandler(async (req: AuthRequest, res: Response) => {
     has('allocationEndWeek') ||
     has('startWeek') ||
     has('endWeek')
+
+  /** Non-window allocation modes — when explicitly set, stale window fields must be suppressed. */
+  const NON_WINDOW_MODES = new Set(['EFFORT', 'FULL_PROJECT', 'CAPACITY_PLAN'])
+  const isExplicitNonWindow = has('allocationMode') && allocationMode !== undefined && allocationMode !== null && NON_WINDOW_MODES.has(allocationMode)
 
   const capacityPayload: NamedResourceCapacityPayload = {
     allocationMode: has('allocationMode')
@@ -222,20 +222,32 @@ router.put('/:id', asyncHandler(async (req: AuthRequest, res: Response) => {
 
     allocationPct: has('allocationPct') ? allocationPct : existing.allocationPct,
 
-    allocationStartWeek: has('allocationStartWeek')
-      ? allocationStartWeek
-      : has('startWeek')
-        ? undefined
-        : existing.allocationStartWeek,
+    // When allocationMode is explicitly a non-window mode (EFFORT, FULL_PROJECT, CAPACITY_PLAN),
+    // suppress stale window fields regardless of what the NR previously had.
+    // This prevents the projection from misinterpreting historical windows as TIMELINE intent.
+    allocationStartWeek: isExplicitNonWindow
+      ? null
+      : has('allocationStartWeek')
+        ? allocationStartWeek
+        : has('startWeek')
+          ? undefined
+          : existing.allocationStartWeek,
 
-    allocationEndWeek: has('allocationEndWeek')
-      ? allocationEndWeek
-      : has('endWeek')
-        ? undefined
-        : existing.allocationEndWeek,
+    allocationEndWeek: isExplicitNonWindow
+      ? null
+      : has('allocationEndWeek')
+        ? allocationEndWeek
+        : has('endWeek')
+          ? undefined
+          : existing.allocationEndWeek,
 
-    startWeek: has('startWeek') ? startWeek : existing.startWeek,
-    endWeek: has('endWeek') ? endWeek : existing.endWeek,
+    startWeek: isExplicitNonWindow
+      ? null
+      : has('startWeek') ? startWeek : existing.startWeek,
+
+    endWeek: isExplicitNonWindow
+      ? null
+      : has('endWeek') ? endWeek : existing.endWeek,
   }
 
   const resource = await prisma.$transaction(async tx => {
@@ -259,18 +271,24 @@ router.put('/:id', asyncHandler(async (req: AuthRequest, res: Response) => {
         },
       })
     } else {
-      // No capacity changes — ensure a profile exists without changing legacy fields.
-      // Suppress window fields so an EFFORT-mode NR with historical window values
-      // does not have its projection silently changed to TIMELINE.
-      await upsertNRProfileAndProjectLegacy(tx, projectId, id, rtId, {
-        allocationMode: existing.allocationMode,
-        allocationPercent: existing.allocationPercent,
-        allocationPct: existing.allocationPct,
-        allocationStartWeek: null,
-        allocationEndWeek: null,
-        startWeek: null,
-        endWeek: null,
+      // No capacity changes — preserve existing profile row identity if present.
+      // Only create a profile if one does not already exist.
+      const existingProfiles = await tx.capacityProfile.findMany({
+        where: { namedResourceId: id, projectId },
+        select: { id: true },
       })
+      if (existingProfiles.length === 0) {
+        // Create a profile from existing legacy fields
+        await upsertNRProfileAndProjectLegacy(tx, projectId, id, rtId, {
+          allocationMode: existing.allocationMode,
+          allocationPercent: existing.allocationPercent,
+          allocationPct: existing.allocationPct,
+          allocationStartWeek: null,
+          allocationEndWeek: null,
+          startWeek: null,
+          endWeek: null,
+        })
+      }
       // Don't touch legacy fields — existing values remain intact
       updated = await tx.namedResource.findFirst({ where: { id } })
       if (!updated) throw new Error('NamedResource not found after update')
@@ -297,12 +315,30 @@ router.patch('/:id', asyncHandler(async (req: AuthRequest, res: Response) => {
   if (!existing) { res.status(404).json({ error: 'Named resource not found' }); return }
   const { allocationMode, allocationPercent, allocationStartWeek, allocationEndWeek } = req.body
 
+  const NON_WINDOW_MODES = new Set(['EFFORT', 'FULL_PROJECT', 'CAPACITY_PLAN'])
+  const hasPatch = (k: string) => Object.prototype.hasOwnProperty.call(req.body, k)
+  const isExplicitNonWindowPatch = hasPatch('allocationMode') && allocationMode !== undefined && allocationMode !== null && NON_WINDOW_MODES.has(allocationMode)
+
   const capacityPayload: NamedResourceCapacityPayload = {
-    allocationMode: allocationMode ?? existing.allocationMode,
-    allocationPercent: allocationPercent ?? existing.allocationPercent,
-    allocationStartWeek: allocationStartWeek ?? existing.allocationStartWeek,
-    allocationEndWeek: allocationEndWeek ?? existing.allocationEndWeek,
+    allocationMode: hasPatch('allocationMode') ? allocationMode : existing.allocationMode,
+
+    allocationPercent: hasPatch('allocationPercent') ? allocationPercent : existing.allocationPercent,
+
     allocationPct: existing.allocationPct,
+
+    // Non-window mode suppresses stale window fields
+    allocationStartWeek: isExplicitNonWindowPatch
+      ? null
+      : hasPatch('allocationStartWeek')
+        ? allocationStartWeek
+        : existing.allocationStartWeek,
+
+    allocationEndWeek: isExplicitNonWindowPatch
+      ? null
+      : hasPatch('allocationEndWeek')
+        ? allocationEndWeek
+        : existing.allocationEndWeek,
+
     startWeek: existing.startWeek,
     endWeek: existing.endWeek,
   }

--- a/server/src/routes/namedResources.ts
+++ b/server/src/routes/namedResources.ts
@@ -250,6 +250,33 @@ router.put('/:id', asyncHandler(async (req: AuthRequest, res: Response) => {
       : has('endWeek') ? endWeek : existing.endWeek,
   }
 
+/**
+ * Build a capacity payload for the missing-profile case in non-capacity PUT.
+ *
+ * When no CapacityProfile exists and the PUT only changes non-capacity fields
+ * (name/pricingModel), create a profile from existing legacy fields.
+ * - TIMELINE mode preserves existing window fields (allocationStartWeek > startWeek)
+ * - Non-window modes (EFFORT, FULL_PROJECT, CAPACITY_PLAN) suppress window fields
+ */
+function buildMissingProfilePayload(existing: any): NamedResourceCapacityPayload {
+  const isTimeline = existing.allocationMode === 'TIMELINE'
+  const startWeek = isTimeline
+    ? (existing.allocationStartWeek ?? existing.startWeek ?? null)
+    : null
+  const endWeek = isTimeline
+    ? (existing.allocationEndWeek ?? existing.endWeek ?? null)
+    : null
+  return {
+    allocationMode: existing.allocationMode,
+    allocationPercent: existing.allocationPercent,
+    allocationPct: existing.allocationPct,
+    allocationStartWeek: startWeek,
+    allocationEndWeek: endWeek,
+    startWeek,
+    endWeek,
+  }
+}
+
   const resource = await prisma.$transaction(async tx => {
     // Write non-capacity fields first
     await tx.namedResource.update({ where: { id }, data: nrData })
@@ -270,6 +297,7 @@ router.put('/:id', asyncHandler(async (req: AuthRequest, res: Response) => {
           endWeek: projection.allocationEndWeek,
         },
       })
+
     } else {
       // No capacity changes — preserve existing profile row identity if present.
       // Only create a profile if one does not already exist.
@@ -279,15 +307,9 @@ router.put('/:id', asyncHandler(async (req: AuthRequest, res: Response) => {
       })
       if (existingProfiles.length === 0) {
         // Create a profile from existing legacy fields
-        await upsertNRProfileAndProjectLegacy(tx, projectId, id, rtId, {
-          allocationMode: existing.allocationMode,
-          allocationPercent: existing.allocationPercent,
-          allocationPct: existing.allocationPct,
-          allocationStartWeek: null,
-          allocationEndWeek: null,
-          startWeek: null,
-          endWeek: null,
-        })
+        // For TIMELINE mode, preserve existing window fields.
+        // For non-window modes, suppress stale windows.
+        await upsertNRProfileAndProjectLegacy(tx, projectId, id, rtId, buildMissingProfilePayload(existing))
       }
       // Don't touch legacy fields — existing values remain intact
       updated = await tx.namedResource.findFirst({ where: { id } })

--- a/server/src/test/capacityProfileLegacyProjection.test.ts
+++ b/server/src/test/capacityProfileLegacyProjection.test.ts
@@ -203,4 +203,41 @@ describe('projectCapacityProfileToLegacyAllocation', () => {
     expect(result!.allocationPercent).toBe(100)
     expect(result!.lossy).toBe(false)
   })
+
+  it('projects availabilityWindow without explicit segments using startWeek/endWeek from profile', () => {
+    const result = projectCapacityProfileToLegacyAllocation(
+      profile({
+        planningBasis: 'availabilityWindow',
+        source: 'availabilityWindow',
+        defaultPercent: 75,
+        startWeek: 2,
+        endWeek: 10,
+      }),
+    )
+
+    expect(result!.allocationMode).toBe('TIMELINE')
+    expect(result!.allocationPercent).toBe(75)
+    expect(result!.allocationStartWeek).toBe(2)
+    expect(result!.allocationEndWeek).toBe(10)
+    expect(result!.lossy).toBe(false)
+  })
+
+  it('projects demandFollowing with explicit startWeek/endWeek as TIMELINE', () => {
+    // When a demand-following profile has start/end week set, it behaves
+    // like an availability window — project to TIMELINE with the window.
+    const result = projectCapacityProfileToLegacyAllocation(
+      profile({
+        planningBasis: 'demandFollowing',
+        source: 'fixed',
+        defaultPercent: 100,
+        startWeek: 0,
+        endWeek: 13,
+      }),
+    )
+
+    expect(result!.allocationMode).toBe('TIMELINE')
+    expect(result!.allocationStartWeek).toBe(0)
+    expect(result!.allocationEndWeek).toBe(13)
+    expect(result!.lossy).toBe(false)
+  })
 })

--- a/server/src/test/capacityProfilePersistedDtoIntegration.test.ts
+++ b/server/src/test/capacityProfilePersistedDtoIntegration.test.ts
@@ -1538,5 +1538,121 @@ describe('persisted capacity-profile DTO integration', () => {
       expect(rtRow.namedResources).toHaveLength(1)
       expect(rtRow.namedResources[0].capacityProfile).toBeDefined()
     })
+
+    it('non-capacity PUT preserves existing CAPACITY_PLAN state', async () => {
+      const cpRtId = 'rt-cap-plan'
+      const cpNrId = 'nr-cap-plan'
+      addResourceType(cpRtId, 'CapPlan RT', 1)
+      addNamedResource(cpNrId, 'CapPlan Person', cpRtId, {
+        allocationMode: 'CAPACITY_PLAN',
+        allocationPercent: 100,
+        allocationStartWeek: null,
+        allocationEndWeek: null,
+        pricingModel: 'PRO_RATA',
+      })
+      // Pre-create a matching profile (simulating previous profile-first write)
+      addPersistedProfile('cp-cap-plan', {
+        resourceTypeId: null,
+        namedResourceId: cpNrId,
+        ownerKind: 'NAMED_PERSON',
+        planningBasis: 'CAPACITY_PROFILE',
+        source: 'SQUAD_PLANNER',
+        defaultPercent: 100,
+        startWeek: null,
+        endWeek: null,
+      })
+      // Add backlog + timeline so Resource Profile route produces a row
+      addEpic('epic-cp', 'CapPlan Epic')
+      addFeature('feat-cp', 'CapPlan Feature', 'epic-cp')
+      addUserStory('story-cp', 'feat-cp')
+      addTask('task-cp', 'story-cp', cpRtId, 80)
+      storeRef.current.timelineEntries.push({ featureId: 'feat-cp', startWeek: 0, durationWeeks: 4 })
+
+      const res = await request(app)
+        .put(`/api/projects/${projectId}/resource-types/${cpRtId}/named-resources/${cpNrId}`)
+        .set('Authorization', authHeader)
+        .send({ name: 'Renamed Only' })
+
+      expect(res.status).toBe(200)
+
+      // NamedResource name updated, capacity state preserved
+      expect(res.body.name).toBe('Renamed Only')
+      expect(res.body.allocationMode).toBe('CAPACITY_PLAN')
+      expect(res.body.allocationPercent).toBe(100)
+      expect(res.body.allocationPct).toBe(100)
+
+      // CapacityProfile preserved
+      const profile = storeRef.current.capacityProfiles.find(
+        (p: any) => p.namedResourceId === cpNrId,
+      )
+      expect(profile).toBeDefined()
+      expect(profile!.planningBasis).toBe('CAPACITY_PROFILE')
+      expect(profile!.source).toBe('SQUAD_PLANNER')
+
+      // Profile-first row survives sync
+      const profilesAfter = storeRef.current.capacityProfiles.filter(
+        (p: any) => p.namedResourceId === cpNrId,
+      )
+      expect(profilesAfter).toHaveLength(1)
+      expect(profilesAfter[0].planningBasis).toBe('CAPACITY_PROFILE')
+    })
+
+    it('non-capacity PUT does not infer TIMELINE from historical window values', async () => {
+      const histRtId = 'rt-hist'
+      const histNrId = 'nr-hist'
+      addResourceType(histRtId, 'Hist RT', 1)
+      addNamedResource(histNrId, 'Hist Person', histRtId, {
+        allocationMode: 'EFFORT',
+        allocationPercent: 100,
+        startWeek: 2,
+        endWeek: 10,
+        allocationStartWeek: 2,
+        allocationEndWeek: 10,
+        pricingModel: 'ACTUAL_DAYS',
+      })
+      // Pre-create a matching profile (simulating previous profile-first write)
+      addPersistedProfile('cp-hist', {
+        resourceTypeId: null,
+        namedResourceId: histNrId,
+        ownerKind: 'NAMED_PERSON',
+        planningBasis: 'DEMAND_FOLLOWING',
+        source: 'FIXED',
+        defaultPercent: 100,
+        startWeek: 2,
+        endWeek: 10,
+      })
+      // Add backlog + timeline so Resource Profile route produces a row
+      addEpic('epic-hist', 'Hist Epic')
+      addFeature('feat-hist', 'Hist Feature', 'epic-hist')
+      addUserStory('story-hist', 'feat-hist')
+      addTask('task-hist', 'story-hist', histRtId, 80)
+      storeRef.current.timelineEntries.push({ featureId: 'feat-hist', startWeek: 0, durationWeeks: 4 })
+
+      const res = await request(app)
+        .put(`/api/projects/${projectId}/resource-types/${histRtId}/named-resources/${histNrId}`)
+        .set('Authorization', authHeader)
+        .send({ name: 'Renamed Only' })
+
+      expect(res.status).toBe(200)
+
+      // NamedResource name updated, capacity state preserved
+      expect(res.body.name).toBe('Renamed Only')
+      expect(res.body.allocationMode).toBe('EFFORT')
+      expect(res.body.allocationPercent).toBe(100)
+
+      // Route did not infer TIMELINE just because existing startWeek/endWeek values are present
+      const profile = storeRef.current.capacityProfiles.find(
+        (p: any) => p.namedResourceId === histNrId,
+      )
+      expect(profile).toBeDefined()
+      expect(profile!.planningBasis).toBe('DEMAND_FOLLOWING')
+
+      // Profile-first row survives sync
+      const profilesAfter = storeRef.current.capacityProfiles.filter(
+        (p: any) => p.namedResourceId === histNrId,
+      )
+      expect(profilesAfter).toHaveLength(1)
+      expect(profilesAfter[0].planningBasis).toBe('DEMAND_FOLLOWING')
+    })
   })
  })

--- a/server/src/test/capacityProfilePersistedDtoIntegration.test.ts
+++ b/server/src/test/capacityProfilePersistedDtoIntegration.test.ts
@@ -1895,5 +1895,81 @@ describe('persisted capacity-profile DTO integration', () => {
       expect(res.body.allocationStartWeek).toBe(4)
       expect(res.body.allocationEndWeek).toBe(8)
     })
+
+    it('non-capacity PUT creates TIMELINE profile with preserved window when missing', async () => {
+      const mtRtId = 'rt-miss-tl'
+      const mtNrId = 'nr-miss-tl'
+      addResourceType(mtRtId, 'MissTL RT', 1)
+      addNamedResource(mtNrId, 'MissTL Person', mtRtId, {
+        allocationMode: 'TIMELINE',
+        allocationPercent: 60,
+        allocationStartWeek: 4,
+        allocationEndWeek: 9,
+        startWeek: 4,
+        endWeek: 9,
+        pricingModel: 'ACTUAL_DAYS',
+      })
+      // No backlog/timeline — not checking Resource Profile response
+
+      const res = await request(app)
+        .put(`/api/projects/${projectId}/resource-types/${mtRtId}/named-resources/${mtNrId}`)
+        .set('Authorization', authHeader)
+        .send({ name: 'Renamed Only' })
+
+      expect(res.status).toBe(200)
+      expect(res.body.name).toBe('Renamed Only')
+      // Legacy fields preserved
+      expect(res.body.allocationMode).toBe('TIMELINE')
+      expect(res.body.allocationStartWeek).toBe(4)
+      expect(res.body.allocationEndWeek).toBe(9)
+
+      // New profile created with TIMELINE semantics
+      const profile = storeRef.current.capacityProfiles.find(
+        (p: any) => p.namedResourceId === mtNrId,
+      )
+      expect(profile).toBeDefined()
+      expect(profile!.planningBasis).toBe('AVAILABILITY_WINDOW')
+      expect(profile!.source).toBe('AVAILABILITY_WINDOW')
+      expect(profile!.startWeek).toBe(4)
+      expect(profile!.endWeek).toBe(9)
+      expect(profile!.defaultPercent).toBe(60)
+    })
+
+    it('non-capacity PUT creates EFFORT profile with null windows when missing', async () => {
+      const meRtId = 'rt-miss-eff'
+      const meNrId = 'nr-miss-eff'
+      addResourceType(meRtId, 'MissEff RT', 1)
+      addNamedResource(meNrId, 'MissEff Person', meRtId, {
+        allocationMode: 'EFFORT',
+        allocationPercent: 100,
+        startWeek: 3,
+        endWeek: 8,
+        allocationStartWeek: 3,
+        allocationEndWeek: 8,
+        pricingModel: 'PRO_RATA',
+      })
+
+      const res = await request(app)
+        .put(`/api/projects/${projectId}/resource-types/${meRtId}/named-resources/${meNrId}`)
+        .set('Authorization', authHeader)
+        .send({ name: 'Renamed Only' })
+
+      expect(res.status).toBe(200)
+      expect(res.body.name).toBe('Renamed Only')
+      // Legacy fields preserved (not rewritten)
+      expect(res.body.allocationMode).toBe('EFFORT')
+      expect(res.body.allocationStartWeek).toBe(3)
+      expect(res.body.allocationEndWeek).toBe(8)
+
+      // New profile created with null windows (stale windows suppressed)
+      const profile = storeRef.current.capacityProfiles.find(
+        (p: any) => p.namedResourceId === meNrId,
+      )
+      expect(profile).toBeDefined()
+      expect(profile!.planningBasis).toBe('DEMAND_FOLLOWING')
+      expect(profile!.startWeek).toBeNull()
+      expect(profile!.endWeek).toBeNull()
+      expect(profile!.defaultPercent).toBe(100)
+    })
   })
  })

--- a/server/src/test/capacityProfilePersistedDtoIntegration.test.ts
+++ b/server/src/test/capacityProfilePersistedDtoIntegration.test.ts
@@ -1654,5 +1654,246 @@ describe('persisted capacity-profile DTO integration', () => {
       expect(profilesAfter).toHaveLength(1)
       expect(profilesAfter[0].planningBasis).toBe('DEMAND_FOLLOWING')
     })
+
+    it('explicit EFFORT suppresses stale window fields', async () => {
+      const effRtId = 'rt-eff-stale'
+      const effNrId = 'nr-eff-stale'
+      addResourceType(effRtId, 'EffStale RT', 1)
+      // NR has stale window values from a previous TIMELINE state
+      addNamedResource(effNrId, 'EffStale Person', effRtId, {
+        allocationMode: 'TIMELINE',
+        allocationPercent: 75,
+        startWeek: 2,
+        endWeek: 10,
+        allocationStartWeek: 2,
+        allocationEndWeek: 10,
+        pricingModel: 'ACTUAL_DAYS',
+      })
+      addEpic('epic-eff', 'Eff Epic')
+      addFeature('feat-eff', 'Eff Feature', 'epic-eff')
+      addUserStory('story-eff', 'feat-eff')
+      addTask('task-eff', 'story-eff', effRtId, 80)
+      storeRef.current.timelineEntries.push({ featureId: 'feat-eff', startWeek: 0, durationWeeks: 4 })
+
+      const res = await request(app)
+        .put(`/api/projects/${projectId}/resource-types/${effRtId}/named-resources/${effNrId}`)
+        .set('Authorization', authHeader)
+        .send({ allocationMode: 'EFFORT', allocationPercent: 100 })
+
+      expect(res.status).toBe(200)
+      expect(res.body.allocationMode).toBe('EFFORT')
+      expect(res.body.allocationPercent).toBe(100)
+      expect(res.body.startWeek).toBeNull()
+      expect(res.body.endWeek).toBeNull()
+      expect(res.body.allocationStartWeek).toBeNull()
+      expect(res.body.allocationEndWeek).toBeNull()
+
+      const profile = storeRef.current.capacityProfiles.find(
+        (p: any) => p.namedResourceId === effNrId,
+      )
+      expect(profile).toBeDefined()
+      expect(profile!.planningBasis).toBe('DEMAND_FOLLOWING')
+      expect(profile!.startWeek).toBeNull()
+      expect(profile!.endWeek).toBeNull()
+    })
+
+    it('explicit FULL_PROJECT suppresses stale window fields', async () => {
+      const fpRtId = 'rt-fp-stale'
+      const fpNrId = 'nr-fp-stale'
+      addResourceType(fpRtId, 'FPStale RT', 1)
+      addNamedResource(fpNrId, 'FPStale Person', fpRtId, {
+        allocationMode: 'TIMELINE',
+        allocationPercent: 75,
+        startWeek: 2,
+        endWeek: 10,
+        allocationStartWeek: 2,
+        allocationEndWeek: 10,
+        pricingModel: 'PRO_RATA',
+      })
+      addEpic('epic-fp', 'Fp Epic')
+      addFeature('feat-fp', 'Fp Feature', 'epic-fp')
+      addUserStory('story-fp', 'feat-fp')
+      addTask('task-fp', 'story-fp', fpRtId, 80)
+      storeRef.current.timelineEntries.push({ featureId: 'feat-fp', startWeek: 0, durationWeeks: 4 })
+
+      const res = await request(app)
+        .put(`/api/projects/${projectId}/resource-types/${fpRtId}/named-resources/${fpNrId}`)
+        .set('Authorization', authHeader)
+        .send({ allocationMode: 'FULL_PROJECT', allocationPercent: 80 })
+
+      expect(res.status).toBe(200)
+      expect(res.body.allocationMode).toBe('FULL_PROJECT')
+      expect(res.body.allocationPercent).toBe(80)
+      expect(res.body.startWeek).toBeNull()
+      expect(res.body.endWeek).toBeNull()
+
+      const profile = storeRef.current.capacityProfiles.find(
+        (p: any) => p.namedResourceId === fpNrId,
+      )
+      expect(profile).toBeDefined()
+      expect(profile!.planningBasis).toBe('WHOLE_PROJECT_ALLOCATION')
+      expect(profile!.startWeek).toBeNull()
+      expect(profile!.endWeek).toBeNull()
+    })
+
+    it('explicit TIMELINE preserves window fields', async () => {
+      const tlRtId = 'rt-tl-window'
+      const tlNrId = 'nr-tl-window'
+      addResourceType(tlRtId, 'TLWindow RT', 1)
+      addNamedResource(tlNrId, 'TLWindow Person', tlRtId, {
+        allocationMode: 'EFFORT',
+        allocationPercent: 100,
+        startWeek: null,
+        endWeek: null,
+        pricingModel: 'ACTUAL_DAYS',
+      })
+      addEpic('epic-tl', 'TL Epic')
+      addFeature('feat-tl', 'TL Feature', 'epic-tl')
+      addUserStory('story-tl', 'feat-tl')
+      addTask('task-tl', 'story-tl', tlRtId, 80)
+      storeRef.current.timelineEntries.push({ featureId: 'feat-tl', startWeek: 0, durationWeeks: 4 })
+
+      const res = await request(app)
+        .put(`/api/projects/${projectId}/resource-types/${tlRtId}/named-resources/${tlNrId}`)
+        .set('Authorization', authHeader)
+        .send({ allocationMode: 'TIMELINE', allocationPercent: 50, startWeek: 3, endWeek: 8 })
+
+      expect(res.status).toBe(200)
+      expect(res.body.allocationMode).toBe('TIMELINE')
+      expect(res.body.allocationPercent).toBe(50)
+      expect(res.body.startWeek).toBe(3)
+      expect(res.body.endWeek).toBe(8)
+    })
+
+    it('rename-only PUT preserves existing multi-segment profile identity', async () => {
+      const segRtId = 'rt-rename-seg'
+      const segNrId = 'nr-rename-seg'
+      addResourceType(segRtId, 'RenameSeg RT', 1)
+      addNamedResource(segNrId, 'RenameSeg Person', segRtId, {
+        allocationMode: 'TIMELINE',
+        allocationPercent: 75,
+        allocationStartWeek: 2,
+        allocationEndWeek: 10,
+        startWeek: 2,
+        endWeek: 10,
+        pricingModel: 'ACTUAL_DAYS',
+      })
+      addEpic('epic-rs', 'RenameSeg Epic')
+      addFeature('feat-rs', 'RenameSeg Feature', 'epic-rs')
+      addUserStory('story-rs', 'feat-rs')
+      addTask('task-rs', 'story-rs', segRtId, 80)
+      storeRef.current.timelineEntries.push({ featureId: 'feat-rs', startWeek: 0, durationWeeks: 4 })
+
+      // Pre-create a multi-segment CapacityProfile
+      addPersistedProfile('cp-rename-seg', {
+        resourceTypeId: null,
+        namedResourceId: segNrId,
+        ownerKind: 'NAMED_PERSON',
+        planningBasis: 'AVAILABILITY_WINDOW',
+        source: 'AVAILABILITY_WINDOW',
+        defaultPercent: 75,
+        startWeek: 2,
+        endWeek: 10,
+      })
+      storeRef.current.capacitySegments.push(
+        { id: 'seg-rs-1', capacityProfileId: 'cp-rename-seg', startWeek: 2, endWeek: 5, capacityPercent: 75, source: 'AVAILABILITY_WINDOW', createdAt: new Date(), updatedAt: new Date() },
+        { id: 'seg-rs-2', capacityProfileId: 'cp-rename-seg', startWeek: 6, endWeek: 10, capacityPercent: 75, source: 'AVAILABILITY_WINDOW', createdAt: new Date(), updatedAt: new Date() },
+      )
+
+      const res = await request(app)
+        .put(`/api/projects/${projectId}/resource-types/${segRtId}/named-resources/${segNrId}`)
+        .set('Authorization', authHeader)
+        .send({ name: 'Renamed Person' })
+
+      expect(res.status).toBe(200)
+      expect(res.body.name).toBe('Renamed Person')
+      expect(res.body.allocationMode).toBe('TIMELINE')
+
+      // Same profile row identity preserved
+      const profile = storeRef.current.capacityProfiles.find(
+        (p: any) => p.id === 'cp-rename-seg',
+      )
+      expect(profile).toBeDefined()
+      expect(profile!.planningBasis).toBe('AVAILABILITY_WINDOW')
+
+      // All segments still exist
+      const remainingSegments = storeRef.current.capacitySegments.filter(
+        (s: any) => s.capacityProfileId === 'cp-rename-seg',
+      )
+      expect(remainingSegments).toHaveLength(2)
+
+      // Legacy fields not rewritten
+      expect(res.body.allocationStartWeek).toBe(2)
+      expect(res.body.allocationEndWeek).toBe(10)
+      expect(res.body.startWeek).toBe(2)
+      expect(res.body.endWeek).toBe(10)
+    })
+
+    it('PATCH null clears allocationStartWeek/allocationEndWeek', async () => {
+      const pcRtId = 'rt-patch-clear'
+      const pcNrId = 'nr-patch-clear'
+      addResourceType(pcRtId, 'PatchClear RT', 1)
+      addNamedResource(pcNrId, 'PatchClear Person', pcRtId, {
+        allocationMode: 'TIMELINE',
+        allocationPercent: 50,
+        allocationStartWeek: 3,
+        allocationEndWeek: 9,
+        startWeek: 3,
+        endWeek: 9,
+        pricingModel: 'ACTUAL_DAYS',
+      })
+      addEpic('epic-pc', 'PatchClear Epic')
+      addFeature('feat-pc', 'PatchClear Feature', 'epic-pc')
+      addUserStory('story-pc', 'feat-pc')
+      addTask('task-pc', 'story-pc', pcRtId, 80)
+      storeRef.current.timelineEntries.push({ featureId: 'feat-pc', startWeek: 0, durationWeeks: 4 })
+
+      const res = await request(app)
+        .patch(`/api/projects/${projectId}/resource-types/${pcRtId}/named-resources/${pcNrId}`)
+        .set('Authorization', authHeader)
+        .send({ allocationStartWeek: null, allocationEndWeek: null })
+
+      expect(res.status).toBe(200)
+      // allocationStartWeek/allocationEndWeek cleared
+      expect(res.body.allocationStartWeek).toBeNull()
+      expect(res.body.allocationEndWeek).toBeNull()
+      // allocationMode stays TIMELINE (mode was explicitly set, not inferred from window)
+      expect(res.body.allocationMode).toBe('TIMELINE')
+      // startWeek/endWeek are projected from the profile — null since window cleared
+      expect(res.body.startWeek).toBeNull()
+      expect(res.body.endWeek).toBeNull()
+    })
+
+    it('PATCH omission preserves existing allocationStartWeek/allocationEndWeek', async () => {
+      const poRtId = 'rt-patch-omit'
+      const poNrId = 'nr-patch-omit'
+      addResourceType(poRtId, 'PatchOmit RT', 1)
+      addNamedResource(poNrId, 'PatchOmit Person', poRtId, {
+        allocationMode: 'TIMELINE',
+        allocationPercent: 50,
+        allocationStartWeek: 4,
+        allocationEndWeek: 8,
+        startWeek: 4,
+        endWeek: 8,
+        pricingModel: 'PRO_RATA',
+      })
+      addEpic('epic-po', 'PatchOmit Epic')
+      addFeature('feat-po', 'PatchOmit Feature', 'epic-po')
+      addUserStory('story-po', 'feat-po')
+      addTask('task-po', 'story-po', poRtId, 80)
+      storeRef.current.timelineEntries.push({ featureId: 'feat-po', startWeek: 0, durationWeeks: 4 })
+
+      const res = await request(app)
+        .patch(`/api/projects/${projectId}/resource-types/${poRtId}/named-resources/${poNrId}`)
+        .set('Authorization', authHeader)
+        .send({ allocationPercent: 60 })
+
+      expect(res.status).toBe(200)
+      // allocationStartWeek/allocationEndWeek preserved from existing
+      expect(res.body.allocationMode).toBe('TIMELINE')
+      expect(res.body.allocationPercent).toBe(60)
+      expect(res.body.allocationStartWeek).toBe(4)
+      expect(res.body.allocationEndWeek).toBe(8)
+    })
   })
  })

--- a/server/src/test/capacityProfilePersistedDtoIntegration.test.ts
+++ b/server/src/test/capacityProfilePersistedDtoIntegration.test.ts
@@ -62,7 +62,15 @@ const { storeRef, createStore, makeStoreClient } = vi.hoisted(() => {
   function filter(arr: any[], where: any): any[] {
     if (!where || Object.keys(where).length === 0) return [...arr]
     const entries = Object.entries(where)
-    return arr.filter(r => entries.every(([k, v]) => r[k] === v))
+    return arr.filter(r =>
+      entries.every(([k, v]) => {
+        // Handle { in: [...] } operator
+        if (v !== null && typeof v === 'object' && 'in' in v) {
+          return (v as { in: unknown[] }).in.includes(r[k])
+        }
+        return r[k] === v
+      }),
+    )
   }
 
   function findOne(arr: any[], where: any): any | null {
@@ -330,9 +338,16 @@ const { storeRef, createStore, makeStoreClient } = vi.hoisted(() => {
     }
 
     function deleteWhere(arrKey: string, where: any): { count: number } {
-      const before = (store() as any)[arrKey].length
-      ;(store() as any)[arrKey] = (store() as any)[arrKey].filter(
-        (r: any) => !Object.entries(where).every(([k, v]) => r[k] === v),
+      const arr = (store() as any)[arrKey]
+      const before = arr.length
+      ;(store() as any)[arrKey] = arr.filter((r: any) =>
+        Object.entries(where).every(([k, v]) => {
+          // Handle { in: [...] } operator
+          if (v !== null && typeof v === 'object' && 'in' in v) {
+            return !(v as { in: unknown[] }).in.includes(r[k])
+          }
+          return r[k] !== v
+        }),
       )
       return { count: before - (store() as any)[arrKey].length }
     }
@@ -1366,6 +1381,162 @@ describe('persisted capacity-profile DTO integration', () => {
 
       // pricingModel remains a separate field
       expect(nr.pricingModel).toBe('ACTUAL_DAYS')
+    })
+
+    it('PUT with only allocationPct updates percent consistently', async () => {
+      addResourceType('rt-pct-1', 'Pct RT', 1)
+      addNamedResource('nr-pct-1', 'Pct Person', 'rt-pct-1', {
+        allocationPercent: 100,
+        allocationPct: 100,
+        pricingModel: 'PRO_RATA',
+      })
+
+      const res = await request(app)
+        .put(`/api/projects/${projectId}/resource-types/rt-pct-1/named-resources/nr-pct-1`)
+        .set('Authorization', authHeader)
+        .send({ name: 'Updated Person', allocationPct: 50 })
+
+      expect(res.status).toBe(200)
+
+      // NamedResource fields
+      const nr = storeRef.current.namedResources.find((n: any) => n.id === 'nr-pct-1')
+      expect(nr).toBeDefined()
+      expect(nr.allocationPct).toBe(50)
+      expect(nr.allocationPercent).toBe(50)
+
+      // CapacityProfile
+      const profile = storeRef.current.capacityProfiles.find(
+        (p: any) => p.namedResourceId === 'nr-pct-1',
+      )
+      expect(profile).toBeDefined()
+      expect(profile!.defaultPercent).toBe(50)
+
+      // Profile-first row survives sync
+      const profilesAfter = storeRef.current.capacityProfiles.filter(
+        (p: any) => p.namedResourceId === 'nr-pct-1',
+      )
+      expect(profilesAfter).toHaveLength(1)
+      expect(profilesAfter[0].defaultPercent).toBe(50)
+    })
+
+    it('PUT with startWeek/endWeek infers TIMELINE and preserves window', async () => {
+      const winRtId = 'rt-win-1'
+      const winNrId = 'nr-win-1'
+      addResourceType(winRtId, 'Window RT', 1)
+      addNamedResource(winNrId, 'Window Person', winRtId, {
+        allocationMode: 'EFFORT',
+        allocationPercent: 100,
+        pricingModel: 'ACTUAL_DAYS',
+      })
+      // Add backlog + timeline so Resource Profile route produces a row
+      addEpic('epic-win', 'Win Epic')
+      addFeature('feat-win', 'Win Feature', 'epic-win')
+      addUserStory('story-win', 'feat-win')
+      addTask('task-win', 'story-win', winRtId, 80)
+      storeRef.current.timelineEntries.push({ featureId: 'feat-win', startWeek: 0, durationWeeks: 4 })
+
+      const res = await request(app)
+        .put(`/api/projects/${projectId}/resource-types/${winRtId}/named-resources/${winNrId}`)
+        .set('Authorization', authHeader)
+        .send({ name: 'Window Person', startWeek: 2, endWeek: 10 })
+
+      expect(res.status).toBe(200)
+
+      // NamedResource compatibility fields
+      const nr = storeRef.current.namedResources.find((n: any) => n.id === winNrId)
+      expect(nr).toBeDefined()
+      expect(nr.startWeek).toBe(2)
+      expect(nr.endWeek).toBe(10)
+      expect(nr.allocationStartWeek).toBe(2)
+      expect(nr.allocationEndWeek).toBe(10)
+      expect(nr.allocationMode).toBe('TIMELINE')
+
+      // CapacityProfile
+      const profile = storeRef.current.capacityProfiles.find(
+        (p: any) => p.namedResourceId === winNrId,
+      )
+      expect(profile).toBeDefined()
+      expect(profile!.startWeek).toBe(2)
+      expect(profile!.endWeek).toBe(10)
+      expect(profile!.planningBasis).toBe('AVAILABILITY_WINDOW')
+
+      // Resource Profile response remains compatible
+      const rpRes = await request(app)
+        .get(`/api/projects/${projectId}/resource-profile`)
+        .set('Authorization', authHeader)
+      expect(rpRes.status).toBe(200)
+      const rtRow = rpRes.body.resourceRows?.find((r: any) => r.resourceTypeId === winRtId)
+      expect(rtRow).toBeDefined()
+      expect(rtRow.namedResources).toHaveLength(1)
+      expect(rtRow.namedResources[0].capacityProfile).toBeDefined()
+    })
+
+    it('stale segments are cleaned up when updating to non-segmented profile', async () => {
+      const segRtId = 'rt-seg-clean'
+      const segNrId = 'nr-seg-clean'
+      addResourceType(segRtId, 'SegClean RT', 1)
+      addNamedResource(segNrId, 'SegClean Person', segRtId, {
+        allocationMode: 'EFFORT',
+        allocationPercent: 100,
+        pricingModel: 'PRO_RATA',
+      })
+      // Add backlog + timeline so Resource Profile route produces a row
+      addEpic('epic-seg-clean', 'SegClean Epic')
+      addFeature('feat-seg-clean', 'SegClean Feature', 'epic-seg-clean')
+      addUserStory('story-seg-clean', 'feat-seg-clean')
+      addTask('task-seg-clean', 'story-seg-clean', segRtId, 80)
+      storeRef.current.timelineEntries.push({ featureId: 'feat-seg-clean', startWeek: 0, durationWeeks: 4 })
+      // Manually add a pre-existing profile with segments (simulating a prior state)
+      addPersistedProfile('cp-seg-clean', {
+        resourceTypeId: null,
+        namedResourceId: segNrId,
+        ownerKind: 'NAMED_PERSON',
+        planningBasis: 'AVAILABILITY_WINDOW',
+        source: 'AVAILABILITY_WINDOW',
+        defaultPercent: 75,
+        startWeek: 2,
+        endWeek: 10,
+      })
+      storeRef.current.capacitySegments.push(
+        { id: 'seg-clean-1', capacityProfileId: 'cp-seg-clean', startWeek: 2, endWeek: 5, capacityPercent: 75, source: 'AVAILABILITY_WINDOW', createdAt: new Date(), updatedAt: new Date() },
+        { id: 'seg-clean-2', capacityProfileId: 'cp-seg-clean', startWeek: 6, endWeek: 10, capacityPercent: 75, source: 'AVAILABILITY_WINDOW', createdAt: new Date(), updatedAt: new Date() },
+      )
+
+      // Call PUT to EFFORT (non-segmented)
+      const res = await request(app)
+        .put(`/api/projects/${projectId}/resource-types/${segRtId}/named-resources/${segNrId}`)
+        .set('Authorization', authHeader)
+        .send({ name: 'Cleaned Person', allocationMode: 'EFFORT', allocationPercent: 100 })
+
+      expect(res.status).toBe(200)
+
+      // Old profile removed
+      const oldProfile = storeRef.current.capacityProfiles.find((p: any) => p.id === 'cp-seg-clean')
+      expect(oldProfile).toBeUndefined()
+
+      // New profile exists with correct planning basis
+      const newProfile = storeRef.current.capacityProfiles.find(
+        (p: any) => p.namedResourceId === segNrId,
+      )
+      expect(newProfile).toBeDefined()
+      expect(newProfile!.planningBasis).toBe('DEMAND_FOLLOWING')
+      expect(newProfile!.source).toBe('FIXED')
+
+      // No stale segments remain for the old profile
+      const staleSegments = storeRef.current.capacitySegments.filter(
+        (s: any) => s.capacityProfileId === 'cp-seg-clean',
+      )
+      expect(staleSegments).toHaveLength(0)
+
+      // Resource Profile response still has one named-resource row
+      const rpRes = await request(app)
+        .get(`/api/projects/${projectId}/resource-profile`)
+        .set('Authorization', authHeader)
+      expect(rpRes.status).toBe(200)
+      const rtRow = rpRes.body.resourceRows?.find((r: any) => r.resourceTypeId === segRtId)
+      expect(rtRow).toBeDefined()
+      expect(rtRow.namedResources).toHaveLength(1)
+      expect(rtRow.namedResources[0].capacityProfile).toBeDefined()
     })
   })
  })

--- a/server/src/test/capacityProfilePersistedDtoIntegration.test.ts
+++ b/server/src/test/capacityProfilePersistedDtoIntegration.test.ts
@@ -1248,4 +1248,124 @@ describe('persisted capacity-profile DTO integration', () => {
       expect(nr.pricingModel).toBe('PRO_RATA')
     })
   })
+
+  describe('8. Named-resource profile-first write integration', () => {
+    const pwrRtId = 'rt-pwr-1'
+    const pwrNrId = 'nr-pwr-1'
+
+    it('PUT creates CapacityProfile row and preserves compatibility fields', async () => {
+      addResourceType(pwrRtId, 'Write RT', 1)
+      addNamedResource(pwrNrId, 'Write Person', pwrRtId, {
+        pricingModel: 'PRO_RATA',
+      })
+
+      const res = await request(app)
+        .put(`/api/projects/${projectId}/resource-types/${pwrRtId}/named-resources/${pwrNrId}`)
+        .set('Authorization', authHeader)
+        .send({
+          name: 'Updated Person',
+          allocationMode: 'TIMELINE',
+          allocationPercent: 75,
+          allocationPct: 75,
+          allocationStartWeek: 2,
+          allocationEndWeek: 10,
+          startWeek: 2,
+          endWeek: 10,
+          pricingModel: 'PRO_RATA',
+        })
+
+      expect(res.status).toBe(200)
+
+      // CapacityProfile row exists with profile-first data
+      const profiles = storeRef.current.capacityProfiles.filter(
+        (cp: any) => cp.namedResourceId === pwrNrId,
+      )
+      expect(profiles).toHaveLength(1)
+      const cp = profiles[0]
+      expect(cp.ownerKind).toBe('NAMED_PERSON')
+      expect(cp.planningBasis).toBe('AVAILABILITY_WINDOW')
+      expect(cp.source).toBe('AVAILABILITY_WINDOW')
+      expect(cp.defaultPercent).toBe(75)
+      expect(cp.startWeek).toBe(2)
+      expect(cp.endWeek).toBe(10)
+
+      // NamedResource compatibility fields updated
+      const nr = storeRef.current.namedResources.find((n: any) => n.id === pwrNrId)
+      expect(nr).toBeDefined()
+      expect(nr.allocationMode).toBe('TIMELINE')
+      expect(nr.allocationPercent).toBe(75)
+      expect(nr.allocationPct).toBe(75)
+      expect(nr.allocationStartWeek).toBe(2)
+      expect(nr.allocationEndWeek).toBe(10)
+      expect(nr.startWeek).toBe(2)
+      expect(nr.endWeek).toBe(10)
+      expect(nr.pricingModel).toBe('PRO_RATA')
+      expect(nr.name).toBe('Updated Person')
+
+      // Profile-first row was not overwritten by legacy-derived sync
+      // (sync preserves this NR's profile)
+      const profilesAfterSync = storeRef.current.capacityProfiles.filter(
+        (cp: any) => cp.namedResourceId === pwrNrId,
+      )
+      expect(profilesAfterSync).toHaveLength(1)
+      expect(profilesAfterSync[0].planningBasis).toBe('AVAILABILITY_WINDOW')
+    })
+
+    it('Resource Profile response remains compatible with capacity profile enrichment', async () => {
+      addResourceType('rt-cr-1', 'Compat RT', 1)
+      addNamedResource('nr-cr-1', 'Compat Person', 'rt-cr-1', {
+        allocationMode: 'TIMELINE',
+        allocationPercent: 75,
+        allocationStartWeek: 2,
+        allocationEndWeek: 10,
+        pricingModel: 'ACTUAL_DAYS',
+      })
+      // Add backlog + timeline so the Resource Profile route produces a resource row
+      addEpic('epic-cr', 'Compat Epic')
+      addFeature('feat-cr', 'Compat Feature', 'epic-cr')
+      addUserStory('story-cr', 'feat-cr')
+      addTask('task-cr', 'story-cr', 'rt-cr-1', 80)
+      storeRef.current.timelineEntries.push({ featureId: 'feat-cr', startWeek: 0, durationWeeks: 4 })
+      // Manually add a matching persisted profile so the adapter reconciles
+      addPersistedProfile('cp-cr-1', {
+        resourceTypeId: null,
+        namedResourceId: 'nr-cr-1',
+        ownerKind: 'NAMED_PERSON',
+        planningBasis: 'AVAILABILITY_WINDOW',
+        source: 'AVAILABILITY_WINDOW',
+        defaultPercent: 75,
+        startWeek: 2,
+        endWeek: 10,
+      })
+
+      const res = await request(app)
+        .get(`/api/projects/${projectId}/resource-profile`)
+        .set('Authorization', authHeader)
+
+      expect(res.status).toBe(200)
+      expect(res.body.resourceRows).toBeDefined()
+
+      const rtRow = res.body.resourceRows.find((r: any) => r.resourceTypeId === 'rt-cr-1')
+      expect(rtRow).toBeDefined()
+
+      // One named resource, not duplicated
+      expect(rtRow.namedResources).toHaveLength(1)
+      const nr = rtRow.namedResources[0]
+      expect(nr.id).toBe('nr-cr-1')
+
+      // capacityProfile present with expected data
+      expect(nr.capacityProfile).toBeDefined()
+      expect(nr.capacityProfile.planningBasis).toBe('availabilityWindow')
+      expect(nr.capacityProfile.source).toBe('availabilityWindow')
+
+      // Legacy allocation fields remain present
+      expect(nr.allocationMode).toBe('TIMELINE')
+      expect(nr.allocationPercent).toBe(75)
+      expect(nr.allocationStartWeek).toBe(2)
+      expect(nr.allocationEndWeek).toBe(10)
+
+      // pricingModel remains a separate field
+      expect(nr.pricingModel).toBe('ACTUAL_DAYS')
+    })
+  })
  })

--- a/server/src/test/namedResourceCapacityProfileWrites.test.ts
+++ b/server/src/test/namedResourceCapacityProfileWrites.test.ts
@@ -1,0 +1,237 @@
+/**
+ * namedResourceCapacityProfileWrites.test.ts — Unit tests for the
+ * profile-first write helper.
+ *
+ * These tests verify that upsertNRProfileAndProjectLegacy correctly converts
+ * legacy payloads to capacity profiles, projects back to legacy fields, and
+ * handles multi-segment and edge cases.
+ *
+ * @see server/src/lib/namedResourceCapacityProfileWrites.ts
+ */
+
+import { describe, expect, it, vi } from 'vitest'
+import { upsertNRProfileAndProjectLegacy } from '../lib/namedResourceCapacityProfileWrites.js'
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function mockTx() {
+  const store: {
+    capacityProfiles: any[]
+    capacitySegments: any[]
+  } = {
+    capacityProfiles: [],
+    capacitySegments: [],
+  }
+
+  const tx = {
+    capacityProfile: {
+      deleteMany: vi.fn(async (args: any) => {
+        if (args?.where?.namedResourceId) {
+          store.capacityProfiles = store.capacityProfiles.filter(
+            (p: any) => p.namedResourceId !== args.where.namedResourceId,
+          )
+        } else if (args?.where?.projectId) {
+          store.capacityProfiles = store.capacityProfiles.filter(
+            (p: any) => p.projectId !== args.where.projectId,
+          )
+        } else {
+          store.capacityProfiles = []
+        }
+        return { count: 0 }
+      }),
+      create: vi.fn(async (args: any) => {
+        const data = args.data ?? args
+        const record = { id: `cp-${store.capacityProfiles.length + 1}`, ...data }
+        store.capacityProfiles.push(record)
+        return { ...record }
+      }),
+    },
+    capacitySegment: {
+      deleteMany: vi.fn(async (args: any) => {
+        if (args?.where?.capacityProfile?.namedResourceId) {
+          store.capacitySegments = store.capacitySegments.filter(
+            (s: any) => s.capacityProfileId !==
+              store.capacityProfiles.find(
+                (p: any) => p.namedResourceId === args.where.capacityProfile.namedResourceId,
+              )?.id,
+          )
+        } else if (args?.where?.capacityProfileId) {
+          store.capacitySegments = store.capacitySegments.filter(
+            (s: any) => s.capacityProfileId !== args.where.capacityProfileId,
+          )
+        } else {
+          store.capacitySegments = []
+        }
+        return { count: 0 }
+      }),
+      create: vi.fn(async (args: any) => {
+        const data = args.data ?? args
+        const record = { id: `seg-${store.capacitySegments.length + 1}`, ...data }
+        store.capacitySegments.push(record)
+        return { ...record }
+      }),
+    },
+    _store: store,
+  }
+
+  return tx
+}
+
+const projectId = 'proj-1'
+const nrId = 'nr-1'
+const rtId = 'rt-1'
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe('upsertNRProfileAndProjectLegacy', () => {
+  it('converts EFFORT payload to DEMAND_FOLLOWING profile and projects back to EFFORT', async () => {
+    const tx = mockTx() as any
+
+    const result = await upsertNRProfileAndProjectLegacy(tx, projectId, nrId, rtId, {
+      allocationMode: 'EFFORT',
+      allocationPercent: 100,
+    })
+
+    // Projected legacy fields
+    expect(result.allocationMode).toBe('EFFORT')
+    expect(result.allocationPercent).toBe(100)
+    expect(result.allocationStartWeek).toBeNull()
+    expect(result.allocationEndWeek).toBeNull()
+    expect(result.lossy).toBe(false)
+
+    // Persisted profile
+    expect(tx._store.capacityProfiles).toHaveLength(1)
+    const cp = tx._store.capacityProfiles[0]
+    expect(cp.namedResourceId).toBe(nrId)
+    expect(cp.resourceTypeId).toBe(rtId)
+    expect(cp.ownerKind).toBe('NAMED_PERSON')
+    expect(cp.planningBasis).toBe('DEMAND_FOLLOWING')
+    expect(cp.source).toBe('FIXED')
+    expect(cp.defaultPercent).toBe(100)
+
+    // No segments for EFFORT
+    expect(cp.segments).toBeUndefined()
+    expect(tx._store.capacitySegments).toHaveLength(0)
+  })
+
+  it('converts TIMELINE payload with availability window', async () => {
+    const tx = mockTx() as any
+
+    const result = await upsertNRProfileAndProjectLegacy(tx, projectId, nrId, rtId, {
+      allocationMode: 'TIMELINE',
+      allocationPercent: 75,
+      allocationStartWeek: 2,
+      allocationEndWeek: 10,
+    })
+
+    // Projected legacy fields
+    expect(result.allocationMode).toBe('TIMELINE')
+    expect(result.allocationPercent).toBe(75)
+    expect(result.allocationStartWeek).toBe(2)
+    expect(result.allocationEndWeek).toBe(10)
+    expect(result.lossy).toBe(false)
+
+    // Persisted profile
+    const cp = tx._store.capacityProfiles[0]
+    expect(cp.planningBasis).toBe('AVAILABILITY_WINDOW')
+    expect(cp.source).toBe('AVAILABILITY_WINDOW')
+    expect(cp.defaultPercent).toBe(75)
+    expect(cp.startWeek).toBe(2)
+    expect(cp.endWeek).toBe(10)
+  })
+
+  it('uses allocationPct as fallback for percent', async () => {
+    const tx = mockTx() as any
+
+    const result = await upsertNRProfileAndProjectLegacy(tx, projectId, nrId, rtId, {
+      allocationMode: 'EFFORT',
+      allocationPct: 50,
+    })
+
+    expect(result.allocationPercent).toBe(50)
+    expect(tx._store.capacityProfiles[0].defaultPercent).toBe(50)
+  })
+
+  it('defaults to EFFORT/100 when no payload fields provided', async () => {
+    const tx = mockTx() as any
+
+    const result = await upsertNRProfileAndProjectLegacy(tx, projectId, nrId, rtId, {})
+
+    expect(result.allocationMode).toBe('EFFORT')
+    expect(result.allocationPercent).toBe(100)
+    expect(result.allocationStartWeek).toBeNull()
+    expect(result.allocationEndWeek).toBeNull()
+  })
+
+  it('replaces existing profile on subsequent writes (transactional cleanup)', async () => {
+    const tx = mockTx() as any
+
+    // First write: TIMELINE with window
+    await upsertNRProfileAndProjectLegacy(tx, projectId, nrId, rtId, {
+      allocationMode: 'TIMELINE',
+      allocationPercent: 75,
+      allocationStartWeek: 2,
+      allocationEndWeek: 10,
+    })
+
+    expect(tx._store.capacityProfiles).toHaveLength(1)
+
+    // Second write: EFFORT (no window, no segments)
+    const result = await upsertNRProfileAndProjectLegacy(tx, projectId, nrId, rtId, {
+      allocationMode: 'EFFORT',
+      allocationPercent: 100,
+    })
+
+    expect(result.allocationMode).toBe('EFFORT')
+    expect(result.allocationStartWeek).toBeNull()
+    expect(result.allocationEndWeek).toBeNull()
+
+    // Old profile was replaced (delete + create) — new profile matches new mode
+    expect(tx._store.capacityProfiles).toHaveLength(1)
+    expect(tx._store.capacityProfiles[0].planningBasis).toBe('DEMAND_FOLLOWING')
+
+    // No stale segments
+    expect(tx._store.capacitySegments).toHaveLength(0)
+  })
+
+  it('converts FULL_PROJECT payload', async () => {
+    const tx = mockTx() as any
+
+    const result = await upsertNRProfileAndProjectLegacy(tx, projectId, nrId, rtId, {
+      allocationMode: 'FULL_PROJECT',
+      allocationPercent: 100,
+    })
+
+    expect(result.allocationMode).toBe('FULL_PROJECT')
+    expect(result.lossy).toBe(false)
+
+    const cp = tx._store.capacityProfiles[0]
+    expect(cp.planningBasis).toBe('WHOLE_PROJECT_ALLOCATION')
+    expect(cp.source).toBe('FIXED')
+  })
+
+  it('converts CAPACITY_PLAN payload', async () => {
+    const tx = mockTx() as any
+
+    const result = await upsertNRProfileAndProjectLegacy(tx, projectId, nrId, rtId, {
+      allocationMode: 'CAPACITY_PLAN',
+      allocationPercent: 100,
+    })
+
+    expect(result.allocationMode).toBe('CAPACITY_PLAN')
+    expect(result.lossy).toBe(false)
+
+    const cp = tx._store.capacityProfiles[0]
+    expect(cp.planningBasis).toBe('CAPACITY_PROFILE')
+    expect(cp.source).toBe('SQUAD_PLANNER')
+  })
+
+  it('does not mutate the input payload object', async () => {
+    const tx = mockTx() as any
+    const payload = { allocationMode: 'TIMELINE', allocationPercent: 50 }
+
+    await upsertNRProfileAndProjectLegacy(tx, projectId, nrId, rtId, payload)
+
+    expect(payload).toEqual({ allocationMode: 'TIMELINE', allocationPercent: 50 })
+  })
+})

--- a/server/src/test/namedResourceCapacityProfileWrites.test.ts
+++ b/server/src/test/namedResourceCapacityProfileWrites.test.ts
@@ -15,6 +15,8 @@ import { upsertNRProfileAndProjectLegacy } from '../lib/namedResourceCapacityPro
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
 function mockTx() {
+  let cpCounter = 0
+  let segCounter = 0
   const store: {
     capacityProfiles: any[]
     capacitySegments: any[]
@@ -25,8 +27,27 @@ function mockTx() {
 
   const tx = {
     capacityProfile: {
+      findMany: vi.fn(async (args: any) => {
+        let results = [...store.capacityProfiles]
+        if (args?.where) {
+          const where = args.where
+          if (where.namedResourceId) {
+            results = results.filter(p => p.namedResourceId === where.namedResourceId)
+          }
+          if (where.projectId) {
+            results = results.filter(p => p.projectId === where.projectId)
+          }
+        }
+        // Handle select (just return all fields — test only uses .id)
+        return results
+      }),
       deleteMany: vi.fn(async (args: any) => {
-        if (args?.where?.namedResourceId) {
+        if (args?.where?.id?.in) {
+          const ids = args.where.id.in as string[]
+          store.capacityProfiles = store.capacityProfiles.filter(
+            (p: any) => !ids.includes(p.id),
+          )
+        } else if (args?.where?.namedResourceId) {
           store.capacityProfiles = store.capacityProfiles.filter(
             (p: any) => p.namedResourceId !== args.where.namedResourceId,
           )
@@ -40,15 +61,21 @@ function mockTx() {
         return { count: 0 }
       }),
       create: vi.fn(async (args: any) => {
+        cpCounter++
         const data = args.data ?? args
-        const record = { id: `cp-${store.capacityProfiles.length + 1}`, ...data }
+        const record = { id: `cp-${cpCounter}`, ...data }
         store.capacityProfiles.push(record)
         return { ...record }
       }),
     },
     capacitySegment: {
       deleteMany: vi.fn(async (args: any) => {
-        if (args?.where?.capacityProfile?.namedResourceId) {
+        if (args?.where?.capacityProfileId?.in) {
+          const ids = args.where.capacityProfileId.in as string[]
+          store.capacitySegments = store.capacitySegments.filter(
+            (s: any) => !ids.includes(s.capacityProfileId),
+          )
+        } else if (args?.where?.capacityProfile?.namedResourceId) {
           store.capacitySegments = store.capacitySegments.filter(
             (s: any) => s.capacityProfileId !==
               store.capacityProfiles.find(
@@ -65,8 +92,9 @@ function mockTx() {
         return { count: 0 }
       }),
       create: vi.fn(async (args: any) => {
+        segCounter++
         const data = args.data ?? args
-        const record = { id: `seg-${store.capacitySegments.length + 1}`, ...data }
+        const record = { id: `seg-${segCounter}`, ...data }
         store.capacitySegments.push(record)
         return { ...record }
       }),
@@ -260,5 +288,62 @@ describe('upsertNRProfileAndProjectLegacy', () => {
     const tx4 = mockTx() as any
     await upsertNRProfileAndProjectLegacy(tx4, projectId, `${nrId}-4`, rtId, {})
     expect(tx4._store.capacityProfiles[0].ownerKind).toBe('NAMED_PERSON')
+  })
+
+  it('allocationPct-only payload projects percent correctly when allocationPercent is omitted', async () => {
+    const tx = mockTx() as any
+
+    const result = await upsertNRProfileAndProjectLegacy(tx, projectId, nrId, rtId, {
+      allocationPct: 50,
+    })
+
+    expect(result.allocationPercent).toBe(50)
+    expect(tx._store.capacityProfiles[0].defaultPercent).toBe(50)
+  })
+
+  it('startWeek/endWeek-only payload preserves window through projection', async () => {
+    const tx = mockTx() as any
+
+    const result = await upsertNRProfileAndProjectLegacy(tx, projectId, nrId, rtId, {
+      startWeek: 2,
+      endWeek: 10,
+    })
+
+    // Helper should treat presence of start/end as TIMELINE-compatible
+    expect(result.allocationMode).toBe('TIMELINE')
+    expect(result.allocationStartWeek).toBe(2)
+    expect(result.allocationEndWeek).toBe(10)
+    expect(result.allocationPercent).toBe(100)
+    expect(result.lossy).toBe(false)
+
+    // Persisted profile should have the window
+    const cp = tx._store.capacityProfiles[0]
+    expect(cp.startWeek).toBe(2)
+    expect(cp.endWeek).toBe(10)
+  })
+
+  it('explicit cleanup deletes stale segments by concrete profile IDs', async () => {
+    const tx = mockTx() as any
+
+    // First write: create a profile
+    await upsertNRProfileAndProjectLegacy(tx, projectId, nrId, rtId, {
+      allocationMode: 'TIMELINE',
+      allocationPercent: 50,
+      startWeek: 0,
+      endWeek: 4,
+    })
+    expect(tx._store.capacityProfiles).toHaveLength(1)
+    const firstProfileId = tx._store.capacityProfiles[0].id
+
+    // Second write: different mode — should replace profile
+    await upsertNRProfileAndProjectLegacy(tx, projectId, nrId, rtId, {
+      allocationMode: 'EFFORT',
+      allocationPercent: 100,
+    })
+
+    // Old profile should be gone
+    expect(tx._store.capacityProfiles).toHaveLength(1)
+    expect(tx._store.capacityProfiles[0].id).not.toBe(firstProfileId)
+    expect(tx._store.capacityProfiles[0].planningBasis).toBe('DEMAND_FOLLOWING')
   })
 })

--- a/server/src/test/namedResourceCapacityProfileWrites.test.ts
+++ b/server/src/test/namedResourceCapacityProfileWrites.test.ts
@@ -103,7 +103,7 @@ describe('upsertNRProfileAndProjectLegacy', () => {
     expect(tx._store.capacityProfiles).toHaveLength(1)
     const cp = tx._store.capacityProfiles[0]
     expect(cp.namedResourceId).toBe(nrId)
-    expect(cp.resourceTypeId).toBe(rtId)
+    expect(cp.resourceTypeId).toBeNull()
     expect(cp.ownerKind).toBe('NAMED_PERSON')
     expect(cp.planningBasis).toBe('DEMAND_FOLLOWING')
     expect(cp.source).toBe('FIXED')
@@ -233,5 +233,32 @@ describe('upsertNRProfileAndProjectLegacy', () => {
     await upsertNRProfileAndProjectLegacy(tx, projectId, nrId, rtId, payload)
 
     expect(payload).toEqual({ allocationMode: 'TIMELINE', allocationPercent: 50 })
+  })
+
+  it('uses synthetic true → PLANNED_RESOURCE owner kind', async () => {
+    const tx = mockTx() as any
+
+    await upsertNRProfileAndProjectLegacy(tx, projectId, nrId, rtId, {}, { synthetic: true })
+
+    expect(tx._store.capacityProfiles).toHaveLength(1)
+    expect(tx._store.capacityProfiles[0].ownerKind).toBe('PLANNED_RESOURCE')
+  })
+
+  it('uses synthetic false/null/undefined → NAMED_PERSON owner kind', async () => {
+    const tx1 = mockTx() as any
+    await upsertNRProfileAndProjectLegacy(tx1, projectId, nrId, rtId, {}, { synthetic: false })
+    expect(tx1._store.capacityProfiles[0].ownerKind).toBe('NAMED_PERSON')
+
+    const tx2 = mockTx() as any
+    await upsertNRProfileAndProjectLegacy(tx2, projectId, `${nrId}-2`, rtId, {}, { synthetic: null })
+    expect(tx2._store.capacityProfiles[0].ownerKind).toBe('NAMED_PERSON')
+
+    const tx3 = mockTx() as any
+    await upsertNRProfileAndProjectLegacy(tx3, projectId, `${nrId}-3`, rtId, {}, {})
+    expect(tx3._store.capacityProfiles[0].ownerKind).toBe('NAMED_PERSON')
+
+    const tx4 = mockTx() as any
+    await upsertNRProfileAndProjectLegacy(tx4, projectId, `${nrId}-4`, rtId, {})
+    expect(tx4._store.capacityProfiles[0].ownerKind).toBe('NAMED_PERSON')
   })
 })

--- a/server/src/test/namedResources.test.ts
+++ b/server/src/test/namedResources.test.ts
@@ -65,6 +65,19 @@ describe('named-resource capacity profile write', () => {
       .send({ name: 'Updated' })
 
     expect(upsertNRProfileAndProjectLegacy).toHaveBeenCalledWith(tx, 'proj-1', 'nr-1', 'rt-1', expect.any(Object))
+    // Route writes all projected compatibility fields to NamedResource
+    expect(tx.namedResource.update).toHaveBeenCalledWith({
+      where: { id: 'nr-1' },
+      data: {
+        allocationMode: 'EFFORT',
+        allocationPercent: 100,
+        allocationPct: 100,
+        allocationStartWeek: null,
+        allocationEndWeek: null,
+        startWeek: null,
+        endWeek: null,
+      },
+    })
   })
 
   it('PATCH named-resource update calls upsertNRProfileAndProjectLegacy inside the transaction', async () => {
@@ -96,6 +109,8 @@ describe('named-resource capacity profile write', () => {
     expect(upsertNRProfileAndProjectLegacy).toHaveBeenCalledWith(tx, 'proj-1', 'nr-1', 'rt-1', expect.objectContaining({
       allocationMode: 'TIMELINE',
     }))
+    // Sync called with preserveNamedResourceIds
+    expect(syncCapacityProfilesForProject).toHaveBeenCalledWith(tx, 'proj-1', { preserveNamedResourceIds: ['nr-1'] })
   })
 
   it('PUT calls both upsertNRProfileAndProjectLegacy (profile-first) and sync (role-level fill)', async () => {
@@ -117,7 +132,7 @@ describe('named-resource capacity profile write', () => {
     // Profile-first write is called
     expect(upsertNRProfileAndProjectLegacy).toHaveBeenCalled()
     // Sync also called to create role-level and other profiles
-    expect(syncCapacityProfilesForProject).toHaveBeenCalledWith(tx, 'proj-1')
+    expect(syncCapacityProfilesForProject).toHaveBeenCalledWith(tx, 'proj-1', { preserveNamedResourceIds: ['nr-1'] })
   })
 
   it('DELETE named-resource still calls sync for full project reconciliation', async () => {

--- a/server/src/test/namedResources.test.ts
+++ b/server/src/test/namedResources.test.ts
@@ -54,6 +54,9 @@ describe('named-resource capacity profile write', () => {
     vi.mocked(prisma.namedResource.findFirst).mockResolvedValue({ id: 'nr-1', resourceTypeId: 'rt-1' } as never)
 
     const tx = {
+      capacityProfile: {
+        findMany: vi.fn().mockResolvedValue([]),
+      },
       namedResource: {
         update: vi.fn().mockResolvedValue({ id: 'nr-1', name: 'Updated' }),
         findFirst: vi.fn().mockResolvedValue({ id: 'nr-1', name: 'Updated' }),
@@ -118,6 +121,9 @@ describe('named-resource capacity profile write', () => {
     vi.mocked(prisma.namedResource.findFirst).mockResolvedValue({ id: 'nr-1', resourceTypeId: 'rt-1' } as never)
 
     const tx = {
+      capacityProfile: {
+        findMany: vi.fn().mockResolvedValue([]),
+      },
       namedResource: {
         update: vi.fn().mockResolvedValue({ id: 'nr-1', name: 'Updated' }),
         findFirst: vi.fn().mockResolvedValue({ id: 'nr-1', name: 'Updated' }),
@@ -205,6 +211,9 @@ describe('named-resource capacity profile write', () => {
     vi.mocked(upsertNRProfileAndProjectLegacy).mockRejectedValueOnce(new Error('profile write failed'))
 
     const tx = {
+      capacityProfile: {
+        findMany: vi.fn().mockResolvedValue([]),
+      },
       namedResource: { update: vi.fn().mockResolvedValue({ id: 'nr-1' }) },
       project: { update: vi.fn() },
     }

--- a/server/src/test/namedResources.test.ts
+++ b/server/src/test/namedResources.test.ts
@@ -1,9 +1,29 @@
+/**
+ * namedResources.test.ts — Route-level tests for named-resource capacity
+ * profile write path.
+ *
+ * These tests verify that named-resource create/update uses the profile-first
+ * write path (upsertNRProfileAndProjectLegacy) instead of the legacy sync.
+ */
+
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import request from 'supertest'
 import jwt from 'jsonwebtoken'
 import { app } from '../index.js'
 import { prisma } from '../lib/prisma.js'
 import { syncCapacityProfilesForProject } from '../lib/syncCapacityProfiles.js'
+import type { LegacyAllocationProjection } from '../lib/capacityProfileLegacyProjection.js'
+
+// Mock the new profile-first write helper
+vi.mock('../lib/namedResourceCapacityProfileWrites.js', () => ({
+  upsertNRProfileAndProjectLegacy: vi.fn().mockResolvedValue({
+    allocationMode: 'EFFORT',
+    allocationPercent: 100,
+    allocationStartWeek: null,
+    allocationEndWeek: null,
+    lossy: false,
+  } as LegacyAllocationProjection),
+}))
 
 vi.mock('../lib/syncCapacityProfiles.js', () => ({
   syncCapacityProfilesForProject: vi.fn().mockResolvedValue({
@@ -15,6 +35,8 @@ vi.mock('../lib/syncCapacityProfiles.js', () => ({
   }),
 }))
 
+import { upsertNRProfileAndProjectLegacy } from '../lib/namedResourceCapacityProfileWrites.js'
+
 process.env.JWT_SECRET = 'test-secret'
 
 const userId = 'user-1'
@@ -25,8 +47,8 @@ beforeEach(() => {
   vi.clearAllMocks()
 })
 
-describe('named-resource capacity profile sync', () => {
-  it('PUT named-resource update calls sync inside the transaction', async () => {
+describe('named-resource capacity profile write', () => {
+  it('PUT named-resource update calls upsertNRProfileAndProjectLegacy inside the transaction', async () => {
     vi.mocked(prisma.project.findFirst).mockResolvedValue({ id: 'proj-1', ownerId: userId } as never)
     vi.mocked(prisma.resourceType.findFirst).mockResolvedValue({ id: 'rt-1', projectId: 'proj-1', allocationMode: 'EFFORT' } as never)
     vi.mocked(prisma.namedResource.findFirst).mockResolvedValue({ id: 'nr-1', resourceTypeId: 'rt-1' } as never)
@@ -42,13 +64,23 @@ describe('named-resource capacity profile sync', () => {
       .set('Authorization', authHeader)
       .send({ name: 'Updated' })
 
-    expect(syncCapacityProfilesForProject).toHaveBeenCalledWith(tx, 'proj-1')
+    expect(upsertNRProfileAndProjectLegacy).toHaveBeenCalledWith(tx, 'proj-1', 'nr-1', 'rt-1', expect.any(Object))
   })
 
-  it('PATCH named-resource update calls sync inside the transaction', async () => {
+  it('PATCH named-resource update calls upsertNRProfileAndProjectLegacy inside the transaction', async () => {
     vi.mocked(prisma.project.findFirst).mockResolvedValue({ id: 'proj-1', ownerId: userId } as never)
     vi.mocked(prisma.resourceType.findFirst).mockResolvedValue({ id: 'rt-1', projectId: 'proj-1', allocationMode: 'EFFORT' } as never)
-    vi.mocked(prisma.namedResource.findFirst).mockResolvedValue({ id: 'nr-1', resourceTypeId: 'rt-1' } as never)
+    vi.mocked(prisma.namedResource.findFirst).mockResolvedValue({
+      id: 'nr-1',
+      resourceTypeId: 'rt-1',
+      allocationMode: 'EFFORT',
+      allocationPercent: 100,
+      allocationPct: 100,
+      allocationStartWeek: null,
+      allocationEndWeek: null,
+      startWeek: null,
+      endWeek: null,
+    } as never)
 
     const tx = {
       namedResource: { update: vi.fn().mockResolvedValue({ id: 'nr-1' }) },
@@ -61,10 +93,12 @@ describe('named-resource capacity profile sync', () => {
       .set('Authorization', authHeader)
       .send({ allocationMode: 'TIMELINE' })
 
-    expect(syncCapacityProfilesForProject).toHaveBeenCalledWith(tx, 'proj-1')
+    expect(upsertNRProfileAndProjectLegacy).toHaveBeenCalledWith(tx, 'proj-1', 'nr-1', 'rt-1', expect.objectContaining({
+      allocationMode: 'TIMELINE',
+    }))
   })
 
-  it('sync is called with tx object, not bare prisma, on PUT', async () => {
+  it('PUT calls both upsertNRProfileAndProjectLegacy (profile-first) and sync (role-level fill)', async () => {
     vi.mocked(prisma.project.findFirst).mockResolvedValue({ id: 'proj-1', ownerId: userId } as never)
     vi.mocked(prisma.resourceType.findFirst).mockResolvedValue({ id: 'rt-1', projectId: 'proj-1', allocationMode: 'EFFORT' } as never)
     vi.mocked(prisma.namedResource.findFirst).mockResolvedValue({ id: 'nr-1', resourceTypeId: 'rt-1' } as never)
@@ -80,11 +114,13 @@ describe('named-resource capacity profile sync', () => {
       .set('Authorization', authHeader)
       .send({ name: 'Updated' })
 
+    // Profile-first write is called
+    expect(upsertNRProfileAndProjectLegacy).toHaveBeenCalled()
+    // Sync also called to create role-level and other profiles
     expect(syncCapacityProfilesForProject).toHaveBeenCalledWith(tx, 'proj-1')
-    expect(syncCapacityProfilesForProject).not.toHaveBeenCalledWith(prisma, 'proj-1')
   })
 
-  it('DELETE named-resource calls sync after delete and count update, in correct order', async () => {
+  it('DELETE named-resource still calls sync for full project reconciliation', async () => {
     vi.mocked(prisma.project.findFirst).mockResolvedValue({ id: 'proj-1', ownerId: userId } as never)
     vi.mocked(prisma.resourceType.findFirst).mockResolvedValue({ id: 'rt-1', projectId: 'proj-1', allocationMode: 'EFFORT' } as never)
     vi.mocked(prisma.namedResource.findFirst).mockResolvedValue({ id: 'nr-1', resourceTypeId: 'rt-1' } as never)
@@ -107,12 +143,7 @@ describe('named-resource capacity profile sync', () => {
 
     expect(res.status).toBe(204)
 
-    // Each operation happened
-    expect(deleteFn).toHaveBeenCalledWith({ where: { id: 'nr-1' } })
-    expect(countFn).toHaveBeenCalledWith({ where: { resourceTypeId: 'rt-1' } })
-    expect(updateFn).toHaveBeenCalledWith(
-      expect.objectContaining({ where: { id: 'rt-1' }, data: { count: 0 } }),
-    )
+    // DELETE still uses full sync (profile cleanup)
     expect(syncCapacityProfilesForProject).toHaveBeenCalledWith(tx, 'proj-1')
 
     // Call order: delete < count < update < sync
@@ -149,12 +180,12 @@ describe('named-resource capacity profile sync', () => {
     expect(res.status).not.toBe(204)
   })
 
-  it('PUT sync failure propagates and route returns error', async () => {
+  it('PUT upsertNRProfileAndProjectLegacy failure propagates and route returns error', async () => {
     vi.mocked(prisma.project.findFirst).mockResolvedValue({ id: 'proj-1', ownerId: userId } as never)
     vi.mocked(prisma.resourceType.findFirst).mockResolvedValue({ id: 'rt-1', projectId: 'proj-1', allocationMode: 'EFFORT' } as never)
     vi.mocked(prisma.namedResource.findFirst).mockResolvedValue({ id: 'nr-1', resourceTypeId: 'rt-1' } as never)
 
-    vi.mocked(syncCapacityProfilesForProject).mockRejectedValueOnce(new Error('sync failed'))
+    vi.mocked(upsertNRProfileAndProjectLegacy).mockRejectedValueOnce(new Error('profile write failed'))
 
     const tx = {
       namedResource: { update: vi.fn().mockResolvedValue({ id: 'nr-1' }) },
@@ -167,7 +198,7 @@ describe('named-resource capacity profile sync', () => {
       .set('Authorization', authHeader)
       .send({ name: 'Updated' })
 
-    // Sync failure should propagate — not a 200
+    // Helper failure should propagate — not a 200
     expect(res.status).not.toBe(200)
   })
 })

--- a/server/src/test/namedResources.test.ts
+++ b/server/src/test/namedResources.test.ts
@@ -54,7 +54,10 @@ describe('named-resource capacity profile write', () => {
     vi.mocked(prisma.namedResource.findFirst).mockResolvedValue({ id: 'nr-1', resourceTypeId: 'rt-1' } as never)
 
     const tx = {
-      namedResource: { update: vi.fn().mockResolvedValue({ id: 'nr-1', name: 'Updated' }) },
+      namedResource: {
+        update: vi.fn().mockResolvedValue({ id: 'nr-1', name: 'Updated' }),
+        findFirst: vi.fn().mockResolvedValue({ id: 'nr-1', name: 'Updated' }),
+      },
       project: { update: vi.fn() },
     }
     vi.mocked(prisma.$transaction).mockImplementation(async (fn: any) => fn(tx))
@@ -64,22 +67,18 @@ describe('named-resource capacity profile write', () => {
       .set('Authorization', authHeader)
       .send({ name: 'Updated' })
 
+    // Helper still called to ensure a profile exists
     expect(upsertNRProfileAndProjectLegacy).toHaveBeenCalledWith(tx, 'proj-1', 'nr-1', 'rt-1', expect.any(Object))
-    // Route writes all projected compatibility fields to NamedResource
+    // Non-capacity update always happens (name field)
     expect(tx.namedResource.update).toHaveBeenCalledWith({
       where: { id: 'nr-1' },
-      data: {
-        allocationMode: 'EFFORT',
-        allocationPercent: 100,
-        allocationPct: 100,
-        allocationStartWeek: null,
-        allocationEndWeek: null,
-        startWeek: null,
-        endWeek: null,
-      },
+      data: { name: 'Updated' },
     })
+    // No capacity-input → route does NOT update legacy fields via a second update
+    expect(tx.namedResource.update).toHaveBeenCalledTimes(1)
+    // Route re-reads the NR after creating the profile
+    expect(tx.namedResource.findFirst).toHaveBeenCalledWith({ where: { id: 'nr-1' } })
   })
-
   it('PATCH named-resource update calls upsertNRProfileAndProjectLegacy inside the transaction', async () => {
     vi.mocked(prisma.project.findFirst).mockResolvedValue({ id: 'proj-1', ownerId: userId } as never)
     vi.mocked(prisma.resourceType.findFirst).mockResolvedValue({ id: 'rt-1', projectId: 'proj-1', allocationMode: 'EFFORT' } as never)
@@ -119,7 +118,10 @@ describe('named-resource capacity profile write', () => {
     vi.mocked(prisma.namedResource.findFirst).mockResolvedValue({ id: 'nr-1', resourceTypeId: 'rt-1' } as never)
 
     const tx = {
-      namedResource: { update: vi.fn().mockResolvedValue({ id: 'nr-1', name: 'Updated' }) },
+      namedResource: {
+        update: vi.fn().mockResolvedValue({ id: 'nr-1', name: 'Updated' }),
+        findFirst: vi.fn().mockResolvedValue({ id: 'nr-1', name: 'Updated' }),
+      },
       project: { update: vi.fn() },
     }
     vi.mocked(prisma.$transaction).mockImplementation(async (fn: any) => fn(tx))

--- a/server/src/test/resourceTypes.test.ts
+++ b/server/src/test/resourceTypes.test.ts
@@ -565,6 +565,7 @@ describe('named-resource auto-name race safety', () => {
         resourceType: { update: vi.fn().mockResolvedValue({}) },
         project: { update: vi.fn().mockResolvedValue({}) },
         capacityProfile: {
+          findMany: vi.fn().mockResolvedValue([]),
           deleteMany: vi.fn().mockResolvedValue({ count: 0 }),
           create: vi.fn().mockResolvedValue({ id: 'cp-new' }),
         },

--- a/server/src/test/resourceTypes.test.ts
+++ b/server/src/test/resourceTypes.test.ts
@@ -548,14 +548,29 @@ describe('named-resource auto-name race safety', () => {
       count: 0,
     } as never)
     vi.mocked(prisma.namedResource.count).mockResolvedValue(0)
+    let createdName = 'Unknown'
+    const mockCreate = vi.fn().mockImplementation(async ({ data }: any) => {
+      createdName = data.name
+      return { id: 'nr-new', name: data.name, ...data }
+    })
+    const mockUpdate = vi.fn().mockImplementation(async ({ data }: any) => ({ id: 'nr-new', name: createdName, ...data }))
+
     vi.mocked(prisma.$transaction).mockImplementation(async (fn: any) =>
       fn({
         namedResource: {
           count: vi.fn().mockResolvedValue(1),
-          create: vi.fn().mockImplementation(async ({ data }: any) => ({ id: 'nr-new', ...data })),
+          create: mockCreate,
+          update: mockUpdate,
         },
         resourceType: { update: vi.fn().mockResolvedValue({}) },
         project: { update: vi.fn().mockResolvedValue({}) },
+        capacityProfile: {
+          deleteMany: vi.fn().mockResolvedValue({ count: 0 }),
+          create: vi.fn().mockResolvedValue({ id: 'cp-new' }),
+        },
+        capacitySegment: {
+          deleteMany: vi.fn().mockResolvedValue({ count: 0 }),
+        },
       }),
     )
   })

--- a/server/src/test/syncCapacityProfiles.test.ts
+++ b/server/src/test/syncCapacityProfiles.test.ts
@@ -370,4 +370,22 @@ describe('syncCapacityProfilesForProject', () => {
     expect(prisma.capacityProfile.create).not.toHaveBeenCalled()
   })
 
+  it('accepts preserveNamedResourceIds option and filters persisted profiles', async () => {
+    vi.mocked(mapProjectToCapacityProfiles).mockReturnValue([
+      { id: 'nr-1', projectId: 'proj-1', owner: { kind: 'namedPerson' as const, id: 'nr-1', name: 'NR 1' }, planningBasis: 'demandFollowing' as const, source: 'fixed' as const, defaultPercent: 100, startWeek: null, endWeek: null, segments: [], legacy: null as any },
+    ])
+    // Persisted profile for NR (profile-first row)
+    vi.mocked(prisma.capacityProfile.findMany).mockResolvedValue([
+      { id: 'cp-nr-1', ownerKind: 'NAMED_PERSON', resourceTypeId: null, namedResourceId: 'nr-1', planningBasis: 'DEMAND_FOLLOWING', source: 'FIXED', defaultPercent: 100, startWeek: null, endWeek: null, segments: [] },
+    ] as any)
+    vi.mocked(prisma.capacityProfile.create).mockResolvedValue({ id: 'cp-new' } as any)
+    vi.mocked(prisma.capacityProfile.delete).mockResolvedValue({} as any)
+
+    await syncCapacityProfilesForProject(prisma, 'proj-1', { preserveNamedResourceIds: ['nr-1'] })
+
+    // Preserved NR's persisted profile should not be created or deleted
+    expect(prisma.capacityProfile.create).not.toHaveBeenCalled()
+    expect(prisma.capacityProfile.delete).not.toHaveBeenCalled()
+  })
+
 })


### PR DESCRIPTION
## Summary

Migrate the named-resource capacity/profile write path so capacity-related updates are written to `CapacityProfile` / `CapacitySegment` first, then projected back into legacy fields for compatibility.

Refs #340 — Phase 3 of the capacity profile source-of-truth migration plan.

## Blocker fixes (review cycle 3)

| Blocker | Resolution |
|---|---|
| **Non-capacity PUT rewrites existing mode** | Added `hasCapacityInput` check. When no capacity fields are supplied, the route does a non-capacity update (name/pricingModel only) and creates a profile from existing values with suppressed window fields so EFFORT-mode NRs with historical window values are not silently changed to TIMELINE. When capacity fields are supplied but `allocationMode` is omitted, the helper infers TIMELINE from explicit `startWeek`/`endWeek` as designed. |

## Previous blocker fixes

| Blocker | Resolution |
|---|---|
| **1. Sync overwrites profile-first row** | Added `preserveNamedResourceIds` option to `syncCapacityProfilesForProject`. |
| **2. Missing compatibility fields** | Routes write `allocationPct`, `startWeek`, `endWeek`. |
| **3. Synthetic/planned owner kind** | Helper accepts `{ synthetic }` → `PLANNED_RESOURCE`. |
| **4. Route coverage mostly mocked** | Real integration tests in shared in-memory store. |
| **5. Stale segment cleanup not proven** | Explicit profile lookup + ID-based delete. |
| **6. Field precedence drops valid inputs** | `hasOwnProperty` checks; `allocationMode` defaults to `undefined` for inference. |

## New tests this round

### Integration tests

**Test A — non-capacity PUT preserves CAPACITY_PLAN state**
PUT `{ name: 'Renamed Only' }` on NR with `CAPACITY_PLAN`. Asserts name updated, `allocationMode` remains `CAPACITY_PLAN`, profile `CAPACITY_PROFILE`/`SQUAD_PLANNER` preserved, survives sync.

**Test B — non-capacity PUT does not infer TIMELINE from historical windows**
PUT `{ name: 'Renamed Only' }` on NR with `EFFORT` + `startWeek: 2, endWeek: 10`. Asserts name updated, `allocationMode` remains `EFFORT`, profile `DEMAND_FOLLOWING`, no TIMELINE inference.

### Updated tests

`PUT named-resource update calls helper inside transaction` — updated to match new behavior: non-capacity PUT calls helper (profile creation) but does NOT update legacy fields; uses `findFirst` instead.

`PUT calls both helper and sync` — mock tx now includes `findFirst`.

## Guardrails

- No `server/prisma/schema.prisma` changes
- No `server/prisma/migrations` changes
- No ResourceType / role-level write path changes
- No Squad Planner apply changes
- No global reconciliation direction flip
- No API response shape changes
- No client UI changes
- No Commercial formulas/totals changes
- No scheduler/leveller/Squad Planner algorithm changes
- Legacy fields remain on NamedResource (not removed)
- Schema diffs: none; Client file changes: none

## Validation

```
Server typecheck: PASS
Server lint:         PASS
Server tests:        PASS (all)
Client typecheck:    PASS
Client lint:         PASS
Client build:        PASS
Schema diffs:        none
Client changes:      none
```

Do not merge. Wait for review.