### PR TITLE
fix(#353): harden Windows local E2E runner

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -52,6 +52,9 @@ jobs:
       - name: Install all dependencies
         run: npm ci
 
+      # ── Validate local E2E runner ─────────────────────────────────
+      - name: Validate local E2E runner loads env correctly
+        run: node scripts/run-e2e-local.mjs --validate
       # ── TypeScript type-checking ──────────────────────────────────
       - name: TypeScript check (client)
         working-directory: client

--- a/README.md
+++ b/README.md
@@ -147,8 +147,8 @@ cd server && npm test
 cd server && npx tsc --noEmit
 cd client && npx tsc --noEmit
 
-# E2E (requires both dev servers running)
-cd e2e && ./node_modules/.bin/playwright test --workers=1
+# E2E (local runner starts isolated API/Vite servers, chooses free ports, and skips screenshots)
+npm run test:e2e:local
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -147,8 +147,12 @@ cd server && npm test
 cd server && npx tsc --noEmit
 cd client && npx tsc --noEmit
 
-# E2E (local runner starts isolated API/Vite servers, chooses free ports, and skips screenshots)
+# E2E (preferred — local runner starts isolated API/Vite servers, chooses free ports)
+# Loads server/.env, runs e2e-cleanup before seed, passes resolved env to all processes
 npm run test:e2e:local
+
+# E2E (requires both dev servers already running)
+npm run test:e2e
 ```
 
 ---
@@ -248,6 +252,7 @@ Day rates per resource type (global defaults + project overrides) and cost colum
 | Resource Optimiser — Phase 4 frontend drawer with mode selector (speed/utilisation/balanced), per-RT count constraints, optional budget/duration ceilings, ranked candidate cards with KPI deltas, and apply-with-snapshot rollback | #239 |
 | Timeline workflow cleanup — canonical Update timeline CTA, hidden Level current timeline action, advanced planning copy updates | #314 |
 | Resource Counts allocation controls — stable named-resource columns, clearer planning-basis labels, preserved mode switching/start/end/allocation updates, and stale-banner behaviour | #315 |
+| Windows E2E local runner — unified env loading (server/.env + shell), cleanup-before-seed, resolved env across all processes | #354 |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ cp server/.env.example server/.env
 
 `server/.env.example` contains sensible defaults for local development. Edit it if your PostgreSQL credentials differ from the Docker command above.
 
+> **JWT_SECRET:** The example file includes a dev-only secret (`local-dev-jwt-secret-at-least-32-chars!!`) that works for local development. **Replace it with a secure random string in production** (e.g. `openssl rand -hex 32`). The server rejects values shorter than 32 characters or the placeholder `change-me-in-production`.
+
 #### Email / SMTP (optional)
 
 Email is used for password reset links and org invite emails. Without SMTP configured, both flows still work — the email content and link are printed to the server console instead.

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -4,6 +4,8 @@ import tailwindcss from '@tailwindcss/vite'
 import path from 'path'
 
 // https://vite.dev/config/
+const apiTarget = process.env.VITE_API_URL ?? process.env.API_URL ?? 'http://localhost:3001'
+
 export default defineConfig({
   plugins: [react(), tailwindcss()],
   resolve: {
@@ -13,12 +15,12 @@ export default defineConfig({
   },
   server: {
     proxy: {
-      '/api': 'http://localhost:3001',
+      '/api': apiTarget,
     },
   },
   preview: {
     proxy: {
-      '/api': 'http://localhost:3001',
+      '/api': apiTarget,
     },
   },
 })

--- a/e2e/TESTS.md
+++ b/e2e/TESTS.md
@@ -19,9 +19,9 @@ npx playwright test --grep "CSV import"    # filter by name
 npx playwright test --ui                   # interactive UI mode
 ```
 
-**Prerequisites:** Both dev servers must be running:
-- API: `node dist/index.js` on `:3001`
-- Client: `npx vite` on `:5173`
+**Prerequisites:**
+- `npm run test:e2e:local` starts isolated API/Vite servers itself, chooses free ports, and is preferred for local Windows/dev validation.
+- `npm run test:e2e`, `npm run test:e2e:headed`, and direct `npx playwright test` expect the app/dev servers to already be running, unless CI/workflow automation starts them separately.
 
 **Credentials:** `TEST_EMAIL` / `TEST_PASSWORD` env vars (default: `test@example.com` / `password123`)
 

--- a/e2e/TESTS.md
+++ b/e2e/TESTS.md
@@ -8,6 +8,8 @@
 # From repo root
 npm run test:e2e              # headless (use for CI / pre-PR check)
 npm run test:e2e:headed       # with browser visible (debugging)
+# Local Windows/dev runner starts isolated API/Vite servers and chooses free ports
+npm run test:e2e:local
 npm run test:e2e:report       # open last HTML report
 
 # From /e2e directory

--- a/e2e/tests/backlog.spec.ts
+++ b/e2e/tests/backlog.spec.ts
@@ -336,13 +336,15 @@ test.describe('Backlog', () => {
     await page.getByRole('button', { name: /backlog/i }).click()
 
     // Create two epics
-    await page.getByRole('button', { name: /add epic/i }).click()
+    await page.getByRole('button', { name: /^\+ add epic$/i }).click()
     await page.getByPlaceholder(/epic name/i).fill('E2E Epic Alpha')
     await page.getByRole('button', { name: /save epic/i }).click()
+    await expect(page.getByText('E2E Epic Alpha')).toBeVisible({ timeout: 10_000 })
 
-    await page.getByRole('button', { name: /add epic/i }).click()
+    await page.getByRole('button', { name: /^\+ add epic$/i }).click()
     await page.getByPlaceholder(/epic name/i).fill('E2E Epic Beta')
     await page.getByRole('button', { name: /save epic/i }).click()
+    await expect(page.getByText('E2E Epic Beta')).toBeVisible({ timeout: 10_000 })
 
     // Drag handles (⠿) should be visible on hover
     const epicRows = page.locator('.group').filter({ hasText: /E2E Epic Alpha/ })

--- a/e2e/tests/resource-profile.spec.ts
+++ b/e2e/tests/resource-profile.spec.ts
@@ -325,11 +325,12 @@ test.describe('Resource Profile — cache invalidation from Timeline', () => {
 
     // Manual override: move feature to week 8 (extends one RT's cache horizon)
     await page.locator('[title="Core API"]').first().click()
-    await expect(page.getByText('Start week:').first()).toBeVisible({ timeout: 8_000 })
-    await page.locator('input[min="0"]:not([id])').first().fill('8')
-    await page.getByRole('button', { name: /^save$/i }).click()
+    const featureEditPanel = page.locator('.sticky').filter({ hasText: 'Core API' }).last()
+    await expect(featureEditPanel.getByText('Start week:')).toBeVisible({ timeout: 8_000 })
+    await featureEditPanel.locator('input[type="number"]').first().fill('8')
+    await featureEditPanel.getByRole('button', { name: /^save$/i }).click()
     await expect(
-      page.getByRole('button', { name: /reset to auto/i })
+      featureEditPanel.getByRole('button', { name: /reset to auto/i })
     ).toBeVisible({ timeout: 10_000 })
 
     // ── Navigate to Resource Profile ──

--- a/e2e/tests/templates.spec.ts
+++ b/e2e/tests/templates.spec.ts
@@ -12,11 +12,13 @@ test.describe('Template Library', () => {
   })
 
   test('can create a new template', async ({ page }) => {
+    const templateName = `E2E Template ${Date.now()}`
+
     await page.goto('/templates')
     await page.getByRole('button', { name: /new template/i }).click()
-    await page.getByPlaceholder(/template name/i).fill('E2E Template')
-    await page.getByRole('button', { name: /save/i }).click()
-    await expect(page.getByText('E2E Template').first()).toBeVisible()
+    await page.getByPlaceholder(/template name/i).fill(templateName)
+    await page.getByRole('button', { name: /^save template$/i }).click()
+    await expect(page.getByText(templateName).first()).toBeVisible({ timeout: 10_000 })
   })
 
   test('Export CSV button is visible', async ({ page }) => {
@@ -25,12 +27,15 @@ test.describe('Template Library', () => {
   })
 
   test('can create a template task with XS complexity hours', async ({ page }) => {
+    const templateName = `E2E XS Template ${Date.now()}`
+
     await page.goto('/templates')
     // Create a template first
     await page.getByRole('button', { name: /new template/i }).click()
-    await page.getByPlaceholder(/template name/i).fill('E2E XS Template')
-    await page.getByRole('button', { name: /save/i }).click()
-    await page.getByText('E2E XS Template').first().click()
+    await page.getByPlaceholder(/template name/i).fill(templateName)
+    await page.getByRole('button', { name: /^save template$/i }).click()
+    await expect(page.getByText(templateName).first()).toBeVisible({ timeout: 10_000 })
+    await page.getByText(templateName).first().click()
 
     // Add a task
     await page.getByRole('button', { name: /add task/i }).click()

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "lint": "npm run lint --workspace=client && npm run lint --workspace=server",
     "typecheck": "npm run typecheck --workspace=client && npm run typecheck --workspace=server",
     "test:e2e": "npm run test --workspace=e2e",
+    "test:e2e:local": "node scripts/run-e2e-local.mjs",
     "test:e2e:headed": "npm run test:headed --workspace=e2e",
     "test:e2e:report": "npm run report --workspace=e2e",
     "screenshots": "npm run screenshots --workspace=e2e",

--- a/scripts/run-e2e-local.mjs
+++ b/scripts/run-e2e-local.mjs
@@ -1,0 +1,220 @@
+#!/usr/bin/env node
+/**
+ * Local E2E runner.
+ *
+ * Starts isolated API + Vite dev servers, validates that the API is actually
+ * Monrad Estimator (not another service on the same port), then runs Playwright.
+ */
+import { spawn } from 'node:child_process'
+import net from 'node:net'
+import { fileURLToPath } from 'node:url'
+
+
+const root = fileURLToPath(new URL('..', import.meta.url))
+const serverDir = fileURLToPath(new URL('../server/', import.meta.url))
+const clientDir = fileURLToPath(new URL('../client/', import.meta.url))
+const e2eDir = fileURLToPath(new URL('../e2e/', import.meta.url))
+
+const host = process.env.E2E_HOST ?? '127.0.0.1'
+const preferredApiPort = Number(process.env.E2E_API_PORT ?? process.env.PORT ?? 3001)
+const preferredClientPort = Number(process.env.E2E_CLIENT_PORT ?? 5173)
+const apiPort = await findAvailablePort(preferredApiPort)
+const clientPort = await findAvailablePort(preferredClientPort, new Set([apiPort]))
+const apiUrl = `http://${host}:${apiPort}`
+const baseUrl = `http://${host}:${clientPort}`
+const children = []
+
+console.log(`[e2e-local] API: ${apiUrl}${apiPort === preferredApiPort ? '' : ` (preferred :${preferredApiPort} was unavailable)`}`)
+console.log(`[e2e-local] Client: ${baseUrl}${clientPort === preferredClientPort ? '' : ` (preferred :${preferredClientPort} was unavailable)`}`)
+
+try {
+  await run('npx', ['prisma', 'migrate', 'deploy'], { cwd: serverDir })
+  await run('npx', ['prisma', 'generate'], { cwd: serverDir })
+  await run('npx', ['tsx', 'prisma/seed.ts'], { cwd: serverDir })
+
+  const api = start('npx', ['tsx', 'src/index.ts'], {
+    cwd: serverDir,
+    env: {
+      NODE_ENV: 'test',
+      PORT: String(apiPort),
+      CLIENT_URL: baseUrl,
+    },
+    label: 'api',
+  })
+  children.push(api)
+
+  const client = start('npx', ['vite', '--host', host, '--port', String(clientPort), '--strictPort'], {
+    cwd: clientDir,
+    env: {
+      VITE_API_URL: apiUrl,
+    },
+    label: 'vite',
+  })
+  children.push(client)
+
+  await waitForMonradApi(apiUrl)
+  await waitForClient(baseUrl)
+  await waitForProxy(baseUrl)
+
+  await run('npx', ['playwright', 'test', '--grep-invert', '@screenshots', ...process.argv.slice(2)], {
+    cwd: e2eDir,
+    env: {
+      BASE_URL: baseUrl,
+      API_URL: apiUrl,
+      NODE_ENV: 'test',
+    },
+    inherit: true,
+  })
+} finally {
+  await stopChildren()
+}
+
+function start(command, args, options) {
+  const spec = resolveCommand(command, args)
+  const child = spawn(spec.command, spec.args, {
+    cwd: options.cwd,
+    env: { ...process.env, ...options.env },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  })
+
+  child.stdout.on('data', data => process.stdout.write(`[${options.label}] ${data}`))
+  child.stderr.on('data', data => process.stderr.write(`[${options.label}] ${data}`))
+  child.on('error', error => {
+    console.error(`[${options.label}] failed to start: ${error.message}`)
+  })
+  child.on('exit', code => {
+    if (code !== null && code !== 0) {
+      console.error(`[${options.label}] exited with code ${code}`)
+    }
+  })
+
+  return child
+}
+
+function run(command, args, options = {}) {
+  return new Promise((resolve, reject) => {
+    const spec = resolveCommand(command, args)
+    const child = spawn(spec.command, spec.args, {
+      cwd: options.cwd,
+      env: { ...process.env, ...options.env },
+      stdio: options.inherit ? 'inherit' : ['ignore', 'pipe', 'pipe'],
+    })
+
+    let output = ''
+    if (!options.inherit) {
+      child.stdout.on('data', data => {
+        output += data.toString()
+        process.stdout.write(data)
+      })
+      child.stderr.on('data', data => {
+        output += data.toString()
+        process.stderr.write(data)
+      })
+    }
+    child.on('error', reject)
+
+    child.on('exit', code => {
+      if (code === 0 || options.allowFailure) resolve(output)
+      else reject(new Error(`${command} ${args.join(' ')} failed with exit code ${code}`))
+    })
+  })
+}
+
+function resolveCommand(command, args) {
+  if (process.platform === 'win32' && command === 'npx') {
+    const npmCli = process.env.npm_execpath
+    if (!npmCli) throw new Error('npm_execpath is required to run npx commands on Windows')
+    return { command: process.execPath, args: [npmCli, 'exec', '--', ...args] }
+  }
+  return { command, args }
+}
+
+async function findAvailablePort(startPort, reserved = new Set()) {
+  for (let port = startPort; port < startPort + 100; port++) {
+    if (reserved.has(port)) continue
+    if (await isPortAvailable(port)) return port
+  }
+  throw new Error(`No available port found starting at ${startPort}`)
+}
+
+async function isPortAvailable(port) {
+  if (await portRespondsToHttp(port)) return false
+
+  return new Promise(resolve => {
+    const server = net.createServer()
+    server.once('error', () => resolve(false))
+    server.once('listening', () => server.close(() => resolve(true)))
+    server.listen(port, host)
+  })
+}
+
+async function portRespondsToHttp(port) {
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), 500)
+  try {
+    await fetch(`http://${host}:${port}/health`, { signal: controller.signal })
+    return true
+  } catch {
+    return false
+  } finally {
+    clearTimeout(timeout)
+  }
+}
+
+async function waitForMonradApi(url) {
+  await waitFor(`Monrad API at ${url}`, async () => {
+    const response = await fetch(`${url}/health`)
+    if (!response.ok) throw new Error(`HTTP ${response.status}`)
+    const body = await response.json()
+    if (body.status !== 'ok' || body.service !== 'monrad-estimator') {
+      throw new Error(`Unexpected health payload: ${JSON.stringify(body)}`)
+    }
+  })
+}
+
+async function waitForClient(url) {
+  await waitFor(`Vite client at ${url}`, async () => {
+    const response = await fetch(url)
+    if (!response.ok) throw new Error(`HTTP ${response.status}`)
+    const html = await response.text()
+    if (!html.includes('Monrad Estimator')) throw new Error('Client HTML did not contain Monrad title')
+  })
+}
+
+async function waitForProxy(url) {
+  await waitFor(`Vite API proxy at ${url}/api/projects`, async () => {
+    const response = await fetch(`${url}/api/projects`)
+    const body = await response.json()
+    if (response.status !== 401 || !['AUTH_REQUIRED', 'Unauthorized'].includes(body.code ?? body.error)) {
+      throw new Error(`Unexpected proxy response ${response.status}: ${JSON.stringify(body)}`)
+    }
+  })
+}
+
+async function waitFor(label, check) {
+  const deadline = Date.now() + 60_000
+  let lastError
+  while (Date.now() < deadline) {
+    try {
+      await check()
+      console.log(`[e2e-local] Ready: ${label}`)
+      return
+    } catch (error) {
+      lastError = error
+      await new Promise(resolve => setTimeout(resolve, 1_000))
+    }
+  }
+  throw new Error(`Timed out waiting for ${label}: ${lastError?.message ?? 'unknown error'}`)
+}
+
+async function stopChildren() {
+  for (const child of children.reverse()) {
+    if (child.killed) continue
+    if (process.platform === 'win32' && child.pid) {
+      await run('taskkill', ['/PID', String(child.pid), '/T', '/F'], { allowFailure: true })
+    } else {
+      child.kill('SIGTERM')
+    }
+  }
+  await new Promise(resolve => setTimeout(resolve, 1_000))
+}

--- a/scripts/run-e2e-local.mjs
+++ b/scripts/run-e2e-local.mjs
@@ -77,9 +77,27 @@ if (process.argv.includes('--validate')) {
   const keys = Object.keys(fileEnv).sort()
   console.log(`[e2e-local] server/.env loaded: ${keys.length} var(s)`)
   console.log(`[e2e-local] DATABASE_URL: ${resolvedEnv.DATABASE_URL ? 'set' : 'unset'}`)
+  // Also validate JWT_SECRET — catches stale .env files with old placeholder
+  const js = resolvedEnv.JWT_SECRET ?? ''
+  if (!js || js === 'change-me-in-production' || js.length < 32) {
+    console.error('[e2e-local] JWT_SECRET: INVALID (missing, too short, or placeholder)')
+    process.exit(1)
+  }
   console.log('[e2e-local] Validation OK')
   process.exit(0)
 }
+
+// ── Preflight checks ─────────────────────────────────────────────────────────
+// Must have a valid JWT_SECRET — the API rejects the old placeholder at startup.
+const jwtSecret = resolvedEnv.JWT_SECRET ?? ''
+if (!jwtSecret || jwtSecret === 'change-me-in-production' || jwtSecret.length < 32) {
+  console.error('[e2e-local] ERROR: JWT_SECRET is missing, too short, or still set to "change-me-in-production".')
+  console.error('[e2e-local] The example env uses "local-dev-jwt-secret-at-least-32-chars!!" — copy it:')
+  console.error('[e2e-local]   cp server/.env.example server/.env')
+  console.error('[e2e-local] Or set a custom value of 32+ characters.')
+  process.exit(1)
+}
+
 // ── Port discovery ──────────────────────────────────────────────────────────
 
 const host = process.env.E2E_HOST ?? '127.0.0.1'

--- a/scripts/run-e2e-local.mjs
+++ b/scripts/run-e2e-local.mjs
@@ -16,6 +16,7 @@
 import { spawn } from 'node:child_process'
 import fs from 'node:fs'
 import net from 'node:net'
+import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 
@@ -28,7 +29,7 @@ const e2eDir = fileURLToPath(new URL('../e2e/', import.meta.url))
 
 /** Read and parse server/.env, return a plain object. */
 function loadDotEnv() {
-  const envPath = fileURLToPath(new URL('server/.env', root))
+  const envPath = path.join(root, 'server', '.env')
   let raw
   try {
     raw = fs.readFileSync(envPath, 'utf8')
@@ -69,6 +70,16 @@ function loadDotEnv() {
 const fileEnv = loadDotEnv()
 const resolvedEnv = { ...fileEnv, ...process.env }
 
+// ── Validation mode ──────────────────────────────────────────────────────────
+// `--validate` loads and merges server/.env then exits — lets CI check the
+// runner can parse without starting servers.
+if (process.argv.includes('--validate')) {
+  const keys = Object.keys(fileEnv).sort()
+  console.log(`[e2e-local] server/.env loaded: ${keys.length} var(s)`)
+  console.log(`[e2e-local] DATABASE_URL: ${resolvedEnv.DATABASE_URL ? 'set' : 'unset'}`)
+  console.log('[e2e-local] Validation OK')
+  process.exit(0)
+}
 // ── Port discovery ──────────────────────────────────────────────────────────
 
 const host = process.env.E2E_HOST ?? '127.0.0.1'

--- a/scripts/run-e2e-local.mjs
+++ b/scripts/run-e2e-local.mjs
@@ -1,11 +1,20 @@
 #!/usr/bin/env node
 /**
  * Local E2E runner.
+ *   - Loads server/.env and merges with shell env (shell wins).
+ *   - Runs e2e-cleanup before seed so repeated runs start clean.
+ *   - Starts API and Vite on dynamic ports, runs Playwright tests.
+ *   - Cleans up child processes on exit.
  *
- * Starts isolated API + Vite dev servers, validates that the API is actually
- * Monrad Estimator (not another service on the same port), then runs Playwright.
+ * Usage:
+ *   cd <repo-root>
+ *   npm run test:e2e:local
+ *
+ *   # Pass extra args to Playwright:
+ *   npm run test:e2e:local -- --grep "auth"
  */
 import { spawn } from 'node:child_process'
+import fs from 'node:fs'
 import net from 'node:net'
 import { fileURLToPath } from 'node:url'
 
@@ -14,6 +23,53 @@ const root = fileURLToPath(new URL('..', import.meta.url))
 const serverDir = fileURLToPath(new URL('../server/', import.meta.url))
 const clientDir = fileURLToPath(new URL('../client/', import.meta.url))
 const e2eDir = fileURLToPath(new URL('../e2e/', import.meta.url))
+
+// ── Environment loading ──────────────────────────────────────────────────────
+
+/** Read and parse server/.env, return a plain object. */
+function loadDotEnv() {
+  const envPath = fileURLToPath(new URL('server/.env', root))
+  let raw
+  try {
+    raw = fs.readFileSync(envPath, 'utf8')
+  } catch {
+    // server/.env missing — that's fine, use process.env only
+    return {}
+  }
+
+  const parsed = {}
+  for (const line of raw.split(/\r?\n/)) {
+    const trimmed = line.trim()
+    if (!trimmed || trimmed.startsWith('#')) continue
+
+    // Strip optional `export ` prefix
+    const cleaned = trimmed.startsWith('export ') ? trimmed.slice(7).trimStart() : trimmed
+
+    const sepIdx = cleaned.indexOf('=')
+    if (sepIdx <= 0) continue
+
+    const key = cleaned.slice(0, sepIdx).trim()
+    if (!key) continue
+
+    let value = cleaned.slice(sepIdx + 1).trim()
+
+    // Unwrap matching quotes (single or double)
+    if ((value.startsWith("'") && value.endsWith("'")) ||
+        (value.startsWith('"') && value.endsWith('"'))) {
+      value = value.slice(1, -1)
+    }
+
+    parsed[key] = value
+  }
+
+  return parsed
+}
+
+/** Merged env: file values first, shell env wins. */
+const fileEnv = loadDotEnv()
+const resolvedEnv = { ...fileEnv, ...process.env }
+
+// ── Port discovery ──────────────────────────────────────────────────────────
 
 const host = process.env.E2E_HOST ?? '127.0.0.1'
 const preferredApiPort = Number(process.env.E2E_API_PORT ?? process.env.PORT ?? 3001)
@@ -28,13 +84,21 @@ console.log(`[e2e-local] API: ${apiUrl}${apiPort === preferredApiPort ? '' : ` (
 console.log(`[e2e-local] Client: ${baseUrl}${clientPort === preferredClientPort ? '' : ` (preferred :${preferredClientPort} was unavailable)`}`)
 
 try {
-  await run('npx', ['prisma', 'migrate', 'deploy'], { cwd: serverDir })
-  await run('npx', ['prisma', 'generate'], { cwd: serverDir })
-  await run('npx', ['tsx', 'prisma/seed.ts'], { cwd: serverDir })
+  // ── Prisma ──────────────────────────────────────────────────────────────
+  await run('npx', ['prisma', 'migrate', 'deploy'], { cwd: serverDir, env: resolvedEnv })
+  await run('npx', ['prisma', 'generate'], { cwd: serverDir, env: resolvedEnv })
 
+  // ── Cleanup before seed ─────────────────────────────────────────────────
+  await run('npx', ['tsx', 'scripts/e2e-cleanup.ts'], { cwd: serverDir, env: resolvedEnv })
+
+  // ── Seed ────────────────────────────────────────────────────────────────
+  await run('npx', ['tsx', 'prisma/seed.ts'], { cwd: serverDir, env: resolvedEnv })
+
+  // ── Start API ───────────────────────────────────────────────────────────
   const api = start('npx', ['tsx', 'src/index.ts'], {
     cwd: serverDir,
-    env: {
+    env: resolvedEnv,
+    extraEnv: {
       NODE_ENV: 'test',
       PORT: String(apiPort),
       CLIENT_URL: baseUrl,
@@ -43,22 +107,27 @@ try {
   })
   children.push(api)
 
+  // ── Start Vite ──────────────────────────────────────────────────────────
   const client = start('npx', ['vite', '--host', host, '--port', String(clientPort), '--strictPort'], {
     cwd: clientDir,
-    env: {
+    env: resolvedEnv,
+    extraEnv: {
       VITE_API_URL: apiUrl,
     },
     label: 'vite',
   })
   children.push(client)
 
+  // ── Wait for services ───────────────────────────────────────────────────
   await waitForMonradApi(apiUrl)
   await waitForClient(baseUrl)
   await waitForProxy(baseUrl)
 
+  // ── Playwright ──────────────────────────────────────────────────────────
   await run('npx', ['playwright', 'test', '--grep-invert', '@screenshots', ...process.argv.slice(2)], {
     cwd: e2eDir,
-    env: {
+    env: resolvedEnv,
+    extraEnv: {
       BASE_URL: baseUrl,
       API_URL: apiUrl,
       NODE_ENV: 'test',
@@ -69,39 +138,41 @@ try {
   await stopChildren()
 }
 
-function start(command, args, options) {
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function start(command, args, { cwd, env, extraEnv = {}, label }) {
   const spec = resolveCommand(command, args)
   const child = spawn(spec.command, spec.args, {
-    cwd: options.cwd,
-    env: { ...process.env, ...options.env },
+    cwd,
+    env: { ...env, ...extraEnv },
     stdio: ['ignore', 'pipe', 'pipe'],
   })
 
-  child.stdout.on('data', data => process.stdout.write(`[${options.label}] ${data}`))
-  child.stderr.on('data', data => process.stderr.write(`[${options.label}] ${data}`))
+  child.stdout.on('data', data => process.stdout.write(`[${label}] ${data}`))
+  child.stderr.on('data', data => process.stderr.write(`[${label}] ${data}`))
   child.on('error', error => {
-    console.error(`[${options.label}] failed to start: ${error.message}`)
+    console.error(`[${label}] failed to start: ${error.message}`)
   })
   child.on('exit', code => {
     if (code !== null && code !== 0) {
-      console.error(`[${options.label}] exited with code ${code}`)
+      console.error(`[${label}] exited with code ${code}`)
     }
   })
 
   return child
 }
 
-function run(command, args, options = {}) {
+function run(command, args, { cwd, env, extraEnv = {}, inherit, allowFailure } = {}) {
   return new Promise((resolve, reject) => {
     const spec = resolveCommand(command, args)
     const child = spawn(spec.command, spec.args, {
-      cwd: options.cwd,
-      env: { ...process.env, ...options.env },
-      stdio: options.inherit ? 'inherit' : ['ignore', 'pipe', 'pipe'],
+      cwd,
+      env: { ...env, ...extraEnv },
+      stdio: inherit ? 'inherit' : ['ignore', 'pipe', 'pipe'],
     })
 
     let output = ''
-    if (!options.inherit) {
+    if (!inherit) {
       child.stdout.on('data', data => {
         output += data.toString()
         process.stdout.write(data)
@@ -114,7 +185,7 @@ function run(command, args, options = {}) {
     child.on('error', reject)
 
     child.on('exit', code => {
-      if (code === 0 || options.allowFailure) resolve(output)
+      if (code === 0 || allowFailure) resolve(output)
       else reject(new Error(`${command} ${args.join(' ')} failed with exit code ${code}`))
     })
   })

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,5 +1,7 @@
 DATABASE_URL="postgresql://postgres:postgres@localhost:5432/monrad_estimator"
-JWT_SECRET="change-me-in-production"
+# JWT signing secret — this dev-only value (32+ chars) works for local dev;
+# REPLACE with a secure random string in production (e.g. openssl rand -hex 32)
+JWT_SECRET="local-dev-jwt-secret-at-least-32-chars!!"
 PORT=3001
 CLIENT_URL="http://localhost:5173"
 # Email (SMTP) — leave blank in dev to log emails to console instead of sending

--- a/server/scripts/e2e-cleanup.ts
+++ b/server/scripts/e2e-cleanup.ts
@@ -1,9 +1,8 @@
 /**
- * E2E test data cleanup script.
+ * Deletes all data created by the Playwright test user and any FeatureTemplates
+ * whose name starts with the E2E prefix ("E2E ").
  *
- * Deletes all data created by the Playwright test user (test@example.com)
- * and any FeatureTemplates whose name starts with the E2E prefix ("E2E ").
- *
+ * User email is taken from TEST_EMAIL env var (default: test@example.com).
  * Safe to run against a local dev database; never run against production.
  *
  * Usage:
@@ -11,12 +10,13 @@
  *   # or via npm:
  *   cd server && npm run e2e:cleanup
  */
-
+import 'dotenv/config'
 import { PrismaPg } from '@prisma/adapter-pg'
 import { PrismaClient } from '@prisma/client'
-import 'dotenv/config'
-
-const E2E_EMAIL = 'test@example.com'
+/**
+ * Default E2E test user email. Override via TEST_EMAIL env var.
+ */
+const E2E_EMAIL = process.env.TEST_EMAIL ?? 'test@example.com'
 const E2E_TEMPLATE_PREFIX = 'E2E '
 
 const adapter = new PrismaPg({ connectionString: process.env.DATABASE_URL })

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -50,7 +50,7 @@ app.use(pinoHttp({ logger }))
 app.use(cors({ origin: process.env.CLIENT_URL ?? 'http://localhost:5173' }))
 app.use(express.json({ limit: '10mb' }))
 
-app.get('/health', (_req, res) => res.json({ status: 'ok' }))
+app.get('/health', (_req, res) => res.json({ status: 'ok', service: 'monrad-estimator' }))
 app.use('/api/bootstrap', bootstrapRoutes)
 app.use('/api/auth', authRoutes)
 app.use('/api/projects', projectRoutes)


### PR DESCRIPTION
## Summary

Adds a repo-level local E2E runner for Windows/dev validation that starts isolated API and Vite servers on free ports, verifies the Monrad API instead of any port-conflicting service, and then runs Playwright. Also tightens the flaky selectors that failed during the Windows investigation.

## Related issue

Closes #353

## Changes

- Added `npm run test:e2e:local` backed by `scripts/run-e2e-local.mjs`.
- Runner applies migrations, generates Prisma client, seeds test data, chooses free API/client ports, validates `/health`, validates the Vite proxy, and force-cleans child processes on Windows.
- Updated Vite proxy config to honor `VITE_API_URL` / `API_URL` for isolated local E2E ports.
- Added a Monrad-specific `service` marker to `/health` so the runner can reject non-Monrad services on the preferred port.
- Hardened existing Playwright selectors in `backlog.spec.ts`, `resource-profile.spec.ts`, and `templates.spec.ts` after the Windows reproduction.
- Documented the local E2E runner in `README.md` and `e2e/TESTS.md`.

## E2E Tests

**Tests added/modified:**
- Modified: `backlog.spec.ts` — make epic creation in drag-handle test wait for the created rows and avoid matching `Add feature` buttons.
- Modified: `resource-profile.spec.ts` — scope manual feature override inputs to the inline edit panel.
- Modified: `templates.spec.ts` — use unique template names and exact Save Template button matching.
- Added harness: `scripts/run-e2e-local.mjs` — local Windows/dev E2E runner.

**E2E test results (`npm run test:e2e:local`):**
```
91 passed (58.2s)
```

## Testing

- [ ] `npm test` passes in `/server`
- [x] `npx tsc --noEmit` passes in `/server` via `npm run typecheck`
- [x] `npx tsc --noEmit` passes in `/client` via `npm run typecheck`
- [x] `npm run test:e2e:local` passes (Playwright local runner — starts isolated API/Vite servers)
- [x] `e2e/TESTS.md` updated to reflect test runner changes

## Notes

- Root cause reproduced on Windows: port `:3001` was occupied by a Docker-published non-Monrad service, so the previous local flow could validate the wrong HTTP service and leave Playwright pointed at a mismatched API/proxy. The new runner chooses free ports and asserts the API health payload contains `service: "monrad-estimator"`.
- The Windows native dependency/install fixes from PR #347 remain unchanged.
- CI should still use the existing `npm run test:e2e` workflow; this PR adds a local/dev runner rather than replacing CI behavior.