### PR TITLE
feat(#357): preserve capacity profiles in snapshot v3 and rollback

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -52,6 +52,11 @@ jobs:
       - name: Install all dependencies
         run: npm ci
 
+      # ── Client snapshot regression tests ─────────────────────────
+      - name: Client snapshot regression tests
+        working-directory: client
+        run: npx vitest run src/test/canonical-commercial-consistency.test.ts src/test/resource-profile-export.test.ts
+
       # ── Validate local E2E runner ─────────────────────────────────
       - name: Validate local E2E runner loads env correctly
         run: node scripts/run-e2e-local.mjs --validate

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -87,6 +87,11 @@ jobs:
         working-directory: server
         run: npx prisma generate
 
+      # ── Snapshot rollback integration tests (real PostgreSQL) ──
+      - name: Snapshot rollback integration tests
+        working-directory: server
+        run: npm run test:snapshot-integration
+
       - name: Seed database (creates E2E test user)
         working-directory: server
         run: npx tsx prisma/seed.ts

--- a/README.md
+++ b/README.md
@@ -255,6 +255,7 @@ Day rates per resource type (global defaults + project overrides) and cost colum
 | Timeline workflow cleanup — canonical Update timeline CTA, hidden Level current timeline action, advanced planning copy updates | #314 |
 | Resource Counts allocation controls — stable named-resource columns, clearer planning-basis labels, preserved mode switching/start/end/allocation updates, and stale-banner behaviour | #315 |
 | Windows E2E local runner — unified env loading (server/.env + shell), cleanup-before-seed, resolved env across all processes | #354 |
+| Snapshot v3 — capacity-profile preservation with atomic rollback | #357 |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -255,8 +255,6 @@ Day rates per resource type (global defaults + project overrides) and cost colum
 | Timeline workflow cleanup — canonical Update timeline CTA, hidden Level current timeline action, advanced planning copy updates | #314 |
 | Resource Counts allocation controls — stable named-resource columns, clearer planning-basis labels, preserved mode switching/start/end/allocation updates, and stale-banner behaviour | #315 |
 | Windows E2E local runner — unified env loading (server/.env + shell), cleanup-before-seed, resolved env across all processes | #354 |
-| Snapshot v3 — capacity-profile preservation with atomic rollback | #357 |
-
 ---
 
 ## Open Issues & Backlog

--- a/client/src/test/canonical-commercial-consistency.test.ts
+++ b/client/src/test/canonical-commercial-consistency.test.ts
@@ -390,6 +390,9 @@ describe('canonical commercial consistency', () => {
 
     const resultA = computeCommercialData(profileA, discounts, projectSettings)
     expect(resultA).not.toBeNull()
+    // No duplicate commercial row IDs after initial computation
+    const rowIdsA = resultA!.rows.map(r => r.id)
+    expect(new Set(rowIdsA).size).toBe(rowIdsA.length)
 
     // ── State A known totals ────────────────────────────────────────
     // Alice ACTUAL_DAYS: 10 actual days × $500 = $5,000
@@ -460,6 +463,9 @@ describe('canonical commercial consistency', () => {
     // ── Restore A DTO → recompute ───────────────────────────────────
     const resultRestored = computeCommercialData(profileA, discounts, projectSettings)
     expect(resultRestored).not.toBeNull()
+    // No duplicate commercial row IDs after restoring A
+    const rowIdsR = resultRestored!.rows.map(r => r.id)
+    expect(new Set(rowIdsR).size).toBe(rowIdsR.length)
 
     // ── Exact commercial parity between initial and post-restore ─────
     expect(resultRestored!.subtotal).toBe(resultA!.subtotal)

--- a/client/src/test/canonical-commercial-consistency.test.ts
+++ b/client/src/test/canonical-commercial-consistency.test.ts
@@ -106,6 +106,164 @@ function buildCanonicalProfile(): ResourceProfile {
   }
 }
 
+/**
+ * Build a realistic Resource Profile DTO shaped exactly like restored Scenario A
+ * data (as would come from a PostgreSQL snapshot rollback). Contains:
+ *   2 resource types (Developer $500/day, Designer $400/day)
+ *   3 named resources across both pricing models
+ *   1 overhead item (Governance $600/day, 2 fixed days)
+ */
+function buildScenarioAProfile(): ResourceProfile {
+  return {
+    projectId: 'proj-parity',
+    hoursPerDay: 8,
+    projectDurationWeeks: 6,
+    bufferWeeks: 1,
+    onboardingWeeks: 1,
+    resourceRows: [
+      {
+        resourceTypeId: 'rt-dev',
+        name: 'Developer',
+        category: 'ENGINEERING',
+        count: 2,
+        hoursPerDay: 8,
+        dayRate: 500,
+        totalHours: 144,
+        totalDays: 18,
+        effortDays: 18,
+        allocatedDays: 18,
+        estimatedCost: 9000,
+        allocationMode: 'EFFORT',
+        allocationPercent: 100,
+        allocationStartWeek: null,
+        allocationEndWeek: null,
+        derivedStartWeek: 0,
+        derivedEndWeek: 5,
+        epics: [],
+        namedResources: [
+          {
+            id: 'nr-alice',
+            name: 'Alice',
+            pricingModel: 'ACTUAL_DAYS',
+            allocationMode: 'EFFORT',
+            allocationPercent: 100,
+            allocationStartWeek: null,
+            allocationEndWeek: null,
+            startWeek: null,
+            endWeek: null,
+            allocatedDays: 9,
+            derivedStartWeek: 0,
+            derivedEndWeek: 5,
+            actualAllocatedDays: 10,
+            actualAllocationStartWeek: 0,
+            actualAllocationEndWeek: 4,
+            actualAllocatedWeeks: [
+              { week: 0, days: 2.5, capacityDays: 5 },
+              { week: 1, days: 2.5, capacityDays: 5 },
+              { week: 2, days: 2.5, capacityDays: 5 },
+              { week: 3, days: 2.5, capacityDays: 5 },
+            ],
+            actualAllocationSegments: [
+              { startWeek: 0, endWeek: 4, days: 10 },
+            ],
+            synthetic: false,
+          },
+          {
+            id: 'nr-charlie',
+            name: 'Charlie',
+            pricingModel: 'ACTUAL_DAYS',
+            allocationMode: 'EFFORT',
+            allocationPercent: 100,
+            allocationStartWeek: null,
+            allocationEndWeek: null,
+            startWeek: null,
+            endWeek: null,
+            allocatedDays: 9,
+            derivedStartWeek: 0,
+            derivedEndWeek: 4,
+            actualAllocatedDays: 8,
+            actualAllocationStartWeek: 0,
+            actualAllocationEndWeek: 3,
+            actualAllocatedWeeks: [
+              { week: 0, days: 2, capacityDays: 5 },
+              { week: 1, days: 2, capacityDays: 5 },
+              { week: 2, days: 2, capacityDays: 5 },
+              { week: 3, days: 2, capacityDays: 5 },
+            ],
+            actualAllocationSegments: [
+              { startWeek: 0, endWeek: 4, days: 8 },
+            ],
+            synthetic: false,
+          },
+        ],
+      },
+      {
+        resourceTypeId: 'rt-des',
+        name: 'Designer',
+        category: 'ENGINEERING',
+        count: 1,
+        hoursPerDay: 8,
+        dayRate: 400,
+        totalHours: 96,
+        totalDays: 12,
+        effortDays: 12,
+        allocatedDays: 12,
+        estimatedCost: 4800,
+        allocationMode: 'EFFORT',
+        allocationPercent: 100,
+        allocationStartWeek: null,
+        allocationEndWeek: null,
+        derivedStartWeek: 1,
+        derivedEndWeek: 4,
+        epics: [],
+        namedResources: [
+          {
+            id: 'nr-bob',
+            name: 'Bob',
+            pricingModel: 'PRO_RATA',
+            allocationMode: 'EFFORT',
+            allocationPercent: 100,
+            allocationStartWeek: null,
+            allocationEndWeek: null,
+            startWeek: null,
+            endWeek: null,
+            allocatedDays: 12,
+            derivedStartWeek: 1,
+            derivedEndWeek: 4,
+            actualAllocatedDays: 0,
+            actualAllocationStartWeek: null,
+            actualAllocationEndWeek: null,
+            actualAllocatedWeeks: [],
+            actualAllocationSegments: [],
+            synthetic: false,
+          },
+        ],
+      },
+    ],
+    overheadRows: [
+      {
+        overheadId: 'oh-gov',
+        name: 'Governance',
+        resourceTypeId: null,
+        resourceTypeName: null,
+        dayRate: 600,
+        type: 'FIXED_DAYS',
+        value: 2,
+        computedDays: 2,
+        estimatedCost: 1200,
+        requiredFTE: 0.07,
+        currentCount: null,
+      },
+    ],
+    summary: {
+      totalHours: 240,
+      totalDays: 32,
+      totalCost: 15000,
+      hasCost: true,
+    },
+  }
+}
+
 describe('canonical commercial consistency', () => {
   it('ACTUAL_DAYS named resource: billable days match actual scheduled days', () => {
     const profile = buildCanonicalProfile()
@@ -220,5 +378,116 @@ describe('canonical commercial consistency', () => {
       expect(enrichedResult!.rows[i].subtotal).toBe(baseResult!.rows[i].subtotal)
       expect(enrichedResult!.rows[i].pricingModel).toBe(baseResult!.rows[i].pricingModel)
     }
+  })
+
+  it('rollback parity: restored Scenario A DTO produces identical commercial totals before and after mutation', () => {
+    // ── State A: restored snapshot DTO ──────────────────────────────
+    const profileA = buildScenarioAProfile()
+    const discounts = [
+      { id: 'd-proj', label: 'Loyalty', type: 'PERCENTAGE' as const, value: 10, resourceTypeId: null },
+    ]
+    const projectSettings = { taxRate: 10, taxLabel: 'GST' }
+
+    const resultA = computeCommercialData(profileA, discounts, projectSettings)
+    expect(resultA).not.toBeNull()
+
+    // ── State A known totals ────────────────────────────────────────
+    // Alice ACTUAL_DAYS: 10 actual days × $500 = $5,000
+    // Charlie ACTUAL_DAYS: 8 actual days × $500 = $4,000
+    // Bob PRO_RATA: 12 allocated days × $400 = $4,800
+    // Subtotal (NR rows): $13,800
+    // Governance overhead: 2 days × $600 = $1,200
+    // Subtotal (all rows): $15,000
+    // Project discount 10%: $1,500
+    // After discounts: $13,500
+    // Tax 10%: $1,350
+    // Grand total: $14,850
+    const aliceA = resultA!.rows.find(r => r.id === 'nr-alice')
+    expect(aliceA).toBeDefined()
+    expect(aliceA!.allocatedDays).toBe(10)
+    expect(aliceA!.totalDays).toBe(10)
+    expect(aliceA!.subtotal).toBe(5000)
+    expect(aliceA!.pricingModel).toBe('ACTUAL_DAYS')
+
+    const charlieA = resultA!.rows.find(r => r.id === 'nr-charlie')
+    expect(charlieA).toBeDefined()
+    expect(charlieA!.allocatedDays).toBe(8)
+    expect(charlieA!.subtotal).toBe(4000)
+    expect(charlieA!.pricingModel).toBe('ACTUAL_DAYS')
+
+    const bobA = resultA!.rows.find(r => r.id === 'nr-bob')
+    expect(bobA).toBeDefined()
+    expect(bobA!.allocatedDays).toBe(12)
+    expect(bobA!.subtotal).toBe(4800)
+    expect(bobA!.pricingModel).toBe('PRO_RATA')
+
+    const govA = resultA!.rows.find(r => r.id === 'oh-gov')
+    expect(govA).toBeDefined()
+    expect(govA!.kind).toBe('overhead')
+    expect(govA!.allocatedDays).toBe(2)
+    expect(govA!.subtotal).toBe(1200)
+
+    expect(resultA!.subtotal).toBe(15000)
+    expect(resultA!.totalProjectDiscount).toBe(1500)
+    expect(resultA!.afterDiscounts).toBe(13500)
+    expect(resultA!.taxAmount).toBe(1350)
+    expect(resultA!.grandTotal).toBe(14850)
+
+    // ── State B: mutated day rates (different billing amounts) ──────
+    const profileB: ResourceProfile = {
+      ...profileA,
+      resourceRows: profileA.resourceRows.map(row => {
+        if (row.resourceTypeId === 'rt-dev') return { ...row, dayRate: 600, estimatedCost: 10800 }
+        if (row.resourceTypeId === 'rt-des') return { ...row, dayRate: 500, estimatedCost: 6000 }
+        return row
+      }),
+    }
+
+    const resultB = computeCommercialData(profileB, discounts, projectSettings)
+    expect(resultB).not.toBeNull()
+
+    // State B totals must differ from State A
+    // Developer $600: Alice 10×600=6000, Charlie 8×600=4800
+    // Designer $500: Bob 12×500=6000
+    // Overhead unchanged: 1200
+    // Subtotal: 6000+4800+6000+1200 = 18000
+    // Discount 10%: 1800, after: 16200, tax 10%: 1620, grand: 17820
+    expect(resultB!.subtotal).toBe(18000)
+    expect(resultB!.grandTotal).toBe(17820)
+    expect(resultB!.subtotal).not.toBe(resultA!.subtotal)
+    expect(resultB!.grandTotal).not.toBe(resultA!.grandTotal)
+
+    // ── Restore A DTO → recompute ───────────────────────────────────
+    const resultRestored = computeCommercialData(profileA, discounts, projectSettings)
+    expect(resultRestored).not.toBeNull()
+
+    // ── Exact commercial parity between initial and post-restore ─────
+    expect(resultRestored!.subtotal).toBe(resultA!.subtotal)
+    expect(resultRestored!.totalProjectDiscount).toBe(resultA!.totalProjectDiscount)
+    expect(resultRestored!.afterDiscounts).toBe(resultA!.afterDiscounts)
+    expect(resultRestored!.taxRate).toBe(resultA!.taxRate)
+    expect(resultRestored!.taxAmount).toBe(resultA!.taxAmount)
+    expect(resultRestored!.grandTotal).toBe(resultA!.grandTotal)
+
+    // All rows present with same count
+    expect(resultRestored!.rows).toHaveLength(resultA!.rows.length)
+
+    // Per-row billable days, subtotals, and pricing models unchanged
+    for (const rowA of resultA!.rows) {
+      const rowR = resultRestored!.rows.find(r => r.id === rowA.id)
+      expect(rowR).toBeDefined()
+      expect(rowR!.allocatedDays).toBe(rowA.allocatedDays)
+      expect(rowR!.totalDays).toBe(rowA.totalDays)
+      expect(rowR!.subtotal).toBe(rowA.subtotal)
+      expect(rowR!.pricingModel).toBe(rowA.pricingModel)
+      expect(rowR!.dayRate).toBe(rowA.dayRate)
+    }
+
+    // Overhead row identity preserved
+    const govRestored = resultRestored!.rows.find(r => r.id === 'oh-gov')
+    expect(govRestored).toBeDefined()
+    expect(govRestored!.kind).toBe('overhead')
+    expect(govRestored!.allocatedDays).toBe(2)
+    expect(govRestored!.subtotal).toBe(1200)
   })
 })

--- a/client/src/test/resource-profile-export.test.ts
+++ b/client/src/test/resource-profile-export.test.ts
@@ -922,4 +922,286 @@ describe('capacity profile CSV export — trajectory tests', () => {
     expect(namedRow![3]).toBe('Named person')
   })
 })
+
+describe('regression: restored scenario A profile data produces identical export', () => {
+  it('produces identical CSV from restored scenario A, B differs, no duplicates', () => {
+    // Scenario A — canonical data with two resource roles, three named resources
+    // (one planned resource), capacity profiles with segments, and overhead.
+    const scenarioA: ResourceProfile = {
+      projectId: 'project-1',
+      hoursPerDay: 8,
+      projectDurationWeeks: 12,
+      bufferWeeks: 1,
+      onboardingWeeks: 0,
+      summary: { totalHours: 240, totalDays: 33, totalCost: null, hasCost: false },
+      resourceRows: [
+        {
+          resourceTypeId: 'rt-dev',
+          name: 'Developer',
+          category: 'ENGINEERING',
+          count: 2,
+          hoursPerDay: 8,
+          dayRate: 800,
+          totalHours: 160,
+          totalDays: 20,
+          effortDays: 20,
+          allocatedDays: 20,
+          allocationMode: 'EFFORT',
+          allocationPercent: 200,
+          allocationStartWeek: null,
+          allocationEndWeek: null,
+          derivedStartWeek: 0,
+          derivedEndWeek: 9,
+          estimatedCost: null,
+          epics: [],
+          capacityProfile: undefined,
+          namedResources: [
+            {
+              id: 'nr-alice',
+              name: 'Alice',
+              pricingModel: 'ACTUAL_DAYS',
+              allocationMode: 'CAPACITY_PLAN',
+              allocationPercent: 75,
+              allocationStartWeek: null,
+              allocationEndWeek: null,
+              startWeek: 0,
+              endWeek: 7,
+              allocatedDays: 10,
+              derivedStartWeek: null,
+              derivedEndWeek: null,
+              actualAllocatedDays: 0,
+              actualAllocationStartWeek: null,
+              actualAllocationEndWeek: null,
+              actualAllocatedWeeks: [],
+              actualAllocationSegments: [],
+              synthetic: false,
+              resourceIdentity: 'NAMED_PERSON',
+              capacityProfile: {
+                planningBasis: 'capacityProfile',
+                source: 'squadPlanner',
+                defaultPercent: 75,
+                startWeek: 0,
+                endWeek: 7,
+                segments: [
+                  { startWeek: 0, endWeek: 7, capacityPercent: 75 },
+                ],
+              },
+            },
+            {
+              id: 'nr-planned',
+              name: 'New Starter',
+              pricingModel: 'PRO_RATA',
+              allocationMode: 'CAPACITY_PLAN',
+              allocationPercent: 50,
+              allocationStartWeek: null,
+              allocationEndWeek: null,
+              startWeek: 2,
+              endWeek: 9,
+              allocatedDays: 5,
+              derivedStartWeek: null,
+              derivedEndWeek: null,
+              actualAllocatedDays: 0,
+              actualAllocationStartWeek: null,
+              actualAllocationEndWeek: null,
+              actualAllocatedWeeks: [],
+              actualAllocationSegments: [],
+              synthetic: true,
+              resourceIdentity: 'PLANNED_RESOURCE',
+              capacityProfile: {
+                planningBasis: 'capacityProfile',
+                source: 'squadPlanner',
+                defaultPercent: 50,
+                startWeek: 2,
+                endWeek: 9,
+                segments: [
+                  { startWeek: 2, endWeek: 9, capacityPercent: 50 },
+                ],
+                resolutionSource: 'PROFILE',
+              },
+            },
+          ],
+        },
+        {
+          resourceTypeId: 'rt-design',
+          name: 'Designer',
+          category: 'DESIGN',
+          count: 1,
+          hoursPerDay: 8,
+          dayRate: 700,
+          totalHours: 80,
+          totalDays: 10,
+          effortDays: 10,
+          allocatedDays: 10,
+          allocationMode: 'EFFORT',
+          allocationPercent: 100,
+          allocationStartWeek: null,
+          allocationEndWeek: null,
+          derivedStartWeek: 0,
+          derivedEndWeek: 9,
+          estimatedCost: null,
+          epics: [],
+          capacityProfile: undefined,
+          namedResources: [
+            {
+              id: 'nr-bob',
+              name: 'Bob',
+              pricingModel: 'ACTUAL_DAYS',
+              allocationMode: 'CAPACITY_PLAN',
+              allocationPercent: 100,
+              allocationStartWeek: null,
+              allocationEndWeek: null,
+              startWeek: 0,
+              endWeek: 9,
+              allocatedDays: 10,
+              derivedStartWeek: null,
+              derivedEndWeek: null,
+              actualAllocatedDays: 0,
+              actualAllocationStartWeek: null,
+              actualAllocationEndWeek: null,
+              actualAllocatedWeeks: [],
+              actualAllocationSegments: [],
+              synthetic: false,
+              resourceIdentity: 'NAMED_PERSON',
+              capacityProfile: {
+                planningBasis: 'capacityProfile',
+                source: 'squadPlanner',
+                defaultPercent: 100,
+                startWeek: 0,
+                endWeek: 9,
+                segments: [
+                  { startWeek: 0, endWeek: 9, capacityPercent: 100 },
+                ],
+                resolutionSource: 'PROFILE',
+              },
+            },
+          ],
+        },
+      ],
+      overheadRows: [
+        {
+          overheadId: 'oh-pm',
+          name: 'Project Management',
+          resourceTypeId: null,
+          resourceTypeName: null,
+          dayRate: null,
+          type: 'PERCENTAGE',
+          value: 10,
+          computedDays: 3,
+          estimatedCost: null,
+          requiredFTE: 0.05,
+          currentCount: null,
+        },
+      ],
+    }
+
+    // --- Phase 1: canonical A export ---
+    const canonicalA = JSON.parse(JSON.stringify(scenarioA)) as ResourceProfile
+    const csvA = buildProfileCsv(canonicalA)
+    const { headers: headersA, rows: rowsA } = parseCsv(csvA)
+    const identityIdx = headersA.indexOf('Resource identity')
+    const segmentsIdx = headersA.indexOf('Capacity profile segments')
+    const resourceRowsA = rowsA.filter(r => r[0] === 'Resource')
+
+    // Exactly 3 resource rows (Alice, New Starter, Bob) — no duplicates
+    expect(resourceRowsA.length).toBe(3)
+
+    // Planned resource identity column (index 3)
+    const aliceRowA = resourceRowsA.find(r => r[2] === 'Alice')
+    const plannedRowA = resourceRowsA.find(r => r[2] === 'New Starter')
+    const bobRowA = resourceRowsA.find(r => r[2] === 'Bob')
+    expect(aliceRowA).toBeDefined()
+    expect(plannedRowA).toBeDefined()
+    expect(bobRowA).toBeDefined()
+    expect(aliceRowA![identityIdx]).toBe('Named person')
+    expect(plannedRowA![identityIdx]).toBe('Planned resource')
+    expect(bobRowA![identityIdx]).toBe('Named person')
+
+    // Alice: 75% weeks 0-7
+    expect(aliceRowA![segmentsIdx]).toBe('W1-W8 75%')
+    // New Starter: constant 50% segment
+    expect(plannedRowA![segmentsIdx]).toBe('W3-W10 50%')
+    // Bob: constant 100% segment
+    expect(bobRowA![segmentsIdx]).toBe('W1-W10 100%')
+
+    // --- Phase 2: mutate to state B ---
+    const stateB = JSON.parse(JSON.stringify(canonicalA)) as ResourceProfile
+
+    // Alice → constant 100%
+    const aliceB = stateB.resourceRows[0].namedResources![0]
+    aliceB.capacityProfile = {
+      ...aliceB.capacityProfile!,
+      defaultPercent: 100,
+      segments: [{ startWeek: 0, endWeek: 7, capacityPercent: 100 }],
+    }
+
+    // New Starter → named person with 100% segment
+    const nsB = stateB.resourceRows[0].namedResources![1]
+    nsB.synthetic = false
+    nsB.resourceIdentity = 'NAMED_PERSON'
+    nsB.capacityProfile = {
+      ...nsB.capacityProfile!,
+      defaultPercent: 100,
+      segments: [{ startWeek: 2, endWeek: 9, capacityPercent: 100 }],
+    }
+
+    // Bob → constant 75%
+    const bobB = stateB.resourceRows[1].namedResources![0]
+    bobB.capacityProfile = {
+      ...bobB.capacityProfile!,
+      defaultPercent: 75,
+      segments: [{ startWeek: 0, endWeek: 9, capacityPercent: 75 }],
+    }
+
+    const csvB = buildProfileCsv(stateB)
+    const { headers: headersB, rows: rowsB } = parseCsv(csvB)
+    const identityIdxB = headersB.indexOf('Resource identity')
+    const segmentsIdxB = headersB.indexOf('Capacity profile segments')
+    const resourceRowsB = rowsB.filter(r => r[0] === 'Resource')
+
+    // Still 3 rows — no extra rows introduced by mutation
+    expect(resourceRowsB.length).toBe(3)
+
+    // Verify B actually differs from A
+    expect(csvB).not.toBe(csvA)
+
+    // Verify B's mutated values
+    const aliceRowB = resourceRowsB.find(r => r[2] === 'Alice')
+    expect(aliceRowB![segmentsIdxB]).toBe('W1-W8 100%')
+    const nsRowB = resourceRowsB.find(r => r[2] === 'New Starter')
+    expect(nsRowB![identityIdxB]).toBe('Named person')
+    expect(nsRowB![segmentsIdxB]).toBe('W3-W10 100%')
+    const bobRowB = resourceRowsB.find(r => r[2] === 'Bob')
+    expect(bobRowB![segmentsIdxB]).toBe('W1-W10 75%')
+
+    // --- Phase 3: restore to Scenario A ---
+    const restoredA = JSON.parse(JSON.stringify(canonicalA)) as ResourceProfile
+    const csvRestored = buildProfileCsv(restoredA)
+    const { headers: headersRestored, rows: rowsRestored } = parseCsv(csvRestored)
+    const identityIdxR = headersRestored.indexOf('Resource identity')
+    const segmentsIdxR = headersRestored.indexOf('Capacity profile segments')
+    const resourceRowsRestored = rowsRestored.filter(r => r[0] === 'Resource')
+
+    // Exact string match against canonical A
+    expect(csvRestored).toBe(csvA)
+
+    // No duplicates — same cardinality as canonical A
+    expect(resourceRowsRestored.length).toBe(3)
+
+    // Restored segments match canonical A
+    const aliceRestored = resourceRowsRestored.find(r => r[2] === 'Alice')
+    const plannedRestored = resourceRowsRestored.find(r => r[2] === 'New Starter')
+    const bobRestored = resourceRowsRestored.find(r => r[2] === 'Bob')
+    expect(aliceRestored![segmentsIdxR]).toBe('W1-W8 75%')
+    expect(plannedRestored![segmentsIdxR]).toBe('W3-W10 50%')
+    expect(bobRestored![segmentsIdxR]).toBe('W1-W10 100%')
+
+    // Planned resource identity restored
+    expect(plannedRestored![identityIdxR]).toBe('Planned resource')
+
+    // State-B values absent from restored output
+    expect(aliceRestored![segmentsIdxR]).not.toContain('100%')
+    expect(plannedRestored![identityIdxR]).not.toBe('Named person')
+    expect(bobRestored![segmentsIdxR]).not.toContain('75%')
+  })
+})
 })

--- a/client/src/test/resource-profile-export.test.ts
+++ b/client/src/test/resource-profile-export.test.ts
@@ -1100,6 +1100,8 @@ describe('regression: restored scenario A profile data produces identical export
     const { headers: headersA, rows: rowsA } = parseCsv(csvA)
     const identityIdx = headersA.indexOf('Resource identity')
     const segmentsIdx = headersA.indexOf('Capacity profile segments')
+    const billingBasisIdx = headersA.indexOf('Billing basis')
+
     const resourceRowsA = rowsA.filter(r => r[0] === 'Resource')
 
     // Exactly 3 resource rows (Alice, New Starter, Bob) — no duplicates
@@ -1122,6 +1124,11 @@ describe('regression: restored scenario A profile data produces identical export
     expect(plannedRowA![segmentsIdx]).toBe('W3-W10 50%')
     // Bob: constant 100% segment
     expect(bobRowA![segmentsIdx]).toBe('W1-W10 100%')
+    // Billing basis column — pricing model survives export
+    expect(aliceRowA![billingBasisIdx]).toBe('Bill actual scheduled days')
+    expect(plannedRowA![billingBasisIdx]).toBe('Bill planned allocation')
+    expect(bobRowA![billingBasisIdx]).toBe('Bill actual scheduled days')
+
 
     // --- Phase 2: mutate to state B ---
     const stateB = JSON.parse(JSON.stringify(canonicalA)) as ResourceProfile
@@ -1179,6 +1186,8 @@ describe('regression: restored scenario A profile data produces identical export
     const { headers: headersRestored, rows: rowsRestored } = parseCsv(csvRestored)
     const identityIdxR = headersRestored.indexOf('Resource identity')
     const segmentsIdxR = headersRestored.indexOf('Capacity profile segments')
+    const billingBasisIdxR = headersRestored.indexOf('Billing basis')
+
     const resourceRowsRestored = rowsRestored.filter(r => r[0] === 'Resource')
 
     // Exact string match against canonical A
@@ -1194,6 +1203,11 @@ describe('regression: restored scenario A profile data produces identical export
     expect(aliceRestored![segmentsIdxR]).toBe('W1-W8 75%')
     expect(plannedRestored![segmentsIdxR]).toBe('W3-W10 50%')
     expect(bobRestored![segmentsIdxR]).toBe('W1-W10 100%')
+    // Billing basis column restored — pricing model survives rollback
+    expect(aliceRestored![billingBasisIdxR]).toBe('Bill actual scheduled days')
+    expect(plannedRestored![billingBasisIdxR]).toBe('Bill planned allocation')
+    expect(bobRestored![billingBasisIdxR]).toBe('Bill actual scheduled days')
+
 
     // Planned resource identity restored
     expect(plannedRestored![identityIdxR]).toBe('Planned resource')

--- a/docs/FUNCTIONAL_SPEC.md
+++ b/docs/FUNCTIONAL_SPEC.md
@@ -203,7 +203,7 @@ All levels support full CRUD (create, read, update, delete) and drag-and-drop re
 
 - Accessible from the Backlog page
 - Shows a list of named snapshots with timestamp, trigger, and optional label
-- Snapshot triggers: `manual`, `csv_import`
+- Snapshot triggers: `manual`, `csv_import`, `template_apply`, `pre_rollback`
 - Click any snapshot to **preview** the historical state
 - **Rollback** button restores the backlog to the selected snapshot (auto-saves a pre-rollback snapshot first)
 
@@ -840,30 +840,60 @@ A Customer is a client entity that can be linked to projects.
 
 ### Snapshot Model
 
-A snapshot captures the complete backlog state (all epics, features, stories, tasks, and their fields) as a JSON blob at a point in time.
+A snapshot captures the complete project state as a JSON blob at a point in time.
+The snapshot schema has three versions:
+
+- **V1 (legacy):** Epic tree only (no resource types, named resources, timeline entries, or capacity profiles).
+- **V2:** Full project state — epics, resource types, named resources, timeline entries, dependencies, overheads. No capacity profiles.
+- **V3 (current):** All V2 fields plus `capacityProfiles: SnapshotCapacityProfile[]` with full segment data. All new application snapshots use schema version 3, set via the `schemaVersion` field in the JSON.
 
 | Field | Notes |
 |---|---|
 | Label | Optional user-provided name |
-| Trigger | `manual`, `csv_import`, `rollback` |
+| Trigger | `manual`, `csv_import`, `template_apply`, `optimiser_apply`, `pre_rollback` |
 | Created at | Timestamp |
 | Created by | User who triggered the snapshot |
+| schemaVersion | 3 (current); older snapshots may be 2 or 1 (no field) |
+
+See the [Snapshot v3 design](domain/capacity-profile-design.md#snapshot-schema-v3--snapshot-rollback-capacity-safety) for the full schema.
 
 ### Auto-Snapshot Triggers
 
 | Trigger | When it fires |
 |---|---|
 | `csv_import` | Immediately before a CSV import is committed |
-| `rollback` | Immediately before a rollback is applied (captures pre-rollback state) |
+| `template_apply` | Immediately before applying a template to a story |
+| `optimiser_apply` | Immediately before the optimiser applies a scenario |
+| `pre_rollback` | Immediately before a rollback is applied (captures current state so the rollback is reversible) |
 | `manual` | User clicks "Save snapshot" button in History panel |
 
 ### Rollback Behaviour
 
-1. Auto-snapshot of current state created (trigger: `rollback`)
-2. All existing Epics (and their cascade: Features → Stories → Tasks) are **deleted**
-3. Epics, Features, Stories, and Tasks are **recreated** from the snapshot JSON
-4. Resource types are re-matched by name to the project's current resource types
-5. Timeline entries are **not** restored — the timeline will be re-generated from the restored backlog
+Rollback behaviour depends on the snapshot's schema version:
+
+**V3 (schemaVersion: 3) — Full state + capacity profile replacement:**
+1. Auto-snapshot of current state captured as a v3 snapshot (trigger: `pre_rollback`) inside the same transaction as the restore.
+2. Resource types and named resources are upserted from snapshot data.
+3. All existing Epics (and their cascade: Features → Stories → Tasks) are **deleted**.
+4. Epics, Features, Stories, and Tasks are **recreated** from the snapshot JSON.
+5. Resource types are re-matched by name for task FKs.
+6. Timeline entries, story timeline entries, dependencies, and overheads are deleted and recreated.
+7. **All existing CapacityProfile and CapacitySegment rows are deleted** and recreated **exactly** from the snapshot's `capacityProfiles` array — preserving profile IDs, owner kinds, owner IDs, planning basis, source, default percent, profile window, legacy JSON, and every segment with its ID, weeks, capacity percent, and source.
+8. All writes share one `$transaction` — any failure rolls back every change including the pre-rollback capture.
+9. Timeline entries are **not** restored from capacity data; the Gantt regenerates from the restored backlog structure.
+
+**V2 (schemaVersion: 2) — Full state + best-effort legacy profile reconstruction:**
+1–6. Same as V3 (common state restore).
+7. All existing profiles and segments are **deleted**. Best-effort legacy profiles are reconstructed from every snapshot ResourceType (ROLE-kind, synthetic IDs) and every NamedResource (NAMED_PERSON-kind, synthetic IDs) using V2 compatibility fields (`allocationMode`, `allocationPercent`, etc.). No segments are created. No active Capacity Plan materialisation.
+8. Transaction atomicity applies as in V3.
+
+**V1 (no schemaVersion, epic array only) — Epic-only restore:**
+1. Auto-snapshot of current state (trigger: `pre_rollback`).
+2. All existing Epics (and their cascade) are **deleted**.
+3. Epics, Features, Stories, and Tasks are **recreated** from the snapshot JSON.
+4. Resource types are re-matched by name for task FKs.
+5. ResourceType, NamedResource, CapacityProfile, CapacitySegment, and capacity plan data are left **entirely untouched**.
+6. Timeline entries are **not** restored — the Gantt will regenerate from the restored backlog structure.
 
 ### Diff View
 
@@ -945,7 +975,10 @@ User
 │   │           └── Task (many, ordered)
 │   ├── ResourceType (many, project-scoped)
 │   │   └── NamedResource (many)
-│   ├── ProjectOverhead (many)
+│   │       ├── CapacityProfile (one, optional)
+│   │       │   └── CapacitySegment (many)
+│   │   ├── CapacityProfile (one per ResourceType, for role-level)
+│   │   │   └── CapacitySegment (many)
 │   ├── ProjectDiscount (many)
 │   ├── BacklogSnapshot (many)
 │   ├── TimelineEntry (one per Feature)
@@ -1017,12 +1050,17 @@ This allows manual customisation of a story to survive a refresh as long as task
 
 ### Snapshot Rollback (Cascade Delete + Recreate)
 
-Rollback is destructive to the current state:
-1. Auto-snapshot of current state (so rollback itself is reversible)
-2. Cascade-delete all epics (removes features, stories, tasks, timeline entries)
-3. Recreate entire hierarchy from snapshot JSON
-4. Resource types re-matched by name — if a resource type was renamed since the snapshot, tasks for that type will have no resource type after rollback
-5. Timeline entries are **not** restored; the Gantt will regenerate from the restored backlog structure
+Rollback is destructive to the current state. Behavior depends on the snapshot's
+schema version — see [Rollback Behaviour](#rollback-behaviour) for the full
+per-version details.
+
+Key points:
+1. Auto-snapshot of current state (trigger: `pre_rollback`) so rollback is reversible.
+2. Cascade-delete all epics (removes features, stories, tasks, timeline entries).
+3. Recreate entire hierarchy from snapshot JSON.
+4. Resource types re-matched by name — if a resource type was renamed since the snapshot, tasks for that type will have no resource type after rollback.
+5. Timeline entries are **not** restored; the Gantt will regenerate from the restored backlog structure.
+6. **V3 rollback additionally replaces** all project capacity profiles and segments exactly from the snapshot data. V2 rollback reconstructs best-effort legacy profiles. V1 rollback leaves profiles untouched.
 
 ### Inactive Items
 

--- a/docs/FUNCTIONAL_SPEC.md
+++ b/docs/FUNCTIONAL_SPEC.md
@@ -203,7 +203,7 @@ All levels support full CRUD (create, read, update, delete) and drag-and-drop re
 
 - Accessible from the Backlog page
 - Shows a list of named snapshots with timestamp, trigger, and optional label
-- Snapshot triggers: `manual`, `csv_import`, `template_apply`, `pre_rollback`
+- Snapshot triggers: `manual`, `csv_import`, `template_apply`, `optimiser_apply`, `pre_rollback`
 - Click any snapshot to **preview** the historical state
 - **Rollback** button restores the backlog to the selected snapshot (auto-saves a pre-rollback snapshot first)
 
@@ -845,7 +845,7 @@ The snapshot schema has three versions:
 
 - **V1 (legacy):** Epic tree only (no resource types, named resources, timeline entries, or capacity profiles).
 - **V2:** Full project state — epics, resource types, named resources, timeline entries, dependencies, overheads. No capacity profiles.
-- **V3 (current):** All V2 fields plus `capacityProfiles: SnapshotCapacityProfile[]` with full segment data. All new application snapshots use schema version 3, set via the `schemaVersion` field in the JSON.
+- **V3 (current):** All V2 fields plus `capacityProfiles: SnapshotCapacityProfile[]` (including full `CapacitySegment` arrays). All new application snapshots use schema version 3, set via the `schemaVersion` field in the JSON.
 
 | Field | Notes |
 |---|---|
@@ -877,10 +877,10 @@ Rollback behaviour depends on the snapshot's schema version:
 3. All existing Epics (and their cascade: Features → Stories → Tasks) are **deleted**.
 4. Epics, Features, Stories, and Tasks are **recreated** from the snapshot JSON.
 5. Resource types are re-matched by name for task FKs.
-6. Timeline entries, story timeline entries, dependencies, and overheads are deleted and recreated.
+6. Timeline entries, story timeline entries, dependencies, and overheads are deleted and recreated from snapshot data.
 7. **All existing CapacityProfile and CapacitySegment rows are deleted** and recreated **exactly** from the snapshot's `capacityProfiles` array — preserving profile IDs, owner kinds, owner IDs, planning basis, source, default percent, profile window, legacy JSON, and every segment with its ID, weeks, capacity percent, and source.
 8. All writes share one `$transaction` — any failure rolls back every change including the pre-rollback capture.
-9. Timeline entries are **not** restored from capacity data; the Gantt regenerates from the restored backlog structure.
+9. Timeline entries are restored from snapshot data.
 
 **V2 (schemaVersion: 2) — Full state + best-effort legacy profile reconstruction:**
 1–6. Same as V3 (common state restore).
@@ -981,6 +981,7 @@ User
 │   │   │   └── CapacitySegment (many)
 │   ├── ProjectDiscount (many)
 │   ├── BacklogSnapshot (many)
+│   │   └── CapacityProfile (many, per project, own segments)
 │   ├── TimelineEntry (one per Feature)
 │   └── GeneratedDocument (many)
 ├── Customer (many, owned by user)

--- a/docs/FUNCTIONAL_SPEC.md
+++ b/docs/FUNCTIONAL_SPEC.md
@@ -203,7 +203,7 @@ All levels support full CRUD (create, read, update, delete) and drag-and-drop re
 
 - Accessible from the Backlog page
 - Shows a list of named snapshots with timestamp, trigger, and optional label
-- Snapshot triggers: `manual`, `csv_import`, `template_apply`, `optimiser_apply`, `pre_rollback`
+- Snapshot triggers: `manual`, `csv_import`, `template_apply`, `optimiser_apply`, `level_resources`, `pre_rollback`
 - Click any snapshot to **preview** the historical state
 - **Rollback** button restores the backlog to the selected snapshot (auto-saves a pre-rollback snapshot first)
 
@@ -850,7 +850,7 @@ The snapshot schema has three versions:
 | Field | Notes |
 |---|---|
 | Label | Optional user-provided name |
-| Trigger | `manual`, `csv_import`, `template_apply`, `optimiser_apply`, `pre_rollback` |
+| Trigger | `manual`, `csv_import`, `template_apply`, `optimiser_apply`, `level_resources`, `pre_rollback` |
 | Created at | Timestamp |
 | Created by | User who triggered the snapshot |
 | schemaVersion | 3 (current); older snapshots may be 2 or 1 (no field) |
@@ -861,11 +861,12 @@ See the [Snapshot v3 design](domain/capacity-profile-design.md#snapshot-schema-v
 
 | Trigger | When it fires |
 |---|---|
-| `csv_import` | Immediately before a CSV import is committed |
-| `template_apply` | Immediately before applying a template to a story |
-| `optimiser_apply` | Immediately before the optimiser applies a scenario |
-| `pre_rollback` | Immediately before a rollback is applied (captures current state so the rollback is reversible) |
 | `manual` | User clicks "Save snapshot" button in History panel |
+| `csv_import` | Immediately before a CSV import is committed |
+| `template_apply` | Immediately before applying a template to a story or refreshing from template |
+| `optimiser_apply` | Immediately before the Optimiser or Squad Planner applies a scenario |
+| `level_resources` | Immediately before resource levelling is applied from the Timeline page |
+| `pre_rollback` | Immediately before a rollback is applied (captures current state so the rollback is reversible) |
 
 ### Rollback Behaviour
 
@@ -880,7 +881,6 @@ Rollback behaviour depends on the snapshot's schema version:
 6. Timeline entries, story timeline entries, dependencies, and overheads are deleted and recreated from snapshot data.
 7. **All existing CapacityProfile and CapacitySegment rows are deleted** and recreated **exactly** from the snapshot's `capacityProfiles` array — preserving profile IDs, owner kinds, owner IDs, planning basis, source, default percent, profile window, legacy JSON, and every segment with its ID, weeks, capacity percent, and source.
 8. All writes share one `$transaction` — any failure rolls back every change including the pre-rollback capture.
-9. Timeline entries are restored from snapshot data.
 
 **V2 (schemaVersion: 2) — Full state + best-effort legacy profile reconstruction:**
 1–6. Same as V3 (common state restore).
@@ -975,13 +975,12 @@ User
 │   │           └── Task (many, ordered)
 │   ├── ResourceType (many, project-scoped)
 │   │   └── NamedResource (many)
-│   │       ├── CapacityProfile (one, optional)
+│   │       ├── CapacityProfile (zero-or-more, during migration)
 │   │       │   └── CapacitySegment (many)
-│   │   ├── CapacityProfile (one per ResourceType, for role-level)
+│   │   ├── CapacityProfile (zero-or-more, during migration)
 │   │   │   └── CapacitySegment (many)
 │   ├── ProjectDiscount (many)
-│   ├── BacklogSnapshot (many)
-│   │   └── CapacityProfile (many, per project, own segments)
+│   ├── BacklogSnapshot (many, v3 JSON embeds serialized CapacityProfile[])
 │   ├── TimelineEntry (one per Feature)
 │   └── GeneratedDocument (many)
 ├── Customer (many, owned by user)
@@ -1057,12 +1056,11 @@ per-version details.
 
 Key points:
 1. Auto-snapshot of current state (trigger: `pre_rollback`) so rollback is reversible.
-2. Cascade-delete all epics (removes features, stories, tasks, timeline entries).
+2. Cascade-delete all epics (removes features, stories, and tasks).
 3. Recreate entire hierarchy from snapshot JSON.
 4. Resource types re-matched by name — if a resource type was renamed since the snapshot, tasks for that type will have no resource type after rollback.
-5. Timeline entries are **not** restored; the Gantt will regenerate from the restored backlog structure.
+5. **V3 & V2:** Timeline entries, story timeline entries, dependencies, and overheads are restored from snapshot data. **V1:** Timeline entries are **not** restored — the Gantt will regenerate from the restored backlog structure.
 6. **V3 rollback additionally replaces** all project capacity profiles and segments exactly from the snapshot data. V2 rollback reconstructs best-effort legacy profiles. V1 rollback leaves profiles untouched.
-
 ### Inactive Items
 
 `isActive = false` on any level excludes that level and all its children from:

--- a/docs/domain/capacity-profile-design.md
+++ b/docs/domain/capacity-profile-design.md
@@ -213,7 +213,7 @@ Resource Profile should explain staffing and assignment:
 
 Use plain labels such as **Capacity profile**, **Reserved capacity**, **Assigned work**, **Assigned days**, **Named person**, and **Planned resource**.
 
-**Current implementation status (PR #356, pending merge):** Resource Profile and CSV
+**Current implementation status:** PR #356 (merged) made Resource Profile and CSV
 reads resolve each owner in this order: a valid persisted
 `CapacityProfile`/`CapacitySegment`; active Capacity Plan slot materialisation only when
 `shouldFallbackToActiveCapacityPlan` requires it; then pure legacy fields.
@@ -269,9 +269,9 @@ Billing basis: Bill actual scheduled days
 Billable days: 52.8
 ```
 
-### Pending implementation (PR #356, open)
+### PR #356 implementation (merged)
 
-On merge, the CSV export in `useResourceProfileExport.ts` will implement the following
+After PR #356 merged, the CSV export in `useResourceProfileExport.ts` implemented the following
 columns, aligned with the design above:
 
 | Column | Source | Notes |
@@ -318,7 +318,7 @@ Billable days: based on reserved/planned capacity
 4. **Resource Counts cleanup** — address #311 and split simple capacity from detailed profile editing.
 5. **Export cleanup** — redesign Resource Profile export around plain-English handover sections.
 6. **First-class capacity profiles** — add segmented capacity profile model and editor.
-7. **Resource Profile and Export Adoption (PR #356, pending merge)** — adopt profile-first
+7. **Resource Profile and Export Adoption** — PR #356 (merged). Adopt profile-first
    reads in Resource Profile route and export hook; add adapter, legacy projection helper,
    resolutionSource; add Planning basis, Profile source, Default capacity %, Profile
    start/end CSV columns.
@@ -379,7 +379,7 @@ It produces a structured report with:
   data.
 - **After PR #355**, write-path routes (`PUT/PATCH/DELETE` resource-types and
   named-resources) use `syncCapacityProfilesForProject` to keep the additive read model
-  in sync. PR #356 (pending merge) extends read adoption to the Resource Profile route
+  in sync. PR #356 extended read adoption to the Resource Profile route
   and export hook.
 - **No schema or migration changes** are required for the backfill/reconciliation.
 - The backfill is idempotent — running it multiple times is safe.
@@ -506,10 +506,8 @@ Tests use the real `syncCapacityProfilesForProject` helper (not mocked). See `se
 
 ## Resource Profile and Export Adoption
 
-> **Pending merge:** This section describes changes introduced by PR #356, which is
-> currently open and awaiting review (branch `feature/capacity-profile-resource-profile-reads`).
-> The adapter, route projection, client types, and CSV export changes described below
-> will become authoritative when PR #356 merges to `main`.
+> **Note:** This section describes changes shipped by PR #356 (merged).
+
 
 ### Adapter
 
@@ -625,9 +623,8 @@ format (e.g. `W1-W4 50%; W5-W10 100%`), structurally distinct from the existing
 - **Profile-first read precedence.** The adapter uses persisted `CapacityProfile`
   data directly when the owner-specific profile exists (`resolutionSource: 'PROFILE'`).
   No reconciliation gate is used — the old behaviour of falling back on mismatch
-  was replaced by direct persisted-profile usage (PR #356, pending merge).
+  was replaced by direct persisted-profile usage (PR #356, merged).
 - **Fallback precedence (exact order):**
-  1. Persisted owner-specific profile → `resolutionSource: 'PROFILE'`.
   2. Active Capacity Plan materialisation → `resolutionSource: 'ACTIVE_CAPACITY_PLAN'`.
      Applies only when `shouldFallbackToActiveCapacityPlan` logic requires it
      (e.g. `allocationMode === 'CAPACITY_PLAN'` with no explicit profile override).
@@ -708,3 +705,145 @@ format (e.g. `W1-W4 50%; W5-W10 100%`), structurally distinct from the existing
 
 See the separate [`capacity-profile-source-of-truth-migration-plan.md`](capacity-profile-source-of-truth-migration-plan.md) for the staged migration plan, field audit, regression matrix, and open decisions.
 
+
+## Snapshot schema v3 / snapshot rollback capacity safety
+
+> **Pending merge:** PR #357 (open, branch `feature/snapshot-v3-capacity-profiles`)
+> extends the BacklogSnapshot to version 3 so that rollback preserves capacity
+> profile data. This section describes the v3 design; it will become authoritative
+> when PR #357 merges to `main`.
+
+### Motivation
+
+Before PR #357, snapshots captured the epic tree only (V1) or the full project
+state minus capacity profiles (V2). A rollback would either leave profiles untouched
+(V1) or reconstruct them from legacy compatibility fields (V2). Neither preserved
+segmented capacity data, explicit `PLANNED_RESOURCE` ownership, or manual profile
+configuration.
+
+V3 makes capacity profiles a first-class citizen of the snapshot/rollback mechanism.
+The profile and segment data captured at snapshot time is restored exactly on
+rollback, without interpolation or reconstruction.
+
+### Schema versions
+
+| Version | `schemaVersion` | Profile behaviour |
+|---------|-----------------|-------------------|
+| V1 | absent (bare epic array or `{ epics }` without `schemaVersion`) | Epic tree only. No RT, NR, profile, segment, timeline, or capacity-plan data. Rollback leaves profiles untouched. |
+| V2 | `2` | Full state except profiles. Rollback deletes all existing profiles/segments and reconstructs best-effort legacy profiles from V2 compatibility fields (`allocationMode`, `allocationPercent`, etc.). No segments are recreated. |
+| V3 | `3` | Full state including `capacityProfiles: SnapshotCapacityProfile[]`. Rollback deletes all existing profiles/segments and replaces them exactly from snapshot data. |
+
+### V3 payload — preserved fields
+
+Each `SnapshotCapacityProfile` (in `projectSnapshotTypes.ts`):
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `id` | `string` | Original profile ID, persisted exactly |
+| `ownerKind` | `ROLE` / `NAMED_PERSON` / `PLANNED_RESOURCE` | Original owner kind |
+| `resourceTypeId` | `string \| null` | Non-null for ROLE; null otherwise |
+| `namedResourceId` | `string \| null` | Non-null for NAMED_PERSON/PLANNED_RESOURCE; null otherwise |
+| `planningBasis` | enum | Original planning basis (DEMAND_FOLLOWING, AVAILABILITY_WINDOW, etc.) |
+| `source` | enum | Original profile source (FIXED, MANUAL, SQUAD_PLANNER, etc.) |
+| `defaultPercent` | `number \| null` | Profile-level default capacity % |
+| `startWeek` / `endWeek` | `number \| null` | Nullable profile window |
+| `legacy` | `unknown` | Original legacy JSON (may be `null`); preserved verbatim |
+| `segments` | `SnapshotCapacitySegment[]` | Full segment set |
+
+Each `SnapshotCapacitySegment`:
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `id` | `string` | Segment ID, persisted exactly |
+| `startWeek` | `number` | Start week (inclusive) |
+| `endWeek` | `number` | End week (inclusive) |
+| `capacityPercent` | `number` | Capacity percentage for this window |
+| `source` | enum | Original segment source |
+
+### Deterministic ordering
+
+Profiles are ordered by:
+1. `ownerKind` (alphabetical: NAMED_PERSON, PLANNED_RESOURCE, ROLE)
+2. Owner identity (`resourceTypeId` for ROLE, `namedResourceId` for NAMED_PERSON/PLANNED_RESOURCE)
+3. Profile ID (deterministic tie-breaker)
+
+Segments within each profile are ordered by:
+1. `startWeek` (ascending)
+2. `endWeek` (ascending)
+3. Segment ID (deterministic tie-breaker)
+
+This ordering (implemented by `sortSnapshotProfiles` and `sortSnapshotSegments` in
+`projectSnapshotValidation.ts`) ensures deterministic JSON output regardless of
+insertion order or database retrieval order.
+
+### Pre-rollback capture (transaction-safe)
+
+Before any destructive rollback write, a v3 snapshot of the current project state
+(including all capacity profiles and segments) is captured with `trigger: 'pre_rollback'`
+inside the same `$transaction` as the restore. This guarantees:
+- The pre-rollback state is fully reversible (user can roll back to the pre-rollback snapshot).
+- If the rollback transaction fails, the pre-rollback capture is rolled back too — no orphaned pre-rollback entries.
+- Retention follows `pruneSnapshots` (keep 20 most-recent per project).
+
+### Validation (pre-rollback structural checks)
+
+The snapshot payload is validated by `validateSnapshotV3` before any destructive
+operation begins:
+
+- Profile and segment IDs: non-empty strings, globally unique within the snapshot.
+- `ownerKind`: must belong to `[ROLE, NAMED_PERSON, PLANNED_RESOURCE]`.
+- Shape rules per owner kind (e.g. ROLE requires `resourceTypeId` and null `namedResourceId`).
+- Owner reference integrity: referenced IDs exist in the snapshot's own `resourceTypes`/`namedResources` lists.
+- Every `NamedResource.resourceTypeId` and every non-null `overheadItems.resourceTypeId` exists in the snapshot's `resourceTypes` list.
+- `planningBasis`, `source` (profile and segment): belong to the supported Prisma enum sets.
+- Numeric validations: `defaultPercent` (null or finite ≥ 0), `startWeek`/`endWeek` (null or finite number, end ≥ start), `capacityPercent` (finite ≥ 0).
+- `legacy` is captured as-is (`unknown`); its content is not validated.
+
+Explicitly not rejected: duplicate owners (preserved for #361), >100% role aggregate,
+overlapping/discontinuous segments. These are valid profile shapes.
+
+A cross-project relation preflight verifies that all snapshot resource types,
+named resources, and resource-type FKs on overhead items do not belong to another
+project in the current DB state, preventing orphaned cross-project references
+before any write begins.
+
+### V3 restore — exact profile replacement
+
+The restore (`recreateV3CapacityProfiles` in `projectSnapshotCapacity.ts`)
+runs inside the same atomic `$transaction` as the full project state restore:
+
+1. Pre-rollback v3 capture of current state.
+2. Common state restore: upsert RTs, upsert NRs, delete-and-recreate epics (cascade),
+   update project fields, delete-and-recreate timeline/story entries/dependencies/overheads.
+3. Delete ALL existing `CapacityProfile` and `CapacitySegment` rows for the project.
+4. Recreate every profile with exact snapshot IDs, `projectId` forced to the route
+   project, owner IDs, enum values, nulls, and `legacy`. Every segment recreated
+   with exact `id`, profile FK, values, and `source`.
+5. `pruneSnapshots` inside the same transaction.
+
+No broad legacy sync or CapacityPlan interpolation follows.
+
+### V1 and V2 restore behaviour
+
+**V1 (epic-only):** Deletes only epics (cascade). Leaves RTs, NRs, profiles, segments,
+and capacity plan data untouched.
+
+**V2 (full state + legacy reconstruction):** Restores full common state, then deletes
+all existing profiles/segments and creates best-effort legacy profiles from
+V2 compatibility fields. **Role profiles for every ResourceType** (synthetic IDs
+`snapshot-v2-role-{rtId}`), **named-person profiles for every NamedResource**
+(synthetic IDs `snapshot-v2-named-{nrId}`).
+No segments are created. No active Capacity Plan materialisation. Planned-resource ownership and manual segment fidelity are not claimed for V2-restored profiles.
+
+### Scope boundaries
+
+- **No Prisma schema migration in #357.** Capacity profiles live in the existing
+  `BacklogSnapshot.snapshot` JSON column. Types, validation, and capacity helpers
+  are pure runtime additions.
+- **Capacity Plan history is owned by #359.** PR #357 does not snapshot or restore
+  the `CapacityPlan` table or its periods/entries.
+- **Duplicate owner consolidation is owned by #361.**
+- **BuildSnapshot produces v3** for all new snapshots (manual, `csv_import`,
+  `template_apply`, `optimiser_apply`, `pre_rollback` triggers).
+- **Existing V1 and V2 snapshots remain readable** and restore successfully with
+  version-appropriate profile handling.

--- a/docs/domain/capacity-profile-design.md
+++ b/docs/domain/capacity-profile-design.md
@@ -717,10 +717,9 @@ See the separate [`capacity-profile-source-of-truth-migration-plan.md`](capacity
 
 ## Snapshot schema v3 / snapshot rollback capacity safety
 
-> **Pending merge:** PR #357 (open, branch `feature/snapshot-v3-capacity-profiles`)
+> **Pending merge:** PR #367 (open, branch `feature/snapshot-v3-capacity-profiles`)
 > extends the BacklogSnapshot to version 3 so that rollback preserves capacity
-> profile data. This section describes the v3 design; it will become authoritative
-> when PR #357 merges to `main`.
+> profile data. This section describes the implemented v3 behaviour pending merge.
 
 ### Motivation
 
@@ -734,13 +733,19 @@ V3 makes capacity profiles a first-class citizen of the snapshot/rollback mechan
 The profile and segment data captured at snapshot time is restored exactly on
 rollback, without interpolation or reconstruction.
 
+V3 does not prune owners that are outside the profile snapshot boundary. The
+common restore upserts captured `ResourceType` and `NamedResource` metadata but
+retains post-snapshot owners, compatibility fields, `TemplateTask.resourceTypeId`
+links, and `ProjectDiscount` rows. Only `CapacityProfile` and `CapacitySegment`
+rows are replaced exactly from the v3 payload.
+
 ### Schema versions
 
 | Version | `schemaVersion` | Profile behaviour |
 |---------|-----------------|-------------------|
 | V1 | absent (bare epic array or `{ epics }` without `schemaVersion`) | Epic tree only. No RT, NR, profile, segment, timeline, or capacity-plan data. Rollback leaves profiles untouched. |
 | V2 | `2` | Full state except profiles. Rollback deletes all existing profiles/segments and reconstructs best-effort legacy profiles from V2 compatibility fields (`allocationMode`, `allocationPercent`, etc.). No segments are recreated. |
-| V3 | `3` | Full state including `capacityProfiles: SnapshotCapacityProfile[]`. Rollback deletes all existing profiles/segments and replaces them exactly from snapshot data. |
+| V3 | `3` | Full state including `capacityProfiles: SnapshotCapacityProfile[]`. Rollback replaces profiles/segments exactly; ResourceType/NamedResource rows created after the snapshot and their non-snapshot metadata remain intact. |
 
 ### V3 payload — preserved fields
 
@@ -822,8 +827,10 @@ The restore (`recreateV3CapacityProfiles` in `projectSnapshotCapacity.ts`)
 runs inside the same atomic `$transaction` as the full project state restore:
 
 1. Pre-rollback v3 capture of current state.
-2. Common state restore: upsert RTs, upsert NRs, delete-and-recreate epics (cascade),
-   update project fields, delete-and-recreate timeline/story entries/dependencies/overheads.
+2. Common state restore: upsert captured RTs and NRs, delete-and-recreate epics
+   (cascade), update project fields, and delete-and-recreate timeline/story
+   entries, dependencies, and overheads. Owners absent from the snapshot are
+   not deleted; `TemplateTask` links and `ProjectDiscount` rows are untouched.
 3. Delete ALL existing `CapacityProfile` and `CapacitySegment` rows for the project.
 4. Recreate every profile with exact snapshot IDs, `projectId` forced to the route
    project, owner IDs, enum values, nulls, and `legacy`. Every segment recreated

--- a/docs/domain/capacity-profile-design.md
+++ b/docs/domain/capacity-profile-design.md
@@ -630,7 +630,10 @@ format (e.g. `W1-W4 50%; W5-W10 100%`), structurally distinct from the existing
   data directly when the owner-specific profile exists (`resolutionSource: 'PROFILE'`).
   No reconciliation gate is used — the old behaviour of falling back on mismatch
   was replaced by direct persisted-profile usage (PR #356, merged).
-- **Fallback precedence (exact order):**
+- **Resolution precedence (exact order):**
+  1. Persisted owner-specific profile → `resolutionSource: 'PROFILE'`.
+     The adapter uses a persisted `CapacityProfile`/`CapacitySegment` directly
+     when it exists for the owner.
   2. Active Capacity Plan materialisation → `resolutionSource: 'ACTIVE_CAPACITY_PLAN'`.
      Applies only when `shouldFallbackToActiveCapacityPlan` logic requires it
      (e.g. `allocationMode === 'CAPACITY_PLAN'` with no explicit profile override).
@@ -675,9 +678,9 @@ format (e.g. `W1-W4 50%; W5-W10 100%`), structurally distinct from the existing
   and carry their profile metadata as a unit — segments are a property of the
   profile, not a split of the entity.
 - **Duplicate persisted conflicts do not block fallback.** If the adapter's profile
-  map encounters duplicate entries for the same owner key (should not occur under
-  normal operation, but defensive), it does not throw or block — the duplicate
-  entry is skipped and the fallback tier (`LEGACY` or `ACTIVE_CAPACITY_PLAN`)
+  map encounters duplicate entries for the same owner key (possible in migration
+  states preceding #361, handled defensively), it does not throw or block — the
+  duplicate entry is skipped and the fallback tier (`LEGACY` or `ACTIVE_CAPACITY_PLAN`)
   applies for that owner as if no profile existed.
 - **Role and named-resource lookups are independently keyed.** Role (ResourceType)
   profiles are keyed by `resourceTypeId`; named-resource (NamedResource) profiles

--- a/docs/domain/capacity-profile-design.md
+++ b/docs/domain/capacity-profile-design.md
@@ -214,9 +214,15 @@ Resource Profile should explain staffing and assignment:
 Use plain labels such as **Capacity profile**, **Reserved capacity**, **Assigned work**, **Assigned days**, **Named person**, and **Planned resource**.
 
 **Current implementation status:** PR #356 (merged) made Resource Profile and CSV
-reads resolve each owner in this order: a valid persisted
-`CapacityProfile`/`CapacitySegment`; active Capacity Plan slot materialisation only when
-`shouldFallbackToActiveCapacityPlan` requires it; then pure legacy fields.
+reads resolve each owner in this order:
+
+1. **Persisted owner-specific profile** → `resolutionSource: PROFILE` — a valid persisted
+   `CapacityProfile`/`CapacitySegment` exists for the owner.
+2. **Active Capacity Plan fallback** → `resolutionSource: ACTIVE_CAPACITY_PLAN` —
+   materialise from active `CapacityPlan` periods only when
+   `shouldFallbackToActiveCapacityPlan` requires it.
+3. **Pure legacy fallback** → `resolutionSource: LEGACY` — derive from legacy
+   `ResourceType`/`NamedResource` fields.
 Persisted profile adoption drives display and export from `CapacityProfile`/`CapacitySegment`
 data. Separately, the pre-existing active Capacity Plan fallback in
 `namedResourceAssignments.ts` uses segment-aware trajectory capacity for named-resource
@@ -747,7 +753,7 @@ Each `SnapshotCapacityProfile` (in `projectSnapshotTypes.ts`):
 | `source` | enum | Original profile source (FIXED, MANUAL, SQUAD_PLANNER, etc.) |
 | `defaultPercent` | `number \| null` | Profile-level default capacity % |
 | `startWeek` / `endWeek` | `number \| null` | Nullable profile window |
-| `legacy` | `unknown` | Original legacy JSON (may be `null`); preserved verbatim |
+| `legacy` | `SnapshotJsonValue` | Original legacy JSON (may be `null`); preserved verbatim |
 | `segments` | `SnapshotCapacitySegment[]` | Full segment set |
 
 Each `SnapshotCapacitySegment`:

--- a/docs/domain/capacity-profile-source-of-truth-migration-plan.md
+++ b/docs/domain/capacity-profile-source-of-truth-migration-plan.md
@@ -1,8 +1,8 @@
 # Capacity Profile — Source-of-Truth Migration Plan
 
 **Epic:** #340  
-**Status:** Phase 1 (Read-side contracts) — PR #356 (open, pending merge)  
-**PR:** #344 (plan document), #356 (read adoption; open)
+**Status:** Phase 1 (Read-side contracts) ✅ (PR #356 merged)  
+**PR:** #344 (plan document), #356 (read adoption; merged)
 
 ## Overview
 
@@ -11,7 +11,7 @@ Issues #326, #336, #337, #338, #339, and issue #341 define the `CapacityProfile`
 PR #336 added the persisted-read endpoint (`GET /capacity-profiles`) with a reconciliation
 gate — persisted profiles were used only when they matched legacy-derived expectations.
 
-PR #356 (profile-first read adoption, currently open and pending merge) removes the
+PR #356 (profile-first read adoption, merged) removed the
 reconciliation gate for the Resource Profile route. Resolution is owner-specific and
 ordered: a valid persisted profile (`resolutionSource: 'PROFILE'`); active Capacity Plan
 materialisation only when `shouldFallbackToActiveCapacityPlan` requires it
@@ -29,7 +29,7 @@ allocation data.
 
 ## Principles
 
-1. **Read adoption before write migration.** Read paths were migrated first (#336). PR #355 (merged) then established profile-first writes for ResourceType and NamedResource write paths. PR #356 (pending merge) extends read adoption to Resource Profile and exports.
+1. **Read adoption before write migration.** Read paths were migrated first (#336). PR #355 (merged) then established profile-first writes for ResourceType and NamedResource write paths. PR #356 (merged) extended read adoption to Resource Profile and exports.
 2. **Migrate one authoritative write path at a time.** Each phase flips one write path to produce capacity profiles as source of truth and project legacy fields as compatibility.
 3. **Keep legacy fields as compatibility projections** until all consumers have migrated. Do not remove them until #342.
 4. **Commercial remains billing-only.** Capacity profiles describe availability, not billing.
@@ -99,10 +99,145 @@ This means:
 - `server/src/lib/capacityProfileLegacyProjection.ts` — #341 helper: `projectCapacityProfileToLegacyAllocation` projects profile data into legacy display field shape
 - `server/src/lib/projectPlanningModel.ts` — reads RT/NR allocation fields for resource-demand calculation
 - `server/src/lib/namedResourceAssignments.ts` — reads NR allocation fields for assignment logic
-- `server/src/lib/scheduler.ts` — consumes allocation fields, `phantomSlots` uses `count`
-- `server/src/lib/leveller.ts` — reads resource availability for levelling
-- `server/src/lib/capacityPlanMaterialisation.ts` — materialises capacity plans into segments
-- `server/src/lib/capacity-planning/` — Squad Planner helpers
+
+### Phase 2b — Snapshot v3 capacity-profile preservation 🚧 (PR #357 open, pending merge)
+
+PR #357 (open, pending merge, branch `feature/snapshot-v3-capacity-profiles`) extends the
+BacklogSnapshot schema to version 3 so that rollback preserves capacity profile data.
+Snapshot v3 is the first-class representation for capacity profiles; v2 and v1 snapshots
+are still accepted on restore without data loss.
+
+#### Schema versions
+
+| Version | Identifier | Content |
+|---------|-----------|---------|
+| **V1** | No `schemaVersion` field (bare epic array or `{ epics: … }` without `schemaVersion`) | Epic tree only. No resource types, named resources, timeline entries, dependencies, overheads, or capacity profiles. |
+| **V2** | `schemaVersion: 2` | Epic tree + project fields + resource types + named resources + timeline entries + story timeline entries + dependencies + overhead items. No first-class capacity profiles. |
+| **V3** | `schemaVersion: 3` | All V2 fields plus `capacityProfiles: SnapshotCapacityProfile[]`. Each profile carries its full segment set. |
+
+#### V3 snapshot content
+
+`buildSnapshot` (in `snapshots.ts`) returns `schemaVersion: 3` for all new application snapshots
+(manual, `csv_import`, `template_apply`, `optimiser_apply`, and `pre_rollback` triggers). The
+v3 payload includes:
+
+- **CapacityProfile**: `id`, `ownerKind` (`ROLE`/`NAMED_PERSON`/`PLANNED_RESOURCE`), `resourceTypeId`
+  or `namedResourceId` (owner identity), `planningBasis`, `source`, `defaultPercent` (nullable),
+  `startWeek`/`endWeek` (nullable profile window), `legacy` (original legacy JSON, which may be
+  `null`), and `segments`.
+- **CapacitySegment** (per profile): `id`, `startWeek`, `endWeek`, `capacityPercent`, `source`.
+- Profiles are ordered deterministically: owner identity (ownerKind → resourceTypeId/namedResourceId) → profile ID.
+- Segments are ordered deterministically: startWeek → endWeek → segment ID.
+
+#### Pre-rollback capture
+
+Before any destructive write, the current project state is captured as a v3 snapshot
+(`trigger: 'pre_rollback'`) inside the same transaction that applies the rollback. This
+makes any rollback itself reversible — the pre-rollback snapshot captures capacity profiles
+along with every other project dimension. Retention of the pre-rollback snapshot is subject
+to the same `pruneSnapshots` (keep 20 most-recent) policy as all other snapshots.
+
+#### V3 validation
+
+Before any destructive write begins, the target snapshot is validated structurally:
+
+- Profile `id` and segment `id`: non-empty, globally unique within the snapshot.
+- `ownerKind`: member of `[ROLE, NAMED_PERSON, PLANNED_RESOURCE]`.
+- Owner-kind shape rules: `ROLE` requires non-empty `resourceTypeId` and null `namedResourceId`;
+  `NAMED_PERSON`/`PLANNED_RESOURCE` require non-empty `namedResourceId` and null `resourceTypeId`.
+- Owner reference integrity: `resourceTypeId` exists in the snapshot's `resourceTypes` list;
+  `namedResourceId` exists in `namedResources`; the named resource's own `resourceTypeId` also exists.
+- Every `NamedResource.resourceTypeId` and every non-null `overheadItems.resourceTypeId` exists in the snapshot's `resourceTypes` list.
+- `planningBasis` and `source` belong to the supported Prisma enum sets.
+- `defaultPercent`: null or finite ≥ 0.
+- Profile `startWeek`/`endWeek`: null or finite number with end ≥ start.
+- Segment `startWeek`/`endWeek`: finite numbers with end ≥ start.
+- Segment `capacityPercent`: finite ≥ 0.
+- Segment `source`: supported enum value.
+- The `legacy` field is captured as-is (`unknown`); its content is not validated.
+
+What is **not** rejected:
+- Duplicate owner keys (same `resourceTypeId`/`namedResourceId` across multiple profiles) —
+  preserved for #361 (consolidation).
+- Role-level aggregate > 100% — valid for multi-resource roles.
+- Overlapping or discontinuous segments — the profile shape is preserved exactly.
+
+Additionally, a cross-project relation preflight verifies that all snapshot
+`resourceTypes`, `namedResources`, and resource-type FKs on overhead items do not
+belong to another project in the current DB state, preventing orphaned
+cross-project references before any write begins.
+
+#### V3 restore (exact replacement)
+
+V3 restore runs in the same atomic `$transaction` as the full project state restore:
+
+1. Pre-rollback v3 snapshot of current project state.
+2. Common v2 restoration: upsert ResourceTypes, upsert NamedResources, delete-and-recreate
+   epics (with cascade), update project fields, delete-and-recreate timeline entries,
+   story timeline entries, dependencies, and overhead items.
+3. **Capacity profile replacement**: delete ALL existing `CapacityProfile` and
+   `CapacitySegment` rows for the project, then recreate every profile with its exact
+   snapshot IDs, `projectId` forced to the route project, owner IDs, enum values, nulls,
+   and `legacy`. Every segment is recreated with exact `id`, profile FK, values, and `source`.
+4. `pruneSnapshots` (retention policy) inside the same transaction.
+
+All writes share one transaction — any failure before commit rolls back every change
+including the pre-rollback capture. The restore is an exact replacement: no broad legacy
+sync or CapacityPlan interpolation follows.
+
+#### V1 restore (epic-only)
+
+V1 snapshots contain only an epic tree (no resource types, named resources, capacity
+profiles, segments, timeline entries, or capacity plan data). Restoring a V1 snapshot:
+
+- Deletes only epics (cascade) and recreates the tree from snapshot JSON.
+- Leaves ResourceType, NamedResource, CapacityProfile, CapacitySegment, and capacity
+  plan data entirely untouched.
+- Resource types are still re-matched by name for task FKs (same as always).
+- Timeline entries are **not** restored (same as always — Gantt regenerates).
+
+#### V2 restore (full state + best-effort legacy profile reconstruction)
+
+V2 snapshots capture the full project state but have no first-class `capacityProfiles`
+array. During V2 restore:
+1. Full common state is restored (RTs, NRs, epics, timeline, dependencies, overheads).
+
+2. `recreateV2CapacityProfiles` runs: all existing project profiles and segments are
+   **deleted**, then best-effort legacy profiles are created:
+   - **Role profiles** for every snapshot `ResourceType` — each role gets a ROLE-kind
+     profile with synthetic ID `snapshot-v2-role-{rtId}`.
+   - **Named-person profiles** for every snapshot `NamedResource` — each named resource
+     gets a NAMED_PERSON-kind profile with synthetic ID `snapshot-v2-named-{nrId}`.
+   - `planningBasis` and `source` mapped from the legacy `allocationMode` field
+     (`TIMELINE → AVAILABILITY_WINDOW`, `FULL_PROJECT → WHOLE_PROJECT_ALLOCATION`,
+     `CAPACITY_PLAN → CAPACITY_PROFILE`, `EFFORT`/others → `DEMAND_FOLLOWING`).
+   - Effective availability window resolved from `allocationPercent`/`allocationPct`
+     and `allocationStartWeek`/`allocationEndWeek`/`startWeek`/`endWeek` precedence.
+   - All profiles capture the original V2 field values in their `legacy` JSON.
+3. **No segments are created** — V2 snapshots do not carry segment data, so profile
+   availability is represented only at the profile level (no per-segment breakdown).
+4. **No active Capacity Plan materialisation** — the V2 restore helper never reads
+   the active `CapacityPlan`. Planned-resource ownership and manual segment fidelity
+   are not claimed for V2-restored profiles.
+5. The delete-and-recreate is inside the same transaction as the full state restore.
+
+#### No Prisma schema migration in #357
+
+PR #357 introduces no Prisma schema migration. The `capacityProfiles` field is stored
+inside the existing `BacklogSnapshot.snapshot` JSON column. The new TypeScript types,
+validation, and capacity helpers are pure runtime additions.
+
+#### Out of scope: Capacity Plan history (#359)
+
+Capacity Plan history — snapshotting and restoring the `CapacityPlan` table and its
+periods/entries — is not part of PR #357. Rollback of capacity plan data is tracked
+by #359 and will be addressed separately.
+
+**Server lib snapshot v3 files:**
+- `server/src/lib/projectSnapshotTypes.ts` — SnapshotV1, SnapshotV2, SnapshotV3 type definitions, `SnapshotCapacityProfile`, `SnapshotCapacitySegment`, type guards, `parseSnapshotData`
+- `server/src/lib/projectSnapshotValidation.ts` — `validateSnapshotV3` structural validation, `sortSnapshotProfiles`, `sortSnapshotSegments` stable ordering
+- `server/src/lib/projectSnapshotCapacity.ts` — `recreateV2CapacityProfiles` (legacy reconstruction), `recreateV3CapacityProfiles` (exact replacement)
+- `server/src/lib/snapshotUtils.ts` — `pruneSnapshots` (retention policy, keep 20 most-recent)
 
 **Client:**
 - `client/src/components/resource-profile/ResourceProfileTab.tsx` — displays resource rows, reads `capacityProfile` if present, shows profile source tag and segments when authoritative
@@ -125,15 +260,15 @@ The audit above classifies all fields. Remaining decisions:
 | Multi-segment backward projection | (a) truncate to first/last segment start/end; (b) leave empty; (c) emit contiguous merged range | **(c)** — merged range is safest for backward compat but semantically lossy — document limitation |
 | `allocationPct` removal | (a) keep both forever; (b) normalise to `allocationPercent` only in migration | **(b)** — source-of-truth migration is the right moment |
 
-### Phase 1 — Harden read-side contracts 🚧 (PR #356 open, pending merge)
+### Phase 1 — Harden read-side contracts ✅ (PR #356 merged)
 
-PR #356 (open, pending merge) implements profile-first read adoption in the Resource
+PR #356 (merged) implemented profile-first read adoption in the Resource
 Profile route and export hook. The adapter (`capacityProfileResourceAdapter.ts`) uses
 profile-first precedence (no reconciliation gate), adds `resolutionSource`,
 `defaultPercent`, `startWeek`, `endWeek` to the output, and the legacy projection
 helper (`capacityProfileLegacyProjection.ts`) projects profile data into display fields.
 
-**Evidence from the PR #356 branch:**
+**Evidence from PR #356 (merged):**
 
 - **Resource Profile** reads capacity-profile DTOs safely via `buildResourceCapacityProfileMap`
   (tested: `capacityProfileResourceAdapter.test.ts` — 7 tests covering profile-first,
@@ -150,8 +285,7 @@ helper (`capacityProfileLegacyProjection.ts`) projects profile data into display
 export CSV → parsed spreadsheet columns. Consider adding if CSV parser roundtrip
 is a requirement.
 
-> **Note:** These changes exist on the `feature/capacity-profile-resource-profile-reads`
-> branch. They will become authoritative when PR #356 merges to `main`.
+> **Note:** These changes merged via PR #356 to `main`.
 
 >
 > **Adoption invariants maintained by PR #356:**
@@ -183,13 +317,13 @@ is a requirement.
 >   existing paths. Commercial billing formulas, billable days, discounts, tax,
 >   and totals remain unaffected.
 >
-### Phase 2 — Compatibility projection helpers 🚧 (PR #356 open, pending merge)
+### Phase 2 — Compatibility projection helpers ✅ (PR #356 merged)
 
-`projectCapacityProfileToLegacyAllocation` in `capacityProfileLegacyProjection.ts` is
-introduced by the PR #356 branch. It is a pure, lossy-aware projection helper that
+`projectCapacityProfileToLegacyAllocation` in `capacityProfileLegacyProjection.ts` was
+introduced by PR #356 (merged). It is a pure, lossy-aware projection helper that
 converts a `CapacityProfile` back into legacy allocation field shapes (`allocationMode`,
 `allocationPercent`, `allocationStartWeek`, `allocationEndWeek`) without writing
-to the database. On merge, the Resource Profile route will use it to project profile
+to the database. After PR #356 merged, the Resource Profile route uses it to project profile
 data into display fields when a resolved profile exists.
 
 **Write state:** PR #355 already performs profile-first writes and compatibility
@@ -433,8 +567,8 @@ segments. Multi-segment profiles are not yet consumed for per-week capacity cons
 | `timeline.ts` | RT/NR allocation fields | No | Profile DTO migration needed |
 | `projectPlanningModel.ts` | RT allocation fields | No | Profile DTO migration needed |
 | `leveller.ts` | RT/NR capacity constraints | No | Profile DTO migration needed |
-| `resourceProfile.ts` | RT/NR allocation fields (display) | Yes (PR #356 branch) | Already projects from profile when available |
-| `useResourceProfileExport.ts` | NR legacy fields (backup) | Yes (PR #356 branch) | Already prefers profile columns |
+| `resourceProfile.ts` | RT/NR allocation fields (display) | Yes (PR #356) | Already projects from profile when available |
+| `useResourceProfileExport.ts` | NR legacy fields (backup) | Yes (PR #356) | Already prefers profile columns |
 
 > **Important:** #342 is a field-cleanup chore, not a behavioural-change issue. It does
 > not authorise scheduler, leveller, Timeline, or Squad Planner algorithm changes. It
@@ -446,7 +580,7 @@ segments. Multi-segment profiles are not yet consumed for per-week capacity cons
 **Next step for #342:** Migrate each consumer above to read profile DTO data when
 available, starting with those that already have profile-aware infrastructure
 (the route and export hook in `resourceProfile.ts` and `useResourceProfileExport.ts`
-are already done on the PR #356 branch — focus on `scheduler.ts`, `timeline.ts`,
+are already done from PR #356 — focus on `scheduler.ts`, `timeline.ts`,
 `projectPlanningModel.ts`, and `leveller.ts`).
 
 

--- a/docs/domain/capacity-profile-source-of-truth-migration-plan.md
+++ b/docs/domain/capacity-profile-source-of-truth-migration-plan.md
@@ -105,7 +105,8 @@ This means:
 PR #357 (open, pending merge, branch `feature/snapshot-v3-capacity-profiles`) extends the
 BacklogSnapshot schema to version 3 so that rollback preserves capacity profile data.
 Snapshot v3 is the first-class representation for capacity profiles; v2 and v1 snapshots
-are still accepted on restore without data loss.
+are still accepted on restore, but v1 is epic-only (profiles untouched) and v2 is
+best-effort compatibility reconstruction (no segments or planned-resource ownership restored).
 
 #### Schema versions
 

--- a/docs/domain/capacity-profile-source-of-truth-migration-plan.md
+++ b/docs/domain/capacity-profile-source-of-truth-migration-plan.md
@@ -234,11 +234,106 @@ Capacity Plan history — snapshotting and restoring the `CapacityPlan` table an
 periods/entries — is not part of PR #357. Rollback of capacity plan data is tracked
 by #359 and will be addressed separately.
 
-**Server lib snapshot v3 files:**
-- `server/src/lib/projectSnapshotTypes.ts` — SnapshotV1, SnapshotV2, SnapshotV3 type definitions, `SnapshotCapacityProfile`, `SnapshotCapacitySegment`, type guards, `parseSnapshotData`
-- `server/src/lib/projectSnapshotValidation.ts` — `validateSnapshotV3` structural validation, `sortSnapshotProfiles`, `sortSnapshotSegments` stable ordering
-- `server/src/lib/projectSnapshotCapacity.ts` — `recreateV2CapacityProfiles` (legacy reconstruction), `recreateV3CapacityProfiles` (exact replacement)
-- `server/src/lib/snapshotUtils.ts` — `pruneSnapshots` (retention policy, keep 20 most-recent)
+### Null-state discrimination & PostgreSQL rollback CI 🚧 (PR #367 open, pending merge)
+
+PR #367 (open, pending, branch `feature/v3-snapshot-null-state`) introduces the
+`LegacyFieldDiscriminator` type that disambiguates three distinct null-states for the
+`CapacityProfile.legacy` JSON field and adds parameterised null-state detection that
+fails closed. The PR also adds a real PostgreSQL rollback integration suite as a
+required blocking CI step.
+
+#### Legacy discriminator: DB_NULL / JSON_NULL / VALUE
+
+The `legacy` field in `SnapshotCapacityProfile` stores the original per-profile JSON
+state captured at snapshot time. When reading this field back, there are three
+semantically distinct states:
+
+| Discriminator | DB representation | Meaning |
+|---------------|-------------------|---------|
+| **DB_NULL** | The `legacy` column is `NULL` in the database (or absent from the JSON payload) | No legacy data was ever captured — the profile was created directly from profile-first paths, not derived from legacy fields. |
+| **JSON_NULL** | The `legacy` column stores the JSON literal `null` (`… "legacy": null …` in the snapshot JSON) | Legacy data was intentionally captured as absent at snapshot time — the profile was snapshot-aware but had no legacy state to preserve. |
+| **VALUE** | The `legacy` column stores a non-null JSON value (object, array, string, number, boolean) | Legacy data was captured and is available. VALUE excludes the top-level JSON `null` literal but **allows `null` nested inside the value** (e.g., `{"allocationPercent": null, "allocationMode": "TIMELINE"}`). |
+
+The discriminator is resolved by checking the Postgres column null (`DB_NULL`) first,
+then parsing the JSON to distinguish `JSON_NULL` from `VALUE`. This tri-state exists
+because the `BacklogSnapshot.snapshot` column is a JSON column that roundtrips through
+Prisma's JSON type; a SQL `NULL` in the column and a JSON `null` value inside the
+JSON document are distinct in Postgres but collapse to the same `null` at the
+application level without explicit discrimination.
+
+#### Parameterised null-state detection
+
+The null-state detection function `resolveLegacyFieldState` is parameterised by a
+`lookup` callback so that callers can provide different query strategies (direct DB
+read, snapshot JSON parse, or cached lookup) without duplicating logic:
+
+```typescript
+function resolveLegacyFieldState(
+  projectId: string,
+  lookup: (projectId: string) => Promise<unknown | null>,
+): Promise<LegacyFieldDiscriminator>
+```
+
+**Fail-closed contract:** If the `lookup` callback rejects (query error) or returns
+`undefined`/`null` for the whole row (missing snapshot), the function returns
+`JSON_NULL` (the safest default — the caller must not assume VALUE data exists).
+It **never** returns `VALUE` on error, never throws, and never produces a false
+positive that would cause callers to interpret absent data as present.
+
+```typescript
+// Behaviour table
+// lookup result              → discriminator
+// Error/throw                → JSON_NULL (fail closed)
+// null | undefined (no row)  → JSON_NULL (fail closed)
+// DB NULL column             → DB_NULL
+// JSON null value            → JSON_NULL
+// Non-null JSON value        → VALUE
+```
+
+#### Real PostgreSQL rollback integration suite
+
+PR #367 introduces a dedicated rollback integration test suite that exercises the
+full snapshot → restore roundtrip against a **real PostgreSQL instance** (not
+mocked/SQLite). This suite:
+
+- Is defined in `server/src/test/rollback-pg/` and uses the same `testcontainers`
+  pattern (or direct Docker PostgreSQL) as the existing PostgreSQL integration tests.
+- Creates a fresh test project with ResourceTypes, NamedResources, epics, tasks,
+  capacity profiles and segments (V3 snapshot target).
+- Takes a V3 snapshot, mutates the project state (delete profiles, change fields),
+  then restores from the snapshot and asserts exact equality.
+- Exercises the `DB_NULL`, `JSON_NULL`, and `VALUE` discriminator paths with
+  dedicated test cases.
+- Asserts transaction atomicity: a mid-rollback failure leaves no partial state.
+
+**CI integration:** The PostgreSQL rollback suite is configured in `.github/workflows/`
+as a **required distinct CI step** that runs after the Prisma `migrations` +
+`generate` step and before any seed or application-start step. This ensures:
+
+1. Schema migrations are confirmed compatible with the target PostgreSQL version.
+2. The Prisma client is generated from the just-migrated schema.
+3. Rollback correctness is verified on a real PostgreSQL database **before** any
+   seed data or app containers start.
+4. A rollback regression blocks CI immediately — it is **not** configured with
+   `continue-on-error` or `skip`, and a failure fails the workflow.
+
+The step definition in CI:
+
+```yaml
+# PostgreSQL rollback integration (required, blocking)
+# Runs after migrations+generate, before seed/start
+```
+
+#### PR #367 status
+
+PR #367 remains **open and pending** merge. It blocks on:
+- Review of the `LegacyFieldDiscriminator` contract and fail-closed semantics.
+- Confirmation that the CI step runs at the correct stage (after migrations+generate,
+  before seed/start) and is marked as required (non-skippable).
+- No overclaim on data-loss protection: the integration suite verifies that rollback
+  restores exactly what was captured, but does **not** guarantee that rollback is a
+  universal data-loss prevention mechanism — it validates the snapshot/restore
+  machinery itself, not user behaviour or external triggers.
 
 **Client:**
 - `client/src/components/resource-profile/ResourceProfileTab.tsx` — displays resource rows, reads `capacityProfile` if present, shows profile source tag and segments when authoritative

--- a/docs/domain/planning-resource-commercial-boundaries.md
+++ b/docs/domain/planning-resource-commercial-boundaries.md
@@ -460,6 +460,11 @@ fields (`allocationMode`, `allocationPercent`, etc.) with no segment fidelity.
 - Commercial billing basis (`pricingModel`) is snapshotted via V2/V3 `namedResources`
   and remains Commercial-owned; V3 does not introduce a separate billing-basis
   snapshot field.
+- ProjectDiscount rows remain Commercial-owned and are not serialized into V3 snapshots.
+  During rollback, discounts linked to pruned ResourceTypes are deleted before those
+  owners are removed; project-wide discounts and discounts for target ResourceTypes
+  are preserved. A pruned role discount is never promoted to project-wide scope by
+  setting `resourceTypeId` to `null`.
 - Capacity Plan history (Capacity Plan periods/entries) is **not** part of PR #367;
   it is tracked by #359 separately.
 

--- a/docs/domain/planning-resource-commercial-boundaries.md
+++ b/docs/domain/planning-resource-commercial-boundaries.md
@@ -429,42 +429,52 @@ data survives rollback:
 
 **Resource Profile boundary strengthened.** Since `CapacityProfile` / `CapacitySegment`
 data is owned by Resource Profile (capacity inputs), V3 snapshots preserve this
-data exactly. A rollback would no longer reconstruct profiles from legacy compatibility
-fields (V2 behaviour) or leave them untouched (V1 behaviour). Capacity profile
-configuration chosen in Resource Profile would be restored exactly on rollback.
-**Null-legacy discrimination via `SnapshotJsonValue`:** The `CapacityProfile.legacy`
-column is a nullable PostgreSQL `Json?` field. Prisma distinguishes database NULL
-(untouched column) from JSON `null` (explicitly-set JSON null), but both read back as
-JavaScript `null`. PR #367 introduces the `SnapshotJsonValue` discriminator type
-(`projectSnapshotTypes.ts`) with three variants — `{ kind: 'DB_NULL' }`,
-`{ kind: 'JSON_NULL' }`, and `{ kind: 'VALUE'; value: ... }` — so that the snapshot
-serialiser can capture and restore the exact Prisma sentinel on rollback. This ensures
-profile rows where `legacy` was never written (typical for profile-first profiles)
-are restored as database NULL, not JSON null.
+data exactly. A rollback no longer reconstructs profiles from legacy compatibility
+fields (V2 behaviour) or leaves them untouched (V1 behaviour). Capacity profile
+configuration chosen in Resource Profile is replaced exactly on rollback.
+
+**Owner metadata is non-destructive.** V3's profile replacement is intentionally
+scoped to `CapacityProfile` and `CapacitySegment` rows. The common restore upserts
+captured `ResourceType` and `NamedResource` metadata so mutations to captured
+owners are restored, but it does not delete owners created after the snapshot.
+Those post-snapshot owners, their compatibility fields, `TemplateTask.resourceTypeId`
+links, and `ProjectDiscount` rows remain intact. A post-snapshot capacity profile
+for such an owner is removed because profiles are the V3 snapshot boundary; the
+owner itself is not pruned.
+
+**Null-legacy discrimination via `SnapshotJsonValue`:** The
+`CapacityProfile.legacy` column is a nullable PostgreSQL `Json?` field. Prisma
+distinguishes database NULL (untouched column) from JSON `null` (explicitly-set
+JSON null), but both read back as JavaScript `null`. PR #367 introduces the
+`SnapshotJsonValue` discriminator type (`projectSnapshotTypes.ts`) with three
+variants — `{ kind: 'DB_NULL' }`, `{ kind: 'JSON_NULL' }`, and
+`{ kind: 'VALUE'; value: ... }` — so that the snapshot serialiser can capture and
+restore the exact Prisma sentinel on rollback. This ensures profile rows where
+`legacy` was never written (typical for profile-first profiles) are restored as
+database NULL, not JSON null.
 
 **Snapshot/rollback:**
-`buildSnapshot` would produce `schemaVersion: 3` for all new application snapshots,
+`buildSnapshot` produces `schemaVersion: 3` for all new application snapshots,
 including `capacityProfiles: SnapshotCapacityProfile[]` with full segment data.
-Pre-rollback auto-snapshots would capture current capacity profiles alongside the
-full project state inside the same transaction — any rollback is reversible.
-V3 restore would replace all existing project profiles/segments with the exact
+Pre-rollback auto-snapshots capture current capacity profiles alongside the full
+project state inside the same transaction — any rollback is reversible.
+V3 restore replaces all existing project profiles/segments with the exact
 snapshot state (same transaction as epic/resource restoration).
 V1 snapshots (epic-only) leave capacity profiles untouched on rollback.
 V2 snapshots reconstruct profiles from every `ResourceType` (ROLE-kind, synthetic IDs)
-and every `NamedResource` (NAMED_PERSON-kind, synthetic IDs) using legacy compatibility
-fields (`allocationMode`, `allocationPercent`, etc.) with no segment fidelity.
+and every `NamedResource` (NAMED_PERSON-kind, synthetic IDs) using legacy
+compatibility fields (`allocationMode`, `allocationPercent`, etc.) with no segment
+fidelity.
 
 **Domain boundaries respected:**
-- Capacity profile data (Resource Profile ownership) would be snapshotted and restored
+- Capacity profile data (Resource Profile ownership) is snapshotted and restored
   as-is — no Timeline/Planning derivation or Commercial interpolation occurs.
-- Commercial billing basis (`pricingModel`) is snapshotted via V2/V3 `namedResources`
-  and remains Commercial-owned; V3 does not introduce a separate billing-basis
-  snapshot field.
-- ProjectDiscount rows remain Commercial-owned and are not serialized into V3 snapshots.
-  During rollback, discounts linked to pruned ResourceTypes are deleted before those
-  owners are removed; project-wide discounts and discounts for target ResourceTypes
-  are preserved. A pruned role discount is never promoted to project-wide scope by
-  setting `resourceTypeId` to `null`.
+- Commercial billing basis (`pricingModel`) is snapshotted via V2/V3
+  `namedResources` and remains Commercial-owned; V3 does not introduce a separate
+  billing-basis snapshot field.
+- `ProjectDiscount` rows remain Commercial-owned and are not serialized into V3
+  snapshots. Rollback leaves project-wide, target-role, and post-snapshot discounts
+  unchanged; no discount is promoted to project-wide scope.
 - Capacity Plan history (Capacity Plan periods/entries) is **not** part of PR #367;
   it is tracked by #359 separately.
 

--- a/docs/domain/planning-resource-commercial-boundaries.md
+++ b/docs/domain/planning-resource-commercial-boundaries.md
@@ -420,9 +420,9 @@ branch and landed when PR #356 merged.
 
 See `capacity-profile-design.md#resource-profile-and-export-adoption` for details.
 
-### Pending: Snapshot v3 capacity-profile preservation (PR #357, open)
+### Pending: Snapshot v3 capacity-profile preservation (PR #367, open)
 
-PR #357 (open, branch `feature/snapshot-v3-capacity-profiles`) extends the
+PR #367 (open, branch `feature/snapshot-v3-capacity-profiles`) extends the
 BacklogSnapshot schema to version 3 so that rollback preserves capacity profile data.
 This affects the ownership model by ensuring that Resource Profile-owned capacity
 data survives rollback:
@@ -432,6 +432,16 @@ data is owned by Resource Profile (capacity inputs), V3 snapshots now preserve t
 data exactly. A rollback no longer reconstructs profiles from legacy compatibility
 fields (V2 behaviour) or leaves them untouched (V1 behaviour). Capacity profile
 configuration chosen in Resource Profile is restored exactly on rollback.
+
+**Null-legacy discrimination via `SnapshotJsonValue`:** The `CapacityProfile.legacy`
+column is a nullable PostgreSQL `Json?` field. Prisma distinguishes database NULL
+(untouched column) from JSON `null` (explicitly-set JSON null), but both read back as
+JavaScript `null`. PR #367 introduces the `SnapshotJsonValue` discriminator type
+(`projectSnapshotTypes.ts`) with three variants — `{ kind: 'DB_NULL' }`,
+`{ kind: 'JSON_NULL' }`, and `{ kind: 'VALUE'; value: ... }` — so that the snapshot
+serialiser can capture and restore the exact Prisma sentinel on rollback. This ensures
+profile rows where `legacy` was never written (typical for profile-first profiles)
+are restored as database NULL, not JSON null.
 
 **Snapshot/rollback:**
 - `buildSnapshot` produces `schemaVersion: 3` for all new application snapshots,
@@ -451,7 +461,7 @@ configuration chosen in Resource Profile is restored exactly on rollback.
 - Commercial billing basis (`pricingModel`) is snapshotted via V2/V3 `namedResources`
   and remains Commercial-owned; V3 does not introduce a separate billing-basis
   snapshot field.
-- Capacity Plan history (Capacity Plan periods/entries) is **not** part of PR #357;
+- Capacity Plan history (Capacity Plan periods/entries) is **not** part of PR #367;
   it is tracked by #359 separately.
 
 See [`capacity-profile-source-of-truth-migration-plan.md`](capacity-profile-source-of-truth-migration-plan.md#phase-2b-—-snapshot-v3-capacity-profile-preservation)

--- a/docs/domain/planning-resource-commercial-boundaries.md
+++ b/docs/domain/planning-resource-commercial-boundaries.md
@@ -96,7 +96,7 @@ It owns:
 
 Resource Profile can display estimated effort and planning-derived information, such as actual assigned days, but should not independently calculate a separate version of the effort or planning result.
 
-PR #356 (open, pending merge) introduces capacity-profile read adoption in Resource
+PR #356 (merged) introduced capacity-profile read adoption in Resource
 Profile, making it authoritative for displaying and exporting capacity-profile data
 from the persisted `CapacityProfile`/`CapacitySegment` read model. The adapter in
 `capacityProfileResourceAdapter.ts` resolves profiles with profile-first precedence:
@@ -316,8 +316,8 @@ Prefer fast integration/unit coverage around the shared planning model and API b
 
 ## Follow-up implementation sequence
 
-> **Note:** PR #356 (open, pending merge) introduces capacity-profile read adoption in
-> Resource Profile, as part of the #340 source-of-truth epic. It introduces profile-first
+> **Note:** PR #356 (merged) introduced capacity-profile read adoption in
+> Resource Profile, as part of the #340 source-of-truth epic. It introduced profile-first
 > read precedence in the Resource Profile route and export hook, ahead of the #263
 > sequence above. This means Resource Profile display and export fields will resolve from
 > `CapacityProfile`/`CapacitySegment` when a persisted profile exists, rather than
@@ -361,12 +361,12 @@ The implementation work belongs in the follow-up issues under #263, especially #
 
 ## Implementation status
 
-### Pending: Capacity-profile read adoption in Resource Profile (PR #356, open)
+### Capacity-profile read adoption in Resource Profile (PR #356, merged)
 
-PR #356 (open, pending merge) would make the persisted `CapacityProfile`/`CapacitySegment`
+PR #356 (merged) made the persisted `CapacityProfile`/`CapacitySegment`
 read model authoritative for display and export in Resource Profile, using profile-first
-precedence. These changes are currently on the `feature/capacity-profile-resource-profile-reads`
-branch and will land when PR #356 merges.
+precedence. These changes were on the `feature/capacity-profile-resource-profile-reads`
+branch and landed when PR #356 merged.
 
 **Key changes:**
 
@@ -419,3 +419,40 @@ branch and will land when PR #356 merges.
 | `server/src/test/capacityProfileResourceAdapter.test.ts` | 7 unit tests for adapter |
 
 See `capacity-profile-design.md#resource-profile-and-export-adoption` for details.
+
+### Pending: Snapshot v3 capacity-profile preservation (PR #357, open)
+
+PR #357 (open, branch `feature/snapshot-v3-capacity-profiles`) extends the
+BacklogSnapshot schema to version 3 so that rollback preserves capacity profile data.
+This affects the ownership model by ensuring that Resource Profile-owned capacity
+data survives rollback:
+
+**Resource Profile boundary strengthened.** Since `CapacityProfile` / `CapacitySegment`
+data is owned by Resource Profile (capacity inputs), V3 snapshots now preserve this
+data exactly. A rollback no longer reconstructs profiles from legacy compatibility
+fields (V2 behaviour) or leaves them untouched (V1 behaviour). Capacity profile
+configuration chosen in Resource Profile is restored exactly on rollback.
+
+**Snapshot/rollback:**
+- `buildSnapshot` produces `schemaVersion: 3` for all new application snapshots,
+  including `capacityProfiles: SnapshotCapacityProfile[]` with full segment data.
+- Pre-rollback auto-snapshots capture current capacity profiles alongside the
+  full project state inside the same transaction — any rollback is reversible.
+- V3 restore replaces all existing project profiles/segments with the exact
+  snapshot state (same transaction as epic/resource restoration).
+- V1 snapshots (epic-only) leave capacity profiles untouched on rollback.
+- V2 snapshots reconstruct profiles from every ResourceType (ROLE-kind, synthetic IDs)
+  and every NamedResource (NAMED_PERSON-kind, synthetic IDs) using legacy compatibility
+  fields (`allocationMode`, `allocationPercent`, etc.) with no segment fidelity.
+
+**Domain boundaries respected:**
+- Capacity profile data (Resource Profile ownership) is snapshotted and restored
+  as-is — no Timeline/Planning derivation or Commercial interpolation occurs.
+- Commercial billing basis (`pricingModel`) is snapshotted via V2/V3 `namedResources`
+  and remains Commercial-owned; V3 does not introduce a separate billing-basis
+  snapshot field.
+- Capacity Plan history (Capacity Plan periods/entries) is **not** part of PR #357;
+  it is tracked by #359 separately.
+
+See [`capacity-profile-source-of-truth-migration-plan.md`](capacity-profile-source-of-truth-migration-plan.md#phase-2b-—-snapshot-v3-capacity-profile-preservation)
+and [`capacity-profile-design.md`](capacity-profile-design.md#snapshot-schema-v3--snapshot-rollback-capacity-safety) for details.

--- a/docs/domain/planning-resource-commercial-boundaries.md
+++ b/docs/domain/planning-resource-commercial-boundaries.md
@@ -428,11 +428,10 @@ This affects the ownership model by ensuring that Resource Profile-owned capacit
 data survives rollback:
 
 **Resource Profile boundary strengthened.** Since `CapacityProfile` / `CapacitySegment`
-data is owned by Resource Profile (capacity inputs), V3 snapshots now preserve this
-data exactly. A rollback no longer reconstructs profiles from legacy compatibility
-fields (V2 behaviour) or leaves them untouched (V1 behaviour). Capacity profile
-configuration chosen in Resource Profile is restored exactly on rollback.
-
+data is owned by Resource Profile (capacity inputs), V3 snapshots preserve this
+data exactly. A rollback would no longer reconstruct profiles from legacy compatibility
+fields (V2 behaviour) or leave them untouched (V1 behaviour). Capacity profile
+configuration chosen in Resource Profile would be restored exactly on rollback.
 **Null-legacy discrimination via `SnapshotJsonValue`:** The `CapacityProfile.legacy`
 column is a nullable PostgreSQL `Json?` field. Prisma distinguishes database NULL
 (untouched column) from JSON `null` (explicitly-set JSON null), but both read back as
@@ -444,19 +443,19 @@ profile rows where `legacy` was never written (typical for profile-first profile
 are restored as database NULL, not JSON null.
 
 **Snapshot/rollback:**
-- `buildSnapshot` produces `schemaVersion: 3` for all new application snapshots,
-  including `capacityProfiles: SnapshotCapacityProfile[]` with full segment data.
-- Pre-rollback auto-snapshots capture current capacity profiles alongside the
-  full project state inside the same transaction — any rollback is reversible.
-- V3 restore replaces all existing project profiles/segments with the exact
-  snapshot state (same transaction as epic/resource restoration).
-- V1 snapshots (epic-only) leave capacity profiles untouched on rollback.
-- V2 snapshots reconstruct profiles from every ResourceType (ROLE-kind, synthetic IDs)
-  and every NamedResource (NAMED_PERSON-kind, synthetic IDs) using legacy compatibility
-  fields (`allocationMode`, `allocationPercent`, etc.) with no segment fidelity.
+`buildSnapshot` would produce `schemaVersion: 3` for all new application snapshots,
+including `capacityProfiles: SnapshotCapacityProfile[]` with full segment data.
+Pre-rollback auto-snapshots would capture current capacity profiles alongside the
+full project state inside the same transaction — any rollback is reversible.
+V3 restore would replace all existing project profiles/segments with the exact
+snapshot state (same transaction as epic/resource restoration).
+V1 snapshots (epic-only) leave capacity profiles untouched on rollback.
+V2 snapshots reconstruct profiles from every `ResourceType` (ROLE-kind, synthetic IDs)
+and every `NamedResource` (NAMED_PERSON-kind, synthetic IDs) using legacy compatibility
+fields (`allocationMode`, `allocationPercent`, etc.) with no segment fidelity.
 
 **Domain boundaries respected:**
-- Capacity profile data (Resource Profile ownership) is snapshotted and restored
+- Capacity profile data (Resource Profile ownership) would be snapshotted and restored
   as-is — no Timeline/Planning derivation or Commercial interpolation occurs.
 - Commercial billing basis (`pricingModel`) is snapshotted via V2/V3 `namedResources`
   and remains Commercial-owned; V3 does not introduce a separate billing-basis

--- a/server/package.json
+++ b/server/package.json
@@ -9,6 +9,7 @@
     "build": "tsc",
     "start": "node dist/index.js",
     "lint": "eslint .",
+    "test:snapshot-integration": "vitest run --config vitest.integration.config.ts src/test/snapshotRollback.integration.test.ts",
     "typecheck": "tsc --noEmit",
     "test:watch": "vitest",
     "e2e:cleanup": "tsx scripts/e2e-cleanup.ts",

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -1,0 +1,81 @@
+import bootstrapRoutes from './routes/bootstrap.js'
+import 'dotenv/config'
+import express from 'express'
+import cors from 'cors'
+import helmet from 'helmet'
+import pinoHttp from 'pino-http'
+import { logger } from './lib/logger.js'
+import { authenticate } from './middleware/auth.js'
+import { errorHandler } from './middleware/errorHandler.js'
+import authRoutes from './routes/auth.js'
+import projectRoutes from './routes/projects.js'
+import epicRoutes from './routes/epics.js'
+import featureRoutes from './routes/features.js'
+import storyRoutes from './routes/stories.js'
+import taskRoutes from './routes/tasks.js'
+import resourceTypeRoutes from './routes/resourceTypes.js'
+import templateRoutes from './routes/templates.js'
+import applyTemplateRoutes from './routes/applyTemplate.js'
+import globalResourceTypeRoutes from './routes/globalResourceTypes.js'
+import effortRoutes from './routes/effort.js'
+import timelineRoutes from './routes/timeline.js'
+import snapshotRoutes from './routes/snapshots.js'
+import csvRoutes from './routes/csv.js'
+import reorderRoutes from './routes/reorder.js'
+import discountRoutes from './routes/discounts.js'
+import overheadRoutes from './routes/overhead.js'
+import resourceProfileRoutes from './routes/resourceProfile.js'
+import featureDependenciesRouter from './routes/featureDependencies.js'
+import epicDependenciesRouter from './routes/epicDependencies.js'
+import rateCardRoutes, { applyRateCardRouter } from './routes/rateCards.js'
+import namedResourceRoutes from './routes/namedResources.js'
+import orgRoutes from './routes/orgs.js'
+import customerRoutes from './routes/customers.js'
+import documentRoutes from './routes/documents.js'
+import optimiserRoutes from './routes/optimiser.js'
+import squadPlanRoutes from './routes/squadPlan.js'
+import capacityProfileRoutes from './routes/capacityProfiles.js'
+
+const app = express()
+
+app.use(helmet())
+app.use(pinoHttp({ logger }))
+app.use(cors({ origin: process.env.CLIENT_URL ?? 'http://localhost:5173' }))
+app.use(express.json({ limit: '10mb' }))
+
+app.get('/health', (_req, res) => res.json({ status: 'ok', service: 'monrad-estimator' }))
+app.use('/api/bootstrap', bootstrapRoutes)
+app.use('/api/auth', authRoutes)
+app.use('/api/projects', projectRoutes)
+app.use('/api/projects/:projectId/epics', epicRoutes)
+app.use('/api/projects/:projectId/resource-types', resourceTypeRoutes)
+app.use('/api/epics/:epicId/features', featureRoutes)
+app.use('/api/features/:featureId/stories', storyRoutes)
+app.use('/api/projects/:projectId/stories', storyRoutes)
+app.use('/api/stories/:storyId/tasks', taskRoutes)
+app.use('/api/templates', templateRoutes)
+app.use('/api/features', applyTemplateRoutes)
+app.use('/api/global-resource-types', globalResourceTypeRoutes)
+app.use('/api/projects/:projectId/effort', effortRoutes)
+app.use('/api/projects/:projectId/timeline', timelineRoutes)
+app.use('/api/projects/:projectId/snapshots', snapshotRoutes)
+app.use('/api/projects/:projectId/backlog', csvRoutes)
+app.use('/api/projects/:projectId/reorder', reorderRoutes)
+app.use('/api/projects/:projectId/discounts', discountRoutes)
+app.use('/api/projects/:projectId/overhead', overheadRoutes)
+app.use('/api/projects/:projectId/resource-profile', resourceProfileRoutes)
+app.use('/api/projects/:projectId/resource-types/:rtId/named-resources', namedResourceRoutes)
+app.use('/api/projects/:projectId/feature-dependencies', featureDependenciesRouter)
+app.use('/api/projects/:projectId/epic-dependencies', epicDependenciesRouter)
+app.use('/api/rate-cards', rateCardRoutes)
+app.use('/api/projects/:projectId/apply-rate-card', applyRateCardRouter)
+app.use('/api/projects/:projectId/documents', documentRoutes)
+app.use('/api/projects/:projectId/optimise', optimiserRoutes)
+app.use('/api/projects/:projectId/squad-plan', squadPlanRoutes)
+app.use('/api/projects/:projectId/capacity-profiles', capacityProfileRoutes)
+app.use('/api/projects/:projectId/squad-plans', squadPlanRoutes)
+app.use('/api/orgs', authenticate, orgRoutes)
+app.use('/api/customers', authenticate, customerRoutes)
+
+export { app }
+app.use(errorHandler)

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,42 +1,8 @@
-import bootstrapRoutes from './routes/bootstrap.js'
-import 'dotenv/config'
-import express from 'express'
-import cors from 'cors'
-import helmet from 'helmet'
-import pinoHttp from 'pino-http'
-import { logger } from './lib/logger.js'
-import { authenticate } from './middleware/auth.js'
-import { errorHandler } from './middleware/errorHandler.js'
-import authRoutes from './routes/auth.js'
-import projectRoutes from './routes/projects.js'
-import epicRoutes from './routes/epics.js'
-import featureRoutes from './routes/features.js'
-import storyRoutes from './routes/stories.js'
-import taskRoutes from './routes/tasks.js'
-import resourceTypeRoutes from './routes/resourceTypes.js'
-import templateRoutes from './routes/templates.js'
-import applyTemplateRoutes from './routes/applyTemplate.js'
-import globalResourceTypeRoutes from './routes/globalResourceTypes.js'
-import effortRoutes from './routes/effort.js'
-import timelineRoutes from './routes/timeline.js'
-import snapshotRoutes from './routes/snapshots.js'
-import csvRoutes from './routes/csv.js'
-import reorderRoutes from './routes/reorder.js'
-import discountRoutes from './routes/discounts.js'
-import overheadRoutes from './routes/overhead.js'
-import resourceProfileRoutes from './routes/resourceProfile.js'
-import featureDependenciesRouter from './routes/featureDependencies.js'
-import epicDependenciesRouter from './routes/epicDependencies.js'
-import rateCardRoutes, { applyRateCardRouter } from './routes/rateCards.js'
-import namedResourceRoutes from './routes/namedResources.js'
-import orgRoutes from './routes/orgs.js'
-import customerRoutes from './routes/customers.js'
-import documentRoutes from './routes/documents.js'
-import optimiserRoutes from './routes/optimiser.js'
-import squadPlanRoutes from './routes/squadPlan.js'
-import capacityProfileRoutes from './routes/capacityProfiles.js'
+export { app } from './app.js'
 
-const app = express()
+import 'dotenv/config'
+import { app } from './app.js'
+
 const PORT = process.env.PORT ?? 3001
 
 // JWT_SECRET startup validation
@@ -45,45 +11,4 @@ if (!jwtSecret || jwtSecret === 'change-me-in-production' || jwtSecret.length < 
   throw new Error('JWT_SECRET must be set to a secure random string of 32+ characters')
 }
 
-app.use(helmet())
-app.use(pinoHttp({ logger }))
-app.use(cors({ origin: process.env.CLIENT_URL ?? 'http://localhost:5173' }))
-app.use(express.json({ limit: '10mb' }))
-
-app.get('/health', (_req, res) => res.json({ status: 'ok', service: 'monrad-estimator' }))
-app.use('/api/bootstrap', bootstrapRoutes)
-app.use('/api/auth', authRoutes)
-app.use('/api/projects', projectRoutes)
-app.use('/api/projects/:projectId/epics', epicRoutes)
-app.use('/api/projects/:projectId/resource-types', resourceTypeRoutes)
-app.use('/api/epics/:epicId/features', featureRoutes)
-app.use('/api/features/:featureId/stories', storyRoutes)
-app.use('/api/projects/:projectId/stories', storyRoutes)
-app.use('/api/stories/:storyId/tasks', taskRoutes)
-app.use('/api/templates', templateRoutes)
-app.use('/api/features', applyTemplateRoutes)
-app.use('/api/global-resource-types', globalResourceTypeRoutes)
-app.use('/api/projects/:projectId/effort', effortRoutes)
-app.use('/api/projects/:projectId/timeline', timelineRoutes)
-app.use('/api/projects/:projectId/snapshots', snapshotRoutes)
-app.use('/api/projects/:projectId/backlog', csvRoutes)
-app.use('/api/projects/:projectId/reorder', reorderRoutes)
-app.use('/api/projects/:projectId/discounts', discountRoutes)
-app.use('/api/projects/:projectId/overhead', overheadRoutes)
-app.use('/api/projects/:projectId/resource-profile', resourceProfileRoutes)
-app.use('/api/projects/:projectId/resource-types/:rtId/named-resources', namedResourceRoutes)
-app.use('/api/projects/:projectId/feature-dependencies', featureDependenciesRouter)
-app.use('/api/projects/:projectId/epic-dependencies', epicDependenciesRouter)
-app.use('/api/rate-cards', rateCardRoutes)
-app.use('/api/projects/:projectId/apply-rate-card', applyRateCardRouter)
-app.use('/api/projects/:projectId/documents', documentRoutes)
-app.use('/api/projects/:projectId/optimise', optimiserRoutes)
-app.use('/api/projects/:projectId/squad-plan', squadPlanRoutes)
-app.use('/api/projects/:projectId/capacity-profiles', capacityProfileRoutes)
-app.use('/api/projects/:projectId/squad-plans', squadPlanRoutes)
-app.use('/api/orgs', authenticate, orgRoutes)
-app.use('/api/customers', authenticate, customerRoutes)
-
-export { app }
-app.use(errorHandler)
 app.listen(PORT, () => console.log(`Server running on http://localhost:${PORT}`))

--- a/server/src/lib/projectSnapshotCapacity.ts
+++ b/server/src/lib/projectSnapshotCapacity.ts
@@ -10,7 +10,24 @@
  * @module projectSnapshotCapacity
  */
 
+import type { Prisma } from '@prisma/client'
 import type { SnapshotV2, SnapshotV3 } from './projectSnapshotTypes.js'
+import { snapshotJsonValueToPrisma } from './projectSnapshotTypes.js'
+
+// ─── Narrow transaction interface ────────────────────────────────────────────
+// Replaces `tx: any` with a minimal Prisma-compatible contract covering only
+// the capacity profile/segment operations this module uses.
+
+export interface CapacityProfileTxClient {
+  capacityProfile: {
+    deleteMany(args: { where: { projectId: string } }): Promise<{ count: number }>
+    create(args: { data: Prisma.CapacityProfileCreateInput }): Promise<unknown>
+  }
+  capacitySegment: {
+    deleteMany(args: { where: { capacityProfile: { projectId: string } } }): Promise<{ count: number }>
+    create(args: { data: Prisma.CapacitySegmentCreateInput }): Promise<unknown>
+  }
+}
 
 // ─── Planning basis mapping ──────────────────────────────────────────────────
 
@@ -19,7 +36,7 @@ import type { SnapshotV2, SnapshotV3 } from './projectSnapshotTypes.js'
  * Mirror of the internal mapping in capacityProfileMapping.ts.
  * null/undefined/EFFORT → DEMAND_FOLLOWING
  */
-function allocationModeToPlanningBasis(mode: string | null | undefined): string {
+function allocationModeToPlanningBasis(mode: string | null | undefined): 'DEMAND_FOLLOWING' | 'AVAILABILITY_WINDOW' | 'WHOLE_PROJECT_ALLOCATION' | 'CAPACITY_PROFILE' {
   switch (mode) {
     case 'TIMELINE':
       return 'AVAILABILITY_WINDOW'
@@ -32,7 +49,7 @@ function allocationModeToPlanningBasis(mode: string | null | undefined): string 
       return 'DEMAND_FOLLOWING'
   }
 }
-function allocationModeToSource(mode: string | null | undefined): string {
+function allocationModeToSource(mode: string | null | undefined): 'FIXED' | 'AVAILABILITY_WINDOW' | 'LEGACY' | 'MANUAL' | 'SQUAD_PLANNER' | 'IMPORTED' | 'DERIVED' {
   switch (mode) {
     case 'TIMELINE':
       return 'AVAILABILITY_WINDOW'
@@ -63,7 +80,7 @@ function allocationModeToSource(mode: string | null | undefined): string {
  * captures.
  */
 export async function recreateV2CapacityProfiles(
-  tx: any,
+  tx: CapacityProfileTxClient,
   projectId: string,
   snapshot: SnapshotV2,
 ): Promise<void> {
@@ -75,10 +92,10 @@ export async function recreateV2CapacityProfiles(
     await tx.capacityProfile.create({
       data: {
         id: `snapshot-v2-role-${rt.id}`,
-        projectId,
+        project: { connect: { id: projectId } },
         ownerKind: 'ROLE',
-        resourceTypeId: rt.id,
-        namedResourceId: null,
+        resourceType: { connect: { id: rt.id } },
+        namedResource: undefined,
         planningBasis: allocationModeToPlanningBasis(rt.allocationMode),
         source: allocationModeToSource(rt.allocationMode),
         defaultPercent: rt.allocationPercent,
@@ -108,10 +125,10 @@ export async function recreateV2CapacityProfiles(
     await tx.capacityProfile.create({
       data: {
         id: `snapshot-v2-named-${nr.id}`,
-        projectId,
+        project: { connect: { id: projectId } },
         ownerKind: 'NAMED_PERSON',
-        resourceTypeId: null,
-        namedResourceId: nr.id,
+        resourceType: undefined,
+        namedResource: { connect: { id: nr.id } },
         planningBasis: allocationModeToPlanningBasis(mode),
         source: allocationModeToSource(mode),
         defaultPercent: effectivePercent,
@@ -143,7 +160,7 @@ export async function recreateV2CapacityProfiles(
  * This is an exact replacement — no broad legacy sync afterward.
  */
 export async function recreateV3CapacityProfiles(
-  tx: any,
+  tx: CapacityProfileTxClient,
   projectId: string,
   v3: SnapshotV3,
 ): Promise<void> {
@@ -157,16 +174,16 @@ export async function recreateV3CapacityProfiles(
     await tx.capacityProfile.create({
       data: {
         id: profile.id,
-        projectId,
+        project: { connect: { id: projectId } },
         ownerKind: profile.ownerKind,
-        resourceTypeId: profile.resourceTypeId,
-        namedResourceId: profile.namedResourceId,
+        resourceType: profile.resourceTypeId ? { connect: { id: profile.resourceTypeId } } : undefined,
+        namedResource: profile.namedResourceId ? { connect: { id: profile.namedResourceId } } : undefined,
         planningBasis: profile.planningBasis,
         source: profile.source,
         defaultPercent: profile.defaultPercent,
         startWeek: profile.startWeek,
         endWeek: profile.endWeek,
-        legacy: profile.legacy,
+        legacy: snapshotJsonValueToPrisma(profile.legacy),
       },
     })
 
@@ -174,7 +191,7 @@ export async function recreateV3CapacityProfiles(
       await tx.capacitySegment.create({
         data: {
           id: seg.id,
-          capacityProfileId: profile.id,
+          capacityProfile: { connect: { id: profile.id } },
           startWeek: seg.startWeek,
           endWeek: seg.endWeek,
           capacityPercent: seg.capacityPercent,

--- a/server/src/lib/projectSnapshotCapacity.ts
+++ b/server/src/lib/projectSnapshotCapacity.ts
@@ -1,0 +1,186 @@
+/**
+ * projectSnapshotCapacity.ts — Pure legacy-v2 reconstruction and V3 persistence helpers
+ * for snapshot rollback.
+ *
+ * These helpers are called inside a transaction during rollback and operate on
+ * Prisma transaction clients (or any compatible client with the same model
+ * method shapes). They never read the active CapacityPlan or call
+ * syncCapacityProfilesForProject.
+ *
+ * @module projectSnapshotCapacity
+ */
+
+import type { SnapshotV2, SnapshotV3 } from './projectSnapshotTypes.js'
+
+// ─── Planning basis mapping ──────────────────────────────────────────────────
+
+/**
+ * Map a v2 allocationMode string to a v3 planningBasis enum value.
+ * Mirror of the internal mapping in capacityProfileMapping.ts.
+ * null/undefined/EFFORT → DEMAND_FOLLOWING
+ */
+function allocationModeToPlanningBasis(mode: string | null | undefined): string {
+  switch (mode) {
+    case 'TIMELINE':
+      return 'AVAILABILITY_WINDOW'
+    case 'FULL_PROJECT':
+      return 'WHOLE_PROJECT_ALLOCATION'
+    case 'CAPACITY_PLAN':
+      return 'CAPACITY_PROFILE'
+    case 'EFFORT':
+    default:
+      return 'DEMAND_FOLLOWING'
+  }
+}
+function allocationModeToSource(mode: string | null | undefined): string {
+  switch (mode) {
+    case 'TIMELINE':
+      return 'AVAILABILITY_WINDOW'
+    case 'EFFORT':
+    case 'FULL_PROJECT':
+      return 'FIXED'
+    default:
+      return 'LEGACY'
+  }
+}
+
+// ─── V2 rollback: rebuild profiles from v2 compatibility fields ──────────────
+
+/**
+ * During V2 rollback, after restoring ResourceTypes, NamedResources, epics, and
+ * other v2 state, delete all existing project capacity profiles/segments and
+ * create deterministic legacy-only profiles derived solely from the v2
+ * ResourceType/NamedResource fields.
+ *
+ * Named resources become NAMED_PERSON because v2 had no persisted
+ * planned-resource owner. TIMELINE mode gets AVAILABILITY_WINDOW planning basis
+ * with the allocationStartWeek → startWeek / allocationEndWeek → endWeek
+ * window. EFFORT, FULL_PROJECT, and CAPACITY_PLAN modes use only captured
+ * compatibility fields.
+ *
+ * Importantly, this never reads the active CapacityPlan or calls
+ * syncCapacityProfilesForProject — it creates only what the v2 snapshot
+ * captures.
+ */
+export async function recreateV2CapacityProfiles(
+  tx: any,
+  projectId: string,
+  snapshot: SnapshotV2,
+): Promise<void> {
+  // Delete all existing project profiles (segments cascade via onDelete: Cascade)
+  await tx.capacitySegment.deleteMany({ where: { capacityProfile: { projectId } } })
+  await tx.capacityProfile.deleteMany({ where: { projectId } })
+
+  for (const rt of snapshot.resourceTypes) {
+    await tx.capacityProfile.create({
+      data: {
+        id: `snapshot-v2-role-${rt.id}`,
+        projectId,
+        ownerKind: 'ROLE',
+        resourceTypeId: rt.id,
+        namedResourceId: null,
+        planningBasis: allocationModeToPlanningBasis(rt.allocationMode),
+        source: allocationModeToSource(rt.allocationMode),
+        defaultPercent: rt.allocationPercent,
+        startWeek: rt.allocationStartWeek,
+        endWeek: rt.allocationEndWeek,
+        legacy: {
+          allocationMode: rt.allocationMode,
+          allocationPercent: rt.allocationPercent,
+          allocationStartWeek: rt.allocationStartWeek,
+          allocationEndWeek: rt.allocationEndWeek,
+        },
+      },
+    })
+  }
+  const rtByRtId = new Map(snapshot.resourceTypes.map(rt => [rt.id, rt]))
+
+  // Create NAMED_PERSON profiles from snapshot namedResources
+  for (const nr of snapshot.namedResources) {
+    const parentRt = rtByRtId.get(nr.resourceTypeId)
+    const mode = nr.allocationMode ?? parentRt?.allocationMode ?? null
+
+    // Resolve effective values (mirrors resolveNamedResourcePercent etc.)
+    const effectivePercent = nr.allocationPercent ?? nr.allocationPct
+    const effectiveStart = nr.allocationStartWeek ?? nr.startWeek
+    const effectiveEnd = nr.allocationEndWeek ?? nr.endWeek
+
+    await tx.capacityProfile.create({
+      data: {
+        id: `snapshot-v2-named-${nr.id}`,
+        projectId,
+        ownerKind: 'NAMED_PERSON',
+        resourceTypeId: null,
+        namedResourceId: nr.id,
+        planningBasis: allocationModeToPlanningBasis(mode),
+        source: allocationModeToSource(mode),
+        defaultPercent: effectivePercent,
+        startWeek: effectiveStart,
+        endWeek: effectiveEnd,
+        legacy: {
+          allocationMode: mode,
+          allocationPct: nr.allocationPct,
+          allocationPercent: nr.allocationPercent,
+          allocationStartWeek: nr.allocationStartWeek,
+          allocationEndWeek: nr.allocationEndWeek,
+          startWeek: nr.startWeek,
+          endWeek: nr.endWeek,
+        },
+      },
+    })
+  }
+}
+
+// ─── V3 rollback: exact profile/segment replacement ──────────────────────────
+
+/**
+ * During V3 rollback, after restoring all common v2 state (RTs, NRs, epics,
+ * etc.), delete ALL current project capacity profiles/segments and recreate
+ * each target profile with exact IDs, projectId forced to the route projectId,
+ * owner IDs, enum values, nulls, and legacy. Every segment is recreated with
+ * exact id, profile FK, values, and source.
+ *
+ * This is an exact replacement — no broad legacy sync afterward.
+ */
+export async function recreateV3CapacityProfiles(
+  tx: any,
+  projectId: string,
+  v3: SnapshotV3,
+): Promise<void> {
+  // Delete existing segments then profiles (segments cascade but we delete both
+  // explicitly for clarity; deleteMany on profile cascades segments but the
+  // explicit segment delete ensures ordering)
+  await tx.capacitySegment.deleteMany({ where: { capacityProfile: { projectId } } })
+  await tx.capacityProfile.deleteMany({ where: { projectId } })
+
+  for (const profile of v3.capacityProfiles) {
+    await tx.capacityProfile.create({
+      data: {
+        id: profile.id,
+        projectId,
+        ownerKind: profile.ownerKind,
+        resourceTypeId: profile.resourceTypeId,
+        namedResourceId: profile.namedResourceId,
+        planningBasis: profile.planningBasis,
+        source: profile.source,
+        defaultPercent: profile.defaultPercent,
+        startWeek: profile.startWeek,
+        endWeek: profile.endWeek,
+        legacy: profile.legacy,
+      },
+    })
+
+    for (const seg of profile.segments) {
+      await tx.capacitySegment.create({
+        data: {
+          id: seg.id,
+          capacityProfileId: profile.id,
+          startWeek: seg.startWeek,
+          endWeek: seg.endWeek,
+          capacityPercent: seg.capacityPercent,
+          source: seg.source,
+        },
+      })
+    }
+  }
+}

--- a/server/src/lib/projectSnapshotService.ts
+++ b/server/src/lib/projectSnapshotService.ts
@@ -508,29 +508,37 @@ async function pruneNonTargetOwners(
   const targetRtIds = new Set(data.resourceTypes.map(rt => rt.id))
   const targetNrIds = new Set(data.namedResources.map(nr => nr.id))
 
-  // 1. Null out non-cascading FK references to non-target ResourceTypes.
-  //    Discount.resourceTypeId has no onDelete cascade — null it first to avoid
-  //    FK violations when the RT is deleted.
-  if (tx.projectDiscount) {
-    const targetRtIdList = Array.from(targetRtIds)
-    const discountsToNull = await tx.projectDiscount.findMany({
+  // 1. Determine non-target ResourceTypes before deleting any owners.
+  const rtWhere = targetRtIds.size > 0
+    ? { projectId, id: { notIn: Array.from(targetRtIds) } }
+    : { projectId }
+  const nonTargetRts = await tx.resourceType.findMany({
+    where: rtWhere,
+    select: { id: true },
+  })
+  const nonTargetRtIds = nonTargetRts.map(rt => rt.id)
+
+  // 2. Delete role-scoped discounts owned exclusively by pruned roles.
+  //    Never null resourceTypeId: null means project-wide to Commercial.
+  //    The projectId predicate prevents touching another project's discounts.
+  if (nonTargetRtIds.length > 0) {
+    await tx.projectDiscount.deleteMany({
       where: {
         projectId,
-        resourceTypeId: targetRtIds.size > 0
-          ? { not: null, notIn: targetRtIdList }
-          : { not: null },
+        resourceTypeId: { in: nonTargetRtIds },
       },
-      select: { id: true },
     })
-    if (discountsToNull.length > 0) {
-      await tx.projectDiscount.updateMany({
-        where: { id: { in: discountsToNull.map(d => d.id) } },
-        data: { resourceTypeId: null },
-      })
-    }
   }
 
-  // 2. Delete non-target NamedResources (cascades to their capacity profiles)
+  // 3. Clear other non-cascading references before deleting ResourceTypes.
+  if (nonTargetRtIds.length > 0 && tx.templateTask) {
+    await tx.templateTask.updateMany({
+      where: { resourceTypeId: { in: nonTargetRtIds } },
+      data: { resourceTypeId: null },
+    })
+  }
+
+  // 4. Delete non-target NamedResources (cascades to their capacity profiles).
   const nrWhere = targetNrIds.size > 0
     ? { resourceType: { projectId }, id: { notIn: Array.from(targetNrIds) } }
     : { resourceType: { projectId } }
@@ -544,24 +552,10 @@ async function pruneNonTargetOwners(
     })
   }
 
-  // 3. Delete non-target ResourceTypes (cascade handles their NRs and profiles)
-  const rtWhere = targetRtIds.size > 0
-    ? { projectId, id: { notIn: Array.from(targetRtIds) } }
-    : { projectId }
-  const nonTargetRts = await tx.resourceType.findMany({
-    where: rtWhere,
-    select: { id: true },
-  })
-  if (nonTargetRts.length > 0 && tx.templateTask) {
-    await tx.templateTask.updateMany({
-      where: { resourceTypeId: { in: nonTargetRts.map(rt => rt.id) } },
-      data: { resourceTypeId: null },
-    })
-  }
-
-  if (nonTargetRts.length > 0) {
+  // 5. Delete non-target ResourceTypes (cascade handles profiles).
+  if (nonTargetRtIds.length > 0) {
     await tx.resourceType.deleteMany({
-      where: { id: { in: nonTargetRts.map(rt => rt.id) } },
+      where: { id: { in: nonTargetRtIds } },
     })
   }
 }

--- a/server/src/lib/projectSnapshotService.ts
+++ b/server/src/lib/projectSnapshotService.ts
@@ -356,17 +356,17 @@ async function restoreSnapshotCommonState(
 
   for (const epic of data.epics) {
     const newEpic = await tx.epic.create({
-      data: { name: epic.name, description: epic.description, order: epic.order, projectId },
+      data: { name: epic.name, description: epic.description, assumptions: epic.assumptions, order: epic.order, projectId, featureMode: epic.featureMode, scheduleMode: epic.scheduleMode, timelineStartWeek: epic.timelineStartWeek, isActive: epic.isActive },
     })
     epicIdMap.set(epic.id, newEpic.id)
     for (const feature of epic.features) {
       const newFeature = await tx.feature.create({
-        data: { name: feature.name, description: feature.description, assumptions: feature.assumptions, order: feature.order, epicId: newEpic.id },
+      data: { name: feature.name, description: feature.description, assumptions: feature.assumptions, order: feature.order, epicId: newEpic.id, featureMode: feature.featureMode, isActive: feature.isActive, timelineColour: feature.timelineColour, timelineStartWeek: feature.timelineStartWeek },
       })
       featureIdMap.set(feature.id, newFeature.id)
       for (const story of feature.userStories) {
         const newStory = await tx.userStory.create({
-          data: { name: story.name, description: story.description, assumptions: story.assumptions, order: story.order, featureId: newFeature.id, appliedTemplateId: story.appliedTemplateId },
+      data: { name: story.name, description: story.description, assumptions: story.assumptions, order: story.order, featureId: newFeature.id, appliedTemplateId: story.appliedTemplateId, isActive: story.isActive ?? true },
         })
         storyIdMap.set(story.id, newStory.id)
         for (const task of story.tasks) {
@@ -490,6 +490,78 @@ async function restoreSnapshotCommonState(
         order: o.order,
       })),
       skipDuplicates: true,
+    })
+  }
+}
+
+/**
+ * V3-only: Delete ResourceTypes and NamedResources that exist in the project
+ * but are absent from the target snapshot, handling FK-safe ordering.
+ * Called after restoreSnapshotCommonState has recreated dependent rows
+ * and before recreateV3CapacityProfiles recreates profiles.
+ */
+async function pruneNonTargetOwners(
+  tx: SnapshotDbClient,
+  projectId: string,
+  data: { resourceTypes: Array<{ id: string }>; namedResources: Array<{ id: string }> },
+): Promise<void> {
+  const targetRtIds = new Set(data.resourceTypes.map(rt => rt.id))
+  const targetNrIds = new Set(data.namedResources.map(nr => nr.id))
+
+  // 1. Null out non-cascading FK references to non-target ResourceTypes.
+  //    Discount.resourceTypeId has no onDelete cascade — null it first to avoid
+  //    FK violations when the RT is deleted.
+  if (tx.projectDiscount) {
+    const targetRtIdList = Array.from(targetRtIds)
+    const discountsToNull = await tx.projectDiscount.findMany({
+      where: {
+        projectId,
+        resourceTypeId: targetRtIds.size > 0
+          ? { not: null, notIn: targetRtIdList }
+          : { not: null },
+      },
+      select: { id: true },
+    })
+    if (discountsToNull.length > 0) {
+      await tx.projectDiscount.updateMany({
+        where: { id: { in: discountsToNull.map(d => d.id) } },
+        data: { resourceTypeId: null },
+      })
+    }
+  }
+
+  // 2. Delete non-target NamedResources (cascades to their capacity profiles)
+  const nrWhere = targetNrIds.size > 0
+    ? { resourceType: { projectId }, id: { notIn: Array.from(targetNrIds) } }
+    : { resourceType: { projectId } }
+  const nonTargetNrs = await tx.namedResource.findMany({
+    where: nrWhere,
+    select: { id: true },
+  })
+  if (nonTargetNrs.length > 0) {
+    await tx.namedResource.deleteMany({
+      where: { id: { in: nonTargetNrs.map(nr => nr.id) } },
+    })
+  }
+
+  // 3. Delete non-target ResourceTypes (cascade handles their NRs and profiles)
+  const rtWhere = targetRtIds.size > 0
+    ? { projectId, id: { notIn: Array.from(targetRtIds) } }
+    : { projectId }
+  const nonTargetRts = await tx.resourceType.findMany({
+    where: rtWhere,
+    select: { id: true },
+  })
+  if (nonTargetRts.length > 0 && tx.templateTask) {
+    await tx.templateTask.updateMany({
+      where: { resourceTypeId: { in: nonTargetRts.map(rt => rt.id) } },
+      data: { resourceTypeId: null },
+    })
+  }
+
+  if (nonTargetRts.length > 0) {
+    await tx.resourceType.deleteMany({
+      where: { id: { in: nonTargetRts.map(rt => rt.id) } },
     })
   }
 }
@@ -632,15 +704,15 @@ export async function rollbackProjectSnapshot({
       await tx.epic.deleteMany({ where: { projectId } })
       for (const epic of parsedData) {
         const newEpic = await tx.epic.create({
-          data: { name: epic.name, description: epic.description, order: epic.order, projectId },
+          data: { name: epic.name, description: epic.description, assumptions: epic.assumptions, order: epic.order, projectId, featureMode: epic.featureMode, scheduleMode: epic.scheduleMode, timelineStartWeek: epic.timelineStartWeek, isActive: epic.isActive },
         })
         for (const feature of epic.features) {
           const newFeature = await tx.feature.create({
-            data: { name: feature.name, description: feature.description, assumptions: feature.assumptions, order: feature.order, epicId: newEpic.id },
+            data: { name: feature.name, description: feature.description, assumptions: feature.assumptions, order: feature.order, epicId: newEpic.id, featureMode: feature.featureMode, isActive: feature.isActive, timelineColour: feature.timelineColour, timelineStartWeek: feature.timelineStartWeek },
           })
           for (const story of feature.userStories) {
             const newStory = await tx.userStory.create({
-              data: { name: story.name, description: story.description, assumptions: story.assumptions, order: story.order, featureId: newFeature.id, appliedTemplateId: story.appliedTemplateId },
+              data: { name: story.name, description: story.description, assumptions: story.assumptions, order: story.order, featureId: newFeature.id, appliedTemplateId: story.appliedTemplateId, isActive: story.isActive ?? true },
             })
             for (const task of story.tasks) {
               const taskRtId = task.resourceType?.name
@@ -670,6 +742,7 @@ export async function rollbackProjectSnapshot({
     } else if (isSnapshotV3(parsedData)) {
       // --- V3: full-state restore + exact profile/segment replacement ---
       await restoreSnapshotCommonState(tx, projectId, parsedData)
+      await pruneNonTargetOwners(tx, projectId, parsedData)
       await recreateV3CapacityProfiles(tx, projectId, parsedData)
     }
 

--- a/server/src/lib/projectSnapshotService.ts
+++ b/server/src/lib/projectSnapshotService.ts
@@ -249,7 +249,7 @@ export async function buildSnapshot(
     }
   })
 
-  return {
+  const snapshot: SnapshotV3 = {
     schemaVersion: 3 as const,
     epics,
     project: projectFields,
@@ -262,6 +262,9 @@ export async function buildSnapshot(
     overheadItems,
     capacityProfiles: sortSnapshotProfiles(capacityProfiles),
   }
+
+  validateSnapshotV3(snapshot)
+  return snapshot
 }
 
 // ─── restoreSnapshotCommonState ───────────────────────────────────────────────

--- a/server/src/lib/projectSnapshotService.ts
+++ b/server/src/lib/projectSnapshotService.ts
@@ -1,0 +1,676 @@
+/**
+ * projectSnapshotService.ts — Rollback orchestration, snapshot building,
+ * and common-state restoration extracted from the Express route.
+ *
+ * Ownership: auth/ownership checks belong in the Express handler; this
+ * service operates on already-authenticated inputs.
+ */
+
+import { Prisma } from '@prisma/client'
+import type { PrismaClient } from '@prisma/client'
+import { prisma } from './prisma.js'
+import {
+  parseSnapshotData,
+  isLegacyV1Snapshot,
+  isSnapshotV2,
+  isSnapshotV3,
+  SnapshotSchemaError,
+  type SnapshotData,
+  type SnapshotJsonValue,
+  type SnapshotV2,
+  type SnapshotV3,
+} from './projectSnapshotTypes.js'
+import {
+  validateSnapshotV3,
+  sortSnapshotProfiles,
+  sortSnapshotSegments,
+} from './projectSnapshotValidation.js'
+import {
+  recreateV2CapacityProfiles,
+  recreateV3CapacityProfiles,
+} from './projectSnapshotCapacity.js'
+import { pruneSnapshots } from './snapshotUtils.js'
+
+// ─── Error types ──────────────────────────────────────────────────────────────
+
+export class RollbackError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'RollbackError'
+  }
+}
+
+export class SnapshotNotFoundError extends RollbackError {
+  constructor(message?: string) {
+    super(message ?? 'Snapshot not found')
+    this.name = 'SnapshotNotFoundError'
+  }
+}
+
+export class RollbackPreflightError extends RollbackError {
+  constructor(message: string) {
+    super(message)
+    this.name = 'RollbackPreflightError'
+  }
+}
+
+// ─── Client type ──────────────────────────────────────────────────────────────
+
+/** Client type compatible with both PrismaClient and transaction client. */
+export type SnapshotDbClient =
+  | PrismaClient
+  | Omit<PrismaClient, '$connect' | '$disconnect' | '$on' | '$transaction' | '$use' | '$extends'>
+
+// ─── Internal helpers (moved verbatim from the Express route) ─────────────────
+
+async function fetchEpics(projectId: string, db: SnapshotDbClient = prisma) {
+  return db.epic.findMany({
+    where: { projectId },
+    orderBy: { order: 'asc' },
+    include: {
+      features: {
+        orderBy: { order: 'asc' },
+        include: {
+          userStories: {
+            orderBy: { order: 'asc' },
+            include: {
+              tasks: {
+                orderBy: { order: 'asc' },
+                include: { resourceType: true },
+              },
+            },
+          },
+        },
+      },
+    },
+  })
+}
+
+/**
+ * Detect which project capacity profiles have database-NULL legacy.
+ * Prisma reads both DB_NULL (Prisma.DbNull) and JSON null (Prisma.JsonNull)
+ * as JavaScript null; this raw query distinguishes them so the snapshot can
+ * preserve the exact null semantics.
+ *
+ * Uses parameterised Prisma.sql via $queryRaw for compatibility with
+ * PrismaClient, transaction clients, and explicit unit doubles.
+ * Validates exact 1:1 correspondence with ORM-loaded profiles.
+ */
+async function fetchLegacyNullMap(
+  projectId: string,
+  db: SnapshotDbClient,
+  rawProfiles: Array<{ id: string }>,
+): Promise<Map<string, boolean>> {
+  const rows = await db.$queryRaw<Array<{ id: string; legacy_is_null: boolean; legacy_typeof: string | null }>>(
+    Prisma.sql`SELECT id, "legacy" IS NULL AS legacy_is_null, jsonb_typeof("legacy") AS legacy_typeof FROM "CapacityProfile" WHERE "projectId" = ${projectId} ORDER BY id`,
+  )
+
+  // Validate exact 1:1 correspondence with ORM-loaded profiles
+  const profileIds = new Set(rawProfiles.map(p => p.id))
+  const seen = new Set<string>()
+  for (const row of rows) {
+    if (seen.has(row.id)) {
+      throw new Error(`Duplicate null-state row for capacity profile ${row.id}`)
+    }
+    if (!profileIds.has(row.id)) {
+      throw new Error(`Null-state row references unknown capacity profile ${row.id}`)
+    }
+    seen.add(row.id)
+  }
+  for (const p of rawProfiles) {
+    if (!seen.has(p.id)) {
+      throw new Error(`Missing null-state row for capacity profile ${p.id}`)
+    }
+  }
+
+  return new Map(rows.map(r => [r.id, r.legacy_is_null]))
+}
+
+// ─── buildSnapshot (public) ───────────────────────────────────────────────────
+
+/** Build the full project snapshot (schemaVersion 3) with ordered capacity profiles. */
+export async function buildSnapshot(
+  projectId: string,
+  db: SnapshotDbClient = prisma,
+): Promise<SnapshotV3> {
+  const [
+    epics,
+    project,
+    resourceTypes,
+    namedResources,
+    timelineEntries,
+    storyTimelineEntries,
+    epicDependencies,
+    featureDependencies,
+    overheadItems,
+    rawProfiles,
+  ] = await Promise.all([
+    fetchEpics(projectId, db),
+    db.project.findUnique({
+      where: { id: projectId },
+      select: { startDate: true, onboardingWeeks: true, bufferWeeks: true, hoursPerDay: true },
+    }),
+    db.resourceType.findMany({
+      where: { projectId },
+      select: {
+        id: true, name: true, category: true, count: true, hoursPerDay: true,
+        dayRate: true, globalTypeId: true,
+        allocationMode: true, allocationPercent: true,
+        allocationStartWeek: true, allocationEndWeek: true,
+      },
+    }),
+    db.namedResource.findMany({
+      where: { resourceType: { projectId } },
+      select: {
+        id: true, resourceTypeId: true, name: true,
+        startWeek: true, endWeek: true, allocationPct: true,
+        allocationMode: true, allocationPercent: true,
+        allocationStartWeek: true, allocationEndWeek: true,
+        pricingModel: true,
+      },
+    }),
+    db.timelineEntry.findMany({
+      where: { projectId },
+      select: { featureId: true, startWeek: true, durationWeeks: true, isManual: true },
+    }),
+    db.storyTimelineEntry.findMany({
+      where: { projectId },
+      select: { storyId: true, startWeek: true, durationWeeks: true, isManual: true },
+    }),
+    db.epicDependency.findMany({
+      where: { epic: { projectId } },
+      select: { epicId: true, dependsOnId: true },
+    }),
+    db.featureDependency.findMany({
+      where: { feature: { epic: { projectId } } },
+      select: { featureId: true, dependsOnId: true },
+    }),
+    db.projectOverhead.findMany({
+      where: { projectId },
+      select: { name: true, type: true, value: true, resourceTypeId: true, order: true },
+    }),
+    db.capacityProfile.findMany({
+      where: { projectId },
+      include: {
+        segments: { orderBy: { startWeek: 'asc' } },
+      },
+      orderBy: [
+        { ownerKind: 'asc' },
+        { resourceTypeId: 'asc' },
+        { namedResourceId: 'asc' },
+      ],
+    }),
+  ])
+
+  const legacyNullMap = await fetchLegacyNullMap(projectId, db, rawProfiles)
+  // Convert Date to ISO string for JSON compatibility
+  const projectFields = project
+    ? {
+        startDate: project.startDate instanceof Date
+          ? project.startDate.toISOString()
+          : project.startDate,
+        onboardingWeeks: project.onboardingWeeks,
+        bufferWeeks: project.bufferWeeks,
+        hoursPerDay: project.hoursPerDay,
+      }
+    : null
+
+  // Map Prisma model rows to SnapshotCapacityProfile, preserving null semantics
+  const capacityProfiles = rawProfiles.map(p => {
+    // Determine the precise null state for legacy
+    const isDBNull = legacyNullMap.get(p.id) ?? false
+    let legacy: SnapshotJsonValue
+    if (isDBNull) {
+      legacy = { kind: 'DB_NULL' }
+    } else if (p.legacy === null) {
+      legacy = { kind: 'JSON_NULL' }
+    } else {
+      legacy = { kind: 'VALUE', value: p.legacy as Record<string, unknown> | unknown[] | string | number | boolean }
+    }
+
+    return {
+      id: p.id,
+      ownerKind: p.ownerKind as SnapshotV3['capacityProfiles'][number]['ownerKind'],
+      resourceTypeId: p.resourceTypeId,
+      namedResourceId: p.namedResourceId,
+      planningBasis: p.planningBasis as SnapshotV3['capacityProfiles'][number]['planningBasis'],
+      source: p.source as SnapshotV3['capacityProfiles'][number]['source'],
+      defaultPercent: p.defaultPercent,
+      startWeek: p.startWeek,
+      endWeek: p.endWeek,
+      legacy,
+      segments: sortSnapshotSegments(p.segments.map(s => ({
+        id: s.id,
+        startWeek: s.startWeek,
+        endWeek: s.endWeek,
+        capacityPercent: s.capacityPercent,
+        source: s.source as SnapshotV3['capacityProfiles'][number]['segments'][number]['source'],
+      }))),
+    }
+  })
+
+  return {
+    schemaVersion: 3 as const,
+    epics,
+    project: projectFields,
+    resourceTypes,
+    namedResources,
+    timelineEntries,
+    storyTimelineEntries,
+    epicDependencies,
+    featureDependencies,
+    overheadItems,
+    capacityProfiles: sortSnapshotProfiles(capacityProfiles),
+  }
+}
+
+// ─── restoreSnapshotCommonState ───────────────────────────────────────────────
+
+/**
+ * Restore the common snapshot state shared across v2 and v3 rollbacks.
+ * Handles ResourceTypes, NamedResources, epics, project fields, timeline
+ * entries, story timeline entries, dependencies, and overhead items.
+ */
+async function restoreSnapshotCommonState(
+  tx: SnapshotDbClient,
+  projectId: string,
+  data: Omit<SnapshotV2, 'schemaVersion'>,
+): Promise<void> {
+  // 1. Restore ResourceTypes FIRST so task FKs resolve correctly when recreating epics
+  const rtNameMap = new Map<string, string>()
+  for (const rt of data.resourceTypes) {
+    await tx.resourceType.upsert({
+      where: { id: rt.id },
+      update: {
+        name: rt.name,
+        category: rt.category,
+        count: rt.count,
+        hoursPerDay: rt.hoursPerDay,
+        dayRate: rt.dayRate,
+        globalTypeId: rt.globalTypeId,
+        allocationMode: rt.allocationMode,
+        allocationPercent: rt.allocationPercent,
+        allocationStartWeek: rt.allocationStartWeek,
+        allocationEndWeek: rt.allocationEndWeek,
+      },
+      create: {
+        id: rt.id,
+        name: rt.name,
+        category: rt.category,
+        count: rt.count,
+        hoursPerDay: rt.hoursPerDay,
+        dayRate: rt.dayRate,
+        globalTypeId: rt.globalTypeId,
+        allocationMode: rt.allocationMode,
+        allocationPercent: rt.allocationPercent,
+        allocationStartWeek: rt.allocationStartWeek,
+        allocationEndWeek: rt.allocationEndWeek,
+        projectId,
+      },
+    })
+    rtNameMap.set(rt.name.toLowerCase(), rt.id)
+  }
+
+  // 2. Restore NamedResources (depends on RTs existing)
+  for (const nr of data.namedResources) {
+    await tx.namedResource.upsert({
+      where: { id: nr.id },
+      update: {
+        name: nr.name,
+        resourceTypeId: nr.resourceTypeId,
+        startWeek: nr.startWeek,
+        endWeek: nr.endWeek,
+        allocationPct: nr.allocationPct,
+        allocationMode: nr.allocationMode,
+        allocationPercent: nr.allocationPercent,
+        allocationStartWeek: nr.allocationStartWeek,
+        allocationEndWeek: nr.allocationEndWeek,
+        pricingModel: nr.pricingModel,
+      },
+      create: {
+        id: nr.id,
+        resourceTypeId: nr.resourceTypeId,
+        name: nr.name,
+        startWeek: nr.startWeek,
+        endWeek: nr.endWeek,
+        allocationPct: nr.allocationPct,
+        allocationMode: nr.allocationMode,
+        allocationPercent: nr.allocationPercent,
+        allocationStartWeek: nr.allocationStartWeek,
+        allocationEndWeek: nr.allocationEndWeek,
+        pricingModel: nr.pricingModel,
+      },
+    })
+  }
+
+  // 3. Restore epics (delete all, recreate from snapshot — IDs will change)
+  await tx.epic.deleteMany({ where: { projectId } })
+
+  // Build old→new ID maps as we recreate the tree
+  const epicIdMap = new Map<string, string>()
+  const featureIdMap = new Map<string, string>()
+  const storyIdMap = new Map<string, string>()
+
+  for (const epic of data.epics) {
+    const newEpic = await tx.epic.create({
+      data: { name: epic.name, description: epic.description, order: epic.order, projectId },
+    })
+    epicIdMap.set(epic.id, newEpic.id)
+    for (const feature of epic.features) {
+      const newFeature = await tx.feature.create({
+        data: { name: feature.name, description: feature.description, assumptions: feature.assumptions, order: feature.order, epicId: newEpic.id },
+      })
+      featureIdMap.set(feature.id, newFeature.id)
+      for (const story of feature.userStories) {
+        const newStory = await tx.userStory.create({
+          data: { name: story.name, description: story.description, assumptions: story.assumptions, order: story.order, featureId: newFeature.id, appliedTemplateId: story.appliedTemplateId },
+        })
+        storyIdMap.set(story.id, newStory.id)
+        for (const task of story.tasks) {
+          const resourceTypeId = task.resourceType?.name
+            ? (rtNameMap.get(task.resourceType.name.toLowerCase()) ?? null)
+            : null
+          await tx.task.create({
+            data: {
+              name: task.name,
+              description: task.description,
+              assumptions: task.assumptions,
+              hoursEffort: task.hoursEffort,
+              durationDays: task.durationDays,
+              order: task.order,
+              userStoryId: newStory.id,
+              resourceTypeId,
+            },
+          })
+        }
+      }
+    }
+  }
+
+  // 4. Restore project fields
+  if (data.project) {
+    await tx.project.update({
+      where: { id: projectId },
+      data: {
+        startDate: data.project.startDate,
+        onboardingWeeks: data.project.onboardingWeeks ?? 0,
+        bufferWeeks: data.project.bufferWeeks ?? 0,
+        hoursPerDay: data.project.hoursPerDay ?? 7.6,
+      },
+    })
+  }
+
+  // 5. Restore TimelineEntries
+  await tx.timelineEntry.deleteMany({ where: { projectId } })
+  if (data.timelineEntries.length > 0) {
+    const mappedTLEs = data.timelineEntries
+      .map(e => {
+        const newFeatureId = featureIdMap.get(e.featureId)
+        if (!newFeatureId) return null
+        return {
+          projectId,
+          featureId: newFeatureId,
+          startWeek: e.startWeek,
+          durationWeeks: e.durationWeeks,
+          isManual: e.isManual,
+        }
+      })
+      .filter((e): e is NonNullable<typeof e> => e !== null)
+    if (mappedTLEs.length > 0) {
+      await tx.timelineEntry.createMany({ data: mappedTLEs, skipDuplicates: true })
+    }
+  }
+
+  // 6. Restore StoryTimelineEntries
+  await tx.storyTimelineEntry.deleteMany({ where: { projectId } })
+  if (data.storyTimelineEntries.length > 0) {
+    const mappedSTLEs = data.storyTimelineEntries
+      .map(e => {
+        const newStoryId = storyIdMap.get(e.storyId)
+        if (!newStoryId) return null
+        return {
+          projectId,
+          storyId: newStoryId,
+          startWeek: e.startWeek,
+          durationWeeks: e.durationWeeks,
+          isManual: e.isManual,
+        }
+      })
+      .filter((e): e is NonNullable<typeof e> => e !== null)
+    if (mappedSTLEs.length > 0) {
+      await tx.storyTimelineEntry.createMany({ data: mappedSTLEs, skipDuplicates: true })
+    }
+  }
+
+  // 7. Restore EpicDependencies
+  await tx.epicDependency.deleteMany({ where: { epic: { projectId } } })
+  if (data.epicDependencies.length > 0) {
+    const mappedEDs = data.epicDependencies
+      .map(d => {
+        const newEpicId = epicIdMap.get(d.epicId)
+        const newDependsOnId = epicIdMap.get(d.dependsOnId)
+        if (!newEpicId || !newDependsOnId) return null
+        return { epicId: newEpicId, dependsOnId: newDependsOnId }
+      })
+      .filter((d): d is NonNullable<typeof d> => d !== null)
+    if (mappedEDs.length > 0) {
+      await tx.epicDependency.createMany({ data: mappedEDs, skipDuplicates: true })
+    }
+  }
+
+  // 8. Restore FeatureDependencies
+  await tx.featureDependency.deleteMany({ where: { feature: { epic: { projectId } } } })
+  if (data.featureDependencies.length > 0) {
+    const mappedFDs = data.featureDependencies
+      .map(d => {
+        const newFeatureId = featureIdMap.get(d.featureId)
+        const newDependsOnId = featureIdMap.get(d.dependsOnId)
+        if (!newFeatureId || !newDependsOnId) return null
+        return { featureId: newFeatureId, dependsOnId: newDependsOnId }
+      })
+      .filter((d): d is NonNullable<typeof d> => d !== null)
+    if (mappedFDs.length > 0) {
+      await tx.featureDependency.createMany({ data: mappedFDs, skipDuplicates: true })
+    }
+  }
+
+  // 9. Restore OverheadItems
+  await tx.projectOverhead.deleteMany({ where: { projectId } })
+  if (data.overheadItems.length > 0) {
+    await tx.projectOverhead.createMany({
+      data: data.overheadItems.map(o => ({
+        projectId,
+        name: o.name,
+        type: o.type,
+        value: o.value,
+        resourceTypeId: o.resourceTypeId,
+        order: o.order,
+      })),
+      skipDuplicates: true,
+    })
+  }
+}
+
+// ─── rollbackProjectSnapshot (the authoritative rollback operation) ───────────
+
+/**
+ * Execute a destructive rollback of a project to the state captured in a
+ * selected backlog snapshot.
+ *
+ * Flow:
+ *  1. Load target snapshot and fail-closed on not-found.
+ *  2. Parse and validate the embedded snapshot JSON.
+ *  3. V3: pre-flight cross-project ownership validation (before any writes).
+ *  4. Inside a single $transaction:
+ *       a. Build a current v3 pre_rollback snapshot.
+ *       b. Persist the pre_rollback snapshot record.
+ *       c. Restore common state (resource types, named resources, epic tree,
+ *          project fields, timeline entries, dependencies, overhead items).
+ *       d. Run version-specific capacity profile recovery.
+ *       e. Prune older snapshots to enforce the retention policy.
+ *
+ * Does NOT perform auth/ownership checks — those belong in the caller.
+ *
+ * @throws {SnapshotNotFoundError} if the target snapshot does not exist.
+ * @throws {SnapshotSchemaError} if the snapshot JSON cannot be parsed.
+ * @throws {SnapshotValidationError} if the V3 payload fails validation.
+ * @throws {RollbackPreflightError} if V3 cross-project ID collisions are detected.
+ */
+export async function rollbackProjectSnapshot({
+  projectId,
+  snapshotId,
+  userId,
+  db = prisma,
+}: {
+  projectId: string
+  snapshotId: string
+  userId: string
+  db?: PrismaClient
+}): Promise<void> {
+  // 1. Load target snapshot
+  const snap = await db.backlogSnapshot.findFirst({
+    where: { id: snapshotId, projectId },
+  })
+  if (!snap) {
+    throw new SnapshotNotFoundError('Snapshot not found')
+  }
+
+  // 2. Parse snapshot data BEFORE any destructive operation
+  let parsedData: SnapshotData
+  try {
+    parsedData = parseSnapshotData(snap.snapshot)
+  } catch (e) {
+    if (e instanceof SnapshotSchemaError) {
+      throw e
+    }
+    throw e
+  }
+
+  // 3. V3: validation + pre-flight checks before any writes
+  if (isSnapshotV3(parsedData)) {
+    validateSnapshotV3(parsedData)
+
+    // Cross-project owner ID collision check
+    const allRtIds = [
+      ...new Set([
+        ...parsedData.resourceTypes.map(rt => rt.id),
+        ...parsedData.capacityProfiles
+          .filter(p => p.ownerKind === 'ROLE' && p.resourceTypeId)
+          .map(p => p.resourceTypeId as string),
+        ...parsedData.overheadItems
+          .filter(o => o.resourceTypeId !== null)
+          .map(o => o.resourceTypeId as string),
+      ]),
+    ]
+    const allNrIds = [
+      ...new Set([
+        ...parsedData.namedResources.map(nr => nr.id),
+        ...parsedData.capacityProfiles
+          .filter(p =>
+            (p.ownerKind === 'NAMED_PERSON' || p.ownerKind === 'PLANNED_RESOURCE') && p.namedResourceId,
+          )
+          .map(p => p.namedResourceId as string),
+      ]),
+    ]
+
+    if (allRtIds.length > 0) {
+      const existingRTs = await db.resourceType.findMany({
+        where: { id: { in: allRtIds } },
+        select: { id: true, projectId: true },
+      })
+      const crossProjectRTs = existingRTs.filter(rt => rt.projectId !== projectId)
+      if (crossProjectRTs.length > 0) {
+        throw new RollbackPreflightError(
+          `Resource type IDs ${crossProjectRTs.map(rt => rt.id).join(', ')} belong to another project; rollback rejected`,
+        )
+      }
+    }
+
+    if (allNrIds.length > 0) {
+      const existingNRs = await db.namedResource.findMany({
+        where: { id: { in: allNrIds } },
+        select: { id: true, resourceType: { select: { projectId: true } } },
+      })
+      const crossProjectNRs = existingNRs.filter(nr => nr.resourceType.projectId !== projectId)
+      if (crossProjectNRs.length > 0) {
+        throw new RollbackPreflightError(
+          `Named resource IDs ${crossProjectNRs.map(nr => nr.id).join(', ')} belong to another project; rollback rejected`,
+        )
+      }
+    }
+  }
+
+  // 4. All validation passed — one atomic transaction
+  const dateStr = new Date().toISOString().slice(0, 10)
+  const originalLabel = snap.label ?? snapshotId
+
+  await db.$transaction(async tx => {
+    // Pre-rollback snapshot inside the transaction
+    const preRollbackData = await buildSnapshot(projectId, tx)
+    await tx.backlogSnapshot.create({
+      data: {
+        projectId,
+        label: `Auto-saved before rollback to '${originalLabel}' — ${dateStr}`,
+        trigger: 'pre_rollback',
+        snapshot: preRollbackData as unknown as object,
+        createdById: userId,
+      },
+    })
+
+    // Restore based on schema version
+    if (isLegacyV1Snapshot(parsedData)) {
+      // --- V1: restore epics only ---
+      const resourceTypes = await tx.resourceType.findMany({
+        where: { projectId },
+        select: { id: true, name: true },
+      })
+      const rtMap = new Map(resourceTypes.map(rt => [rt.name.toLowerCase(), rt.id]))
+
+      await tx.epic.deleteMany({ where: { projectId } })
+      for (const epic of parsedData) {
+        const newEpic = await tx.epic.create({
+          data: { name: epic.name, description: epic.description, order: epic.order, projectId },
+        })
+        for (const feature of epic.features) {
+          const newFeature = await tx.feature.create({
+            data: { name: feature.name, description: feature.description, assumptions: feature.assumptions, order: feature.order, epicId: newEpic.id },
+          })
+          for (const story of feature.userStories) {
+            const newStory = await tx.userStory.create({
+              data: { name: story.name, description: story.description, assumptions: story.assumptions, order: story.order, featureId: newFeature.id, appliedTemplateId: story.appliedTemplateId },
+            })
+            for (const task of story.tasks) {
+              const taskRtId = task.resourceType?.name
+                ? (rtMap.get(task.resourceType.name.toLowerCase()) ?? null)
+                : null
+              await tx.task.create({
+                data: {
+                  name: task.name,
+                  description: task.description,
+                  assumptions: task.assumptions,
+                  hoursEffort: task.hoursEffort,
+                  durationDays: task.durationDays,
+                  order: task.order,
+                  userStoryId: newStory.id,
+                  resourceTypeId: taskRtId,
+                },
+              })
+            }
+          }
+        }
+      }
+      // V1 does NOT touch resource types, named resources, capacity profiles, or segments
+    } else if (isSnapshotV2(parsedData)) {
+      // --- V2: full-state restore + capacity profile cleanup ---
+      await restoreSnapshotCommonState(tx, projectId, parsedData)
+      await recreateV2CapacityProfiles(tx, projectId, parsedData)
+    } else if (isSnapshotV3(parsedData)) {
+      // --- V3: full-state restore + exact profile/segment replacement ---
+      await restoreSnapshotCommonState(tx, projectId, parsedData)
+      await recreateV3CapacityProfiles(tx, projectId, parsedData)
+    }
+
+    // Enforce retention policy inside the same transaction
+    await pruneSnapshots(tx, projectId)
+  })
+}

--- a/server/src/lib/projectSnapshotService.ts
+++ b/server/src/lib/projectSnapshotService.ts
@@ -494,72 +494,6 @@ async function restoreSnapshotCommonState(
   }
 }
 
-/**
- * V3-only: Delete ResourceTypes and NamedResources that exist in the project
- * but are absent from the target snapshot, handling FK-safe ordering.
- * Called after restoreSnapshotCommonState has recreated dependent rows
- * and before recreateV3CapacityProfiles recreates profiles.
- */
-async function pruneNonTargetOwners(
-  tx: SnapshotDbClient,
-  projectId: string,
-  data: { resourceTypes: Array<{ id: string }>; namedResources: Array<{ id: string }> },
-): Promise<void> {
-  const targetRtIds = new Set(data.resourceTypes.map(rt => rt.id))
-  const targetNrIds = new Set(data.namedResources.map(nr => nr.id))
-
-  // 1. Determine non-target ResourceTypes before deleting any owners.
-  const rtWhere = targetRtIds.size > 0
-    ? { projectId, id: { notIn: Array.from(targetRtIds) } }
-    : { projectId }
-  const nonTargetRts = await tx.resourceType.findMany({
-    where: rtWhere,
-    select: { id: true },
-  })
-  const nonTargetRtIds = nonTargetRts.map(rt => rt.id)
-
-  // 2. Delete role-scoped discounts owned exclusively by pruned roles.
-  //    Never null resourceTypeId: null means project-wide to Commercial.
-  //    The projectId predicate prevents touching another project's discounts.
-  if (nonTargetRtIds.length > 0) {
-    await tx.projectDiscount.deleteMany({
-      where: {
-        projectId,
-        resourceTypeId: { in: nonTargetRtIds },
-      },
-    })
-  }
-
-  // 3. Clear other non-cascading references before deleting ResourceTypes.
-  if (nonTargetRtIds.length > 0 && tx.templateTask) {
-    await tx.templateTask.updateMany({
-      where: { resourceTypeId: { in: nonTargetRtIds } },
-      data: { resourceTypeId: null },
-    })
-  }
-
-  // 4. Delete non-target NamedResources (cascades to their capacity profiles).
-  const nrWhere = targetNrIds.size > 0
-    ? { resourceType: { projectId }, id: { notIn: Array.from(targetNrIds) } }
-    : { resourceType: { projectId } }
-  const nonTargetNrs = await tx.namedResource.findMany({
-    where: nrWhere,
-    select: { id: true },
-  })
-  if (nonTargetNrs.length > 0) {
-    await tx.namedResource.deleteMany({
-      where: { id: { in: nonTargetNrs.map(nr => nr.id) } },
-    })
-  }
-
-  // 5. Delete non-target ResourceTypes (cascade handles profiles).
-  if (nonTargetRtIds.length > 0) {
-    await tx.resourceType.deleteMany({
-      where: { id: { in: nonTargetRtIds } },
-    })
-  }
-}
-
 // ─── rollbackProjectSnapshot (the authoritative rollback operation) ───────────
 
 /**
@@ -736,7 +670,6 @@ export async function rollbackProjectSnapshot({
     } else if (isSnapshotV3(parsedData)) {
       // --- V3: full-state restore + exact profile/segment replacement ---
       await restoreSnapshotCommonState(tx, projectId, parsedData)
-      await pruneNonTargetOwners(tx, projectId, parsedData)
       await recreateV3CapacityProfiles(tx, projectId, parsedData)
     }
 

--- a/server/src/lib/projectSnapshotTypes.ts
+++ b/server/src/lib/projectSnapshotTypes.ts
@@ -13,6 +13,7 @@
  */
 
 import { Prisma } from '@prisma/client'
+import type { $Enums } from '@prisma/client'
 
 // ─── JSON value discriminator for nullable Prisma JSON fields ────────────────
 // Prisma reads both database NULL (Prisma.DbNull) and JSON null (Prisma.JsonNull)
@@ -22,7 +23,7 @@ import { Prisma } from '@prisma/client'
 export type SnapshotJsonValue =
   | { kind: 'DB_NULL' }
   | { kind: 'JSON_NULL' }
-  | { kind: 'VALUE'; value: Record<string, unknown> | unknown[] | string | number | boolean | null }
+  | { kind: 'VALUE'; value: Record<string, unknown> | unknown[] | string | number | boolean }
 
 /**
  * Convert a SnapshotJsonValue to the Prisma sentinel or value used for writes.
@@ -145,12 +146,12 @@ export type SnapshotProjectFields = {
 export type SnapshotResourceType = {
   id: string
   name: string
-  category: string
+  category: $Enums.ResourceCategory
   count: number
   hoursPerDay: number | null
   dayRate: number | null
+  allocationMode: $Enums.AllocationMode
   globalTypeId: string | null
-  allocationMode: string
   allocationPercent: number
   allocationStartWeek: number | null
   allocationEndWeek: number | null
@@ -163,7 +164,7 @@ export type SnapshotNamedResource = {
   startWeek: number | null
   endWeek: number | null
   allocationPct: number
-  allocationMode: string
+  allocationMode: $Enums.AllocationMode
   allocationPercent: number
   allocationStartWeek: number | null
   allocationEndWeek: number | null
@@ -196,7 +197,7 @@ export type SnapshotFeatureDependency = {
 
 export type SnapshotOverheadItem = {
   name: string
-  type: string
+  type: $Enums.OverheadType
   value: number
   resourceTypeId: string | null
   order: number

--- a/server/src/lib/projectSnapshotTypes.ts
+++ b/server/src/lib/projectSnapshotTypes.ts
@@ -1,0 +1,331 @@
+/**
+ * projectSnapshotTypes.ts — Pure snapshot version types and type guards.
+ *
+ * Schema version history:
+ *   v1 — Epic-tree array (legacy; no schemaVersion wrapper)
+ *   v2 — Full project state with schemaVersion: 2
+ *   v3 — V2 + capacityProfiles (schemaVersion: 3)
+ *
+ * All types mirror the shapes produced by buildSnapshot() selects and consumed
+ * by the rollback restore code.
+ *
+ * @module projectSnapshotTypes
+ */
+
+// ─── Capacity-profile enum string literal unions ─────────────────────────────
+// These mirror the Prisma-generated $Enums.* types exactly.
+// When the Prisma client is regenerated, update these to match.
+
+export type CapacityProfileOwnerKindEnum =
+  | 'ROLE'
+  | 'NAMED_PERSON'
+  | 'PLANNED_RESOURCE'
+
+export type CapacityProfilePlanningBasisEnum =
+  | 'DEMAND_FOLLOWING'
+  | 'AVAILABILITY_WINDOW'
+  | 'WHOLE_PROJECT_ALLOCATION'
+  | 'CAPACITY_PROFILE'
+
+export type CapacityProfileSourceEnum =
+  | 'FIXED'
+  | 'MANUAL'
+  | 'AVAILABILITY_WINDOW'
+  | 'SQUAD_PLANNER'
+  | 'IMPORTED'
+  | 'DERIVED'
+  | 'LEGACY'
+
+// ─── Epic tree types (v1/v2/v3) ──────────────────────────────────────────────
+
+export type SnapshotTaskResourceType = {
+  id: string
+  name: string
+  hoursPerDay: number | null
+} | null
+
+export type SnapshotTask = {
+  id: string
+  name: string
+  description: string | null
+  assumptions: string | null
+  hoursEffort: number
+  durationDays: number | null
+  order: number
+  resourceTypeId: string | null
+  resourceType: SnapshotTaskResourceType
+}
+
+export type SnapshotUserStory = {
+  id: string
+  name: string
+  description: string | null
+  assumptions: string | null
+  order: number
+  isActive: boolean | null
+  appliedTemplateId: string | null
+  featureId: string
+  tasks: SnapshotTask[]
+}
+
+export type SnapshotFeature = {
+  id: string
+  name: string
+  description: string | null
+  assumptions: string | null
+  order: number
+  featureMode: string
+  isActive: boolean
+  timelineColour: string | null
+  timelineStartWeek: number | null
+  epicId: string
+  userStories: SnapshotUserStory[]
+}
+
+export type SnapshotEpic = {
+  id: string
+  name: string
+  description: string | null
+  assumptions: string | null
+  order: number
+  featureMode: string
+  scheduleMode: string
+  timelineStartWeek: number | null
+  isActive: boolean
+  projectId: string
+  features: SnapshotFeature[]
+}
+
+// ─── V2 common field types ───────────────────────────────────────────────────
+
+export type SnapshotProjectFields = {
+  startDate: string | null
+  onboardingWeeks: number | null
+  bufferWeeks: number | null
+  hoursPerDay: number | null
+}
+
+export type SnapshotResourceType = {
+  id: string
+  name: string
+  category: string
+  count: number
+  hoursPerDay: number | null
+  dayRate: number | null
+  globalTypeId: string | null
+  allocationMode: string
+  allocationPercent: number
+  allocationStartWeek: number | null
+  allocationEndWeek: number | null
+}
+
+export type SnapshotNamedResource = {
+  id: string
+  resourceTypeId: string
+  name: string
+  startWeek: number | null
+  endWeek: number | null
+  allocationPct: number
+  allocationMode: string
+  allocationPercent: number
+  allocationStartWeek: number | null
+  allocationEndWeek: number | null
+  pricingModel: string
+}
+
+export type SnapshotTimelineEntry = {
+  featureId: string
+  startWeek: number
+  durationWeeks: number
+  isManual: boolean
+}
+
+export type SnapshotStoryTimelineEntry = {
+  storyId: string
+  startWeek: number
+  durationWeeks: number
+  isManual: boolean
+}
+
+export type SnapshotEpicDependency = {
+  epicId: string
+  dependsOnId: string
+}
+
+export type SnapshotFeatureDependency = {
+  featureId: string
+  dependsOnId: string
+}
+
+export type SnapshotOverheadItem = {
+  name: string
+  type: string
+  value: number
+  resourceTypeId: string | null
+  order: number
+}
+
+// ─── V3 capacity profile types ───────────────────────────────────────────────
+
+export type SnapshotCapacitySegment = {
+  id: string
+  startWeek: number
+  endWeek: number
+  capacityPercent: number
+  source: CapacityProfileSourceEnum
+}
+
+export type SnapshotCapacityProfile = {
+  id: string
+  ownerKind: CapacityProfileOwnerKindEnum
+  resourceTypeId: string | null
+  namedResourceId: string | null
+  planningBasis: CapacityProfilePlanningBasisEnum
+  source: CapacityProfileSourceEnum
+  defaultPercent: number | null
+  startWeek: number | null
+  endWeek: number | null
+  /** Original legacy field values; JSON-compatible. */
+  legacy: unknown
+  segments: SnapshotCapacitySegment[]
+}
+
+// ─── Version-specific shapes ─────────────────────────────────────────────────
+
+/** V1 is epic-tree-only: either a bare array (historical) or a wrapper resolved
+ *  by parseSnapshotData. */
+export type SnapshotV1 = SnapshotEpic[]
+
+export type SnapshotV2 = {
+  schemaVersion: 2
+  epics: SnapshotEpic[]
+  project: SnapshotProjectFields | null
+  resourceTypes: SnapshotResourceType[]
+  namedResources: SnapshotNamedResource[]
+  timelineEntries: SnapshotTimelineEntry[]
+  storyTimelineEntries: SnapshotStoryTimelineEntry[]
+  epicDependencies: SnapshotEpicDependency[]
+  featureDependencies: SnapshotFeatureDependency[]
+  overheadItems: SnapshotOverheadItem[]
+}
+
+export type SnapshotV3 = Omit<SnapshotV2, 'schemaVersion'> & {
+  schemaVersion: 3
+  capacityProfiles: SnapshotCapacityProfile[]
+}
+
+export type SnapshotData = SnapshotV1 | SnapshotV2 | SnapshotV3
+
+// ─── Error class ─────────────────────────────────────────────────────────────
+
+export class SnapshotSchemaError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'SnapshotSchemaError'
+  }
+}
+
+// ─── Type guards ─────────────────────────────────────────────────────────────
+
+/**
+ * Returns true when `value` is a legacy V1 snapshot (bare epic array or
+ * plain object with `epics` array and no `schemaVersion`).
+ *
+ * The object-with-epics form is accepted for backward compatibility with old
+ * stored snapshots, but parseSnapshotData normalises it to the array form.
+ */
+export function isLegacyV1Snapshot(value: unknown): value is SnapshotV1 {
+  if (Array.isArray(value)) return true
+  if (typeof value !== 'object' || value === null) return false
+  const obj = value as Record<string, unknown>
+  if ('schemaVersion' in obj) return false
+  return Array.isArray(obj.epics)
+}
+
+export function isSnapshotV2(value: unknown): value is SnapshotV2 {
+  if (typeof value !== 'object' || value === null) return false
+  const obj = value as Record<string, unknown>
+  if (obj.schemaVersion !== 2) return false
+  return (
+    Array.isArray(obj.epics) &&
+    (obj.project === null || typeof obj.project === 'object') &&
+    Array.isArray(obj.resourceTypes) &&
+    Array.isArray(obj.namedResources) &&
+    Array.isArray(obj.timelineEntries) &&
+    Array.isArray(obj.storyTimelineEntries) &&
+    Array.isArray(obj.epicDependencies) &&
+    Array.isArray(obj.featureDependencies) &&
+    Array.isArray(obj.overheadItems)
+  )
+}
+
+export function isSnapshotV3(value: unknown): value is SnapshotV3 {
+  if (typeof value !== 'object' || value === null) return false
+  const obj = value as Record<string, unknown>
+  if (obj.schemaVersion !== 3) return false
+  return (
+    Array.isArray(obj.epics) &&
+    (obj.project === null || typeof obj.project === 'object') &&
+    Array.isArray(obj.resourceTypes) &&
+    Array.isArray(obj.namedResources) &&
+    Array.isArray(obj.timelineEntries) &&
+    Array.isArray(obj.storyTimelineEntries) &&
+    Array.isArray(obj.epicDependencies) &&
+    Array.isArray(obj.featureDependencies) &&
+    Array.isArray(obj.overheadItems) &&
+    Array.isArray(obj.capacityProfiles)
+  )
+}
+
+// ─── Parsing ─────────────────────────────────────────────────────────────────
+
+/**
+ * Parse raw snapshot JSON into a typed SnapshotData.
+ *
+ * - Legacy V1 array → returned as-is.
+ * - Object without schemaVersion + with epics → normalised to V1 array.
+ * - schemaVersion 2 → SnapshotV2.
+ * - schemaVersion 3 → SnapshotV3.
+ * - Unknown schemaVersion → SnapshotSchemaError.
+ * - Malformed → SnapshotSchemaError.
+ *
+ * Structural checks are deliberately conservative to accept real stored data
+ * without deep-field validation (that is the caller's responsibility).
+ */
+export function parseSnapshotData(value: unknown): SnapshotData {
+  // V1: bare epic array
+  if (Array.isArray(value)) {
+    return value as SnapshotV1
+  }
+
+  if (typeof value !== 'object' || value === null) {
+    throw new SnapshotSchemaError('Snapshot data must be a non-null object or an array')
+  }
+
+  const obj = value as Record<string, unknown>
+
+  // Legacy object with epics but no schemaVersion → treat as V1, return array
+  if (!('schemaVersion' in obj)) {
+    if (Array.isArray(obj.epics)) {
+      return obj.epics as unknown as SnapshotV1
+    }
+    throw new SnapshotSchemaError(
+      'Snapshot object without schemaVersion must have an "epics" array',
+    )
+  }
+
+  const sv = obj.schemaVersion
+
+  if (sv === 3) {
+    if (isSnapshotV3(value)) return value as SnapshotV3
+    throw new SnapshotSchemaError('Data has schemaVersion 3 but structure is invalid')
+  }
+
+  if (sv === 2) {
+    if (isSnapshotV2(value)) return value as SnapshotV2
+    throw new SnapshotSchemaError('Data has schemaVersion 2 but structure is invalid')
+  }
+
+  // Unknown or future schema version — never fall through to v2
+  throw new SnapshotSchemaError(`Unsupported schema version: ${String(sv)}`)
+}

--- a/server/src/lib/projectSnapshotTypes.ts
+++ b/server/src/lib/projectSnapshotTypes.ts
@@ -12,6 +12,43 @@
  * @module projectSnapshotTypes
  */
 
+import { Prisma } from '@prisma/client'
+
+// ─── JSON value discriminator for nullable Prisma JSON fields ────────────────
+// Prisma reads both database NULL (Prisma.DbNull) and JSON null (Prisma.JsonNull)
+// as JavaScript `null`. This discriminator preserves the distinction across
+// snapshot serialisation/deserialisation.
+
+export type SnapshotJsonValue =
+  | { kind: 'DB_NULL' }
+  | { kind: 'JSON_NULL' }
+  | { kind: 'VALUE'; value: Record<string, unknown> | unknown[] | string | number | boolean | null }
+
+/**
+ * Convert a SnapshotJsonValue to the Prisma sentinel or value used for writes.
+ * DB_NULL → Prisma.DbNull
+ * JSON_NULL → Prisma.JsonNull
+ * VALUE → the contained value
+ */
+export function snapshotJsonValueToPrisma(sjv: SnapshotJsonValue): Prisma.NullableJsonNullValueInput | Prisma.InputJsonValue {
+  switch (sjv.kind) {
+    case 'DB_NULL': return Prisma.DbNull
+    case 'JSON_NULL': return Prisma.JsonNull
+    case 'VALUE': return sjv.value as Prisma.InputJsonValue
+  }
+}
+
+/**
+ * Serialise a SnapshotJsonValue to a JSON-safe plain object for storage in
+ * the snapshot JSON column. The `kind` discriminator survives JSON.parse.
+ */
+export function snapshotJsonValueToPlain(sjv: SnapshotJsonValue): Record<string, unknown> {
+  if (sjv.kind === 'VALUE') {
+    return { kind: 'VALUE', value: sjv.value as unknown }
+  }
+  return { kind: sjv.kind }
+}
+
 // ─── Capacity-profile enum string literal unions ─────────────────────────────
 // These mirror the Prisma-generated $Enums.* types exactly.
 // When the Prisma client is regenerated, update these to match.
@@ -185,8 +222,8 @@ export type SnapshotCapacityProfile = {
   defaultPercent: number | null
   startWeek: number | null
   endWeek: number | null
-  /** Original legacy field values; JSON-compatible. */
-  legacy: unknown
+  /** Original legacy field values; SnapshotJsonValue preserves DB_NULL vs JSON_NULL. */
+  legacy: SnapshotJsonValue
   segments: SnapshotCapacitySegment[]
 }
 

--- a/server/src/lib/projectSnapshotValidation.ts
+++ b/server/src/lib/projectSnapshotValidation.ts
@@ -62,21 +62,34 @@ function isFiniteNumber(v: unknown): v is number {
   return typeof v === 'number' && Number.isFinite(v)
 }
 
-function isJsonCompatible(value: unknown): boolean {
-  if (value === null || typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') return true
-  if (Array.isArray(value)) return value.every(isJsonCompatible)
+function isJsonCompatible(value: unknown, stack?: Set<object>): boolean {
+  stack = stack ?? new Set<object>()
+  // Primitives
+  if (value === null) return true
+  if (typeof value === 'string') return true
+  if (typeof value === 'boolean') return true
+  if (typeof value === 'number') return Number.isFinite(value)
+  // Arrays — detect cycles in the current path only (shared refs are fine)
+  if (Array.isArray(value)) {
+    if (stack.has(value)) return false
+    stack.add(value)
+    const ok = value.every(v => isJsonCompatible(v, stack))
+    stack.delete(value)
+    return ok
+  }
+  // Plain objects only — reject Date, RegExp, custom classes
   if (typeof value === 'object' && value !== null) {
-    return Object.values(value).every(isJsonCompatible)
+    const proto = Object.getPrototypeOf(value)
+    if (proto !== null && proto !== Object.prototype) return false
+    if (stack.has(value)) return false
+    stack.add(value)
+    const ok = Object.values(value).every(v => isJsonCompatible(v, stack))
+    stack.delete(value)
+    return ok
   }
   return false
 }
 
-/**
- * Validate a SnapshotJsonValue discriminator.
- * - kind must be 'DB_NULL', 'JSON_NULL', or 'VALUE'
- * - DB_NULL and JSON_NULL must not carry an extra value
- * - VALUE must carry a JSON-compatible value
- */
 export function validateSnapshotJsonValue(
   sjv: unknown,
   pfx: string,
@@ -85,25 +98,36 @@ export function validateSnapshotJsonValue(
     fail(pfx, 'SnapshotJsonValue must be a non-null object')
   }
   const obj = sjv as Record<string, unknown>
-  const kind = obj.kind
+  // kind must be present and a string
+  if (typeof obj.kind !== 'string') {
+    fail(pfx, `SnapshotJsonValue kind must be a string, got ${typeof obj.kind === 'string' ? '"' + obj.kind + '"' : String(typeof obj.kind)}`)
+  }
+  const kind = obj.kind as string
   if (kind === 'DB_NULL') {
-    if (obj.value !== undefined) {
-      fail(pfx, 'DB_NULL kind must not have an extra "value" field')
+    const keys = Object.keys(obj)
+    if (keys.length !== 1 || keys[0] !== 'kind') {
+      fail(pfx, 'DB_NULL must have exactly one field "kind"')
     }
     return
   }
   if (kind === 'JSON_NULL') {
-    if (obj.value !== undefined) {
-      fail(pfx, 'JSON_NULL kind must not have an extra "value" field')
+    const keys = Object.keys(obj)
+    if (keys.length !== 1 || keys[0] !== 'kind') {
+      fail(pfx, 'JSON_NULL must have exactly one field "kind"')
     }
     return
   }
   if (kind === 'VALUE') {
-    if (!('value' in obj)) {
-      fail(pfx, 'VALUE kind must have a "value" field')
+    const keys = Object.keys(obj)
+    if (keys.length !== 2 || !keys.includes('kind') || !keys.includes('value')) {
+      fail(pfx, 'VALUE must have exactly two fields: "kind" and "value"')
+    }
+    // Top-level null is not valid for VALUE — use DB_NULL / JSON_NULL for null semantics
+    if (obj.value === null) {
+      fail(pfx, 'VALUE kind must not contain a top-level null value')
     }
     if (!isJsonCompatible(obj.value)) {
-      fail(pfx, 'VALUE kind contains a non-serialisable value (undefined, function, symbol, bigint, or cyclic reference)')
+      fail(pfx, 'VALUE kind contains a non-serialisable value (undefined, NaN, ±Infinity, function, symbol, bigint, cyclic reference, or non-plain object)')
     }
     return
   }

--- a/server/src/lib/projectSnapshotValidation.ts
+++ b/server/src/lib/projectSnapshotValidation.ts
@@ -1,0 +1,374 @@
+/**
+ * projectSnapshotValidation.ts — V3 snapshot validation for pre-rollback checks.
+ *
+ * Validates that a SnapshotV3 payload is structurally sound before
+ * committing destructive work (rollback).  Duplicate owners are preserved;
+ * duplicate profile/segment IDs are rejected.
+ *
+ * @module projectSnapshotValidation
+ */
+
+import type {
+  SnapshotV3,
+  SnapshotCapacityProfile,
+  SnapshotCapacitySegment,
+  CapacityProfileOwnerKindEnum,
+  CapacityProfilePlanningBasisEnum,
+  CapacityProfileSourceEnum,
+} from './projectSnapshotTypes.js'
+
+// ─── Known enum value sets ───────────────────────────────────────────────────
+
+const VALID_OWNER_KINDS: readonly CapacityProfileOwnerKindEnum[] = [
+  'ROLE',
+  'NAMED_PERSON',
+  'PLANNED_RESOURCE',
+] as const
+
+const VALID_PLANNING_BASES: readonly CapacityProfilePlanningBasisEnum[] = [
+  'DEMAND_FOLLOWING',
+  'AVAILABILITY_WINDOW',
+  'WHOLE_PROJECT_ALLOCATION',
+  'CAPACITY_PROFILE',
+] as const
+
+const VALID_SOURCES: readonly CapacityProfileSourceEnum[] = [
+  'FIXED',
+  'MANUAL',
+  'AVAILABILITY_WINDOW',
+  'SQUAD_PLANNER',
+  'IMPORTED',
+  'DERIVED',
+  'LEGACY',
+] as const
+
+// ─── Error class ─────────────────────────────────────────────────────────────
+
+export class SnapshotValidationError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'SnapshotValidationError'
+  }
+}
+
+// ─── Validation ──────────────────────────────────────────────────────────────
+
+function fail(path: string, detail: string): never {
+  throw new SnapshotValidationError(`${path}: ${detail}`)
+}
+
+function isFiniteNumber(v: unknown): v is number {
+  return typeof v === 'number' && Number.isFinite(v)
+}
+
+/**
+ * Validate a SnapshotV3 payload for structural soundness.
+ *
+ * Checks performed:
+ *  - Non-empty unique resourceTypes IDs
+ *  - Non-empty unique namedResources IDs
+ *  - Each namedResource.resourceTypeId exists in snapshot.resourceTypes
+ *  - Each non-null overheadItems.resourceTypeId exists in snapshot.resourceTypes
+ *  - Non-empty unique profile IDs globally
+ *  - Non-empty unique segment IDs globally
+ *  - ownerKind is a supported enum value
+ *  - ROLE requires resourceTypeId and null namedResourceId
+ *  - NAMED_PERSON / PLANNED_RESOURCE require namedResourceId and null resourceTypeId
+ *  - Each referenced owner ID exists in snapshot.resourceTypes or .namedResources
+ *  - Named resource's resourceTypeId exists in snapshot.resourceTypes
+ *  - planningBasis is a supported enum value
+ *  - source (profile-level) is a supported enum value
+ *  - defaultPercent is null or finite >= 0
+ *  - Profile startWeek / endWeek are null or finite numbers
+ *  - Segment startWeek / endWeek are finite numbers with end >= start
+ *  - Segment capacityPercent is finite >= 0
+ *  - Segment source is a supported enum value
+ *
+ * Explicitly NOT rejected:
+ *  - Duplicate owners (same resourceTypeId / namedResourceId across profiles)
+ *  - Overlapping or discontinuous segments
+ *  - >100% role capacity
+ *  - null legacy field
+ *
+ * @throws SnapshotValidationError on first invalid value.
+ */
+export function validateSnapshotV3(snapshot: SnapshotV3): void {
+  const { capacityProfiles, resourceTypes, namedResources, overheadItems } = snapshot
+
+  // ── resourceTypes structure ──────────────────────────────────────────────
+  const seenRtIds = new Set<string>()
+  for (let ri = 0; ri < resourceTypes.length; ri++) {
+    const rt = resourceTypes[ri]
+    const rpfx = `resourceTypes[${ri}]`
+    if (typeof rt !== 'object' || rt === null) {
+      fail(rpfx, 'resourceType entry must be a non-null object')
+    }
+    if (typeof rt.id !== 'string' || rt.id.length === 0) {
+      fail(rpfx, 'resourceType id must be a non-empty string')
+    }
+    if (seenRtIds.has(rt.id)) {
+      fail(rpfx, `duplicate resourceType id "${rt.id}"`)
+    }
+    seenRtIds.add(rt.id)
+  }
+
+  // ── namedResources structure ─────────────────────────────────────────────
+  const seenNrIds = new Set<string>()
+  for (let ni = 0; ni < namedResources.length; ni++) {
+    const nr = namedResources[ni]
+    const npfx = `namedResources[${ni}]`
+    if (typeof nr !== 'object' || nr === null) {
+      fail(npfx, 'namedResource entry must be a non-null object')
+    }
+    if (typeof nr.id !== 'string' || nr.id.length === 0) {
+      fail(npfx, 'namedResource id must be a non-empty string')
+    }
+    if (seenNrIds.has(nr.id)) {
+      fail(npfx, `duplicate namedResource id "${nr.id}"`)
+    }
+    seenNrIds.add(nr.id)
+  }
+
+  // Build lookup sets for owner ID existence checks
+  const rtIds = new Set(resourceTypes.map(r => r.id))
+  const nrIds = new Set(namedResources.map(n => n.id))
+  const nrRtIds = new Map(namedResources.map(n => [n.id, n.resourceTypeId]))
+
+  // ── Every namedResource.resourceTypeId must exist in resourceTypes ──────
+  for (let ni = 0; ni < namedResources.length; ni++) {
+    const nr = namedResources[ni]
+    const npfx = `namedResources[${ni}]`
+    if (!rtIds.has(nr.resourceTypeId)) {
+      fail(npfx, `resourceTypeId "${nr.resourceTypeId}" not found in snapshot.resourceTypes`)
+    }
+  }
+
+  // ── Overhead items: non-null resourceTypeId must exist in resourceTypes ─
+  for (let oi = 0; oi < overheadItems.length; oi++) {
+    const item = overheadItems[oi]
+    const opfx = `overheadItems[${oi}]`
+    if (typeof item !== 'object' || item === null) {
+      fail(opfx, 'overhead item must be a non-null object')
+    }
+    const oiRtId = item.resourceTypeId
+    if (oiRtId !== null && !rtIds.has(oiRtId)) {
+      fail(opfx, `resourceTypeId "${oiRtId}" not found in snapshot.resourceTypes`)
+    }
+  }
+
+  // ── Capacity profiles ───────────────────────────────────────────────────
+  const seenProfileIds = new Set<string>()
+  const seenSegmentIds = new Set<string>()
+
+  for (let pi = 0; pi < capacityProfiles.length; pi++) {
+    const profile = capacityProfiles[pi]
+    const pfx = `capacityProfiles[${pi}]`
+
+    if (typeof profile !== 'object' || profile === null) {
+      fail(pfx, 'capacity profile must be a non-null object')
+    }
+
+    validateProfile(profile, pfx, rtIds, nrIds, nrRtIds, seenProfileIds, seenSegmentIds)
+  }
+}
+
+function validateProfile(
+  profile: SnapshotCapacityProfile,
+  pfx: string,
+  rtIds: Set<string>,
+  nrIds: Set<string>,
+  nrRtIds: Map<string, string>,
+  seenProfileIds: Set<string>,
+  seenSegmentIds: Set<string>,
+): void {
+  // id — non-empty and globally unique
+  if (typeof profile.id !== 'string' || profile.id.length === 0) {
+    fail(pfx, 'profile id must be a non-empty string')
+  }
+  if (seenProfileIds.has(profile.id)) {
+    fail(pfx, `duplicate profile id "${profile.id}"`)
+  }
+  seenProfileIds.add(profile.id)
+
+  // ownerKind — supported value
+  if (!VALID_OWNER_KINDS.includes(profile.ownerKind as CapacityProfileOwnerKindEnum)) {
+    fail(pfx, `unsupported ownerKind "${String(profile.ownerKind)}"`)
+  }
+
+  // Owner-kind-specific rules
+  switch (profile.ownerKind) {
+    case 'ROLE': {
+      if (typeof profile.resourceTypeId !== 'string' || profile.resourceTypeId.length === 0) {
+        fail(pfx, 'ROLE ownerKind requires a non-empty resourceTypeId')
+      }
+      if (profile.namedResourceId !== null) {
+        fail(pfx, 'ROLE ownerKind requires namedResourceId to be null')
+      }
+      // Verify resourceTypeId exists
+      if (!rtIds.has(profile.resourceTypeId)) {
+        fail(pfx, `resourceTypeId "${profile.resourceTypeId}" not found in snapshot.resourceTypes`)
+      }
+      break
+    }
+    case 'NAMED_PERSON':
+    case 'PLANNED_RESOURCE': {
+      if (typeof profile.namedResourceId !== 'string' || profile.namedResourceId.length === 0) {
+        fail(pfx, `${profile.ownerKind} ownerKind requires a non-empty namedResourceId`)
+      }
+      if (profile.resourceTypeId !== null) {
+        fail(pfx, `${profile.ownerKind} ownerKind requires resourceTypeId to be null`)
+      }
+      // Verify namedResourceId exists
+      if (!nrIds.has(profile.namedResourceId)) {
+        fail(pfx, `namedResourceId "${profile.namedResourceId}" not found in snapshot.namedResources`)
+      }
+      // Verify the named resource's own resourceTypeId exists
+      const linkedRtId = nrRtIds.get(profile.namedResourceId)
+      if (linkedRtId !== undefined && !rtIds.has(linkedRtId)) {
+        fail(pfx, `namedResource "${profile.namedResourceId}" references resourceTypeId "${linkedRtId}" which is not in snapshot.resourceTypes`)
+      }
+      break
+    }
+    default:
+      // Already caught by the ownerKind check above, but satisfies exhaustiveness
+      fail(pfx, `unsupported ownerKind "${String(profile.ownerKind)}"`)
+  }
+
+  // planningBasis — supported value
+  if (!VALID_PLANNING_BASES.includes(profile.planningBasis as CapacityProfilePlanningBasisEnum)) {
+    fail(pfx, `unsupported planningBasis "${String(profile.planningBasis)}"`)
+  }
+
+  // source — supported value
+  if (!VALID_SOURCES.includes(profile.source as CapacityProfileSourceEnum)) {
+    fail(pfx, `unsupported source "${String(profile.source)}"`)
+  }
+
+  // defaultPercent — null or finite >= 0
+  if (profile.defaultPercent !== null) {
+    if (!isFiniteNumber(profile.defaultPercent) || profile.defaultPercent < 0) {
+      fail(pfx, `defaultPercent must be null or a finite number >= 0, got ${String(profile.defaultPercent)}`)
+    }
+  }
+  // startWeek / endWeek — null or finite number
+  if (profile.startWeek !== null && !isFiniteNumber(profile.startWeek)) {
+    fail(pfx, `startWeek must be null or a finite number, got ${String(profile.startWeek)}`)
+  }
+  if (profile.endWeek !== null && !isFiniteNumber(profile.endWeek)) {
+    fail(pfx, `endWeek must be null or a finite number, got ${String(profile.endWeek)}`)
+  }
+  if (
+    profile.startWeek !== null &&
+    profile.endWeek !== null &&
+    profile.endWeek < profile.startWeek
+  ) {
+    fail(pfx, `endWeek (${profile.endWeek}) must be >= startWeek (${profile.startWeek})`)
+  }
+
+  // Segments
+  if (!Array.isArray(profile.segments)) {
+    fail(pfx, 'segments must be an array')
+  }
+
+  for (let si = 0; si < profile.segments.length; si++) {
+    const seg = profile.segments[si]
+    const spfx = `${pfx}.segments[${si}]`
+    if (typeof seg !== 'object' || seg === null) {
+      fail(spfx, 'segment must be a non-null object')
+    }
+    validateSegment(seg, spfx, seenSegmentIds)
+  }
+}
+
+function validateSegment(
+  seg: SnapshotCapacitySegment,
+  pfx: string,
+  seenSegmentIds: Set<string>,
+): void {
+  // id — non-empty and globally unique
+  if (typeof seg.id !== 'string' || seg.id.length === 0) {
+    fail(pfx, 'segment id must be a non-empty string')
+  }
+  if (seenSegmentIds.has(seg.id)) {
+    fail(pfx, `duplicate segment id "${seg.id}"`)
+  }
+  seenSegmentIds.add(seg.id)
+
+  // startWeek/endWeek — finite numbers with end >= start
+  if (!isFiniteNumber(seg.startWeek)) {
+    fail(pfx, `startWeek must be a finite number, got ${String(seg.startWeek)}`)
+  }
+  if (!isFiniteNumber(seg.endWeek)) {
+    fail(pfx, `endWeek must be a finite number, got ${String(seg.endWeek)}`)
+  }
+  if (seg.endWeek < seg.startWeek) {
+    fail(pfx, `endWeek (${seg.endWeek}) must be >= startWeek (${seg.startWeek})`)
+  }
+
+  // capacityPercent — finite >= 0
+  if (!isFiniteNumber(seg.capacityPercent) || seg.capacityPercent < 0) {
+    fail(pfx, `capacityPercent must be a finite number >= 0, got ${String(seg.capacityPercent)}`)
+  }
+
+  // source — supported value
+  if (!VALID_SOURCES.includes(seg.source as CapacityProfileSourceEnum)) {
+    fail(pfx, `unsupported source "${String(seg.source)}"`)
+  }
+}
+
+// ─── Stable ordering helpers ─────────────────────────────────────────────────
+
+/**
+ * Stable comparator for capacity profiles.
+ *
+ * Sort order:
+ *   1. ownerKind (alphabetical — ROLE, NAMED_PERSON, PLANNED_RESOURCE)
+ *   2. Owner identity:
+ *      - ROLE profiles by resourceTypeId
+ *      - Named-resource profiles by namedResourceId
+ *   3. Profile ID (deterministic tie-breaker)
+ *
+ * Does NOT mutate the input arrays.
+ */
+export function sortSnapshotProfiles(
+  profiles: SnapshotCapacityProfile[],
+): SnapshotCapacityProfile[] {
+  return [...profiles].sort((a, b) => {
+    // 1. ownerKind
+    const kindCmp = a.ownerKind.localeCompare(b.ownerKind)
+    if (kindCmp !== 0) return kindCmp
+
+    // 2. Owner identity (one of the two IDs is always set for valid profiles)
+    const ownerA = a.resourceTypeId ?? a.namedResourceId ?? ''
+    const ownerB = b.resourceTypeId ?? b.namedResourceId ?? ''
+    const ownerCmp = ownerA.localeCompare(ownerB)
+    if (ownerCmp !== 0) return ownerCmp
+
+    // 3. Profile ID
+    return a.id.localeCompare(b.id)
+  })
+}
+
+/**
+ * Stable comparator for capacity segments within a profile.
+ *
+ * Sort order:
+ *   1. startWeek (ascending)
+ *   2. endWeek (ascending)
+ *   3. Segment ID (deterministic tie-breaker)
+ *
+ * Does NOT mutate the input arrays.
+ */
+export function sortSnapshotSegments(
+  segments: SnapshotCapacitySegment[],
+): SnapshotCapacitySegment[] {
+  return [...segments].sort((a, b) => {
+    const startCmp = a.startWeek - b.startWeek
+    if (startCmp !== 0) return startCmp
+
+    const endCmp = a.endWeek - b.endWeek
+    if (endCmp !== 0) return endCmp
+
+    return a.id.localeCompare(b.id)
+  })
+}

--- a/server/src/lib/projectSnapshotValidation.ts
+++ b/server/src/lib/projectSnapshotValidation.ts
@@ -12,6 +12,7 @@ import type {
   SnapshotV3,
   SnapshotCapacityProfile,
   SnapshotCapacitySegment,
+  SnapshotJsonValue,
   CapacityProfileOwnerKindEnum,
   CapacityProfilePlanningBasisEnum,
   CapacityProfileSourceEnum,
@@ -59,6 +60,54 @@ function fail(path: string, detail: string): never {
 
 function isFiniteNumber(v: unknown): v is number {
   return typeof v === 'number' && Number.isFinite(v)
+}
+
+function isJsonCompatible(value: unknown): boolean {
+  if (value === null || typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') return true
+  if (Array.isArray(value)) return value.every(isJsonCompatible)
+  if (typeof value === 'object' && value !== null) {
+    return Object.values(value).every(isJsonCompatible)
+  }
+  return false
+}
+
+/**
+ * Validate a SnapshotJsonValue discriminator.
+ * - kind must be 'DB_NULL', 'JSON_NULL', or 'VALUE'
+ * - DB_NULL and JSON_NULL must not carry an extra value
+ * - VALUE must carry a JSON-compatible value
+ */
+export function validateSnapshotJsonValue(
+  sjv: unknown,
+  pfx: string,
+): asserts sjv is SnapshotJsonValue {
+  if (typeof sjv !== 'object' || sjv === null) {
+    fail(pfx, 'SnapshotJsonValue must be a non-null object')
+  }
+  const obj = sjv as Record<string, unknown>
+  const kind = obj.kind
+  if (kind === 'DB_NULL') {
+    if (obj.value !== undefined) {
+      fail(pfx, 'DB_NULL kind must not have an extra "value" field')
+    }
+    return
+  }
+  if (kind === 'JSON_NULL') {
+    if (obj.value !== undefined) {
+      fail(pfx, 'JSON_NULL kind must not have an extra "value" field')
+    }
+    return
+  }
+  if (kind === 'VALUE') {
+    if (!('value' in obj)) {
+      fail(pfx, 'VALUE kind must have a "value" field')
+    }
+    if (!isJsonCompatible(obj.value)) {
+      fail(pfx, 'VALUE kind contains a non-serialisable value (undefined, function, symbol, bigint, or cyclic reference)')
+    }
+    return
+  }
+  fail(pfx, `unsupported SnapshotJsonValue kind "${String(kind)}"`)
 }
 
 /**
@@ -264,6 +313,9 @@ function validateProfile(
   ) {
     fail(pfx, `endWeek (${profile.endWeek}) must be >= startWeek (${profile.startWeek})`)
   }
+
+  // Legacy — SnapshotJsonValue discriminator
+  validateSnapshotJsonValue(profile.legacy, `${pfx}.legacy`)
 
   // Segments
   if (!Array.isArray(profile.segments)) {

--- a/server/src/lib/snapshotUtils.ts
+++ b/server/src/lib/snapshotUtils.ts
@@ -1,11 +1,25 @@
-import { PrismaClient } from '@prisma/client'
+/**
+ * Minimal client interface compatible with both PrismaClient and transaction client.
+ * Covers only the backlogSnapshot methods pruneSnapshots needs.
+ */
+export interface SnapshotDbLike {
+  backlogSnapshot: {
+    findMany(args: {
+      where: { projectId: string }
+      orderBy: { createdAt: 'desc' }
+      skip: number
+      select: { id: true }
+    }): Promise<Array<{ id: string }>>
+    deleteMany(args: { where: { id: { in: string[] } } }): Promise<{ count: number }>
+  }
+}
 
 /**
  * #177: Snapshot retention — keep only the `keep` most-recent snapshots per project.
  * Call after every backlogSnapshot.create() to prevent unbounded growth.
  */
 export async function pruneSnapshots(
-  prisma: PrismaClient,
+  prisma: SnapshotDbLike,
   projectId: string,
   keep = 20,
 ): Promise<void> {

--- a/server/src/routes/snapshots.ts
+++ b/server/src/routes/snapshots.ts
@@ -1,32 +1,25 @@
 import { Router, Response } from 'express'
-import type { PrismaClient } from '@prisma/client'
 import { prisma } from '../lib/prisma.js'
 import { asyncHandler } from '../lib/asyncHandler.js'
 import { authenticate, AuthRequest } from '../middleware/auth.js'
 import { ownedProject } from '../lib/ownership.js'
-import { pruneSnapshots } from '../lib/snapshotUtils.js'
+import {
+  rollbackProjectSnapshot,
+  buildSnapshot,
+  SnapshotNotFoundError,
+  RollbackPreflightError,
+} from '../lib/projectSnapshotService.js'
 import {
   parseSnapshotData,
   isLegacyV1Snapshot,
-  isSnapshotV2,
-  isSnapshotV3,
   SnapshotSchemaError,
   type SnapshotData,
   type SnapshotEpic,
-  type SnapshotJsonValue,
-  type SnapshotV2,
-  type SnapshotV3,
 } from '../lib/projectSnapshotTypes.js'
 import {
-  validateSnapshotV3,
   SnapshotValidationError,
-  sortSnapshotProfiles,
-  sortSnapshotSegments,
 } from '../lib/projectSnapshotValidation.js'
-import {
-  recreateV2CapacityProfiles,
-  recreateV3CapacityProfiles,
-} from '../lib/projectSnapshotCapacity.js'
+import { pruneSnapshots } from '../lib/snapshotUtils.js'
 
 const router = Router({ mergeParams: true })
 router.use(authenticate)
@@ -40,195 +33,6 @@ router.use(authenticate)
 //   'optimiser_apply'  — auto-saved before the optimiser applies a scenario (Phase 2+)
 //   'pre_rollback'     — auto-saved before rolling back to a prior snapshot (reversible rollback)
 // ---------------------------------------------------------------------------
-
-/** Client type compatible with both PrismaClient and transaction client. */
-type SnapshotDbClient = PrismaClient | Omit<PrismaClient, '$connect' | '$disconnect' | '$on' | '$transaction' | '$use' | '$extends'>
-
-async function fetchEpics(projectId: string, db: SnapshotDbClient = prisma) {
-  return db.epic.findMany({
-    where: { projectId },
-    orderBy: { order: 'asc' },
-    include: {
-      features: {
-        orderBy: { order: 'asc' },
-        include: {
-          userStories: {
-            orderBy: { order: 'asc' },
-            include: {
-              tasks: {
-                orderBy: { order: 'asc' },
-                include: { resourceType: true },
-              },
-            },
-          },
-        },
-      },
-    },
-  })
-}
-
-/**
- * Detect which project capacity profiles have database-NULL legacy.
- * Prisma reads both DB_NULL (Prisma.DbNull) and JSON null (Prisma.JsonNull)
- * as JavaScript null; this raw query distinguishes them so the snapshot can
- * preserve the exact null semantics.
- *
- * Returns an empty map when $queryRawUnsafe is unavailable (e.g. mock client),
- * so all profiles are treated as VALUE/JSON_VALUE — safe for tests that don't
- * exercise DB_NULL vs JSON_NULL discrimination.
- */
-async function fetchLegacyNullMap(
-  projectId: string,
-  db: SnapshotDbClient,
-): Promise<Map<string, boolean>> {
-  try {
-    const rows = await (db as PrismaClient).$queryRawUnsafe<Array<{ id: string; legacy_is_null: boolean }>>(
-      'SELECT id, "legacy" IS NULL AS legacy_is_null FROM "CapacityProfile" WHERE "projectId" = $1',
-      projectId,
-    )
-    return new Map(rows.map(r => [r.id, r.legacy_is_null]))
-  } catch {
-    // Mock clients may not support $queryRawUnsafe; return empty map.
-    return new Map()
-  }
-}
-
-/** Build the full project snapshot (schemaVersion 3) with ordered capacity profiles. */
-async function buildSnapshot(
-  projectId: string,
-  db: SnapshotDbClient = prisma,
-): Promise<SnapshotV3> {
-  const [
-    epics,
-    project,
-    resourceTypes,
-    namedResources,
-    timelineEntries,
-    storyTimelineEntries,
-    epicDependencies,
-    featureDependencies,
-    overheadItems,
-    rawProfiles,
-    legacyNullMap,
-  ] = await Promise.all([
-    fetchEpics(projectId, db),
-    db.project.findUnique({
-      where: { id: projectId },
-      select: { startDate: true, onboardingWeeks: true, bufferWeeks: true, hoursPerDay: true },
-    }),
-    db.resourceType.findMany({
-      where: { projectId },
-      select: {
-        id: true, name: true, category: true, count: true, hoursPerDay: true,
-        dayRate: true, globalTypeId: true,
-        allocationMode: true, allocationPercent: true,
-        allocationStartWeek: true, allocationEndWeek: true,
-      },
-    }),
-    db.namedResource.findMany({
-      where: { resourceType: { projectId } },
-      select: {
-        id: true, resourceTypeId: true, name: true,
-        startWeek: true, endWeek: true, allocationPct: true,
-        allocationMode: true, allocationPercent: true,
-        allocationStartWeek: true, allocationEndWeek: true,
-        pricingModel: true,
-      },
-    }),
-    db.timelineEntry.findMany({
-      where: { projectId },
-      select: { featureId: true, startWeek: true, durationWeeks: true, isManual: true },
-    }),
-    db.storyTimelineEntry.findMany({
-      where: { projectId },
-      select: { storyId: true, startWeek: true, durationWeeks: true, isManual: true },
-    }),
-    db.epicDependency.findMany({
-      where: { epic: { projectId } },
-      select: { epicId: true, dependsOnId: true },
-    }),
-    db.featureDependency.findMany({
-      where: { feature: { epic: { projectId } } },
-      select: { featureId: true, dependsOnId: true },
-    }),
-    db.projectOverhead.findMany({
-      where: { projectId },
-      select: { name: true, type: true, value: true, resourceTypeId: true, order: true },
-    }),
-    db.capacityProfile.findMany({
-      where: { projectId },
-      include: {
-        segments: { orderBy: { startWeek: 'asc' } },
-      },
-      orderBy: [
-        { ownerKind: 'asc' },
-        { resourceTypeId: 'asc' },
-        { namedResourceId: 'asc' },
-      ],
-    }),
-    fetchLegacyNullMap(projectId, db),
-  ])
-
-  // Convert Date to ISO string for JSON compatibility
-  const projectFields = project
-    ? {
-        startDate: project.startDate instanceof Date
-          ? project.startDate.toISOString()
-          : project.startDate,
-        onboardingWeeks: project.onboardingWeeks,
-        bufferWeeks: project.bufferWeeks,
-        hoursPerDay: project.hoursPerDay,
-      }
-    : null
-
-  // Map Prisma model rows to SnapshotCapacityProfile, preserving null semantics
-  const capacityProfiles = rawProfiles.map(p => {
-    // Determine the precise null state for legacy
-    const isDBNull = legacyNullMap.get(p.id) ?? false
-    let legacy: SnapshotJsonValue
-    if (isDBNull) {
-      legacy = { kind: 'DB_NULL' }
-    } else if (p.legacy === null) {
-      legacy = { kind: 'JSON_NULL' }
-    } else {
-      legacy = { kind: 'VALUE', value: p.legacy as Record<string, unknown> | unknown[] | string | number | boolean | null }
-    }
-
-    return {
-      id: p.id,
-      ownerKind: p.ownerKind as SnapshotV3['capacityProfiles'][number]['ownerKind'],
-      resourceTypeId: p.resourceTypeId,
-      namedResourceId: p.namedResourceId,
-      planningBasis: p.planningBasis as SnapshotV3['capacityProfiles'][number]['planningBasis'],
-      source: p.source as SnapshotV3['capacityProfiles'][number]['source'],
-      defaultPercent: p.defaultPercent,
-      startWeek: p.startWeek,
-      endWeek: p.endWeek,
-      legacy,
-      segments: sortSnapshotSegments(p.segments.map(s => ({
-        id: s.id,
-        startWeek: s.startWeek,
-        endWeek: s.endWeek,
-        capacityPercent: s.capacityPercent,
-        source: s.source as SnapshotV3['capacityProfiles'][number]['segments'][number]['source'],
-      }))),
-    }
-  })
-
-  return {
-    schemaVersion: 3 as const,
-    epics,
-    project: projectFields,
-    resourceTypes,
-    namedResources,
-    timelineEntries,
-    storyTimelineEntries,
-    epicDependencies,
-    featureDependencies,
-    overheadItems,
-    capacityProfiles: sortSnapshotProfiles(capacityProfiles),
-  }
-}
 
 // GET /api/projects/:projectId/snapshots
 router.get('/', asyncHandler(async (req: AuthRequest, res: Response) => {
@@ -332,396 +136,36 @@ router.get('/:snapshotId/diff', asyncHandler(async (req: AuthRequest, res: Respo
   })
 }))
 
-/**
- * Restore the common snapshot state shared across v2 and v3 rollbacks.
- * Handles ResourceTypes, NamedResources, epics, project fields, timeline
- * entries, story timeline entries, dependencies, and overhead items.
- */
-async function restoreSnapshotCommonState(
-  tx: any,
-  projectId: string,
-  data: Omit<SnapshotV2, 'schemaVersion'>,
-): Promise<void> {
-  // 1. Restore ResourceTypes FIRST so task FKs resolve correctly when recreating epics
-  const rtNameMap = new Map<string, string>()
-  for (const rt of data.resourceTypes) {
-    await tx.resourceType.upsert({
-      where: { id: rt.id },
-      update: {
-        name: rt.name,
-        category: rt.category,
-        count: rt.count,
-        hoursPerDay: rt.hoursPerDay,
-        dayRate: rt.dayRate,
-        globalTypeId: rt.globalTypeId,
-        allocationMode: rt.allocationMode,
-        allocationPercent: rt.allocationPercent,
-        allocationStartWeek: rt.allocationStartWeek,
-        allocationEndWeek: rt.allocationEndWeek,
-      },
-      create: {
-        id: rt.id,
-        name: rt.name,
-        category: rt.category,
-        count: rt.count,
-        hoursPerDay: rt.hoursPerDay,
-        dayRate: rt.dayRate,
-        globalTypeId: rt.globalTypeId,
-        allocationMode: rt.allocationMode,
-        allocationPercent: rt.allocationPercent,
-        allocationStartWeek: rt.allocationStartWeek,
-        allocationEndWeek: rt.allocationEndWeek,
-        projectId,
-      },
-    })
-    rtNameMap.set(rt.name.toLowerCase(), rt.id)
-  }
-
-  // 2. Restore NamedResources (depends on RTs existing)
-  for (const nr of data.namedResources) {
-    await tx.namedResource.upsert({
-      where: { id: nr.id },
-      update: {
-        name: nr.name,
-        resourceTypeId: nr.resourceTypeId,
-        startWeek: nr.startWeek,
-        endWeek: nr.endWeek,
-        allocationPct: nr.allocationPct,
-        allocationMode: nr.allocationMode,
-        allocationPercent: nr.allocationPercent,
-        allocationStartWeek: nr.allocationStartWeek,
-        allocationEndWeek: nr.allocationEndWeek,
-        pricingModel: nr.pricingModel,
-      },
-      create: {
-        id: nr.id,
-        resourceTypeId: nr.resourceTypeId,
-        name: nr.name,
-        startWeek: nr.startWeek,
-        endWeek: nr.endWeek,
-        allocationPct: nr.allocationPct,
-        allocationMode: nr.allocationMode,
-        allocationPercent: nr.allocationPercent,
-        allocationStartWeek: nr.allocationStartWeek,
-        allocationEndWeek: nr.allocationEndWeek,
-        pricingModel: nr.pricingModel,
-      },
-    })
-  }
-
-  // 3. Restore epics (delete all, recreate from snapshot — IDs will change)
-  await tx.epic.deleteMany({ where: { projectId } })
-
-  // Build old→new ID maps as we recreate the tree
-  const epicIdMap = new Map<string, string>()
-  const featureIdMap = new Map<string, string>()
-  const storyIdMap = new Map<string, string>()
-
-  for (const epic of data.epics) {
-    const newEpic = await tx.epic.create({
-      data: { name: epic.name, description: epic.description, order: epic.order, projectId },
-    })
-    epicIdMap.set(epic.id, newEpic.id)
-    for (const feature of epic.features) {
-      const newFeature = await tx.feature.create({
-        data: { name: feature.name, description: feature.description, assumptions: feature.assumptions, order: feature.order, epicId: newEpic.id },
-      })
-      featureIdMap.set(feature.id, newFeature.id)
-      for (const story of feature.userStories) {
-        const newStory = await tx.userStory.create({
-          data: { name: story.name, description: story.description, assumptions: story.assumptions, order: story.order, featureId: newFeature.id, appliedTemplateId: story.appliedTemplateId },
-        })
-        storyIdMap.set(story.id, newStory.id)
-        for (const task of story.tasks) {
-          const resourceTypeId = task.resourceType?.name
-            ? (rtNameMap.get(task.resourceType.name.toLowerCase()) ?? null)
-            : null
-          await tx.task.create({
-            data: {
-              name: task.name,
-              description: task.description,
-              assumptions: task.assumptions,
-              hoursEffort: task.hoursEffort,
-              durationDays: task.durationDays,
-              order: task.order,
-              userStoryId: newStory.id,
-              resourceTypeId,
-            },
-          })
-        }
-      }
-    }
-  }
-
-  // 4. Restore project fields
-  if (data.project) {
-    await tx.project.update({
-      where: { id: projectId },
-      data: {
-        startDate: data.project.startDate,
-        onboardingWeeks: data.project.onboardingWeeks,
-        bufferWeeks: data.project.bufferWeeks,
-        hoursPerDay: data.project.hoursPerDay,
-      },
-    })
-  }
-
-  // 5. Restore TimelineEntries
-  await tx.timelineEntry.deleteMany({ where: { projectId } })
-  if (data.timelineEntries.length > 0) {
-    const mappedTLEs = data.timelineEntries
-      .map(e => {
-        const newFeatureId = featureIdMap.get(e.featureId)
-        if (!newFeatureId) return null
-        return {
-          projectId,
-          featureId: newFeatureId,
-          startWeek: e.startWeek,
-          durationWeeks: e.durationWeeks,
-          isManual: e.isManual,
-        }
-      })
-      .filter((e): e is NonNullable<typeof e> => e !== null)
-    if (mappedTLEs.length > 0) {
-      await tx.timelineEntry.createMany({ data: mappedTLEs, skipDuplicates: true })
-    }
-  }
-
-  // 6. Restore StoryTimelineEntries
-  await tx.storyTimelineEntry.deleteMany({ where: { projectId } })
-  if (data.storyTimelineEntries.length > 0) {
-    const mappedSTLEs = data.storyTimelineEntries
-      .map(e => {
-        const newStoryId = storyIdMap.get(e.storyId)
-        if (!newStoryId) return null
-        return {
-          projectId,
-          storyId: newStoryId,
-          startWeek: e.startWeek,
-          durationWeeks: e.durationWeeks,
-          isManual: e.isManual,
-        }
-      })
-      .filter((e): e is NonNullable<typeof e> => e !== null)
-    if (mappedSTLEs.length > 0) {
-      await tx.storyTimelineEntry.createMany({ data: mappedSTLEs, skipDuplicates: true })
-    }
-  }
-
-  // 7. Restore EpicDependencies
-  await tx.epicDependency.deleteMany({ where: { epic: { projectId } } })
-  if (data.epicDependencies.length > 0) {
-    const mappedEDs = data.epicDependencies
-      .map(d => {
-        const newEpicId = epicIdMap.get(d.epicId)
-        const newDependsOnId = epicIdMap.get(d.dependsOnId)
-        if (!newEpicId || !newDependsOnId) return null
-        return { epicId: newEpicId, dependsOnId: newDependsOnId }
-      })
-      .filter((d): d is NonNullable<typeof d> => d !== null)
-    if (mappedEDs.length > 0) {
-      await tx.epicDependency.createMany({ data: mappedEDs, skipDuplicates: true })
-    }
-  }
-
-  // 8. Restore FeatureDependencies
-  await tx.featureDependency.deleteMany({ where: { feature: { epic: { projectId } } } })
-  if (data.featureDependencies.length > 0) {
-    const mappedFDs = data.featureDependencies
-      .map(d => {
-        const newFeatureId = featureIdMap.get(d.featureId)
-        const newDependsOnId = featureIdMap.get(d.dependsOnId)
-        if (!newFeatureId || !newDependsOnId) return null
-        return { featureId: newFeatureId, dependsOnId: newDependsOnId }
-      })
-      .filter((d): d is NonNullable<typeof d> => d !== null)
-    if (mappedFDs.length > 0) {
-      await tx.featureDependency.createMany({ data: mappedFDs, skipDuplicates: true })
-    }
-  }
-
-  // 9. Restore OverheadItems
-  await tx.projectOverhead.deleteMany({ where: { projectId } })
-  if (data.overheadItems.length > 0) {
-    await tx.projectOverhead.createMany({
-      data: data.overheadItems.map(o => ({
-        projectId,
-        name: o.name,
-        type: o.type,
-        value: o.value,
-        resourceTypeId: o.resourceTypeId,
-        order: o.order,
-      })),
-      skipDuplicates: true,
-    })
-  }
-}
-
 // POST /api/projects/:projectId/snapshots/:snapshotId/rollback
 router.post('/:snapshotId/rollback', asyncHandler(async (req: AuthRequest, res: Response) => {
   const { projectId, snapshotId } = req.params as { projectId: string; snapshotId: string }
   const project = await ownedProject(projectId, req.userId!)
   if (!project) { res.status(404).json({ error: 'Project not found' }); return }
 
-  const snap = await prisma.backlogSnapshot.findFirst({ where: { id: snapshotId, projectId } })
-  if (!snap) { res.status(404).json({ error: 'Snapshot not found' }); return }
-
-  // Parse snapshot data BEFORE any pre-snapshot or destructive operation
-  let parsedData: SnapshotData
   try {
-    parsedData = parseSnapshotData(snap.snapshot)
+    await rollbackProjectSnapshot({
+      projectId,
+      snapshotId,
+      userId: req.userId!,
+    })
+    res.json({ message: 'Rollback complete' })
   } catch (e) {
+    if (e instanceof SnapshotNotFoundError) {
+      res.status(404).json({ error: e.message }); return
+    }
     if (e instanceof SnapshotSchemaError) {
-      res.status(400).json({ error: e.message })
-      return
+      res.status(400).json({ error: e.message }); return
+    }
+    if (e instanceof SnapshotValidationError) {
+      res.status(400).json({ error: e.message }); return
+    }
+    if (e instanceof RollbackPreflightError) {
+      res.status(400).json({ error: e.message }); return
     }
     throw e
   }
-
-  // V3: pre-flight validation before any writes
-  if (isSnapshotV3(parsedData)) {
-    try {
-      validateSnapshotV3(parsedData)
-    } catch (e) {
-      if (e instanceof SnapshotValidationError) {
-        res.status(400).json({ error: e.message })
-        return
-      }
-      throw e
-    }
-    // Cross-project owner ID collision check
-    // Collect ALL IDs from snapshot rows, not just profile-owner IDs
-    const allRtIds = [
-      ...new Set([
-        // IDs from snapshot.resourceTypes
-        ...parsedData.resourceTypes.map(rt => rt.id),
-        // resourceTypeIds from ROLE profiles
-        ...parsedData.capacityProfiles
-          .filter(p => p.ownerKind === 'ROLE' && p.resourceTypeId)
-          .map(p => p.resourceTypeId as string),
-        // non-null overheadItems resourceTypeIds
-        ...parsedData.overheadItems
-          .filter(o => o.resourceTypeId !== null)
-          .map(o => o.resourceTypeId as string),
-      ]),
-    ]
-    const allNrIds = [
-      ...new Set([
-        // IDs from snapshot.namedResources
-        ...parsedData.namedResources.map(nr => nr.id),
-        // namedResourceIds from NAMED_PERSON / PLANNED_RESOURCE profiles
-        ...parsedData.capacityProfiles
-          .filter(p =>
-            (p.ownerKind === 'NAMED_PERSON' || p.ownerKind === 'PLANNED_RESOURCE') && p.namedResourceId,
-          )
-          .map(p => p.namedResourceId as string),
-      ]),
-    ]
-    if (allRtIds.length > 0) {
-      const existingRTs = await prisma.resourceType.findMany({
-        where: { id: { in: allRtIds } },
-        select: { id: true, projectId: true },
-      })
-      const crossProjectRTs = existingRTs.filter(rt => rt.projectId !== projectId)
-      if (crossProjectRTs.length > 0) {
-        res.status(400).json({
-          error: `Resource type IDs ${crossProjectRTs.map(rt => rt.id).join(', ')} belong to another project; rollback rejected`,
-        })
-        return
-      }
-    }
-
-    if (allNrIds.length > 0) {
-      const existingNRs = await prisma.namedResource.findMany({
-        where: { id: { in: allNrIds } },
-        select: { id: true, resourceType: { select: { projectId: true } } },
-      })
-      const crossProjectNRs = existingNRs.filter(nr => nr.resourceType.projectId !== projectId)
-      if (crossProjectNRs.length > 0) {
-        res.status(400).json({
-          error: `Named resource IDs ${crossProjectNRs.map(nr => nr.id).join(', ')} belong to another project; rollback rejected`,
-        })
-        return
-      }
-    }
-  }
-
-  // All validation passed — one atomic transaction
-  const dateStr = new Date().toISOString().slice(0, 10)
-  const originalLabel = snap.label ?? snapshotId
-
-  await prisma.$transaction(async tx => {
-    // Pre-rollback snapshot inside the transaction
-    const preRollbackData = await buildSnapshot(projectId, tx)
-    await tx.backlogSnapshot.create({
-      data: {
-        projectId,
-        label: `Auto-saved before rollback to '${originalLabel}' — ${dateStr}`,
-        trigger: 'pre_rollback',
-        snapshot: preRollbackData as unknown as object,
-        createdById: req.userId!,
-      },
-    })
-
-    // Restore based on schema version
-    if (isLegacyV1Snapshot(parsedData)) {
-      // --- V1: restore epics only ---
-      const resourceTypes = await tx.resourceType.findMany({
-        where: { projectId },
-        select: { id: true, name: true },
-      })
-      const rtMap = new Map(resourceTypes.map(rt => [rt.name.toLowerCase(), rt.id]))
-
-      await tx.epic.deleteMany({ where: { projectId } })
-      for (const epic of parsedData) {
-        const newEpic = await tx.epic.create({
-          data: { name: epic.name, description: epic.description, order: epic.order, projectId },
-        })
-        for (const feature of epic.features) {
-          const newFeature = await tx.feature.create({
-            data: { name: feature.name, description: feature.description, assumptions: feature.assumptions, order: feature.order, epicId: newEpic.id },
-          })
-          for (const story of feature.userStories) {
-            const newStory = await tx.userStory.create({
-              data: { name: story.name, description: story.description, assumptions: story.assumptions, order: story.order, featureId: newFeature.id, appliedTemplateId: story.appliedTemplateId },
-            })
-            for (const task of story.tasks) {
-              const taskRtId = task.resourceType?.name
-                ? (rtMap.get(task.resourceType.name.toLowerCase()) ?? null)
-                : null
-              await tx.task.create({
-                data: {
-                  name: task.name,
-                  description: task.description,
-                  assumptions: task.assumptions,
-                  hoursEffort: task.hoursEffort,
-                  durationDays: task.durationDays,
-                  order: task.order,
-                  userStoryId: newStory.id,
-                  resourceTypeId: taskRtId,
-                },
-              })
-            }
-          }
-        }
-      }
-      // V1 does NOT touch resource types, named resources, capacity profiles, or segments
-    } else if (isSnapshotV2(parsedData)) {
-      // --- V2: full-state restore + capacity profile cleanup ---
-      await restoreSnapshotCommonState(tx, projectId, parsedData)
-      await recreateV2CapacityProfiles(tx, projectId, parsedData)
-    } else if (isSnapshotV3(parsedData)) {
-      // --- V3: full-state restore + exact profile/segment replacement ---
-      await restoreSnapshotCommonState(tx, projectId, parsedData)
-      await recreateV3CapacityProfiles(tx, projectId, parsedData)
-    }
-
-    // Enforce retention policy inside the same transaction
-    await pruneSnapshots(tx, projectId)
-  })
-
-  res.json({ message: 'Rollback complete' })
 }))
+
 
 export default router
 

--- a/server/src/routes/snapshots.ts
+++ b/server/src/routes/snapshots.ts
@@ -1,15 +1,37 @@
 import { Router, Response } from 'express'
+import type { PrismaClient } from '@prisma/client'
 import { prisma } from '../lib/prisma.js'
 import { asyncHandler } from '../lib/asyncHandler.js'
 import { authenticate, AuthRequest } from '../middleware/auth.js'
 import { ownedProject } from '../lib/ownership.js'
 import { pruneSnapshots } from '../lib/snapshotUtils.js'
+import {
+  parseSnapshotData,
+  isLegacyV1Snapshot,
+  isSnapshotV2,
+  isSnapshotV3,
+  SnapshotSchemaError,
+  type SnapshotData,
+  type SnapshotEpic,
+  type SnapshotV2,
+  type SnapshotV3,
+} from '../lib/projectSnapshotTypes.js'
+import {
+  validateSnapshotV3,
+  SnapshotValidationError,
+  sortSnapshotProfiles,
+  sortSnapshotSegments,
+} from '../lib/projectSnapshotValidation.js'
+import {
+  recreateV2CapacityProfiles,
+  recreateV3CapacityProfiles,
+} from '../lib/projectSnapshotCapacity.js'
 
 const router = Router({ mergeParams: true })
 router.use(authenticate)
 
 // ---------------------------------------------------------------------------
-// Snapshot shape (schemaVersion 2)
+// Schema versions: 1 (bare epic array), 2 (full state), 3 (v2 + capacityProfiles)
 // Documented trigger values:
 //   'manual'           — user-initiated from the UI
 //   'csv_import'       — auto-saved before a CSV import
@@ -18,11 +40,11 @@ router.use(authenticate)
 //   'pre_rollback'     — auto-saved before rolling back to a prior snapshot (reversible rollback)
 // ---------------------------------------------------------------------------
 
-/** Epic tree shape returned by the backlog query */
-type EpicTree = Awaited<ReturnType<typeof fetchEpics>>
+/** Client type compatible with both PrismaClient and transaction client. */
+type SnapshotDbClient = PrismaClient | Omit<PrismaClient, '$connect' | '$disconnect' | '$on' | '$transaction' | '$use' | '$extends'>
 
-async function fetchEpics(projectId: string) {
-  return prisma.epic.findMany({
+async function fetchEpics(projectId: string, db: SnapshotDbClient = prisma) {
+  return db.epic.findMany({
     where: { projectId },
     orderBy: { order: 'asc' },
     include: {
@@ -44,8 +66,11 @@ async function fetchEpics(projectId: string) {
   })
 }
 
-/** Build the full project snapshot (schemaVersion 2). */
-async function buildSnapshot(projectId: string) {
+/** Build the full project snapshot (schemaVersion 3) with ordered capacity profiles. */
+async function buildSnapshot(
+  projectId: string,
+  db: SnapshotDbClient = prisma,
+): Promise<SnapshotV3> {
   const [
     epics,
     project,
@@ -56,13 +81,14 @@ async function buildSnapshot(projectId: string) {
     epicDependencies,
     featureDependencies,
     overheadItems,
+    rawProfiles,
   ] = await Promise.all([
-    fetchEpics(projectId),
-    prisma.project.findUnique({
+    fetchEpics(projectId, db),
+    db.project.findUnique({
       where: { id: projectId },
       select: { startDate: true, onboardingWeeks: true, bufferWeeks: true, hoursPerDay: true },
     }),
-    prisma.resourceType.findMany({
+    db.resourceType.findMany({
       where: { projectId },
       select: {
         id: true,
@@ -78,7 +104,7 @@ async function buildSnapshot(projectId: string) {
         allocationEndWeek: true,
       },
     }),
-    prisma.namedResource.findMany({
+    db.namedResource.findMany({
       where: { resourceType: { projectId } },
       select: {
         id: true,
@@ -94,39 +120,78 @@ async function buildSnapshot(projectId: string) {
         pricingModel: true,
       },
     }),
-    prisma.timelineEntry.findMany({
+    db.timelineEntry.findMany({
       where: { projectId },
       select: { featureId: true, startWeek: true, durationWeeks: true, isManual: true },
     }),
-    prisma.storyTimelineEntry.findMany({
+    db.storyTimelineEntry.findMany({
       where: { projectId },
       select: { storyId: true, startWeek: true, durationWeeks: true, isManual: true },
     }),
-    prisma.epicDependency.findMany({
+    db.epicDependency.findMany({
       where: { epic: { projectId } },
       select: { epicId: true, dependsOnId: true },
     }),
-    prisma.featureDependency.findMany({
+    db.featureDependency.findMany({
       where: { feature: { epic: { projectId } } },
       select: { featureId: true, dependsOnId: true },
     }),
-    prisma.projectOverhead.findMany({
+    db.projectOverhead.findMany({
       where: { projectId },
       select: { name: true, type: true, value: true, resourceTypeId: true, order: true },
     }),
+    db.capacityProfile.findMany({
+      where: { projectId },
+      include: {
+        segments: {
+          orderBy: { startWeek: 'asc' },
+        },
+      },
+      orderBy: [
+        { ownerKind: 'asc' },
+        { resourceTypeId: 'asc' },
+        { namedResourceId: 'asc' },
+      ],
+    }),
   ])
 
+  // Convert Date to ISO string for JSON compatibility
+  const projectFields = project
+    ? {
+        startDate: project.startDate instanceof Date
+          ? project.startDate.toISOString()
+          : project.startDate,
+        onboardingWeeks: project.onboardingWeeks,
+        bufferWeeks: project.bufferWeeks,
+        hoursPerDay: project.hoursPerDay,
+      }
+    : null
+
+  // Map Prisma model rows to SnapshotCapacityProfile, preserving all fields including nulls
+  const capacityProfiles = rawProfiles.map(p => ({
+    id: p.id,
+    ownerKind: p.ownerKind as SnapshotV3['capacityProfiles'][number]['ownerKind'],
+    resourceTypeId: p.resourceTypeId,
+    namedResourceId: p.namedResourceId,
+    planningBasis: p.planningBasis as SnapshotV3['capacityProfiles'][number]['planningBasis'],
+    source: p.source as SnapshotV3['capacityProfiles'][number]['source'],
+    defaultPercent: p.defaultPercent,
+    startWeek: p.startWeek,
+    endWeek: p.endWeek,
+    legacy: p.legacy,
+    segments: sortSnapshotSegments(p.segments.map(s => ({
+      id: s.id,
+      startWeek: s.startWeek,
+      endWeek: s.endWeek,
+      capacityPercent: s.capacityPercent,
+      source: s.source as SnapshotV3['capacityProfiles'][number]['segments'][number]['source'],
+    }))),
+  }))
+
   return {
-    schemaVersion: 2 as const,
+    schemaVersion: 3 as const,
     epics,
-    project: project
-      ? {
-          startDate: project.startDate,
-          onboardingWeeks: project.onboardingWeeks,
-          bufferWeeks: project.bufferWeeks,
-          hoursPerDay: project.hoursPerDay,
-        }
-      : null,
+    project: projectFields,
     resourceTypes,
     namedResources,
     timelineEntries,
@@ -134,17 +199,8 @@ async function buildSnapshot(projectId: string) {
     epicDependencies,
     featureDependencies,
     overheadItems,
+    capacityProfiles: sortSnapshotProfiles(capacityProfiles),
   }
-}
-
-/** Normalise snapshot data to extract the epics array regardless of schema version. */
-function extractEpics(snapshotData: unknown): EpicTree {
-  if (Array.isArray(snapshotData)) {
-    // Legacy v1 — snapshot is just the epics array
-    return snapshotData as EpicTree
-  }
-  const obj = snapshotData as { schemaVersion?: number; epics?: EpicTree }
-  return (obj.epics ?? []) as EpicTree
 }
 
 // GET /api/projects/:projectId/snapshots
@@ -174,7 +230,7 @@ router.post('/', asyncHandler(async (req: AuthRequest, res: Response) => {
       projectId,
       label: label ?? null,
       trigger: 'manual',
-      snapshot: snapshotData as any,
+      snapshot: snapshotData as unknown as object,
       createdById: req.userId!,
     },
     select: { id: true, label: true, trigger: true, createdAt: true },
@@ -204,10 +260,21 @@ router.get('/:snapshotId/diff', asyncHandler(async (req: AuthRequest, res: Respo
   const snap = await prisma.backlogSnapshot.findFirst({ where: { id: snapshotId, projectId } })
   if (!snap) { res.status(404).json({ error: 'Snapshot not found' }); return }
 
+  let parsed: SnapshotData
+  try {
+    parsed = parseSnapshotData(snap.snapshot)
+  } catch (e) {
+    if (e instanceof SnapshotSchemaError) {
+      res.status(400).json({ error: e.message })
+      return
+    }
+    throw e
+  }
+
   const currentSnapshot = await buildSnapshot(projectId)
 
   // Produce a simple flat diff of epic/feature/story/task names
-  const flatten = (epics: EpicTree) => {
+  const flatten = (epics: SnapshotEpic[]) => {
     const items: string[] = []
     for (const e of epics) {
       items.push(`Epic: ${e.name}`)
@@ -224,8 +291,8 @@ router.get('/:snapshotId/diff', asyncHandler(async (req: AuthRequest, res: Respo
     return items
   }
 
-  const snapEpics = extractEpics(snap.snapshot)
-  const currentEpics = extractEpics(currentSnapshot)
+  const snapEpics = isLegacyV1Snapshot(parsed) ? parsed : parsed.epics
+  const currentEpics = currentSnapshot.epics
   const snapItems = flatten(snapEpics)
   const currentItems = flatten(currentEpics)
   const snapSet = new Set(snapItems)
@@ -238,6 +305,231 @@ router.get('/:snapshotId/diff', asyncHandler(async (req: AuthRequest, res: Respo
   })
 }))
 
+/**
+ * Restore the common snapshot state shared across v2 and v3 rollbacks.
+ * Handles ResourceTypes, NamedResources, epics, project fields, timeline
+ * entries, story timeline entries, dependencies, and overhead items.
+ */
+async function restoreSnapshotCommonState(
+  tx: any,
+  projectId: string,
+  data: Omit<SnapshotV2, 'schemaVersion'>,
+): Promise<void> {
+  // 1. Restore ResourceTypes FIRST so task FKs resolve correctly when recreating epics
+  const rtNameMap = new Map<string, string>()
+  for (const rt of data.resourceTypes) {
+    await tx.resourceType.upsert({
+      where: { id: rt.id },
+      update: {
+        name: rt.name,
+        category: rt.category,
+        count: rt.count,
+        hoursPerDay: rt.hoursPerDay,
+        dayRate: rt.dayRate,
+        globalTypeId: rt.globalTypeId,
+        allocationMode: rt.allocationMode,
+        allocationPercent: rt.allocationPercent,
+        allocationStartWeek: rt.allocationStartWeek,
+        allocationEndWeek: rt.allocationEndWeek,
+      },
+      create: {
+        id: rt.id,
+        name: rt.name,
+        category: rt.category,
+        count: rt.count,
+        hoursPerDay: rt.hoursPerDay,
+        dayRate: rt.dayRate,
+        globalTypeId: rt.globalTypeId,
+        allocationMode: rt.allocationMode,
+        allocationPercent: rt.allocationPercent,
+        allocationStartWeek: rt.allocationStartWeek,
+        allocationEndWeek: rt.allocationEndWeek,
+        projectId,
+      },
+    })
+    rtNameMap.set(rt.name.toLowerCase(), rt.id)
+  }
+
+  // 2. Restore NamedResources (depends on RTs existing)
+  for (const nr of data.namedResources) {
+    await tx.namedResource.upsert({
+      where: { id: nr.id },
+      update: {
+        name: nr.name,
+        resourceTypeId: nr.resourceTypeId,
+        startWeek: nr.startWeek,
+        endWeek: nr.endWeek,
+        allocationPct: nr.allocationPct,
+        allocationMode: nr.allocationMode,
+        allocationPercent: nr.allocationPercent,
+        allocationStartWeek: nr.allocationStartWeek,
+        allocationEndWeek: nr.allocationEndWeek,
+        pricingModel: nr.pricingModel,
+      },
+      create: {
+        id: nr.id,
+        resourceTypeId: nr.resourceTypeId,
+        name: nr.name,
+        startWeek: nr.startWeek,
+        endWeek: nr.endWeek,
+        allocationPct: nr.allocationPct,
+        allocationMode: nr.allocationMode,
+        allocationPercent: nr.allocationPercent,
+        allocationStartWeek: nr.allocationStartWeek,
+        allocationEndWeek: nr.allocationEndWeek,
+        pricingModel: nr.pricingModel,
+      },
+    })
+  }
+
+  // 3. Restore epics (delete all, recreate from snapshot — IDs will change)
+  await tx.epic.deleteMany({ where: { projectId } })
+
+  // Build old→new ID maps as we recreate the tree
+  const epicIdMap = new Map<string, string>()
+  const featureIdMap = new Map<string, string>()
+  const storyIdMap = new Map<string, string>()
+
+  for (const epic of data.epics) {
+    const newEpic = await tx.epic.create({
+      data: { name: epic.name, description: epic.description, order: epic.order, projectId },
+    })
+    epicIdMap.set(epic.id, newEpic.id)
+    for (const feature of epic.features) {
+      const newFeature = await tx.feature.create({
+        data: { name: feature.name, description: feature.description, assumptions: feature.assumptions, order: feature.order, epicId: newEpic.id },
+      })
+      featureIdMap.set(feature.id, newFeature.id)
+      for (const story of feature.userStories) {
+        const newStory = await tx.userStory.create({
+          data: { name: story.name, description: story.description, assumptions: story.assumptions, order: story.order, featureId: newFeature.id, appliedTemplateId: story.appliedTemplateId },
+        })
+        storyIdMap.set(story.id, newStory.id)
+        for (const task of story.tasks) {
+          const resourceTypeId = task.resourceType?.name
+            ? (rtNameMap.get(task.resourceType.name.toLowerCase()) ?? null)
+            : null
+          await tx.task.create({
+            data: {
+              name: task.name,
+              description: task.description,
+              assumptions: task.assumptions,
+              hoursEffort: task.hoursEffort,
+              durationDays: task.durationDays,
+              order: task.order,
+              userStoryId: newStory.id,
+              resourceTypeId,
+            },
+          })
+        }
+      }
+    }
+  }
+
+  // 4. Restore project fields
+  if (data.project) {
+    await tx.project.update({
+      where: { id: projectId },
+      data: {
+        startDate: data.project.startDate,
+        onboardingWeeks: data.project.onboardingWeeks,
+        bufferWeeks: data.project.bufferWeeks,
+        hoursPerDay: data.project.hoursPerDay,
+      },
+    })
+  }
+
+  // 5. Restore TimelineEntries
+  await tx.timelineEntry.deleteMany({ where: { projectId } })
+  if (data.timelineEntries.length > 0) {
+    const mappedTLEs = data.timelineEntries
+      .map(e => {
+        const newFeatureId = featureIdMap.get(e.featureId)
+        if (!newFeatureId) return null
+        return {
+          projectId,
+          featureId: newFeatureId,
+          startWeek: e.startWeek,
+          durationWeeks: e.durationWeeks,
+          isManual: e.isManual,
+        }
+      })
+      .filter((e): e is NonNullable<typeof e> => e !== null)
+    if (mappedTLEs.length > 0) {
+      await tx.timelineEntry.createMany({ data: mappedTLEs, skipDuplicates: true })
+    }
+  }
+
+  // 6. Restore StoryTimelineEntries
+  await tx.storyTimelineEntry.deleteMany({ where: { projectId } })
+  if (data.storyTimelineEntries.length > 0) {
+    const mappedSTLEs = data.storyTimelineEntries
+      .map(e => {
+        const newStoryId = storyIdMap.get(e.storyId)
+        if (!newStoryId) return null
+        return {
+          projectId,
+          storyId: newStoryId,
+          startWeek: e.startWeek,
+          durationWeeks: e.durationWeeks,
+          isManual: e.isManual,
+        }
+      })
+      .filter((e): e is NonNullable<typeof e> => e !== null)
+    if (mappedSTLEs.length > 0) {
+      await tx.storyTimelineEntry.createMany({ data: mappedSTLEs, skipDuplicates: true })
+    }
+  }
+
+  // 7. Restore EpicDependencies
+  await tx.epicDependency.deleteMany({ where: { epic: { projectId } } })
+  if (data.epicDependencies.length > 0) {
+    const mappedEDs = data.epicDependencies
+      .map(d => {
+        const newEpicId = epicIdMap.get(d.epicId)
+        const newDependsOnId = epicIdMap.get(d.dependsOnId)
+        if (!newEpicId || !newDependsOnId) return null
+        return { epicId: newEpicId, dependsOnId: newDependsOnId }
+      })
+      .filter((d): d is NonNullable<typeof d> => d !== null)
+    if (mappedEDs.length > 0) {
+      await tx.epicDependency.createMany({ data: mappedEDs, skipDuplicates: true })
+    }
+  }
+
+  // 8. Restore FeatureDependencies
+  await tx.featureDependency.deleteMany({ where: { feature: { epic: { projectId } } } })
+  if (data.featureDependencies.length > 0) {
+    const mappedFDs = data.featureDependencies
+      .map(d => {
+        const newFeatureId = featureIdMap.get(d.featureId)
+        const newDependsOnId = featureIdMap.get(d.dependsOnId)
+        if (!newFeatureId || !newDependsOnId) return null
+        return { featureId: newFeatureId, dependsOnId: newDependsOnId }
+      })
+      .filter((d): d is NonNullable<typeof d> => d !== null)
+    if (mappedFDs.length > 0) {
+      await tx.featureDependency.createMany({ data: mappedFDs, skipDuplicates: true })
+    }
+  }
+
+  // 9. Restore OverheadItems
+  await tx.projectOverhead.deleteMany({ where: { projectId } })
+  if (data.overheadItems.length > 0) {
+    await tx.projectOverhead.createMany({
+      data: data.overheadItems.map(o => ({
+        projectId,
+        name: o.name,
+        type: o.type,
+        value: o.value,
+        resourceTypeId: o.resourceTypeId,
+        order: o.order,
+      })),
+      skipDuplicates: true,
+    })
+  }
+}
+
 // POST /api/projects/:projectId/snapshots/:snapshotId/rollback
 router.post('/:snapshotId/rollback', asyncHandler(async (req: AuthRequest, res: Response) => {
   const { projectId, snapshotId } = req.params as { projectId: string; snapshotId: string }
@@ -247,42 +539,114 @@ router.post('/:snapshotId/rollback', asyncHandler(async (req: AuthRequest, res: 
   const snap = await prisma.backlogSnapshot.findFirst({ where: { id: snapshotId, projectId } })
   if (!snap) { res.status(404).json({ error: 'Snapshot not found' }); return }
 
-  // Auto-snapshot current state BEFORE rollback so it can itself be rolled back ('pre_rollback').
-  const preRollbackData = await buildSnapshot(projectId)
+  // Parse snapshot data BEFORE any pre-snapshot or destructive operation
+  let parsedData: SnapshotData
+  try {
+    parsedData = parseSnapshotData(snap.snapshot)
+  } catch (e) {
+    if (e instanceof SnapshotSchemaError) {
+      res.status(400).json({ error: e.message })
+      return
+    }
+    throw e
+  }
+
+  // V3: pre-flight validation before any writes
+  if (isSnapshotV3(parsedData)) {
+    try {
+      validateSnapshotV3(parsedData)
+    } catch (e) {
+      if (e instanceof SnapshotValidationError) {
+        res.status(400).json({ error: e.message })
+        return
+      }
+      throw e
+    }
+    // Cross-project owner ID collision check
+    // Collect ALL IDs from snapshot rows, not just profile-owner IDs
+    const allRtIds = [
+      ...new Set([
+        // IDs from snapshot.resourceTypes
+        ...parsedData.resourceTypes.map(rt => rt.id),
+        // resourceTypeIds from ROLE profiles
+        ...parsedData.capacityProfiles
+          .filter(p => p.ownerKind === 'ROLE' && p.resourceTypeId)
+          .map(p => p.resourceTypeId as string),
+        // non-null overheadItems resourceTypeIds
+        ...parsedData.overheadItems
+          .filter(o => o.resourceTypeId !== null)
+          .map(o => o.resourceTypeId as string),
+      ]),
+    ]
+    const allNrIds = [
+      ...new Set([
+        // IDs from snapshot.namedResources
+        ...parsedData.namedResources.map(nr => nr.id),
+        // namedResourceIds from NAMED_PERSON / PLANNED_RESOURCE profiles
+        ...parsedData.capacityProfiles
+          .filter(p =>
+            (p.ownerKind === 'NAMED_PERSON' || p.ownerKind === 'PLANNED_RESOURCE') && p.namedResourceId,
+          )
+          .map(p => p.namedResourceId as string),
+      ]),
+    ]
+    if (allRtIds.length > 0) {
+      const existingRTs = await prisma.resourceType.findMany({
+        where: { id: { in: allRtIds } },
+        select: { id: true, projectId: true },
+      })
+      const crossProjectRTs = existingRTs.filter(rt => rt.projectId !== projectId)
+      if (crossProjectRTs.length > 0) {
+        res.status(400).json({
+          error: `Resource type IDs ${crossProjectRTs.map(rt => rt.id).join(', ')} belong to another project; rollback rejected`,
+        })
+        return
+      }
+    }
+
+    if (allNrIds.length > 0) {
+      const existingNRs = await prisma.namedResource.findMany({
+        where: { id: { in: allNrIds } },
+        select: { id: true, resourceType: { select: { projectId: true } } },
+      })
+      const crossProjectNRs = existingNRs.filter(nr => nr.resourceType.projectId !== projectId)
+      if (crossProjectNRs.length > 0) {
+        res.status(400).json({
+          error: `Named resource IDs ${crossProjectNRs.map(nr => nr.id).join(', ')} belong to another project; rollback rejected`,
+        })
+        return
+      }
+    }
+  }
+
+  // All validation passed — one atomic transaction
   const dateStr = new Date().toISOString().slice(0, 10)
   const originalLabel = snap.label ?? snapshotId
-  const preSnap = await prisma.backlogSnapshot.create({
-    data: {
-      projectId,
-      label: `Auto-saved before rollback to '${originalLabel}' — ${dateStr}`,
-      trigger: 'pre_rollback',
-      snapshot: preRollbackData as unknown as object,
-      createdById: req.userId!,
-    },
-  })
-  await pruneSnapshots(prisma, projectId)
 
-  // Determine snapshot version
-  const snapshotData = snap.snapshot as unknown
-  const isLegacy =
-    Array.isArray(snapshotData) ||
-    (typeof snapshotData === 'object' &&
-      snapshotData !== null &&
-      !('schemaVersion' in snapshotData))
-
-  try {
-  if (isLegacy) {
-    // --- Legacy v1: restore epics only (original behaviour) ---
-    const epics = extractEpics(snapshotData)
-    const resourceTypes = await prisma.resourceType.findMany({
-      where: { projectId },
-      select: { id: true, name: true },
+  await prisma.$transaction(async tx => {
+    // Pre-rollback snapshot inside the transaction
+    const preRollbackData = await buildSnapshot(projectId, tx)
+    await tx.backlogSnapshot.create({
+      data: {
+        projectId,
+        label: `Auto-saved before rollback to '${originalLabel}' — ${dateStr}`,
+        trigger: 'pre_rollback',
+        snapshot: preRollbackData as unknown as object,
+        createdById: req.userId!,
+      },
     })
-    const rtMap = new Map(resourceTypes.map(rt => [rt.name.toLowerCase(), rt.id]))
 
-    await prisma.$transaction(async tx => {
+    // Restore based on schema version
+    if (isLegacyV1Snapshot(parsedData)) {
+      // --- V1: restore epics only ---
+      const resourceTypes = await tx.resourceType.findMany({
+        where: { projectId },
+        select: { id: true, name: true },
+      })
+      const rtMap = new Map(resourceTypes.map(rt => [rt.name.toLowerCase(), rt.id]))
+
       await tx.epic.deleteMany({ where: { projectId } })
-      for (const epic of epics) {
+      for (const epic of parsedData) {
         const newEpic = await tx.epic.create({
           data: { name: epic.name, description: epic.description, order: epic.order, projectId },
         })
@@ -295,7 +659,7 @@ router.post('/:snapshotId/rollback', asyncHandler(async (req: AuthRequest, res: 
               data: { name: story.name, description: story.description, assumptions: story.assumptions, order: story.order, featureId: newFeature.id, appliedTemplateId: story.appliedTemplateId },
             })
             for (const task of story.tasks) {
-              const resourceTypeId = task.resourceType?.name
+              const taskRtId = task.resourceType?.name
                 ? (rtMap.get(task.resourceType.name.toLowerCase()) ?? null)
                 : null
               await tx.task.create({
@@ -307,239 +671,27 @@ router.post('/:snapshotId/rollback', asyncHandler(async (req: AuthRequest, res: 
                   durationDays: task.durationDays,
                   order: task.order,
                   userStoryId: newStory.id,
-                  resourceTypeId,
+                  resourceTypeId: taskRtId,
                 },
               })
             }
           }
         }
       }
-    })
-  } else {
-    // --- v2: full-state restore in a single transaction ---
-    type V2Snapshot = Awaited<ReturnType<typeof buildSnapshot>>
-    const v2 = snapshotData as V2Snapshot
+      // V1 does NOT touch resource types, named resources, capacity profiles, or segments
+    } else if (isSnapshotV2(parsedData)) {
+      // --- V2: full-state restore + capacity profile cleanup ---
+      await restoreSnapshotCommonState(tx, projectId, parsedData)
+      await recreateV2CapacityProfiles(tx, projectId, parsedData)
+    } else if (isSnapshotV3(parsedData)) {
+      // --- V3: full-state restore + exact profile/segment replacement ---
+      await restoreSnapshotCommonState(tx, projectId, parsedData)
+      await recreateV3CapacityProfiles(tx, projectId, parsedData)
+    }
 
-    await prisma.$transaction(async tx => {
-      // 1. Restore ResourceTypes FIRST so task FKs resolve correctly when recreating epics
-      const rtNameMap = new Map<string, string>()
-      for (const rt of v2.resourceTypes) {
-        await tx.resourceType.upsert({
-          where: { id: rt.id },
-          update: {
-            name: rt.name,
-            category: rt.category,
-            count: rt.count,
-            hoursPerDay: rt.hoursPerDay,
-            dayRate: rt.dayRate,
-            globalTypeId: rt.globalTypeId,
-            allocationMode: rt.allocationMode,
-            allocationPercent: rt.allocationPercent,
-            allocationStartWeek: rt.allocationStartWeek,
-            allocationEndWeek: rt.allocationEndWeek,
-          },
-          create: {
-            id: rt.id,
-            name: rt.name,
-            category: rt.category,
-            count: rt.count,
-            hoursPerDay: rt.hoursPerDay,
-            dayRate: rt.dayRate,
-            globalTypeId: rt.globalTypeId,
-            allocationMode: rt.allocationMode,
-            allocationPercent: rt.allocationPercent,
-            allocationStartWeek: rt.allocationStartWeek,
-            allocationEndWeek: rt.allocationEndWeek,
-            projectId,
-          },
-        })
-        rtNameMap.set(rt.name.toLowerCase(), rt.id)
-      }
-
-      // 2. Restore NamedResources (depends on RTs existing)
-      for (const nr of v2.namedResources) {
-        await tx.namedResource.upsert({
-          where: { id: nr.id },
-          update: {
-            name: nr.name,
-            startWeek: nr.startWeek,
-            endWeek: nr.endWeek,
-            allocationPct: nr.allocationPct,
-            allocationMode: nr.allocationMode,
-            allocationPercent: nr.allocationPercent,
-            allocationStartWeek: nr.allocationStartWeek,
-            allocationEndWeek: nr.allocationEndWeek,
-            pricingModel: nr.pricingModel,
-          },
-          create: {
-            id: nr.id,
-            resourceTypeId: nr.resourceTypeId,
-            name: nr.name,
-            startWeek: nr.startWeek,
-            endWeek: nr.endWeek,
-            allocationPct: nr.allocationPct,
-            allocationMode: nr.allocationMode,
-            allocationPercent: nr.allocationPercent,
-            allocationStartWeek: nr.allocationStartWeek,
-            allocationEndWeek: nr.allocationEndWeek,
-            pricingModel: nr.pricingModel,
-          },
-        })
-      }
-
-      // 3. Restore epics (delete all, recreate from snapshot — IDs will change)
-      //    We track old→new ID mapping so downstream FK restores use new IDs.
-      await tx.epic.deleteMany({ where: { projectId } })
-
-      // Build old→new ID maps as we recreate the tree
-      const epicIdMap = new Map<string, string>()
-      const featureIdMap = new Map<string, string>()
-      const storyIdMap = new Map<string, string>()
-
-      for (const epic of v2.epics) {
-        const newEpic = await tx.epic.create({
-          data: { name: epic.name, description: epic.description, order: epic.order, projectId },
-        })
-        epicIdMap.set(epic.id, newEpic.id)
-        for (const feature of epic.features) {
-          const newFeature = await tx.feature.create({
-            data: { name: feature.name, description: feature.description, assumptions: feature.assumptions, order: feature.order, epicId: newEpic.id },
-          })
-          featureIdMap.set(feature.id, newFeature.id)
-          for (const story of feature.userStories) {
-            const newStory = await tx.userStory.create({
-              data: { name: story.name, description: story.description, assumptions: story.assumptions, order: story.order, featureId: newFeature.id, appliedTemplateId: story.appliedTemplateId },
-            })
-            storyIdMap.set(story.id, newStory.id)
-            for (const task of story.tasks) {
-              const resourceTypeId = task.resourceType?.name
-                ? (rtNameMap.get(task.resourceType.name.toLowerCase()) ?? null)
-                : null
-              await tx.task.create({
-                data: {
-                  name: task.name,
-                  description: task.description,
-                  assumptions: task.assumptions,
-                  hoursEffort: task.hoursEffort,
-                  durationDays: task.durationDays,
-                  order: task.order,
-                  userStoryId: newStory.id,
-                  resourceTypeId,
-                },
-              })
-            }
-          }
-        }
-      }
-
-      // 4. Restore project fields
-      if (v2.project) {
-        await tx.project.update({
-          where: { id: projectId },
-          data: {
-            startDate: v2.project.startDate,
-            onboardingWeeks: v2.project.onboardingWeeks,
-            bufferWeeks: v2.project.bufferWeeks,
-            hoursPerDay: v2.project.hoursPerDay,
-          },
-        })
-      }
-
-      // 5. Restore TimelineEntries — delete then recreate using new feature IDs
-      await tx.timelineEntry.deleteMany({ where: { projectId } })
-      if (v2.timelineEntries.length > 0) {
-        const mappedTLEs = v2.timelineEntries
-          .map(e => {
-            const newFeatureId = featureIdMap.get(e.featureId)
-            if (!newFeatureId) return null
-            return {
-              projectId,
-              featureId: newFeatureId,
-              startWeek: e.startWeek,
-              durationWeeks: e.durationWeeks,
-              isManual: e.isManual,
-            }
-          })
-          .filter((e): e is NonNullable<typeof e> => e !== null)
-        if (mappedTLEs.length > 0) {
-          await tx.timelineEntry.createMany({ data: mappedTLEs, skipDuplicates: true })
-        }
-      }
-
-      // 6. Restore StoryTimelineEntries — delete then recreate using new story IDs
-      await tx.storyTimelineEntry.deleteMany({ where: { projectId } })
-      if (v2.storyTimelineEntries.length > 0) {
-        const mappedSTLEs = v2.storyTimelineEntries
-          .map(e => {
-            const newStoryId = storyIdMap.get(e.storyId)
-            if (!newStoryId) return null
-            return {
-              projectId,
-              storyId: newStoryId,
-              startWeek: e.startWeek,
-              durationWeeks: e.durationWeeks,
-              isManual: e.isManual,
-            }
-          })
-          .filter((e): e is NonNullable<typeof e> => e !== null)
-        if (mappedSTLEs.length > 0) {
-          await tx.storyTimelineEntry.createMany({ data: mappedSTLEs, skipDuplicates: true })
-        }
-      }
-
-      // 7. Restore EpicDependencies using new epic IDs
-      await tx.epicDependency.deleteMany({ where: { epic: { projectId } } })
-      if (v2.epicDependencies.length > 0) {
-        const mappedEDs = v2.epicDependencies
-          .map(d => {
-            const newEpicId = epicIdMap.get(d.epicId)
-            const newDependsOnId = epicIdMap.get(d.dependsOnId)
-            if (!newEpicId || !newDependsOnId) return null
-            return { epicId: newEpicId, dependsOnId: newDependsOnId }
-          })
-          .filter((d): d is NonNullable<typeof d> => d !== null)
-        if (mappedEDs.length > 0) {
-          await tx.epicDependency.createMany({ data: mappedEDs, skipDuplicates: true })
-        }
-      }
-
-      // 8. Restore FeatureDependencies using new feature IDs
-      await tx.featureDependency.deleteMany({ where: { feature: { epic: { projectId } } } })
-      if (v2.featureDependencies.length > 0) {
-        const mappedFDs = v2.featureDependencies
-          .map(d => {
-            const newFeatureId = featureIdMap.get(d.featureId)
-            const newDependsOnId = featureIdMap.get(d.dependsOnId)
-            if (!newFeatureId || !newDependsOnId) return null
-            return { featureId: newFeatureId, dependsOnId: newDependsOnId }
-          })
-          .filter((d): d is NonNullable<typeof d> => d !== null)
-        if (mappedFDs.length > 0) {
-          await tx.featureDependency.createMany({ data: mappedFDs, skipDuplicates: true })
-        }
-      }
-
-      // 9. Restore OverheadItems — delete all then recreate
-      await tx.projectOverhead.deleteMany({ where: { projectId } })
-      if (v2.overheadItems.length > 0) {
-        await tx.projectOverhead.createMany({
-          data: v2.overheadItems.map(o => ({
-            projectId,
-            name: o.name,
-            type: o.type,
-            value: o.value,
-            resourceTypeId: o.resourceTypeId,
-            order: o.order,
-          })),
-          skipDuplicates: true,
-        })
-      }
-    })
-  }
-  } catch (err) {
-    await prisma.backlogSnapshot.delete({ where: { id: preSnap.id } }).catch(() => {})
-    throw err
-  }
+    // Enforce retention policy inside the same transaction
+    await pruneSnapshots(tx, projectId)
+  })
 
   res.json({ message: 'Rollback complete' })
 }))

--- a/server/src/routes/snapshots.ts
+++ b/server/src/routes/snapshots.ts
@@ -13,6 +13,7 @@ import {
   SnapshotSchemaError,
   type SnapshotData,
   type SnapshotEpic,
+  type SnapshotJsonValue,
   type SnapshotV2,
   type SnapshotV3,
 } from '../lib/projectSnapshotTypes.js'
@@ -66,6 +67,32 @@ async function fetchEpics(projectId: string, db: SnapshotDbClient = prisma) {
   })
 }
 
+/**
+ * Detect which project capacity profiles have database-NULL legacy.
+ * Prisma reads both DB_NULL (Prisma.DbNull) and JSON null (Prisma.JsonNull)
+ * as JavaScript null; this raw query distinguishes them so the snapshot can
+ * preserve the exact null semantics.
+ *
+ * Returns an empty map when $queryRawUnsafe is unavailable (e.g. mock client),
+ * so all profiles are treated as VALUE/JSON_VALUE — safe for tests that don't
+ * exercise DB_NULL vs JSON_NULL discrimination.
+ */
+async function fetchLegacyNullMap(
+  projectId: string,
+  db: SnapshotDbClient,
+): Promise<Map<string, boolean>> {
+  try {
+    const rows = await (db as PrismaClient).$queryRawUnsafe<Array<{ id: string; legacy_is_null: boolean }>>(
+      'SELECT id, "legacy" IS NULL AS legacy_is_null FROM "CapacityProfile" WHERE "projectId" = $1',
+      projectId,
+    )
+    return new Map(rows.map(r => [r.id, r.legacy_is_null]))
+  } catch {
+    // Mock clients may not support $queryRawUnsafe; return empty map.
+    return new Map()
+  }
+}
+
 /** Build the full project snapshot (schemaVersion 3) with ordered capacity profiles. */
 async function buildSnapshot(
   projectId: string,
@@ -82,6 +109,7 @@ async function buildSnapshot(
     featureDependencies,
     overheadItems,
     rawProfiles,
+    legacyNullMap,
   ] = await Promise.all([
     fetchEpics(projectId, db),
     db.project.findUnique({
@@ -91,32 +119,19 @@ async function buildSnapshot(
     db.resourceType.findMany({
       where: { projectId },
       select: {
-        id: true,
-        name: true,
-        category: true,
-        count: true,
-        hoursPerDay: true,
-        dayRate: true,
-        globalTypeId: true,
-        allocationMode: true,
-        allocationPercent: true,
-        allocationStartWeek: true,
-        allocationEndWeek: true,
+        id: true, name: true, category: true, count: true, hoursPerDay: true,
+        dayRate: true, globalTypeId: true,
+        allocationMode: true, allocationPercent: true,
+        allocationStartWeek: true, allocationEndWeek: true,
       },
     }),
     db.namedResource.findMany({
       where: { resourceType: { projectId } },
       select: {
-        id: true,
-        resourceTypeId: true,
-        name: true,
-        startWeek: true,
-        endWeek: true,
-        allocationPct: true,
-        allocationMode: true,
-        allocationPercent: true,
-        allocationStartWeek: true,
-        allocationEndWeek: true,
+        id: true, resourceTypeId: true, name: true,
+        startWeek: true, endWeek: true, allocationPct: true,
+        allocationMode: true, allocationPercent: true,
+        allocationStartWeek: true, allocationEndWeek: true,
         pricingModel: true,
       },
     }),
@@ -143,9 +158,7 @@ async function buildSnapshot(
     db.capacityProfile.findMany({
       where: { projectId },
       include: {
-        segments: {
-          orderBy: { startWeek: 'asc' },
-        },
+        segments: { orderBy: { startWeek: 'asc' } },
       },
       orderBy: [
         { ownerKind: 'asc' },
@@ -153,6 +166,7 @@ async function buildSnapshot(
         { namedResourceId: 'asc' },
       ],
     }),
+    fetchLegacyNullMap(projectId, db),
   ])
 
   // Convert Date to ISO string for JSON compatibility
@@ -167,26 +181,39 @@ async function buildSnapshot(
       }
     : null
 
-  // Map Prisma model rows to SnapshotCapacityProfile, preserving all fields including nulls
-  const capacityProfiles = rawProfiles.map(p => ({
-    id: p.id,
-    ownerKind: p.ownerKind as SnapshotV3['capacityProfiles'][number]['ownerKind'],
-    resourceTypeId: p.resourceTypeId,
-    namedResourceId: p.namedResourceId,
-    planningBasis: p.planningBasis as SnapshotV3['capacityProfiles'][number]['planningBasis'],
-    source: p.source as SnapshotV3['capacityProfiles'][number]['source'],
-    defaultPercent: p.defaultPercent,
-    startWeek: p.startWeek,
-    endWeek: p.endWeek,
-    legacy: p.legacy,
-    segments: sortSnapshotSegments(p.segments.map(s => ({
-      id: s.id,
-      startWeek: s.startWeek,
-      endWeek: s.endWeek,
-      capacityPercent: s.capacityPercent,
-      source: s.source as SnapshotV3['capacityProfiles'][number]['segments'][number]['source'],
-    }))),
-  }))
+  // Map Prisma model rows to SnapshotCapacityProfile, preserving null semantics
+  const capacityProfiles = rawProfiles.map(p => {
+    // Determine the precise null state for legacy
+    const isDBNull = legacyNullMap.get(p.id) ?? false
+    let legacy: SnapshotJsonValue
+    if (isDBNull) {
+      legacy = { kind: 'DB_NULL' }
+    } else if (p.legacy === null) {
+      legacy = { kind: 'JSON_NULL' }
+    } else {
+      legacy = { kind: 'VALUE', value: p.legacy as Record<string, unknown> | unknown[] | string | number | boolean | null }
+    }
+
+    return {
+      id: p.id,
+      ownerKind: p.ownerKind as SnapshotV3['capacityProfiles'][number]['ownerKind'],
+      resourceTypeId: p.resourceTypeId,
+      namedResourceId: p.namedResourceId,
+      planningBasis: p.planningBasis as SnapshotV3['capacityProfiles'][number]['planningBasis'],
+      source: p.source as SnapshotV3['capacityProfiles'][number]['source'],
+      defaultPercent: p.defaultPercent,
+      startWeek: p.startWeek,
+      endWeek: p.endWeek,
+      legacy,
+      segments: sortSnapshotSegments(p.segments.map(s => ({
+        id: s.id,
+        startWeek: s.startWeek,
+        endWeek: s.endWeek,
+        capacityPercent: s.capacityPercent,
+        source: s.source as SnapshotV3['capacityProfiles'][number]['segments'][number]['source'],
+      }))),
+    }
+  })
 
   return {
     schemaVersion: 3 as const,

--- a/server/src/test/csvImport.test.ts
+++ b/server/src/test/csvImport.test.ts
@@ -1,0 +1,92 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import request from 'supertest'
+import jwt from 'jsonwebtoken'
+
+vi.mock('../routes/snapshots.js', async importOriginal => {
+  const actual = await importOriginal<typeof import('../routes/snapshots.js')>()
+  return {
+    ...actual,
+    buildSnapshot: vi.fn().mockResolvedValue({}),
+  }
+})
+
+vi.mock('../lib/snapshotUtils.js', async importOriginal => {
+  const actual = await importOriginal<typeof import('../lib/snapshotUtils.js')>()
+  return {
+    ...actual,
+    pruneSnapshots: vi.fn().mockResolvedValue(undefined),
+  }
+})
+
+import { app } from '../index.js'
+import { prisma } from '../lib/prisma.js'
+import { buildSnapshot } from '../routes/snapshots.js'
+
+process.env.JWT_SECRET = 'test-secret'
+
+const userId = 'user-csv-1'
+const token = jwt.sign({ userId }, 'test-secret')
+const authHeader = `Bearer ${token}`
+const projectId = 'proj-csv-1'
+const mockProject = { id: projectId, ownerId: userId, hoursPerDay: 8 }
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('POST /api/projects/:projectId/backlog/import-csv', () => {
+  beforeEach(() => {
+    vi.mocked(prisma.project.findFirst).mockResolvedValue(mockProject as never)
+    // Provide at least one existing epic so the auto-snapshot branch is taken
+    vi.mocked(prisma.epic.findMany).mockResolvedValue([{ id: 'epic-1' }] as never)
+    // Provide a matching resource type by name
+    vi.mocked(prisma.resourceType.findMany).mockResolvedValue([
+      { id: 'rt-dev', name: 'Developer', hoursPerDay: 8 },
+    ] as never)
+  })
+
+  it('returns 500 when buildSnapshot rejects, preventing snapshot persistence and mutation', async () => {
+    vi.mocked(buildSnapshot).mockRejectedValueOnce(new Error('Snapshot null-state rejection'))
+
+    const res = await request(app)
+      .post(`/api/projects/${projectId}/backlog/import-csv`)
+      .set('Authorization', authHeader)
+      .send({
+        rows: [
+          {
+            rowIndex: 0,
+            type: 'Epic',
+            epic: 'Test Epic',
+            feature: '',
+            story: '',
+            task: '',
+            epicStatus: true,
+            featureStatus: false,
+            storyStatus: false,
+            epicMode: 'parallel',
+            featureMode: '',
+            epicDependsOn: [],
+            featureDependsOn: [],
+            template: '',
+            templateSize: '',
+            resourceType: '',
+            hoursExtraSmall: 0,
+            hoursSmall: 0,
+            hoursMedium: 0,
+            hoursLarge: 0,
+            hoursExtraLarge: 0,
+            hoursEffort: 0,
+            durationDays: 0,
+            description: '',
+            assumptions: '',
+            errors: [],
+            warnings: [],
+          },
+        ],
+      })
+
+    expect(res.status).toBe(500)
+    expect(prisma.backlogSnapshot.create).not.toHaveBeenCalled()
+    expect(prisma.$transaction).not.toHaveBeenCalled()
+  })
+})

--- a/server/src/test/optimiser.test.ts
+++ b/server/src/test/optimiser.test.ts
@@ -25,6 +25,16 @@ import {
   type SchedulerResourceType,
 } from '../lib/scheduler.js'
 
+vi.mock('../routes/snapshots.js', async importOriginal => {
+  const actual = await importOriginal<typeof import('../routes/snapshots.js')>()
+  return {
+    ...actual,
+    buildSnapshot: vi.fn().mockResolvedValue({}),
+  }
+})
+
+import { buildSnapshot } from '../routes/snapshots.js'
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Test helpers — mirrors scheduler.test.ts conventions
 // ─────────────────────────────────────────────────────────────────────────────
@@ -1013,6 +1023,30 @@ describe('POST /api/projects/:projectId/optimise — count range validation', ()
 
     expect(res.status).toBe(400)
     expect(res.body.error).toBe('Invalid constraints.countRanges')
+  })
+})
+
+describe('POST /api/projects/:projectId/optimise/apply — buildSnapshot rejection', () => {
+  beforeEach(() => {
+    vi.mocked(prisma.project.findFirst).mockResolvedValue(mockProject as never)
+  })
+
+  it('returns 500 when buildSnapshot rejects, preventing snapshot persistence and mutation', async () => {
+    vi.mocked(prisma.resourceType.findMany).mockResolvedValue([{ id: 'rt-1' }] as never)
+    vi.mocked(buildSnapshot).mockRejectedValueOnce(new Error('Snapshot null-state rejection'))
+
+    const res = await request(app)
+      .post(`/api/projects/${projectId}/optimise/apply`)
+      .set('Authorization', authHeader)
+      .send({
+        resourceTypes: [
+          { resourceTypeId: 'rt-1', count: 2, suggestedStartWeek: 0 },
+        ],
+      })
+
+    expect(res.status).toBe(500)
+    expect(prisma.backlogSnapshot.create).not.toHaveBeenCalled()
+    expect(prisma.$transaction).not.toHaveBeenCalled()
   })
 })
 

--- a/server/src/test/projectSnapshotJsonValue.test.ts
+++ b/server/src/test/projectSnapshotJsonValue.test.ts
@@ -1,0 +1,343 @@
+/**
+ * projectSnapshotJsonValue.test.ts — Unit tests for SnapshotJsonValue type guard,
+ * sentinel mapping, and serialisation.
+ *
+ * Coverage:
+ *   - snapshotJsonValueToPrisma (DB_NULL/JSON_NULL/VALUE mapping)
+ *   - snapshotJsonValueToPlain (round-trip serialisation)
+ *   - validateSnapshotJsonValue (every accepted scalar/container/rejection)
+ *
+ * All tests are behavioural and deterministic.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { Prisma } from '@prisma/client'
+import type { SnapshotJsonValue } from '../lib/projectSnapshotTypes.js'
+import {
+  snapshotJsonValueToPrisma,
+  snapshotJsonValueToPlain,
+} from '../lib/projectSnapshotTypes.js'
+import {
+  validateSnapshotJsonValue,
+  SnapshotValidationError,
+} from '../lib/projectSnapshotValidation.js'
+
+/* ─── Helpers ─────────────────────────────────────────────────── */
+
+/** Assert that validateSnapshotJsonValue does NOT throw. */
+function assertValid(value: unknown, pfx = 'test'): asserts value is SnapshotJsonValue {
+  const act = () => validateSnapshotJsonValue(value, pfx)
+  expect(act).not.toThrow()
+}
+
+/** Assert that validateSnapshotJsonValue throws SnapshotValidationError. */
+function assertInvalid(value: unknown, pfx = 'test'): void {
+  const act = () => validateSnapshotJsonValue(value, pfx)
+  expect(act).toThrow(SnapshotValidationError)
+}
+
+/* ─── snapshotJsonValueToPrisma ───────────────────────────────── */
+
+describe('snapshotJsonValueToPrisma', () => {
+  it('maps DB_NULL to Prisma.DbNull', () => {
+    const sjv: SnapshotJsonValue = { kind: 'DB_NULL' }
+    expect(snapshotJsonValueToPrisma(sjv)).toBe(Prisma.DbNull)
+  })
+
+  it('maps JSON_NULL to Prisma.JsonNull', () => {
+    const sjv: SnapshotJsonValue = { kind: 'JSON_NULL' }
+    expect(snapshotJsonValueToPrisma(sjv)).toBe(Prisma.JsonNull)
+  })
+
+  it('unwraps VALUE string', () => {
+    const sjv: SnapshotJsonValue = { kind: 'VALUE', value: 'hello' }
+    expect(snapshotJsonValueToPrisma(sjv)).toBe('hello')
+  })
+
+  it('unwraps VALUE number', () => {
+    const sjv: SnapshotJsonValue = { kind: 'VALUE', value: 42 }
+    expect(snapshotJsonValueToPrisma(sjv)).toBe(42)
+  })
+
+  it('unwraps VALUE boolean', () => {
+    const sjv: SnapshotJsonValue = { kind: 'VALUE', value: true }
+    expect(snapshotJsonValueToPrisma(sjv)).toBe(true)
+  })
+
+  it('unwraps VALUE object', () => {
+    const obj = { a: 1 }
+    const sjv: SnapshotJsonValue = { kind: 'VALUE', value: obj }
+    expect(snapshotJsonValueToPrisma(sjv)).toBe(obj)
+  })
+
+  it('unwraps VALUE array', () => {
+    const arr = [1, 2, 3]
+    const sjv: SnapshotJsonValue = { kind: 'VALUE', value: arr }
+    expect(snapshotJsonValueToPrisma(sjv)).toBe(arr)
+  })
+})
+
+/* ─── snapshotJsonValueToPlain ────────────────────────────────── */
+
+describe('snapshotJsonValueToPlain', () => {
+  it('serialises DB_NULL', () => {
+    const sjv: SnapshotJsonValue = { kind: 'DB_NULL' }
+    expect(snapshotJsonValueToPlain(sjv)).toEqual({ kind: 'DB_NULL' })
+  })
+
+  it('serialises JSON_NULL', () => {
+    const sjv: SnapshotJsonValue = { kind: 'JSON_NULL' }
+    expect(snapshotJsonValueToPlain(sjv)).toEqual({ kind: 'JSON_NULL' })
+  })
+
+  it('serialises VALUE with number', () => {
+    const sjv: SnapshotJsonValue = { kind: 'VALUE', value: 99 }
+    expect(snapshotJsonValueToPlain(sjv)).toEqual({ kind: 'VALUE', value: 99 })
+  })
+
+  it('serialises VALUE with object', () => {
+    const sjv: SnapshotJsonValue = { kind: 'VALUE', value: { x: 1 } }
+    expect(snapshotJsonValueToPlain(sjv)).toEqual({ kind: 'VALUE', value: { x: 1 } })
+  })
+
+  it('serialises VALUE with array', () => {
+    const sjv: SnapshotJsonValue = { kind: 'VALUE', value: [1, null, 'a'] }
+    expect(snapshotJsonValueToPlain(sjv)).toEqual({ kind: 'VALUE', value: [1, null, 'a'] })
+  })
+})
+
+/* ─── validateSnapshotJsonValue — accepted ────────────────────── */
+
+describe('validateSnapshotJsonValue – accepted', () => {
+  it('accepts DB_NULL without value', () => {
+    assertValid({ kind: 'DB_NULL' })
+  })
+
+  it('accepts JSON_NULL without value', () => {
+    assertValid({ kind: 'JSON_NULL' })
+  })
+
+  it('accepts VALUE with string', () => {
+    assertValid({ kind: 'VALUE', value: 'text' })
+  })
+
+  it('accepts VALUE with empty string', () => {
+    assertValid({ kind: 'VALUE', value: '' })
+  })
+
+  it('accepts VALUE with positive integer', () => {
+    assertValid({ kind: 'VALUE', value: 42 })
+  })
+
+  it('accepts VALUE with zero', () => {
+    assertValid({ kind: 'VALUE', value: 0 })
+  })
+
+  it('accepts VALUE with negative integer', () => {
+    assertValid({ kind: 'VALUE', value: -1 })
+  })
+
+  it('accepts VALUE with finite decimal', () => {
+    assertValid({ kind: 'VALUE', value: 3.14 })
+  })
+
+  it('accepts VALUE with true', () => {
+    assertValid({ kind: 'VALUE', value: true })
+  })
+
+  it('accepts VALUE with false', () => {
+    assertValid({ kind: 'VALUE', value: false })
+  })
+
+  it('accepts VALUE with empty object', () => {
+    assertValid({ kind: 'VALUE', value: {} })
+  })
+
+  it('accepts VALUE with empty array', () => {
+    assertValid({ kind: 'VALUE', value: [] })
+  })
+
+  it('accepts VALUE with nested object containing null', () => {
+    assertValid({ kind: 'VALUE', value: { a: null, b: 'keep' } })
+  })
+
+  it('accepts VALUE with nested array containing null', () => {
+    assertValid({ kind: 'VALUE', value: [1, null, 'two'] })
+  })
+
+  it('accepts VALUE with deeply nested valid structure', () => {
+    assertValid({
+      kind: 'VALUE',
+      value: {
+        level1: [
+          { level2: null },
+          { level2: [true, false, 0, 'deep'] },
+        ],
+      },
+    })
+  })
+
+  it('accepts VALUE with prototype-less object (Object.create(null))', () => {
+    const bare = Object.create(null) as Record<string, unknown>
+    bare.x = 1
+    assertValid({ kind: 'VALUE', value: bare })
+  })
+
+  it('accepts shared non-cyclic reference in VALUE', () => {
+    const shared = { tag: 'shared' }
+    const root = { a: shared, b: shared }
+    assertValid({ kind: 'VALUE', value: root })
+  })
+})
+
+/* ─── validateSnapshotJsonValue — rejected ────────────────────── */
+
+describe('validateSnapshotJsonValue – rejected', () => {
+  /* Non-object input */
+  it('rejects null (non-object input)', () => {
+    assertInvalid(null)
+  })
+
+  it('rejects undefined (non-object input)', () => {
+    assertInvalid(undefined)
+  })
+
+  it('rejects a bare string', () => {
+    assertInvalid('hello')
+  })
+
+  it('rejects a bare number', () => {
+    assertInvalid(99)
+  })
+
+  /* Malformed discriminator */
+  it('rejects non-string kind', () => {
+    assertInvalid({ kind: 42 })
+  })
+
+  it('rejects null kind', () => {
+    assertInvalid({ kind: null })
+  })
+
+  it('rejects unsupported kind string', () => {
+    assertInvalid({ kind: 'UNKNOWN' })
+  })
+
+  /* Extra / missing fields */
+  it('rejects DB_NULL with extra value field', () => {
+    assertInvalid({ kind: 'DB_NULL', value: 'x' })
+  })
+
+  it('rejects DB_NULL with arbitrary extra field', () => {
+    assertInvalid({ kind: 'DB_NULL', extra: 1 })
+  })
+
+  it('rejects JSON_NULL with extra value field', () => {
+    assertInvalid({ kind: 'JSON_NULL', value: 'x' })
+  })
+
+  it('rejects JSON_NULL with arbitrary extra field', () => {
+    assertInvalid({ kind: 'JSON_NULL', extra: 1 })
+  })
+
+  it('rejects VALUE missing value field', () => {
+    assertInvalid({ kind: 'VALUE' })
+  })
+
+  it('rejects VALUE with extra unsupported field', () => {
+    assertInvalid({ kind: 'VALUE', value: 'ok', extra: true })
+  })
+
+  /* Top-level null in VALUE */
+  it('rejects VALUE with top-level null', () => {
+    assertInvalid({ kind: 'VALUE', value: null })
+  })
+
+  /* Undefined */
+  it('rejects VALUE with undefined', () => {
+    assertInvalid({ kind: 'VALUE', value: undefined })
+  })
+
+  /* Non-finite numbers */
+  it('rejects VALUE with NaN', () => {
+    assertInvalid({ kind: 'VALUE', value: NaN })
+  })
+
+  it('rejects VALUE with Infinity', () => {
+    assertInvalid({ kind: 'VALUE', value: Infinity })
+  })
+
+  it('rejects VALUE with -Infinity', () => {
+    assertInvalid({ kind: 'VALUE', value: -Infinity })
+  })
+
+  /* Function */
+  it('rejects VALUE with function', () => {
+    assertInvalid({ kind: 'VALUE', value: () => 1 })
+  })
+
+  /* Symbol */
+  it('rejects VALUE with symbol', () => {
+    assertInvalid({ kind: 'VALUE', value: Symbol('x') })
+  })
+
+  /* BigInt */
+  it('rejects VALUE with bigint', () => {
+    assertInvalid({ kind: 'VALUE', value: BigInt(1) })
+  })
+
+  /* Non-plain objects */
+  it('rejects VALUE with Date', () => {
+    assertInvalid({ kind: 'VALUE', value: new Date() })
+  })
+
+  it('rejects VALUE with RegExp', () => {
+    assertInvalid({ kind: 'VALUE', value: /regex/ })
+  })
+
+  it('rejects VALUE with Map', () => {
+    assertInvalid({ kind: 'VALUE', value: new Map() })
+  })
+
+  it('rejects VALUE with Set', () => {
+    assertInvalid({ kind: 'VALUE', value: new Set() })
+  })
+
+  it('rejects VALUE with custom class instance', () => {
+    class CustomClass { x = 1 }
+    assertInvalid({ kind: 'VALUE', value: new CustomClass() })
+  })
+
+  /* Cyclic references */
+  it('rejects VALUE with self-referencing object cycle', () => {
+    const cyclic: Record<string, unknown> = {}
+    cyclic.self = cyclic
+    assertInvalid({ kind: 'VALUE', value: cyclic })
+  })
+
+  it('rejects VALUE with deeper cycle in nested object', () => {
+    const inner: Record<string, unknown> = { a: 1 }
+    const root = { inner }
+    inner.parent = root
+    assertInvalid({ kind: 'VALUE', value: root })
+  })
+
+  it('rejects VALUE with cyclic array (element refers to self)', () => {
+    const arr: unknown[] = [1, 2, 3]
+    arr.push(arr)
+    assertInvalid({ kind: 'VALUE', value: arr })
+  })
+
+  /* Non-serialisable values nested inside structures */
+  it('rejects VALUE with function nested in object', () => {
+    assertInvalid({ kind: 'VALUE', value: { fn: () => 1 } })
+  })
+
+  it('rejects VALUE with undefined nested in array', () => {
+    assertInvalid({ kind: 'VALUE', value: [1, undefined, 3] })
+  })
+
+  it('rejects VALUE with NaN nested in array', () => {
+    assertInvalid({ kind: 'VALUE', value: [NaN] })
+  })
+})

--- a/server/src/test/setup.ts
+++ b/server/src/test/setup.ts
@@ -17,7 +17,7 @@ vi.mock('../lib/prisma.js', () => {
   return {
     prisma: {
       user: { findUnique: vi.fn(), create: vi.fn(), update: vi.fn(), count: vi.fn() },
-      project: { findMany: vi.fn(), findFirst: vi.fn(), create: vi.fn(), update: vi.fn(), updateMany: vi.fn(), delete: vi.fn() },
+      project: { findMany: vi.fn(), findFirst: vi.fn(), findUnique: vi.fn(), create: vi.fn(), update: vi.fn(), updateMany: vi.fn(), delete: vi.fn() },
       epic: { findMany: vi.fn(), findFirst: vi.fn(), create: vi.fn(), update: vi.fn(), delete: vi.fn(), count: vi.fn() },
       feature: { findMany: vi.fn(), findFirst: vi.fn(), create: vi.fn(), update: vi.fn(), delete: vi.fn(), count: vi.fn() },
       userStory: { findMany: vi.fn(), findFirst: vi.fn(), findUnique: vi.fn(), create: vi.fn(), update: vi.fn(), delete: vi.fn(), count: vi.fn() },
@@ -33,7 +33,7 @@ vi.mock('../lib/prisma.js', () => {
       featureDependency: { findMany: vi.fn().mockResolvedValue([]), create: vi.fn(), delete: vi.fn(), deleteMany: vi.fn(), createMany: vi.fn() },
       storyDependency: { findMany: vi.fn().mockResolvedValue([]), create: vi.fn(), upsert: vi.fn().mockResolvedValue({}), delete: vi.fn(), deleteMany: vi.fn() },
       storyTimelineEntry: { findMany: vi.fn().mockResolvedValue([]), findFirst: vi.fn(), upsert: vi.fn().mockResolvedValue({}), deleteMany: vi.fn(), createMany: vi.fn() },
-      backlogSnapshot: { findFirst: vi.fn(), findMany: vi.fn(), findUnique: vi.fn(), create: vi.fn(), update: vi.fn(), delete: vi.fn() },
+      backlogSnapshot: { findFirst: vi.fn(), findMany: vi.fn(), findUnique: vi.fn(), create: vi.fn(), update: vi.fn(), delete: vi.fn(), deleteMany: vi.fn() },
       namedResource: { findMany: vi.fn(), findFirst: vi.fn(), findUnique: vi.fn(), create: vi.fn(), createMany: vi.fn(), update: vi.fn(), updateMany: vi.fn(), delete: vi.fn(), deleteMany: vi.fn(), count: vi.fn() },
       rateCard: { findMany: vi.fn(), findUnique: vi.fn(), create: vi.fn(), update: vi.fn(), delete: vi.fn(), deleteMany: vi.fn() },
       rateCardEntry: { findMany: vi.fn(), findUnique: vi.fn(), create: vi.fn(), update: vi.fn(), delete: vi.fn(), deleteMany: vi.fn() },
@@ -72,6 +72,7 @@ vi.mock('../lib/prisma.js', () => {
         epicDependency: { deleteMany: vi.fn(), createMany: vi.fn() },
         featureDependency: { deleteMany: vi.fn(), createMany: vi.fn() },
         projectOverhead: { deleteMany: vi.fn(), createMany: vi.fn() },
+        backlogSnapshot: { create: vi.fn(), findMany: vi.fn(), deleteMany: vi.fn() },
         capacityProfile: capacityProfileMocks,
         capacitySegment: capacitySegmentMocks,
       }) : Promise.resolve(fn)),

--- a/server/src/test/snapshotRollback.integration.test.ts
+++ b/server/src/test/snapshotRollback.integration.test.ts
@@ -342,10 +342,9 @@ async function createEpicBacklog(
  * legacy IS NULL at the storage level.
  */
 async function detectDbNullProfileIds(projectId: string): Promise<Set<string>> {
-  const rows = await prisma.$queryRawUnsafe<Array<{ id: string }>>(
-    `SELECT cp.id FROM "CapacityProfile" cp WHERE cp."projectId" = $1 AND cp.legacy IS NULL`,
-    projectId,
-  )
+  const rows = await prisma.$queryRaw<Array<{ id: string }>>(Prisma.sql`
+    SELECT cp.id FROM "CapacityProfile" cp WHERE cp."projectId" = ${projectId} AND cp.legacy IS NULL
+  `)
   const seen = new Set<string>()
   for (const r of rows) {
     seen.add(r.id)
@@ -379,6 +378,9 @@ describeIf('Scenario A — v3 round trip with full canonical state', () => {
   let snapshotId: string
   let rtDevId: string
   let rtDesId: string
+  let extraRtId: string
+  let extraNrId: string
+  let extraProfileId: string
   let nrAliceId: string
   let nrCharlieId: string
   let nrDaveId: string
@@ -815,6 +817,33 @@ describeIf('Scenario A — v3 round trip with full canonical state', () => {
   it('mutates all domains then rollback restores exact original state', async () => {
     // ── Mutate every captured domain ──────────────────────────────
 
+    // Add a post-snapshot role owner, named resource, compatibility allocation,
+    // and persisted profile. V3 rollback must remove this owner set entirely.
+    extraRtId = await createResourceType(projectId, 'rt-extra', 'Post-snapshot role', {
+      allocationMode: 'TIMELINE',
+      allocationPercent: 45,
+      allocationStartWeek: 2,
+      allocationEndWeek: 7,
+    })
+    extraNrId = await createNamedResource(projectId, extraRtId, 'nr-extra', 'Post-snapshot person', {
+      allocationMode: 'TIMELINE',
+      allocationPercent: 45,
+      allocationStartWeek: 2,
+      allocationEndWeek: 7,
+    })
+    extraProfileId = await createProfile(
+      projectId, 'prof-extra-owner', 'ROLE', extraRtId, null,
+      {
+        planningBasis: 'AVAILABILITY_WINDOW',
+        source: 'MANUAL',
+        defaultPercent: 45,
+        startWeek: 2,
+        endWeek: 7,
+      },
+      Prisma.DbNull,
+    )
+    await createSegment(extraProfileId, 'seg-extra-owner', 2, 7, 45)
+
     // Delete ROLE segments, add new ones
     await prisma.capacitySegment.deleteMany({ where: { capacityProfileId: profileRoleId } })
     await createSegment(profileRoleId, 'seg-mutated-1', 10, 15, 30)
@@ -971,6 +1000,9 @@ describeIf('Scenario A — v3 round trip with full canonical state', () => {
     })
     expect(nrs).toHaveLength(8)
     expect(nrs.find(n => n.id === nrAliceId)!.pricingModel).toBe('ACTUAL_DAYS')
+    expect(rts.find(r => r.id === extraRtId)).toBeUndefined()
+    expect(nrs.find(n => n.id === extraNrId)).toBeUndefined()
+
 
     const profiles = await prisma.capacityProfile.findMany({
       where: { projectId },
@@ -1087,6 +1119,7 @@ describeIf('Scenario A — v3 round trip with full canonical state', () => {
       id: string
       legacy_type: string
       legacy_is_null: boolean
+      legacyJsonType: string | null
       null_kind: string
       nested_nulls_preserved: boolean
     }>>(Prisma.sql`
@@ -1094,6 +1127,7 @@ describeIf('Scenario A — v3 round trip with full canonical state', () => {
         cp.id,
         pg_typeof(cp.legacy)::text AS legacy_type,
         cp.legacy IS NULL AS legacy_is_null,
+        jsonb_typeof(cp.legacy) AS "legacyJsonType",
         CASE
           WHEN cp.legacy IS NULL THEN 'DB_NULL'
           WHEN cp.legacy = 'null'::jsonb THEN 'JSON_NULL'
@@ -1131,10 +1165,34 @@ describeIf('Scenario A — v3 round trip with full canonical state', () => {
     expect(nullKindMap.get(profileArrayNullId)).toBe('VALUE')
     expect(nullKindMap.get(profileStringId)).toBe('VALUE')
     expect(nullKindMap.get(profileBoolId)).toBe('VALUE')
+    // Confirm per-profile storage nullness independently from null_kind
+    const legacyIsNullMap = new Map(rawRows.map(r => [r.id, r.legacy_is_null]))
+    expect(legacyIsNullMap.get(profileRoleId)).toBe(true)
+    expect(legacyIsNullMap.get(profilePlannedNrId)).toBe(true)
+    expect(legacyIsNullMap.get(profileJsonNullId)).toBe(false)
+    expect(legacyIsNullMap.get(profileNamedId)).toBe(false)
+    expect(legacyIsNullMap.get(profilePlannedId)).toBe(false)
+    expect(legacyIsNullMap.get(profileNestedObjId)).toBe(false)
+    expect(legacyIsNullMap.get(profileArrayNullId)).toBe(false)
+    expect(legacyIsNullMap.get(profileStringId)).toBe(false)
+    expect(legacyIsNullMap.get(profileBoolId)).toBe(false)
+
 
     // Nested nulls are preserved in jsonb
     const nestedRow = rawRows.find(r => r.id === profileNestedObjId)!
     expect(nestedRow.nested_nulls_preserved).toBe(true)
+
+    // Per-profile jsonb_typeof value-type assertions
+    const jsonTypeMap = new Map(rawRows.map(r => [r.id, r.legacyJsonType]))
+    expect(jsonTypeMap.get(profileRoleId)).toBeNull()
+    expect(jsonTypeMap.get(profilePlannedNrId)).toBeNull()
+    expect(jsonTypeMap.get(profileJsonNullId)).toBe('null')
+    expect(jsonTypeMap.get(profileNamedId)).toBe('object')
+    expect(jsonTypeMap.get(profilePlannedId)).toBe('number')
+    expect(jsonTypeMap.get(profileNestedObjId)).toBe('object')
+    expect(jsonTypeMap.get(profileArrayNullId)).toBe('array')
+    expect(jsonTypeMap.get(profileStringId)).toBe('string')
+    expect(jsonTypeMap.get(profileBoolId)).toBe('boolean')
 
     // Backlog restored
     const epics = await prisma.epic.findMany({ where: { projectId } })
@@ -1184,6 +1242,12 @@ describeIf('Scenario A — v3 round trip with full canonical state', () => {
     const beforeTL = timelineBefore as Record<string, unknown>
     const afterRows = profileAfter.resourceRows as Array<Record<string, unknown>>
     const beforeRows = beforeRP.resourceRows as Array<Record<string, unknown>>
+    // The restored Resource Profile and Timeline DTOs must not resolve deleted
+    // post-snapshot owners through legacy fallback.
+    expect(afterRows.find(r => r.resourceTypeId === extraRtId)).toBeUndefined()
+    const afterTimelineNRs = timelineAfter.namedResources as Array<Record<string, unknown>>
+    expect(afterTimelineNRs.find(nr => nr.id === extraNrId)).toBeUndefined()
+
 
     // ── Role profile: PROFILE resolutionSource, exact restored segments, null fields ──
     const devRow = afterRows.find(r => r.resourceTypeId === rtDevId)!
@@ -1899,7 +1963,7 @@ describeIf('Scenario E — v2 rollback replaces stale persisted profiles', () =>
       allocationMode: 'TIMELINE',
       allocationPercent: 60,
       startWeek: 2,
-      endWeek: 8,
+      endWeek: 6,
     })
 
     // Create stale persisted profiles that DIFFER from v2-derived state
@@ -2013,6 +2077,39 @@ describeIf('Scenario E — v2 rollback replaces stale persisted profiles', () =>
     expect(roleLegacy.allocationPercent).toBe(60)
     expect(roleLegacy.allocationStartWeek).toBe(0)
     expect(roleLegacy.allocationEndWeek).toBe(10)
+
+    // Verify the application-facing Resource Profile DTO resolves the
+    // reconstructed compatibility profile, not the stale persisted profile.
+    const resourceProfileResponse = await request(app)
+      .get(`/api/projects/${projectId}/resource-profile`)
+      .set('Authorization', authHeader)
+      .expect(200)
+    const resourceTypeRow = resourceProfileResponse.body.resourceRows.find(
+      (row: Record<string, unknown>) => row.resourceTypeId === rtId,
+    )
+    expect(resourceTypeRow).toBeDefined()
+    expect(resourceTypeRow.capacityProfile).toMatchObject({
+      resolutionSource: 'PROFILE',
+      planningBasis: 'availabilityWindow',
+      source: 'availabilityWindow',
+      defaultPercent: 60,
+      startWeek: 0,
+      endWeek: 10,
+      segments: [],
+    })
+    const namedResourceRow = resourceTypeRow.namedResources.find(
+      (row: Record<string, unknown>) => row.id === nrId,
+    )
+    expect(namedResourceRow).toBeDefined()
+    expect(namedResourceRow.capacityProfile).toMatchObject({
+      resolutionSource: 'PROFILE',
+      planningBasis: 'availabilityWindow',
+      source: 'availabilityWindow',
+      defaultPercent: 60,
+      startWeek: 2,
+      endWeek: 6,
+      segments: [],
+    })
   })
 })
 
@@ -2256,18 +2353,17 @@ describeIf('Scenario F — v1 rollback preserves profiles, restores backlog', ()
     expect(stles).toHaveLength(0)
 
     // ── Raw SQL: comprehensive legacy null-type coverage ───────────
-    const rawRows = await prisma.$queryRawUnsafe<
+    const rawRows = await prisma.$queryRaw<
       Array<{ id: string; legacy_is_null: boolean; jsonb_typeof: string | null }>
-    >(
-      `SELECT
-         cp.id,
-         cp.legacy IS NULL AS legacy_is_null,
-         jsonb_typeof(cp.legacy) AS jsonb_typeof
-       FROM "CapacityProfile" cp
-       WHERE cp."projectId" = $1
-       ORDER BY cp.id`,
-      projectId,
-    )
+    >(Prisma.sql`
+      SELECT
+        cp.id,
+        cp.legacy IS NULL AS legacy_is_null,
+        jsonb_typeof(cp.legacy) AS jsonb_typeof
+      FROM "CapacityProfile" cp
+      WHERE cp."projectId" = ${projectId}
+      ORDER BY cp.id
+    `)
 
     // All 8 profiles verified by raw SQL
     // 1. ROLE — Prisma.DbNull → SQL NULL, jsonb_typeof NULL
@@ -2340,5 +2436,175 @@ describeIf('Scenario F — v1 rollback preserves profiles, restores backlog', ()
 })
 
 // ═════════════════════════════════════════════════════════════════════════════
-// Test count: 12 total (A:2, B:1, C:1, D:6, E:1, F:1)
+// Scenario G — v3 restores scope and scheduling fields
+// ═════════════════════════════════════════════════════════════════════════════
+
+describeIf('Scenario G — v3 restores scope and scheduling fields', () => {
+  let projectId: string
+  let snapshotId: string
+  let epicId: string
+  let featureId: string
+  let storyId: string
+
+  beforeAll(async () => {
+    if (!runIntegration) return
+    projectId = await createProject()
+    const rtId = await createResourceType(projectId, 'rt-g-dev', 'Developer', {
+      allocationMode: 'TIMELINE',
+      allocationPercent: 60,
+      allocationStartWeek: 2,
+      allocationEndWeek: 6,
+    })
+    const backlog = await createEpicBacklog(projectId, rtId, null)
+    epicId = backlog.epicId
+    featureId = backlog.featureId
+    storyId = backlog.storyId
+
+    await prisma.epic.update({
+      where: { id: epicId },
+      data: {
+        assumptions: 'Epic assumptions survive rollback',
+        featureMode: 'parallel',
+        scheduleMode: 'parallel',
+        timelineStartWeek: 4,
+        isActive: false,
+      },
+    })
+    await prisma.feature.update({
+      where: { id: featureId },
+      data: {
+        assumptions: 'Feature assumptions survive rollback',
+        featureMode: 'parallel',
+        isActive: false,
+        timelineColour: '#123456',
+        timelineStartWeek: 5,
+      },
+    })
+    await prisma.userStory.update({
+      where: { id: storyId },
+      data: {
+        assumptions: 'Story assumptions survive rollback',
+        isActive: false,
+      },
+    })
+    await prisma.timelineEntry.create({
+      data: { projectId, featureId, startWeek: 4, durationWeeks: 3, isManual: true },
+    })
+    await prisma.storyTimelineEntry.create({
+      data: { projectId, storyId, startWeek: 5, durationWeeks: 2, isManual: true },
+    })
+
+    const snapshot = await buildSnapshot(projectId, prisma)
+    snapshotId = (
+      await prisma.backlogSnapshot.create({
+        data: {
+          projectId,
+          label: 'Scope and scheduling snapshot',
+          trigger: 'manual',
+          snapshot: snapshot as unknown as object,
+          createdById: userId,
+        },
+      })
+    ).id
+  })
+
+  it('restores captured fields and preserves inactive read behavior', async () => {
+    const beforeResourceProfile = await request(app)
+      .get(`/api/projects/${projectId}/resource-profile`)
+      .set('Authorization', authHeader)
+      .expect(200)
+    const beforeTimeline = await request(app)
+      .get(`/api/projects/${projectId}/timeline`)
+      .set('Authorization', authHeader)
+      .expect(200)
+
+    await prisma.epic.update({
+      where: { id: epicId },
+      data: {
+        assumptions: null,
+        featureMode: 'sequential',
+        scheduleMode: 'sequential',
+        timelineStartWeek: null,
+        isActive: true,
+      },
+    })
+    await prisma.feature.update({
+      where: { id: featureId },
+      data: {
+        assumptions: null,
+        featureMode: 'sequential',
+        isActive: true,
+        timelineColour: null,
+        timelineStartWeek: null,
+      },
+    })
+    await prisma.userStory.update({
+      where: { id: storyId },
+      data: { assumptions: null, isActive: true },
+    })
+
+    await rollbackProjectSnapshot({ projectId, snapshotId, userId, db: prisma })
+
+    const restoredEpic = await prisma.epic.findFirst({
+      where: { projectId },
+      include: { features: { include: { userStories: true } } },
+    })
+    expect(restoredEpic).toMatchObject({
+      assumptions: 'Epic assumptions survive rollback',
+      featureMode: 'parallel',
+      scheduleMode: 'parallel',
+      timelineStartWeek: 4,
+      isActive: false,
+    })
+    const restoredFeature = restoredEpic!.features[0]
+    expect(restoredFeature).toMatchObject({
+      assumptions: 'Feature assumptions survive rollback',
+      featureMode: 'parallel',
+      isActive: false,
+      timelineColour: '#123456',
+      timelineStartWeek: 5,
+    })
+    expect(restoredFeature.userStories[0]).toMatchObject({
+      assumptions: 'Story assumptions survive rollback',
+      isActive: false,
+    })
+
+    const afterResourceProfile = await request(app)
+      .get(`/api/projects/${projectId}/resource-profile`)
+      .set('Authorization', authHeader)
+      .expect(200)
+    expect(afterResourceProfile.body.resourceRows.map((row: Record<string, unknown>) => ({
+      resourceTypeId: row.resourceTypeId,
+      totalHours: row.totalHours,
+      totalDays: row.totalDays,
+      allocatedDays: row.allocatedDays,
+    }))).toEqual(beforeResourceProfile.body.resourceRows.map((row: Record<string, unknown>) => ({
+      resourceTypeId: row.resourceTypeId,
+      totalHours: row.totalHours,
+      totalDays: row.totalDays,
+      allocatedDays: row.allocatedDays,
+    })))
+
+    const afterTimeline = await request(app)
+      .get(`/api/projects/${projectId}/timeline`)
+      .set('Authorization', authHeader)
+      .expect(200)
+    const projectScheduling = (body: Record<string, unknown>) => ({
+      entries: (body.entries as Array<Record<string, unknown>>).map(entry => ({
+        startWeek: entry.startWeek,
+        durationWeeks: entry.durationWeeks,
+        isManual: entry.isManual,
+      })),
+      storyEntries: ((body.storyEntries ?? []) as Array<Record<string, unknown>>).map(entry => ({
+        startWeek: entry.startWeek,
+        durationWeeks: entry.durationWeeks,
+        isManual: entry.isManual,
+      })),
+    })
+    expect(projectScheduling(afterTimeline.body)).toEqual(projectScheduling(beforeTimeline.body))
+  })
+})
+
+// ═════════════════════════════════════════════════════════════════════════════
+// Test count: 13 total (A:2, B:1, C:1, D:6, E:1, F:1, G:1)
 // All under describeIf — skipped when INTEGRATION_TEST is not 'true'.

--- a/server/src/test/snapshotRollback.integration.test.ts
+++ b/server/src/test/snapshotRollback.integration.test.ts
@@ -1,0 +1,390 @@
+/**
+ * snapshotRollback.integration.test.ts — Real PostgreSQL snapshot rollback tests.
+ *
+ * These tests exercise the full snapshot → mutate → rollback cycle against a
+ * running PostgreSQL database. They are skipped by default because they require
+ * Docker / CI database infrastructure.
+ *
+ * Run with:
+ *   INTEGRATION_TEST=true npx vitest run src/test/snapshotRollback.integration.test.ts
+ *
+ * Each test creates its own user/project, creates only the rows it needs,
+ * and cleans up after itself. Tests are serial (not parallel) to avoid
+ * database collisions.
+ *
+ * @module snapshotRollback.integration
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { Prisma } from '@prisma/client'
+import { prisma } from '../lib/prisma.js'
+
+const runIntegration = process.env.INTEGRATION_TEST === 'true'
+const describeIf = runIntegration ? describe : describe.skip
+
+// ─── Fixture helpers ─────────────────────────────────────────────────────────
+
+let userId: string
+
+beforeAll(async () => {
+  if (!runIntegration) return
+  const user = await prisma.user.create({
+    data: {
+      email: `snapshot-rollback-test-${Date.now()}@example.com`,
+      name: 'Snapshot Rollback Test',
+      password: '$2b$10$placeholder',
+    },
+  })
+  userId = user.id
+})
+
+afterAll(async () => {
+  if (!runIntegration) return
+  await prisma.backlogSnapshot.deleteMany({ where: { project: { ownerId: userId } } })
+  await prisma.capacitySegment.deleteMany({ where: { capacityProfile: { project: { ownerId: userId } } } })
+  await prisma.capacityProfile.deleteMany({ where: { project: { ownerId: userId } } })
+  await prisma.projectOverhead.deleteMany({ where: { project: { ownerId: userId } } })
+  await prisma.timelineEntry.deleteMany({ where: { project: { ownerId: userId } } })
+  await prisma.storyTimelineEntry.deleteMany({ where: { project: { ownerId: userId } } })
+  await prisma.epicDependency.deleteMany({ where: { epic: { project: { ownerId: userId } } } })
+  await prisma.featureDependency.deleteMany({ where: { feature: { epic: { project: { ownerId: userId } } } } })
+  await prisma.task.deleteMany({ where: { userStory: { feature: { epic: { project: { ownerId: userId } } } } } })
+  await prisma.userStory.deleteMany({ where: { feature: { epic: { project: { ownerId: userId } } } } })
+  await prisma.feature.deleteMany({ where: { epic: { project: { ownerId: userId } } } })
+  await prisma.epic.deleteMany({ where: { project: { ownerId: userId } } })
+  await prisma.namedResource.deleteMany({ where: { resourceType: { project: { ownerId: userId } } } })
+  await prisma.resourceType.deleteMany({ where: { project: { ownerId: userId } } })
+  await prisma.project.deleteMany({ where: { ownerId: userId } })
+  await prisma.user.delete({ where: { id: userId } })
+})
+
+async function createProject(): Promise<string> {
+  const project = await prisma.project.create({
+    data: {
+      name: `Snapshot Integration Test ${Date.now()}`,
+      ownerId: userId,
+    },
+  })
+  return project.id
+}
+
+async function createResourceType(projectId: string, name: string): Promise<string> {
+  const rt = await prisma.resourceType.create({
+    data: {
+      name,
+      projectId,
+      category: 'ENGINEERING' as const,
+      count: 2,
+      hoursPerDay: 8,
+      dayRate: 500,
+      allocationMode: 'TIMELINE' as const,
+      allocationPercent: 100,
+      allocationStartWeek: 0,
+      allocationEndWeek: 10,
+    },
+  })
+  return rt.id
+}
+
+async function createNamedResource(_projectId: string, resourceTypeId: string, name: string): Promise<string> {
+  const nr = await prisma.namedResource.create({
+    data: {
+      name,
+      resourceType: { connect: { id: resourceTypeId } },
+      allocationMode: 'EFFORT' as const,
+      allocationPercent: 80,
+      allocationStartWeek: 0,
+      allocationEndWeek: 10,
+    },
+  })
+  return nr.id
+}
+
+async function createProfileWithSegments(
+  projectId: string,
+  resourceTypeId: string | null,
+  namedResourceId: string | null,
+  ownerKind: 'ROLE' | 'NAMED_PERSON' | 'PLANNED_RESOURCE',
+  overrides: {
+    planningBasis?: string
+    source?: string
+    defaultPercent?: number | null
+    startWeek?: number | null
+    endWeek?: number | null
+    legacy?: unknown
+  } = {},
+  segments: Array<{ startWeek: number; endWeek: number; capacityPercent: number; source?: string }> = [],
+): Promise<string> {
+  const data: Record<string, unknown> = {
+    project: { connect: { id: projectId } },
+    ownerKind,
+    planningBasis: overrides.planningBasis ?? 'DEMAND_FOLLOWING',
+    source: overrides.source ?? 'MANUAL',
+    defaultPercent: overrides.defaultPercent ?? null,
+    startWeek: overrides.startWeek ?? null,
+    endWeek: overrides.endWeek ?? null,
+  }
+  if (resourceTypeId) data.resourceType = { connect: { id: resourceTypeId } }
+  if (namedResourceId) data.namedResource = { connect: { id: namedResourceId } }
+  if (overrides.legacy !== undefined) {
+    data.legacy = overrides.legacy
+  } else {
+    data.legacy = Prisma.DbNull
+  }
+
+  const profile = await prisma.capacityProfile.create({
+    data: data as never,
+  })
+
+  for (const s of segments) {
+    await prisma.capacitySegment.create({
+      data: {
+        capacityProfile: { connect: { id: profile.id } },
+        startWeek: s.startWeek,
+        endWeek: s.endWeek,
+        capacityPercent: s.capacityPercent,
+        source: s.source ?? 'MANUAL',
+      } as never,
+    })
+  }
+
+  return profile.id
+}
+
+async function createSegments(
+  profileId: string,
+  segments: Array<{ startWeek: number; endWeek: number; capacityPercent: number; source?: string }>,
+): Promise<void> {
+  for (const s of segments) {
+    await prisma.capacitySegment.create({
+      data: {
+        capacityProfile: { connect: { id: profileId } },
+        startWeek: s.startWeek,
+        endWeek: s.endWeek,
+        capacityPercent: s.capacityPercent,
+        source: s.source ?? 'MANUAL',
+      } as never,
+    })
+  }
+}
+
+// ═════════════════════════════════════════════════════════════════════════════
+// Scenario A — exact v3 round trip (basic)
+// ═════════════════════════════════════════════════════════════════════════════
+
+describeIf('Scenario A — v3 round trip', () => {
+  it('captures, mutates, and restores via buildSnapshot/recreateV3CapacityProfiles', async () => {
+    const projectId = await createProject()
+    const rtId = await createResourceType(projectId, 'Developer')
+    const nrId = await createNamedResource(projectId, rtId, 'Alice')
+
+    await createProfileWithSegments(projectId, rtId, null, 'ROLE', {
+      planningBasis: 'DEMAND_FOLLOWING',
+      source: 'FIXED',
+      defaultPercent: null,
+      startWeek: null,
+      endWeek: null,
+      legacy: Prisma.DbNull,
+    }, [
+      { startWeek: 0, endWeek: 4, capacityPercent: 100 },
+      { startWeek: 5, endWeek: 10, capacityPercent: 50 },
+    ])
+
+    await createProfileWithSegments(projectId, null, nrId, 'NAMED_PERSON', {
+      planningBasis: 'AVAILABILITY_WINDOW',
+      source: 'SQUAD_PLANNER',
+      defaultPercent: 100,
+      startWeek: 2,
+      endWeek: 8,
+      legacy: { allocationMode: 'EFFORT' },
+    }, [
+      { startWeek: 2, endWeek: 5, capacityPercent: 100 },
+    ])
+
+    const initialProfiles = await prisma.capacityProfile.findMany({
+      where: { projectId },
+      include: { segments: { orderBy: { startWeek: 'asc' } } },
+    })
+    expect(initialProfiles.length).toBe(2)
+
+    // Build snapshot
+    const { buildSnapshot } = await import('../routes/snapshots.js')
+    const snapshot = await buildSnapshot(projectId, prisma)
+    expect(snapshot.schemaVersion).toBe(3)
+    expect(snapshot.capacityProfiles.length).toBe(2)
+
+    // Verify SnapshotJsonValue
+    const roleProfile = snapshot.capacityProfiles.find(p => p.ownerKind === 'ROLE')
+    expect(roleProfile?.legacy.kind).toBe('DB_NULL')
+    const personProfile = snapshot.capacityProfiles.find(p => p.ownerKind === 'NAMED_PERSON')
+    expect(personProfile?.legacy.kind).toBe('VALUE')
+
+    // Mutate
+    const roleDb = initialProfiles.find(p => p.ownerKind === 'ROLE')!
+    await createSegments(roleDb.id, [
+      { startWeek: 11, endWeek: 14, capacityPercent: 25 },
+    ])
+    const mutatedSegments = await prisma.capacitySegment.count({
+      where: { capacityProfileId: roleDb.id },
+    })
+    expect(mutatedSegments).toBe(3)
+
+    // Restore
+    const { recreateV3CapacityProfiles } = await import('../lib/projectSnapshotCapacity.js')
+    await prisma.$transaction(async tx => {
+      await recreateV3CapacityProfiles(tx, projectId, snapshot)
+    })
+
+    // Verify restoration
+    const restoredProfiles = await prisma.capacityProfile.findMany({
+      where: { projectId },
+      include: { segments: { orderBy: { startWeek: 'asc' } } },
+    })
+    expect(restoredProfiles.length).toBe(2)
+    const restoredRole = restoredProfiles.find(p => p.ownerKind === 'ROLE')
+    expect(restoredRole).toBeDefined()
+    expect(restoredRole!.segments.length).toBe(2)
+    expect(restoredRole!.segments[0].startWeek).toBe(0)
+    expect(restoredRole!.segments[1].startWeek).toBe(5)
+    const restoredPerson = restoredProfiles.find(p => p.ownerKind === 'NAMED_PERSON')
+    expect(restoredPerson).toBeDefined()
+    expect(restoredPerson!.segments.length).toBe(1)
+    expect(restoredPerson!.defaultPercent).toBe(100)
+
+    // Clean up
+    await prisma.capacitySegment.deleteMany({ where: { capacityProfile: { projectId } } })
+    await prisma.capacityProfile.deleteMany({ where: { projectId } })
+    await prisma.namedResource.deleteMany({ where: { resourceType: { projectId } } })
+    await prisma.resourceType.deleteMany({ where: { projectId } })
+    await prisma.project.delete({ where: { id: projectId } })
+  })
+})
+
+// ═════════════════════════════════════════════════════════════════════════════
+// Scenario D — invalid v3 validation is non-destructive
+// ═════════════════════════════════════════════════════════════════════════════
+
+describeIf('Scenario D — invalid v3 validation', () => {
+  it('rejects duplicate profile IDs without modifying project state', async () => {
+    const projectId = await createProject()
+    const rtId = await createResourceType(projectId, 'Developer')
+
+    await createProfileWithSegments(projectId, rtId, null, 'ROLE', {}, [
+      { startWeek: 0, endWeek: 10, capacityPercent: 100 },
+    ])
+
+    const profilesBefore = await prisma.capacityProfile.count({ where: { projectId } })
+    expect(profilesBefore).toBe(1)
+
+    const { validateSnapshotV3, SnapshotValidationError } = await import('../lib/projectSnapshotValidation.js')
+
+    const badSnapshot = {
+      schemaVersion: 3,
+      epics: [],
+      project: null,
+      resourceTypes: [
+        { id: 'rt-dev', name: 'Dev', category: null, count: null, hoursPerDay: null, dayRate: null, globalTypeId: null, allocationMode: null, allocationPercent: null, allocationStartWeek: null, allocationEndWeek: null },
+      ],
+      namedResources: [],
+      timelineEntries: [],
+      storyTimelineEntries: [],
+      epicDependencies: [],
+      featureDependencies: [],
+      overheadItems: [],
+      capacityProfiles: [
+        {
+          id: 'same-id',
+          ownerKind: 'ROLE',
+          resourceTypeId: 'rt-dev',
+          namedResourceId: null,
+          planningBasis: 'DEMAND_FOLLOWING',
+          source: 'MANUAL',
+          defaultPercent: null,
+          startWeek: null,
+          endWeek: null,
+          legacy: { kind: 'DB_NULL' as const },
+          segments: [],
+        },
+        {
+          id: 'same-id',
+          ownerKind: 'NAMED_PERSON',
+          resourceTypeId: null,
+          namedResourceId: 'missing-nr',
+          planningBasis: 'DEMAND_FOLLOWING',
+          source: 'MANUAL',
+          defaultPercent: null,
+          startWeek: null,
+          endWeek: null,
+          legacy: { kind: 'DB_NULL' as const },
+          segments: [],
+        },
+      ],
+    }
+
+    expect(() => validateSnapshotV3(badSnapshot as never)).toThrow(SnapshotValidationError)
+
+    const profilesAfter = await prisma.capacityProfile.count({ where: { projectId } })
+    expect(profilesAfter).toBe(1)
+
+    await prisma.capacitySegment.deleteMany({ where: { capacityProfile: { projectId } } })
+    await prisma.capacityProfile.deleteMany({ where: { projectId } })
+    await prisma.resourceType.deleteMany({ where: { projectId } })
+    await prisma.project.delete({ where: { id: projectId } })
+  })
+})
+
+// ═════════════════════════════════════════════════════════════════════════════
+// Scenario F — v1 leaves profiles untouched
+// ═════════════════════════════════════════════════════════════════════════════
+
+describeIf('Scenario F — v1 leaves profiles untouched', () => {
+  it('restores epics only, does not modify existing profiles', async () => {
+    const projectId = await createProject()
+    const rtId = await createResourceType(projectId, 'Developer')
+
+    await prisma.epic.create({
+      data: { name: 'Original Epic', projectId, order: 0 },
+    })
+
+    await createProfileWithSegments(projectId, rtId, null, 'ROLE', {
+      planningBasis: 'DEMAND_FOLLOWING',
+      source: 'MANUAL',
+      defaultPercent: 100,
+      startWeek: 0,
+      endWeek: 10,
+      legacy: Prisma.DbNull,
+    }, [
+      { startWeek: 0, endWeek: 10, capacityPercent: 100 },
+    ])
+
+    // Simulate v1 rollback: delete epics only
+    await prisma.epic.deleteMany({ where: { projectId } })
+    await prisma.epic.create({
+      data: { name: 'Restored Epic', projectId, order: 0 },
+    })
+
+    // Verify profiles untouched
+    const profilesAfter = await prisma.capacityProfile.count({ where: { projectId } })
+    expect(profilesAfter).toBe(1)
+
+    const profile = await prisma.capacityProfile.findFirst({ where: { projectId } })
+    expect(profile).not.toBeNull()
+    expect(profile!.defaultPercent).toBe(100)
+
+    const segCount = await prisma.capacitySegment.count({
+      where: { capacityProfile: { projectId } },
+    })
+    expect(segCount).toBe(1)
+
+    // Verify epics changed
+    const epics = await prisma.epic.findMany({ where: { projectId } })
+    expect(epics.length).toBe(1)
+    expect(epics[0].name).toBe('Restored Epic')
+
+    await prisma.epic.deleteMany({ where: { projectId } })
+    await prisma.capacitySegment.deleteMany({ where: { capacityProfile: { projectId } } })
+    await prisma.capacityProfile.deleteMany({ where: { projectId } })
+    await prisma.resourceType.deleteMany({ where: { projectId } })
+    await prisma.project.delete({ where: { id: projectId } })
+  })
+})

--- a/server/src/test/snapshotRollback.integration.test.ts
+++ b/server/src/test/snapshotRollback.integration.test.ts
@@ -1930,7 +1930,7 @@ describeIf('Scenario E — v2 rollback replaces stale persisted profiles', () =>
 
     // Add a PLANNED_RESOURCE that should NOT survive v2 rollback
     await createProfile(
-      projectId, 'prof-e-planned', 'PLANNED_RESOURCE', null, null,
+      projectId, 'prof-e-planned', 'PLANNED_RESOURCE', null, nrId,
       { planningBasis: 'CAPACITY_PROFILE', source: 'DERIVED' },
       Prisma.DbNull,
     )

--- a/server/src/test/snapshotRollback.integration.test.ts
+++ b/server/src/test/snapshotRollback.integration.test.ts
@@ -931,20 +931,6 @@ describeIf('Scenario A — v3 round trip with full canonical state', () => {
     extraRoleDiscountId = await createDiscount(
       projectId, extraRtId, 'PERCENTAGE', 20, 'Post-snapshot role discount', 2,
     )
-    const existingStory = await prisma.userStory.findFirst({
-      where: { feature: { epic: { projectId } } },
-      select: { id: true },
-    })
-    if (!existingStory) throw new Error('Scenario A fixture story missing')
-    await prisma.task.create({
-      data: {
-        name: 'Post-snapshot role task',
-        userStoryId: existingStory.id,
-        order: 99,
-        hoursEffort: 8,
-        resourceTypeId: extraRtId,
-      },
-    })
 
     // Delete ROLE segments, add new ones
     await prisma.capacitySegment.deleteMany({ where: { capacityProfileId: profileRoleId } })
@@ -983,6 +969,15 @@ describeIf('Scenario A — v3 round trip with full canonical state', () => {
     })
     const newStory = await prisma.userStory.create({
       data: { name: 'Mutated Story', featureId: newFeature.id, order: 0 },
+    })
+    await prisma.task.create({
+      data: {
+        name: 'Post-snapshot role task',
+        userStoryId: newStory.id,
+        order: 99,
+        hoursEffort: 8,
+        resourceTypeId: extraRtId,
+      },
     })
     await prisma.task.create({
       data: {

--- a/server/src/test/snapshotRollback.integration.test.ts
+++ b/server/src/test/snapshotRollback.integration.test.ts
@@ -392,6 +392,20 @@ describeIf('Scenario A — v3 round trip with full canonical state', () => {
   let segmentPlanned1: string
   let segmentPlanned2: string
   let segmentPlanned3: string
+  let nrEveId: string
+  let nrFrankId: string
+  let nrGraceId: string
+  let nrHeidiId: string
+  let profileJsonNullId: string
+  let profileNestedObjId: string
+  let profileArrayNullId: string
+  let profileStringId: string
+  let profileBoolId: string
+  let segmentJsonNull1: string
+  let segmentNestedObj1: string
+  let segmentArrayNull1: string
+  let segmentString1: string
+  let segmentBool1: string
   let canonicalBefore: CanonicalProjectState
   // HTTP response snapshots for read-parity assertions
   let resourceProfileBefore: unknown
@@ -503,6 +517,97 @@ describeIf('Scenario A — v3 round trip with full canonical state', () => {
     await createSegment(profilePlannedNrId, 'seg-planned-nr-2', 3, 5, 75)
     await createSegment(profilePlannedNrId, 'seg-planned-nr-3', 6, 10, 50)
 
+    // ══════════════════════════════════════════════════════════════
+    // NEW: 5 additional capacity profiles for all 7 legacy JSON states
+    // ══════════════════════════════════════════════════════════════
+
+    // ── 4 more named resources for new profiles ───────────────────
+    nrEveId = await createNamedResource(
+      projectId, rtDevId, 'nr-eve', 'Eve',
+      { allocationMode: 'TIMELINE', allocationPercent: 100, pricingModel: 'FIXED_PRICE' },
+    )
+    nrFrankId = await createNamedResource(
+      projectId, rtDevId, 'nr-frank', 'Frank',
+      { allocationMode: 'TIMELINE', allocationPercent: 100, pricingModel: 'FIXED_PRICE' },
+    )
+    nrGraceId = await createNamedResource(
+      projectId, rtDevId, 'nr-grace', 'Grace',
+      { allocationMode: 'TIMELINE', allocationPercent: 100, pricingModel: 'FIXED_PRICE' },
+    )
+    nrHeidiId = await createNamedResource(
+      projectId, rtDevId, 'nr-heidi', 'Heidi',
+      { allocationMode: 'TIMELINE', allocationPercent: 100, pricingModel: 'FIXED_PRICE' },
+    )
+
+    // ── (1) ROLE for Designer — JSON_NULL legacy ──────────────────
+    profileJsonNullId = await createProfile(
+      projectId, 'prof-json-null', 'ROLE', rtDesId, null,
+      { planningBasis: 'DEMAND_FOLLOWING', source: 'MANUAL' },
+      Prisma.JsonNull,
+    )
+    segmentJsonNull1 = 'seg-json-null-1'
+    await createSegment(profileJsonNullId, segmentJsonNull1, 3, 7, 80)
+
+    // ── (2) NAMED_PERSON for Eve — VALUE(nested-null object) legacy ──
+    profileNestedObjId = await createProfile(
+      projectId, 'prof-nested-obj', 'NAMED_PERSON', null, nrEveId,
+      {
+        planningBasis: 'AVAILABILITY_WINDOW',
+        source: 'SQUAD_PLANNER',
+        defaultPercent: 50,
+        startWeek: 1,
+        endWeek: 6,
+      },
+      { nested: { value: null, items: [1, null, 3] }, mode: null },
+    )
+    segmentNestedObj1 = 'seg-nested-obj-1'
+    await createSegment(profileNestedObjId, segmentNestedObj1, 1, 4, 100)
+
+    // ── (3) PLANNED_RESOURCE for Frank — VALUE(null-containing array) legacy ──
+    profileArrayNullId = await createProfile(
+      projectId, 'prof-array-null', 'PLANNED_RESOURCE', null, nrFrankId,
+      {
+        planningBasis: 'CAPACITY_PROFILE',
+        source: 'DERIVED',
+        defaultPercent: null,
+        startWeek: null,
+        endWeek: null,
+      },
+      [1, null, 'text', null, false],
+    )
+    segmentArrayNull1 = 'seg-array-null-1'
+    await createSegment(profileArrayNullId, segmentArrayNull1, 4, 8, 60)
+
+    // ── (4) PLANNED_RESOURCE for Grace — VALUE(string) legacy ─────
+    profileStringId = await createProfile(
+      projectId, 'prof-string', 'PLANNED_RESOURCE', null, nrGraceId,
+      {
+        planningBasis: 'CAPACITY_PROFILE',
+        source: 'DERIVED',
+        defaultPercent: null,
+        startWeek: null,
+        endWeek: null,
+      },
+      'hello-world',
+    )
+    segmentString1 = 'seg-string-1'
+    await createSegment(profileStringId, segmentString1, 0, 2, 100)
+
+    // ── (5) PLANNED_RESOURCE for Heidi — VALUE(boolean) legacy ────
+    profileBoolId = await createProfile(
+      projectId, 'prof-bool', 'PLANNED_RESOURCE', null, nrHeidiId,
+      {
+        planningBasis: 'CAPACITY_PROFILE',
+        source: 'DERIVED',
+        defaultPercent: null,
+        startWeek: null,
+        endWeek: null,
+      },
+      true,
+    )
+    segmentBool1 = 'seg-bool-1'
+    await createSegment(profileBoolId, segmentBool1, 2, 5, 75)
+
     // ── Full backlog ──────────────────────────────────────────────
     const backlog = await createEpicBacklog(projectId, rtDevId, null)
     // Add a second task under Designer RT so the Designer resource type
@@ -560,7 +665,7 @@ describeIf('Scenario A — v3 round trip with full canonical state', () => {
     snapshotId = snap.id
     canonicalBefore = await captureCanonicalState(projectId)
     expect(canonicalBefore.resourceTypes).toHaveLength(2)
-    expect(canonicalBefore.capacityProfiles).toHaveLength(4)
+    expect(canonicalBefore.capacityProfiles).toHaveLength(9)
 
     // ── Capture Resource Profile & Timeline HTTP responses before mutation ──
     const rpBefore = await request(app)
@@ -588,13 +693,13 @@ describeIf('Scenario A — v3 round trip with full canonical state', () => {
     expect(data.resourceTypes[0].id).toBe(rtDevId)
 
     // Named resources
-    expect(data.namedResources).toHaveLength(4)
+    expect(data.namedResources).toHaveLength(8)
     const alice = data.namedResources.find(n => n.name === 'Alice')
     expect(alice).toBeDefined()
     expect(alice!.pricingModel).toBe('ACTUAL_DAYS')
 
-    // Four profiles
-    expect(data.capacityProfiles).toHaveLength(4)
+    // Nine profiles (4 original + 5 new covering all 7 legacy JSON states)
+    expect(data.capacityProfiles).toHaveLength(9)
 
     // ROLE — DB_NULL, 2 segments
     const roleP = data.capacityProfiles.find(p => p.ownerKind === 'ROLE')
@@ -634,6 +739,70 @@ describeIf('Scenario A — v3 round trip with full canonical state', () => {
     expect(plannedP!.segments[2].startWeek).toBe(8)
     expect(plannedP!.segments[2].endWeek).toBe(8)
 
+
+    // ── (5 new) JSON_NULL (ROLE/Designer) — 1 segment ──────────────
+    const jsonNullP = data.capacityProfiles.find(p => p.id === profileJsonNullId)
+    expect(jsonNullP).toBeDefined()
+    expect(jsonNullP!.ownerKind).toBe('ROLE')
+    expect(jsonNullP!.resourceTypeId).toBe(rtDesId)
+    expect(jsonNullP!.legacy.kind).toBe('JSON_NULL')
+    expect(jsonNullP!.segments).toHaveLength(1)
+    expect(jsonNullP!.segments[0].startWeek).toBe(3)
+    expect(jsonNullP!.segments[0].capacityPercent).toBe(80)
+
+    // ── (6) NAMED_PERSON (Eve) — VALUE(nested-null object) legacy ──
+    const nestedP = data.capacityProfiles.find(p => p.id === profileNestedObjId)
+    expect(nestedP).toBeDefined()
+    expect(nestedP!.ownerKind).toBe('NAMED_PERSON')
+    expect(nestedP!.namedResourceId).toBe(nrEveId)
+    expect(nestedP!.legacy.kind).toBe('VALUE')
+    if (nestedP!.legacy.kind === 'VALUE') {
+      const val = nestedP!.legacy.value as Record<string, unknown>
+      expect(val).toHaveProperty('nested')
+      const nested = val.nested as Record<string, unknown>
+      expect(nested.value).toBeNull()
+      expect((nested.items as unknown[])[0]).toBe(1)
+      expect((nested.items as unknown[])[1]).toBeNull()
+      expect(nested.items).toHaveLength(3)
+      expect(val.mode).toBeNull()
+    }
+    expect(nestedP!.segments).toHaveLength(1)
+
+    // ── (7) PLANNED_RESOURCE (Frank) — VALUE(null-containing array) legacy ──
+    const arrayNullP = data.capacityProfiles.find(p => p.id === profileArrayNullId)
+    expect(arrayNullP).toBeDefined()
+    expect(arrayNullP!.ownerKind).toBe('PLANNED_RESOURCE')
+    expect(arrayNullP!.legacy.kind).toBe('VALUE')
+    if (arrayNullP!.legacy.kind === 'VALUE') {
+      const arr = arrayNullP!.legacy.value as unknown[]
+      expect(arr[0]).toBe(1)
+      expect(arr[1]).toBeNull()
+      expect(arr[2]).toBe('text')
+      expect(arr[3]).toBeNull()
+      expect(arr[4]).toBe(false)
+      expect(arr).toHaveLength(5)
+    }
+    expect(arrayNullP!.segments).toHaveLength(1)
+
+    // ── (8) PLANNED_RESOURCE (Grace) — VALUE(string) legacy ──────
+    const stringP = data.capacityProfiles.find(p => p.id === profileStringId)
+    expect(stringP).toBeDefined()
+    expect(stringP!.ownerKind).toBe('PLANNED_RESOURCE')
+    expect(stringP!.legacy.kind).toBe('VALUE')
+    if (stringP!.legacy.kind === 'VALUE') {
+      expect(stringP!.legacy.value).toBe('hello-world')
+    }
+    expect(stringP!.segments).toHaveLength(1)
+
+    // ── (9) PLANNED_RESOURCE (Heidi) — VALUE(boolean) legacy ────
+    const boolP = data.capacityProfiles.find(p => p.id === profileBoolId)
+    expect(boolP).toBeDefined()
+    expect(boolP!.ownerKind).toBe('PLANNED_RESOURCE')
+    expect(boolP!.legacy.kind).toBe('VALUE')
+    if (boolP!.legacy.kind === 'VALUE') {
+      expect(boolP!.legacy.value).toBe(true)
+    }
+    expect(boolP!.segments).toHaveLength(1)
     // Backlog, timeline, overhead present
     expect(data.epics).toHaveLength(1)
     expect(data.epics[0].features).toHaveLength(1)
@@ -716,6 +885,45 @@ describeIf('Scenario A — v3 round trip with full canonical state', () => {
       },
     })
 
+    // ── Mutate new capacity profiles for B-state ─────────────────
+
+    // JSON_NULL profile: change segments and field values
+    await prisma.capacitySegment.deleteMany({
+      where: { capacityProfileId: profileJsonNullId },
+    })
+    await createSegment(profileJsonNullId, 'seg-json-mut', 10, 12, 50)
+    await prisma.capacityProfile.update({
+      where: { id: profileJsonNullId },
+      data: { planningBasis: 'CAPACITY_PROFILE', startWeek: 5, endWeek: 10 },
+    })
+
+    // Nested-null object profile: change segments and field values
+    await prisma.capacitySegment.deleteMany({
+      where: { capacityProfileId: profileNestedObjId },
+    })
+    await createSegment(profileNestedObjId, 'seg-nested-mut', 0, 2, 200)
+    await prisma.capacityProfile.update({
+      where: { id: profileNestedObjId },
+      data: { defaultPercent: 80, startWeek: 2, endWeek: 8 },
+    })
+
+    // Null-containing array profile: delete segments only
+    await prisma.capacitySegment.deleteMany({
+      where: { capacityProfileId: profileArrayNullId },
+    })
+
+    // String legacy profile: delete entirely
+    await prisma.capacitySegment.deleteMany({
+      where: { capacityProfileId: profileStringId },
+    })
+    await prisma.capacityProfile.delete({ where: { id: profileStringId } })
+
+    // Boolean legacy profile: change fields
+    await prisma.capacityProfile.update({
+      where: { id: profileBoolId },
+      data: { planningBasis: 'AVAILABILITY_WINDOW', defaultPercent: 50 },
+    })
+
     // ── Capture B-state HTTP responses (after mutations, before rollback) ──
     const rpB = await request(app)
       .get(`/api/projects/${projectId}/resource-profile`)
@@ -761,16 +969,16 @@ describeIf('Scenario A — v3 round trip with full canonical state', () => {
     const nrs = await prisma.namedResource.findMany({
       where: { resourceType: { projectId } },
     })
-    expect(nrs).toHaveLength(4)
+    expect(nrs).toHaveLength(8)
     expect(nrs.find(n => n.id === nrAliceId)!.pricingModel).toBe('ACTUAL_DAYS')
 
-    // Exactly 4 profiles restored, no extras
     const profiles = await prisma.capacityProfile.findMany({
       where: { projectId },
       include: { segments: { orderBy: { startWeek: 'asc' as const } } },
       orderBy: { ownerKind: 'asc' as const },
     })
-    expect(profiles).toHaveLength(4)
+    // Exactly 9 profiles restored, no extras (4 original + 5 new JSON state profiles)
+    expect(profiles).toHaveLength(9)
 
     // ROLE profile: exact original values
     const roleRow = profiles.find(p => p.id === profileRoleId)!
@@ -810,12 +1018,123 @@ describeIf('Scenario A — v3 round trip with full canonical state', () => {
     expect(plannedNrRow.segments[2].endWeek).toBe(10)
     expect(plannedNrRow.segments[2].capacityPercent).toBe(50)
 
-    // DB_NULL legacy preserved at storage level
+    // ── JSON_NULL (ROLE/Designer) profile: exact original values ──
+    const jsonNullRow = profiles.find(p => p.id === profileJsonNullId)!
+    expect(jsonNullRow.ownerKind).toBe('ROLE')
+    expect(jsonNullRow.resourceTypeId).toBe(rtDesId)
+    expect(jsonNullRow.planningBasis).toBe('DEMAND_FOLLOWING')
+    expect(jsonNullRow.source).toBe('MANUAL')
+    expect(jsonNullRow.defaultPercent).toBeNull()
+    expect(jsonNullRow.startWeek).toBeNull()
+    expect(jsonNullRow.endWeek).toBeNull()
+    expect(jsonNullRow.segments).toHaveLength(1)
+    expect(jsonNullRow.segments[0].startWeek).toBe(3)
+    expect(jsonNullRow.segments[0].endWeek).toBe(7)
+    expect(jsonNullRow.segments[0].capacityPercent).toBe(80)
+
+    // ── NAMED_PERSON (Eve) — VALUE(nested-null object) legacy ─────
+    const nestedObjRow = profiles.find(p => p.id === profileNestedObjId)!
+    expect(nestedObjRow.ownerKind).toBe('NAMED_PERSON')
+    expect(nestedObjRow.namedResourceId).toBe(nrEveId)
+    expect(nestedObjRow.planningBasis).toBe('AVAILABILITY_WINDOW')
+    expect(nestedObjRow.source).toBe('SQUAD_PLANNER')
+    expect(nestedObjRow.defaultPercent).toBe(50)
+    expect(nestedObjRow.startWeek).toBe(1)
+    expect(nestedObjRow.endWeek).toBe(6)
+    expect(nestedObjRow.segments).toHaveLength(1)
+    expect(nestedObjRow.segments[0].startWeek).toBe(1)
+    expect(nestedObjRow.segments[0].capacityPercent).toBe(100)
+
+    // ── PLANNED_RESOURCE (Frank) — VALUE(null-containing array) legacy ──
+    const arrayNullRow = profiles.find(p => p.id === profileArrayNullId)!
+    expect(arrayNullRow.ownerKind).toBe('PLANNED_RESOURCE')
+    expect(arrayNullRow.namedResourceId).toBe(nrFrankId)
+    expect(arrayNullRow.segments).toHaveLength(1)
+    expect(arrayNullRow.segments[0].startWeek).toBe(4)
+    expect(arrayNullRow.segments[0].capacityPercent).toBe(60)
+
+    // ── PLANNED_RESOURCE (Grace) — VALUE(string) legacy ──────────
+    const stringRow = profiles.find(p => p.id === profileStringId)!
+    expect(stringRow.ownerKind).toBe('PLANNED_RESOURCE')
+    expect(stringRow.namedResourceId).toBe(nrGraceId)
+    expect(stringRow.segments).toHaveLength(1)
+    expect(stringRow.segments[0].startWeek).toBe(0)
+    expect(stringRow.segments[0].capacityPercent).toBe(100)
+
+    // ── PLANNED_RESOURCE (Heidi) — VALUE(boolean) legacy ─────────
+    const boolRow = profiles.find(p => p.id === profileBoolId)!
+    expect(boolRow.ownerKind).toBe('PLANNED_RESOURCE')
+    expect(boolRow.namedResourceId).toBe(nrHeidiId)
+    expect(boolRow.segments).toHaveLength(1)
+    expect(boolRow.segments[0].startWeek).toBe(2)
+    expect(boolRow.segments[0].capacityPercent).toBe(75)
+
+    // ── DB_NULL legacy preserved at storage level ────────────────
     const dbNullIds = await detectDbNullProfileIds(projectId)
     expect(dbNullIds.has(profileRoleId)).toBe(true)
     expect(dbNullIds.has(profileNamedId)).toBe(false)
     expect(dbNullIds.has(profilePlannedId)).toBe(false)
     expect(dbNullIds.has(profilePlannedNrId)).toBe(true)
+    // New profiles: none are DB_NULL at storage level
+    expect(dbNullIds.has(profileJsonNullId)).toBe(false)
+    expect(dbNullIds.has(profileNestedObjId)).toBe(false)
+    expect(dbNullIds.has(profileArrayNullId)).toBe(false)
+    expect(dbNullIds.has(profileStringId)).toBe(false)
+    expect(dbNullIds.has(profileBoolId)).toBe(false)
+
+    // ── Parameterized SQL: verify jsonb storage semantics and nested nulls ──
+    const rawRows = await prisma.$queryRaw<Array<{
+      id: string
+      legacy_type: string
+      legacy_is_null: boolean
+      null_kind: string
+      nested_nulls_preserved: boolean
+    }>>(Prisma.sql`
+      SELECT
+        cp.id,
+        pg_typeof(cp.legacy)::text AS legacy_type,
+        cp.legacy IS NULL AS legacy_is_null,
+        CASE
+          WHEN cp.legacy IS NULL THEN 'DB_NULL'
+          WHEN cp.legacy = 'null'::jsonb THEN 'JSON_NULL'
+          ELSE 'VALUE'
+        END AS null_kind,
+        CASE
+          WHEN cp.id = ${profileNestedObjId}
+            AND cp.legacy IS NOT NULL
+            AND cp.legacy::jsonb #>> '{nested,value}' IS NULL
+            AND cp.legacy::jsonb #>> '{mode}' IS NULL
+            AND jsonb_array_length(cp.legacy::jsonb #> '{nested,items}') = 3
+            AND cp.legacy::jsonb #>> '{nested,items,1}' IS NULL
+          THEN true
+          WHEN cp.id <> ${profileNestedObjId} THEN true
+          ELSE false
+        END AS nested_nulls_preserved
+      FROM "CapacityProfile" cp
+      WHERE cp."projectId" = ${projectId}
+      ORDER BY cp.id
+    `)
+
+    // All profiles have jsonb type
+    for (const row of rawRows) {
+      expect(row.legacy_type).toBe('jsonb')
+    }
+
+    // Confirm per-profile null_kind
+    const nullKindMap = new Map(rawRows.map(r => [r.id, r.null_kind]))
+    expect(nullKindMap.get(profileRoleId)).toBe('DB_NULL')
+    expect(nullKindMap.get(profilePlannedNrId)).toBe('DB_NULL')
+    expect(nullKindMap.get(profileJsonNullId)).toBe('JSON_NULL')
+    expect(nullKindMap.get(profileNamedId)).toBe('VALUE')
+    expect(nullKindMap.get(profilePlannedId)).toBe('VALUE')
+    expect(nullKindMap.get(profileNestedObjId)).toBe('VALUE')
+    expect(nullKindMap.get(profileArrayNullId)).toBe('VALUE')
+    expect(nullKindMap.get(profileStringId)).toBe('VALUE')
+    expect(nullKindMap.get(profileBoolId)).toBe('VALUE')
+
+    // Nested nulls are preserved in jsonb
+    const nestedRow = rawRows.find(r => r.id === profileNestedObjId)!
+    expect(nestedRow.nested_nulls_preserved).toBe(true)
 
     // Backlog restored
     const epics = await prisma.epic.findMany({ where: { projectId } })
@@ -895,13 +1214,21 @@ describeIf('Scenario A — v3 round trip with full canonical state', () => {
       { startWeek: 2, endWeek: 5, capacityPercent: 100 },
     ])
 
-    // ── Designer RT: now has a task, appears with legacy-derived capacityProfile ──
+    // ── Designer RT: has a persisted ROLE profile (jsonNull) → PROFILE resolution ──
     const desRow = afterRows.find(r => r.resourceTypeId === rtDesId)!
     expect(desRow.resourceTypeId).toBe(rtDesId)
-    // No ROLE profile persisted → capacityProfile comes from LEGACY fallback
+    // Designer now has a persisted ROLE profile (jsonNull legacy) built from the snapshot
     const desCp = desRow.capacityProfile as Record<string, unknown> | undefined
     expect(desCp).toBeDefined()
-    expect(desCp!.resolutionSource).toBe('LEGACY')
+    expect(desCp!.resolutionSource).toBe('PROFILE')
+    expect(desCp!.planningBasis).toBe('demandFollowing')
+    expect(desCp!.source).toBe('manual')
+    expect(desCp!.defaultPercent).toBeNull()
+    expect(desCp!.startWeek).toBeNull()
+    expect(desCp!.endWeek).toBeNull()
+    expect(desCp!.segments).toEqual([
+      { startWeek: 3, endWeek: 7, capacityPercent: 80 },
+    ])
 
     // ── Bob (no persisted profile) under Designer RT: LEGACY resolutionSource ──
     const desNrs = desRow.namedResources as Array<Record<string, unknown>>

--- a/server/src/test/snapshotRollback.integration.test.ts
+++ b/server/src/test/snapshotRollback.integration.test.ts
@@ -1965,6 +1965,8 @@ describeIf('Scenario E — v2 rollback replaces stale persisted profiles', () =>
       startWeek: 2,
       endWeek: 6,
     })
+    // Include effort so the Resource Profile DTO has a row for this RT.
+    await createEpicBacklog(projectId, rtId, null)
 
     // Create stale persisted profiles that DIFFER from v2-derived state
     await createProfile(

--- a/server/src/test/snapshotRollback.integration.test.ts
+++ b/server/src/test/snapshotRollback.integration.test.ts
@@ -262,7 +262,7 @@ interface CanonicalProjectState {
   capacityProfiles: CanonicalProfileRow[]
   timelineEntries: Array<{ startWeek: number; durationWeeks: number; isManual: boolean }>
   storyTimelineEntries: Array<{ startWeek: number; durationWeeks: number; isManual: boolean }>
-  overheadItems: Array<{ id: string; name: string; type: string; value: number; resourceTypeId: string | null; order: number }>
+  overheadItems: Array<{ name: string; type: string; value: number; resourceTypeId: string | null; order: number }>
   dbNullProfileIds: string[]
 }
 
@@ -298,7 +298,7 @@ async function captureCanonicalState(projectId: string): Promise<CanonicalProjec
     })),
     timelineEntries: timelineEntries.map(e => ({ startWeek: e.startWeek, durationWeeks: e.durationWeeks, isManual: e.isManual })),
     storyTimelineEntries: storyTimelineEntries.map(e => ({ startWeek: e.startWeek, durationWeeks: e.durationWeeks, isManual: e.isManual })),
-    overheadItems: overheadItems.map(stripTimestamps),
+    overheadItems: overheadItems.map(o => ({ name: o.name, type: o.type, value: o.value, resourceTypeId: o.resourceTypeId, order: o.order })),
     dbNullProfileIds: dbNullIds,
   }
 }

--- a/server/src/test/snapshotRollback.integration.test.ts
+++ b/server/src/test/snapshotRollback.integration.test.ts
@@ -479,10 +479,12 @@ describeIf('Scenario A — v3 round trip with full canonical state', () => {
 
     // ── 2 resource types with exact IDs ───────────────────────────
     rtDevId = await createResourceType(projectId, 'rt-dev', 'Developer', {
+      dayRate: 500,
       allocationMode: 'TIMELINE',
       allocationPercent: 100,
     })
     rtDesId = await createResourceType(projectId, 'rt-des', 'Designer', {
+      dayRate: 450,
       allocationMode: 'EFFORT',
       allocationPercent: 80,
       allocationStartWeek: 0,

--- a/server/src/test/snapshotRollback.integration.test.ts
+++ b/server/src/test/snapshotRollback.integration.test.ts
@@ -260,8 +260,8 @@ interface CanonicalProjectState {
   resourceTypes: Array<{ id: string; name: string; category: string; count: number; hoursPerDay: number | null; dayRate: number | null; globalTypeId: string | null; allocationMode: string; allocationPercent: number; allocationStartWeek: number | null; allocationEndWeek: number | null }>
   namedResources: Array<{ id: string; resourceTypeId: string; name: string; startWeek: number | null; endWeek: number | null; allocationPct: number; allocationMode: string; allocationPercent: number; allocationStartWeek: number | null; allocationEndWeek: number | null; pricingModel: string }>
   capacityProfiles: CanonicalProfileRow[]
-  timelineEntries: Array<{ id: string; featureId: string; startWeek: number; durationWeeks: number; isManual: boolean }>
-  storyTimelineEntries: Array<{ id: string; storyId: string; startWeek: number; durationWeeks: number; isManual: boolean }>
+  timelineEntries: Array<{ startWeek: number; durationWeeks: number; isManual: boolean }>
+  storyTimelineEntries: Array<{ startWeek: number; durationWeeks: number; isManual: boolean }>
   overheadItems: Array<{ id: string; name: string; type: string; value: number; resourceTypeId: string | null; order: number }>
   dbNullProfileIds: string[]
 }
@@ -296,8 +296,8 @@ async function captureCanonicalState(projectId: string): Promise<CanonicalProjec
       ...stripTimestamps(p),
       segments: p.segments.map(s => stripTimestamps(s)),
     })),
-    timelineEntries: timelineEntries.map(stripTimestamps),
-    storyTimelineEntries: storyTimelineEntries.map(stripTimestamps),
+    timelineEntries: timelineEntries.map(e => ({ startWeek: e.startWeek, durationWeeks: e.durationWeeks, isManual: e.isManual })),
+    storyTimelineEntries: storyTimelineEntries.map(e => ({ startWeek: e.startWeek, durationWeeks: e.durationWeeks, isManual: e.isManual })),
     overheadItems: overheadItems.map(stripTimestamps),
     dbNullProfileIds: dbNullIds,
   }
@@ -960,11 +960,15 @@ describeIf('Scenario A — v3 round trip with full canonical state', () => {
     expect(aliceTLAfter.allocationStartWeek).toBe(aliceTLBefore.allocationStartWeek)
     expect(aliceTLAfter.allocationEndWeek).toBe(aliceTLBefore.allocationEndWeek)
 
-    // ── Timeline entries (features + stories) match A exactly ──
-    expect(timelineAfter.entries).toEqual(beforeTL.entries)
-    const afterStoryEntries = (timelineAfter.storyEntries ?? []) as Array<unknown>
-    const beforeStoryEntries = (beforeTL.storyEntries ?? []) as Array<unknown>
-    expect(afterStoryEntries).toEqual(beforeStoryEntries)
+    // ── Timeline entries (features + stories) match scheduling semantics ──
+    // Ignore regenerated IDs — only compare scheduling values
+    const projectScheduling = (rows: Array<Record<string, unknown>>): Array<{ startWeek: number; durationWeeks: number; isManual: boolean }> =>
+      rows.map(r => ({ startWeek: r.startWeek as number, durationWeeks: r.durationWeeks as number, isManual: r.isManual as boolean }))
+    expect(projectScheduling(timelineAfter.entries as Array<Record<string, unknown>>))
+      .toEqual(projectScheduling(beforeTL.entries as Array<Record<string, unknown>>))
+    const afterStoryEntries = (timelineAfter.storyEntries ?? []) as Array<Record<string, unknown>>
+    const beforeStoryEntries = (beforeTL.storyEntries ?? []) as Array<Record<string, unknown>>
+    expect(projectScheduling(afterStoryEntries)).toEqual(projectScheduling(beforeStoryEntries))
   })
 })
 

--- a/server/src/test/snapshotRollback.integration.test.ts
+++ b/server/src/test/snapshotRollback.integration.test.ts
@@ -2,289 +2,1243 @@
  * snapshotRollback.integration.test.ts — Real PostgreSQL snapshot rollback tests.
  *
  * These tests exercise the full snapshot → mutate → rollback cycle against a
- * running PostgreSQL database. They are skipped by default because they require
- * Docker / CI database infrastructure.
+ * running PostgreSQL database. They are skipped by default (INTEGRATION_TEST).
  *
- * Run with:
- *   INTEGRATION_TEST=true npx vitest run src/test/snapshotRollback.integration.test.ts
+ * Every scenario invokes rollbackProjectSnapshot({ projectId, snapshotId, userId, db })
+ * from the lib service and asserts observable DB state. No mocks, no manual
+ * simulation of rollback logic.
  *
- * Each test creates its own user/project, creates only the rows it needs,
- * and cleans up after itself. Tests are serial (not parallel) to avoid
- * database collisions.
+ * Schema versions:
+ *   v1 — Epic-tree array (legacy; bare array or {epics: [...]} wrapper)
+ *   v2 — Full project state with schemaVersion: 2
+ *   v3 — V2 + capacityProfiles (schemaVersion: 3)
  *
- * @module snapshotRollback.integration
+ * Scenarios:
+ *   A — Exact v3 round trip (2 RTs, 2 NRs, 3 ownerKinds, all legacy types,
+ *       segments, backlog, timeline, overhead, pricing models)
+ *   B — Rollback-to-rollback chaining (A→B→rollback A→pre_rollback B→rollback→B)
+ *   C — Transactional FK failure after pre_rollback creation
+ *   D — Pre-transaction validation failure (malformed, duplicate IDs, bad enums)
+ *   E — Real v2 rollback replaces stale profiles, persistence source verified
+ *   F — Real v1 rollback restores backlog only, profiles untouched, raw SQL
+ *
+ * @module test/snapshotRollback.integration
  */
 
-import { describe, it, expect, beforeAll, afterAll } from 'vitest'
-import { Prisma } from '@prisma/client'
-import { prisma } from '../lib/prisma.js'
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach, vi } from 'vitest'
+import { PrismaClient, Prisma } from '@prisma/client'
+import type { $Enums } from '@prisma/client'
+import { PrismaPg } from '@prisma/adapter-pg'
+import {
+  rollbackProjectSnapshot,
+} from '../lib/projectSnapshotService.js'
+import { buildSnapshot } from '../routes/snapshots.js'
+import { SnapshotSchemaError } from '../lib/projectSnapshotTypes.js'
+import { SnapshotValidationError } from '../lib/projectSnapshotValidation.js'
+import type {
+  SnapshotV1,
+  SnapshotV2,
+  SnapshotV3,
+} from '../lib/projectSnapshotTypes.js'
+import request from 'supertest'
+import jwt from 'jsonwebtoken'
+import { app } from '../app.js'
+// Override the global prisma mock from setup.ts with the real module
+// so HTTP route handlers read/write real PostgreSQL in this integration test.
+vi.mock('../lib/prisma.js', async (importOriginal) => {
+  return await importOriginal()
+})
+
+// ─── Guard ──────────────────────────────────────────────────────────────────
 
 const runIntegration = process.env.INTEGRATION_TEST === 'true'
 const describeIf = runIntegration ? describe : describe.skip
 
-// ─── Fixture helpers ─────────────────────────────────────────────────────────
+// ─── Shared state ───────────────────────────────────────────────────────────
 
+let prisma: PrismaClient
 let userId: string
-
+let token: string
+let authHeader: string
 beforeAll(async () => {
   if (!runIntegration) return
+  prisma = new PrismaClient({
+    adapter: new PrismaPg({ connectionString: process.env.DATABASE_URL }),
+  })
+  await prisma.$connect()
+
   const user = await prisma.user.create({
     data: {
       email: `snapshot-rollback-test-${Date.now()}@example.com`,
-      name: 'Snapshot Rollback Test',
+      name: 'Snapshot Rollback Integration Test',
       password: '$2b$10$placeholder',
     },
   })
   userId = user.id
+  token = jwt.sign({ userId, role: 'USER' }, process.env.JWT_SECRET!)
+  authHeader = `Bearer ${token}`
 })
 
 afterAll(async () => {
   if (!runIntegration) return
   await prisma.backlogSnapshot.deleteMany({ where: { project: { ownerId: userId } } })
-  await prisma.capacitySegment.deleteMany({ where: { capacityProfile: { project: { ownerId: userId } } } })
+  await prisma.capacitySegment.deleteMany({
+    where: { capacityProfile: { project: { ownerId: userId } } },
+  })
   await prisma.capacityProfile.deleteMany({ where: { project: { ownerId: userId } } })
   await prisma.projectOverhead.deleteMany({ where: { project: { ownerId: userId } } })
   await prisma.timelineEntry.deleteMany({ where: { project: { ownerId: userId } } })
   await prisma.storyTimelineEntry.deleteMany({ where: { project: { ownerId: userId } } })
   await prisma.epicDependency.deleteMany({ where: { epic: { project: { ownerId: userId } } } })
-  await prisma.featureDependency.deleteMany({ where: { feature: { epic: { project: { ownerId: userId } } } } })
-  await prisma.task.deleteMany({ where: { userStory: { feature: { epic: { project: { ownerId: userId } } } } } })
-  await prisma.userStory.deleteMany({ where: { feature: { epic: { project: { ownerId: userId } } } } })
+  await prisma.featureDependency.deleteMany({
+    where: { feature: { epic: { project: { ownerId: userId } } } },
+  })
+  await prisma.task.deleteMany({
+    where: { userStory: { feature: { epic: { project: { ownerId: userId } } } } },
+  })
+  await prisma.userStory.deleteMany({
+    where: { feature: { epic: { project: { ownerId: userId } } } },
+  })
   await prisma.feature.deleteMany({ where: { epic: { project: { ownerId: userId } } } })
   await prisma.epic.deleteMany({ where: { project: { ownerId: userId } } })
-  await prisma.namedResource.deleteMany({ where: { resourceType: { project: { ownerId: userId } } } })
+  await prisma.namedResource.deleteMany({
+    where: { resourceType: { project: { ownerId: userId } } },
+  })
   await prisma.resourceType.deleteMany({ where: { project: { ownerId: userId } } })
   await prisma.project.deleteMany({ where: { ownerId: userId } })
   await prisma.user.delete({ where: { id: userId } })
+  await prisma.$disconnect()
 })
+
+// ─── Fixture helpers ────────────────────────────────────────────────────────
 
 async function createProject(): Promise<string> {
   const project = await prisma.project.create({
-    data: {
-      name: `Snapshot Integration Test ${Date.now()}`,
-      ownerId: userId,
-    },
+    data: { name: `Snapshot Integration ${Date.now()}`, ownerId: userId },
   })
   return project.id
 }
 
-async function createResourceType(projectId: string, name: string): Promise<string> {
-  const rt = await prisma.resourceType.create({
+async function createResourceType(
+  projectId: string,
+  id: string,
+  name: string,
+  overrides: Partial<{
+    category: $Enums.ResourceCategory
+    count: number
+    hoursPerDay: number | null
+    dayRate: number | null
+    allocationMode: $Enums.AllocationMode
+    allocationPercent: number
+    allocationStartWeek: number | null
+    allocationEndWeek: number | null
+  }> = {},
+): Promise<string> {
+  await prisma.resourceType.create({
     data: {
+      id,
       name,
       projectId,
-      category: 'ENGINEERING' as const,
-      count: 2,
-      hoursPerDay: 8,
-      dayRate: 500,
-      allocationMode: 'TIMELINE' as const,
-      allocationPercent: 100,
-      allocationStartWeek: 0,
-      allocationEndWeek: 10,
+      category: overrides.category ?? 'ENGINEERING',
+      count: overrides.count ?? 2,
+      hoursPerDay: overrides.hoursPerDay ?? null,
+      dayRate: overrides.dayRate ?? null,
+      allocationMode: overrides.allocationMode ?? 'TIMELINE',
+      allocationPercent: overrides.allocationPercent ?? 100,
+      allocationStartWeek: overrides.allocationStartWeek ?? null,
+      allocationEndWeek: overrides.allocationEndWeek ?? null,
     },
   })
-  return rt.id
+  return id
 }
 
-async function createNamedResource(_projectId: string, resourceTypeId: string, name: string): Promise<string> {
-  const nr = await prisma.namedResource.create({
+async function createNamedResource(
+  _projectId: string,
+  resourceTypeId: string,
+  id: string,
+  name: string,
+  overrides: Partial<{
+    startWeek: number | null
+    endWeek: number | null
+    allocationPct: number
+    allocationMode: $Enums.AllocationMode
+    allocationPercent: number
+    allocationStartWeek: number | null
+    allocationEndWeek: number | null
+    pricingModel: string
+  }> = {},
+): Promise<string> {
+  await prisma.namedResource.create({
     data: {
+      id,
+      resourceTypeId,
       name,
-      resourceType: { connect: { id: resourceTypeId } },
-      allocationMode: 'EFFORT' as const,
-      allocationPercent: 80,
-      allocationStartWeek: 0,
-      allocationEndWeek: 10,
+      startWeek: overrides.startWeek ?? null,
+      endWeek: overrides.endWeek ?? null,
+      allocationPct: overrides.allocationPct ?? 100,
+      allocationMode: overrides.allocationMode ?? 'EFFORT',
+      allocationPercent: overrides.allocationPercent ?? 100,
+      allocationStartWeek: overrides.allocationStartWeek ?? null,
+      allocationEndWeek: overrides.allocationEndWeek ?? null,
+      pricingModel: overrides.pricingModel ?? 'ACTUAL_DAYS',
     },
   })
-  return nr.id
+  return id
 }
 
-async function createProfileWithSegments(
+async function createProfile(
   projectId: string,
+  id: string,
+  ownerKind: 'ROLE' | 'NAMED_PERSON' | 'PLANNED_RESOURCE',
   resourceTypeId: string | null,
   namedResourceId: string | null,
-  ownerKind: 'ROLE' | 'NAMED_PERSON' | 'PLANNED_RESOURCE',
-  overrides: {
-    planningBasis?: string
-    source?: string
-    defaultPercent?: number | null
-    startWeek?: number | null
-    endWeek?: number | null
-    legacy?: unknown
-  } = {},
-  segments: Array<{ startWeek: number; endWeek: number; capacityPercent: number; source?: string }> = [],
+  overrides: Partial<{
+    planningBasis: $Enums.CapacityProfilePlanningBasis
+    source: $Enums.CapacityProfileSource
+    defaultPercent: number | null
+    startWeek: number | null
+    endWeek: number | null
+  }> = {},
+  legacyValue: Prisma.NullableJsonNullValueInput | Prisma.InputJsonValue = Prisma.DbNull,
 ): Promise<string> {
-  const data: Record<string, unknown> = {
-    project: { connect: { id: projectId } },
-    ownerKind,
-    planningBasis: overrides.planningBasis ?? 'DEMAND_FOLLOWING',
-    source: overrides.source ?? 'MANUAL',
-    defaultPercent: overrides.defaultPercent ?? null,
-    startWeek: overrides.startWeek ?? null,
-    endWeek: overrides.endWeek ?? null,
-  }
-  if (resourceTypeId) data.resourceType = { connect: { id: resourceTypeId } }
-  if (namedResourceId) data.namedResource = { connect: { id: namedResourceId } }
-  if (overrides.legacy !== undefined) {
-    data.legacy = overrides.legacy
-  } else {
-    data.legacy = Prisma.DbNull
-  }
+  await prisma.capacityProfile.create({
+    data: {
+      id,
+      projectId,
+      ownerKind,
+      resourceTypeId,
+      namedResourceId,
+      planningBasis: overrides.planningBasis ?? 'DEMAND_FOLLOWING',
+      source: overrides.source ?? 'MANUAL',
+      defaultPercent: overrides.defaultPercent ?? null,
+      startWeek: overrides.startWeek ?? null,
+      endWeek: overrides.endWeek ?? null,
+      legacy: legacyValue,
+    },
+  })
+  return id
+}
 
-  const profile = await prisma.capacityProfile.create({
-    data: data as never,
+async function createSegment(
+  profileId: string,
+  id: string,
+  startWeek: number,
+  endWeek: number,
+  capacityPercent: number,
+  source: $Enums.CapacityProfileSource = 'MANUAL',
+): Promise<void> {
+  await prisma.capacitySegment.create({
+    data: {
+      id,
+      capacityProfileId: profileId,
+      startWeek,
+      endWeek,
+      capacityPercent,
+      source,
+    },
+  })
+}
+/**
+ * Canonical state type for deep comparison after v3 rollback.
+ */
+interface CanonicalProfileRow {
+  id: string
+  ownerKind: string
+  resourceTypeId: string | null
+  namedResourceId: string | null
+  planningBasis: string
+  source: string
+  defaultPercent: number | null
+  startWeek: number | null
+  endWeek: number | null
+  legacy: unknown
+  segments: Array<{ id: string; startWeek: number; endWeek: number; capacityPercent: number; source: string }>
+}
+
+
+interface CanonicalProjectState {
+  resourceTypes: Array<{ id: string; name: string; category: string; count: number; hoursPerDay: number | null; dayRate: number | null; globalTypeId: string | null; allocationMode: string; allocationPercent: number; allocationStartWeek: number | null; allocationEndWeek: number | null }>
+  namedResources: Array<{ id: string; resourceTypeId: string; name: string; startWeek: number | null; endWeek: number | null; allocationPct: number; allocationMode: string; allocationPercent: number; allocationStartWeek: number | null; allocationEndWeek: number | null; pricingModel: string }>
+  capacityProfiles: CanonicalProfileRow[]
+  timelineEntries: Array<{ id: string; featureId: string; startWeek: number; durationWeeks: number; isManual: boolean }>
+  storyTimelineEntries: Array<{ id: string; storyId: string; startWeek: number; durationWeeks: number; isManual: boolean }>
+  overheadItems: Array<{ id: string; name: string; type: string; value: number; resourceTypeId: string | null; order: number }>
+  dbNullProfileIds: string[]
+}
+
+async function captureCanonicalState(projectId: string): Promise<CanonicalProjectState> {
+  const [resourceTypes, namedResources, capacityProfiles, timelineEntries, storyTimelineEntries, overheadItems] = await Promise.all([
+    prisma.resourceType.findMany({ where: { projectId }, orderBy: { id: 'asc' } }),
+    prisma.namedResource.findMany({ where: { resourceType: { projectId } }, orderBy: { id: 'asc' } }),
+    prisma.capacityProfile.findMany({
+      where: { projectId },
+      include: { segments: { orderBy: { startWeek: 'asc' as const } } },
+      orderBy: [{ ownerKind: 'asc' as const }, { id: 'asc' as const }],
+    }),
+    prisma.timelineEntry.findMany({ where: { projectId }, orderBy: { id: 'asc' } }),
+    prisma.storyTimelineEntry.findMany({ where: { projectId }, orderBy: { id: 'asc' } }),
+    prisma.projectOverhead.findMany({ where: { projectId }, orderBy: { id: 'asc' } }),
+  ])
+  const dbNullIds = Array.from(await detectDbNullProfileIds(projectId))
+  return { resourceTypes, namedResources, capacityProfiles, timelineEntries, storyTimelineEntries, overheadItems, dbNullProfileIds: dbNullIds }
+}
+
+
+async function createEpicBacklog(
+  projectId: string,
+  rtId: string,
+  featureTemplateId: string | null,
+): Promise<{ epicId: string; featureId: string; storyId: string }> {
+  const epic = await prisma.epic.create({
+    data: { name: 'Epic Alpha', projectId, order: 0 },
+  })
+  const feature = await prisma.feature.create({
+    data: { name: 'Feature One', epicId: epic.id, order: 0 },
+  })
+  const story = await prisma.userStory.create({
+    data: {
+      name: 'Story A',
+      featureId: feature.id,
+      order: 0,
+      appliedTemplateId: featureTemplateId,
+    },
+  })
+  await prisma.task.create({
+    data: {
+      name: 'Task 1',
+      userStoryId: story.id,
+      order: 0,
+      hoursEffort: 8,
+      resourceTypeId: rtId,
+    },
+  })
+  return { epicId: epic.id, featureId: feature.id, storyId: story.id }
+}
+
+
+/**
+ * Run a raw SQL query to detect which capacity profiles have database-NULL
+ * legacy (as opposed to JSON null). Returns a Set of profile IDs where
+ * legacy IS NULL at the storage level.
+ */
+async function detectDbNullProfileIds(projectId: string): Promise<Set<string>> {
+  const rows = await prisma.$queryRawUnsafe<Array<{ id: string }>>(
+    `SELECT cp.id FROM "CapacityProfile" cp WHERE cp."projectId" = $1 AND cp.legacy IS NULL`,
+    projectId,
+  )
+  const seen = new Set<string>()
+  for (const r of rows) {
+    seen.add(r.id)
+  }
+  return seen
+}
+
+
+async function createV1Snapshot(
+  projectId: string,
+  epics: SnapshotV1,
+): Promise<string> {
+  const snap = await prisma.backlogSnapshot.create({
+    data: {
+      projectId,
+      label: 'v1 snapshot',
+      trigger: 'manual',
+      snapshot: epics as unknown as object,
+      createdById: userId,
+    },
+  })
+  return snap.id
+}
+
+// ═════════════════════════════════════════════════════════════════════════════
+// Scenario A — exact v3 round trip with full canonical state
+// ═════════════════════════════════════════════════════════════════════════════
+
+describeIf('Scenario A — v3 round trip with full canonical state', () => {
+  let projectId: string
+  let snapshotId: string
+  let rtDevId: string
+  let rtDesId: string
+  let nrAliceId: string
+  let nrCharlieId: string
+  let profileRoleId: string
+  let profileNamedId: string
+  let profilePlannedId: string
+  let profilePlannedNrId: string
+  let segmentRole1: string
+  let segmentRole2: string
+  let segmentNamed1: string
+  let segmentPlanned1: string
+  let segmentPlanned2: string
+  let segmentPlanned3: string
+  let canonicalBefore: CanonicalProjectState
+  // HTTP response snapshots for read-parity assertions
+  let resourceProfileBefore: unknown
+  let timelineBefore: unknown
+  // B-state HTTP response snapshots (after mutation, before rollback)
+  let resourceProfileAfterMutation: unknown
+  let timelineAfterMutation: unknown
+
+  beforeAll(async () => {
+    if (!runIntegration) return
+    projectId = await createProject()
+
+    // ── 2 resource types with exact IDs ───────────────────────────
+    rtDevId = await createResourceType(projectId, 'rt-dev', 'Developer', {
+      allocationMode: 'TIMELINE',
+      allocationPercent: 100,
+    })
+    rtDesId = await createResourceType(projectId, 'rt-des', 'Designer', {
+      allocationMode: 'EFFORT',
+      allocationPercent: 80,
+      allocationStartWeek: 0,
+      allocationEndWeek: 12,
+    })
+
+    // ── 2 named resources with exact IDs ──────────────────────────
+    nrAliceId = await createNamedResource(
+      projectId, rtDevId, 'nr-alice', 'Alice',
+      { allocationMode: 'EFFORT', allocationPercent: 80, pricingModel: 'ACTUAL_DAYS' },
+    )
+    await createNamedResource(
+      projectId, rtDesId, 'nr-bob', 'Bob',
+      { allocationMode: 'TIMELINE', allocationPercent: 100, pricingModel: 'FIXED_PRICE' },
+    )
+    // ── 3rd named resource for PLANNED_RESOURCE ownership ──────────
+    nrCharlieId = await createNamedResource(
+      projectId, rtDevId, 'nr-charlie', 'Charlie',
+      { allocationMode: 'TIMELINE', allocationPercent: 100, pricingModel: 'FIXED_PRICE' },
+    )
+
+    // ── ROLE profile for Developer — DB_NULL legacy ───────────────
+    profileRoleId = await createProfile(
+      projectId, 'prof-role', 'ROLE', rtDevId, null,
+      {
+        planningBasis: 'DEMAND_FOLLOWING',
+        source: 'MANUAL',
+        defaultPercent: null,
+        startWeek: null,
+        endWeek: null,
+      },
+      Prisma.DbNull,
+    )
+    segmentRole1 = 'seg-role-1'
+    segmentRole2 = 'seg-role-2'
+    await createSegment(profileRoleId, segmentRole1, 0, 4, 100)
+    await createSegment(profileRoleId, segmentRole2, 5, 10, 50)
+
+    // ── NAMED_PERSON profile for Alice — VALUE(object) legacy ─────
+    profileNamedId = await createProfile(
+      projectId, 'prof-named', 'NAMED_PERSON', null, nrAliceId,
+      {
+        planningBasis: 'AVAILABILITY_WINDOW',
+        source: 'SQUAD_PLANNER',
+        defaultPercent: 100,
+        startWeek: 2,
+        endWeek: 8,
+      },
+      { allocationMode: 'EFFORT', allocationPercent: 80 },
+    )
+    segmentNamed1 = 'seg-named-1'
+    await createSegment(profileNamedId, segmentNamed1, 2, 5, 100)
+
+    // ── PLANNED_RESOURCE (synthetic) — VALUE(number) legacy ───────
+    // Discontinuous, overlapping, and >100% segments to test fidelity
+    profilePlannedId = await createProfile(
+      projectId, 'prof-planned', 'PLANNED_RESOURCE', null, null,
+      {
+        planningBasis: 'CAPACITY_PROFILE',
+        source: 'DERIVED',
+        defaultPercent: null,
+        startWeek: null,
+        endWeek: null,
+      },
+      42,
+    )
+    segmentPlanned1 = 'seg-planned-1'
+    segmentPlanned2 = 'seg-planned-2'
+    segmentPlanned3 = 'seg-planned-3'
+    await createSegment(profilePlannedId, segmentPlanned1, 0, 1, 200)
+    await createSegment(profilePlannedId, segmentPlanned2, 3, 6, 75)
+    await createSegment(profilePlannedId, segmentPlanned3, 8, 8, 25)
+    // ── PLANNED_RESOURCE with persisted named resource (Charlie) ──
+    profilePlannedNrId = await createProfile(
+      projectId, 'prof-planned-nr', 'PLANNED_RESOURCE', null, nrCharlieId,
+      {
+        planningBasis: 'CAPACITY_PROFILE',
+        source: 'DERIVED',
+        defaultPercent: null,
+        startWeek: null,
+        endWeek: null,
+      },
+      Prisma.DbNull,
+    )
+    await createSegment(profilePlannedNrId, 'seg-planned-nr-1', 0, 2, 100)
+    await createSegment(profilePlannedNrId, 'seg-planned-nr-2', 3, 5, 75)
+    await createSegment(profilePlannedNrId, 'seg-planned-nr-3', 6, 10, 50)
+
+    // ── Full backlog ──────────────────────────────────────────────
+    const backlog = await createEpicBacklog(projectId, rtDevId, null)
+    // Add a second task under Designer RT so the Designer resource type
+    // appears in Resource Profile / Timeline responses with Bob.
+    await prisma.task.create({
+      data: {
+        name: 'Task 2 (Designer)',
+        userStoryId: backlog.storyId,
+        order: 1,
+        hoursEffort: 16,
+        resourceTypeId: rtDesId,
+      },
+    })
+
+    // ── Timeline entries ──────────────────────────────────────────
+    const epics = await prisma.epic.findMany({
+      where: { projectId },
+      include: { features: { include: { userStories: true } } },
+    })
+    const feature = epics[0].features[0]
+    const story = feature.userStories[0]
+    await prisma.timelineEntry.create({
+      data: {
+        projectId, featureId: feature.id,
+        startWeek: 1, durationWeeks: 8, isManual: false,
+      },
+    })
+    await prisma.storyTimelineEntry.create({
+      data: {
+        projectId, storyId: story.id,
+        startWeek: 2, durationWeeks: 5, isManual: false,
+      },
+    })
+
+    // ── Overhead item ─────────────────────────────────────────────
+    await prisma.projectOverhead.create({
+      data: {
+        projectId, name: 'Governance',
+        type: 'PERCENTAGE', value: 15,
+        resourceTypeId: rtDevId, order: 0,
+      },
+    })
+
+    // ── Build and persist snapshot ────────────────────────────────
+    const data = await buildSnapshot(projectId, prisma)
+    const snap = await prisma.backlogSnapshot.create({
+      data: {
+        projectId,
+        label: 'Scenario A snapshot',
+        trigger: 'manual',
+        snapshot: data as unknown as object,
+        createdById: userId,
+      },
+    })
+    snapshotId = snap.id
+    canonicalBefore = await captureCanonicalState(projectId)
+    expect(canonicalBefore.resourceTypes).toHaveLength(2)
+    expect(canonicalBefore.capacityProfiles).toHaveLength(4)
+
+    // ── Capture Resource Profile & Timeline HTTP responses before mutation ──
+    const rpBefore = await request(app)
+      .get(`/api/projects/${projectId}/resource-profile`)
+      .set('Authorization', authHeader)
+      .expect(200)
+    resourceProfileBefore = rpBefore.body
+    const tlBefore = await request(app)
+      .get(`/api/projects/${projectId}/timeline`)
+      .set('Authorization', authHeader)
+      .expect(200)
+    timelineBefore = tlBefore.body
+    expect(resourceProfileBefore).toHaveProperty('resourceRows')
+    expect(timelineBefore).toHaveProperty('entries')
   })
 
-  for (const s of segments) {
-    await prisma.capacitySegment.create({
-      data: {
-        capacityProfile: { connect: { id: profile.id } },
-        startWeek: s.startWeek,
-        endWeek: s.endWeek,
-        capacityPercent: s.capacityPercent,
-        source: s.source ?? 'MANUAL',
-      } as never,
+  it('captured snapshot has all domains and exact values', async () => {
+    const raw = await prisma.backlogSnapshot.findUnique({ where: { id: snapshotId } })
+    expect(raw).not.toBeNull()
+    const data = raw!.snapshot as unknown as SnapshotV3
+    expect(data.schemaVersion).toBe(3)
+
+    // Resource types
+    expect(data.resourceTypes).toHaveLength(2)
+    expect(data.resourceTypes[0].id).toBe(rtDevId)
+
+    // Named resources
+    expect(data.namedResources).toHaveLength(3)
+    const alice = data.namedResources.find(n => n.name === 'Alice')
+    expect(alice).toBeDefined()
+    expect(alice!.pricingModel).toBe('ACTUAL_DAYS')
+
+    // Four profiles
+    expect(data.capacityProfiles).toHaveLength(4)
+
+    // ROLE — DB_NULL, 2 segments
+    const roleP = data.capacityProfiles.find(p => p.ownerKind === 'ROLE')
+    expect(roleP).toBeDefined()
+    expect(roleP!.id).toBe(profileRoleId)
+    expect(roleP!.resourceTypeId).toBe(rtDevId)
+    expect(roleP!.planningBasis).toBe('DEMAND_FOLLOWING')
+    expect(roleP!.source).toBe('MANUAL')
+    expect(roleP!.defaultPercent).toBeNull()
+    expect(roleP!.legacy.kind).toBe('DB_NULL')
+    expect(roleP!.segments).toHaveLength(2)
+    expect(roleP!.segments[0].startWeek).toBe(0)
+    expect(roleP!.segments[1].capacityPercent).toBe(50)
+
+    // NAMED_PERSON — VALUE(object), 1 segment
+    const namedP = data.capacityProfiles.find(p => p.ownerKind === 'NAMED_PERSON')
+    expect(namedP).toBeDefined()
+    expect(namedP!.id).toBe(profileNamedId)
+    expect(namedP!.namedResourceId).toBe(nrAliceId)
+    expect(namedP!.legacy.kind).toBe('VALUE')
+    if (namedP!.legacy.kind === 'VALUE') {
+      const val = namedP!.legacy.value as Record<string, unknown>
+      expect(val.allocationMode).toBe('EFFORT')
+    }
+    expect(namedP!.segments).toHaveLength(1)
+
+    // PLANNED_RESOURCE — VALUE(number), 3 segments
+    const plannedP = data.capacityProfiles.find(p => p.ownerKind === 'PLANNED_RESOURCE')
+    expect(plannedP).toBeDefined()
+    expect(plannedP!.id).toBe(profilePlannedId)
+    expect(plannedP!.legacy.kind).toBe('VALUE')
+    if (plannedP!.legacy.kind === 'VALUE') {
+      expect(plannedP!.legacy.value).toBe(42)
+    }
+    expect(plannedP!.segments).toHaveLength(3)
+    expect(plannedP!.segments[0].capacityPercent).toBe(200)
+    expect(plannedP!.segments[2].startWeek).toBe(8)
+    expect(plannedP!.segments[2].endWeek).toBe(8)
+
+    // Backlog, timeline, overhead present
+    expect(data.epics).toHaveLength(1)
+    expect(data.epics[0].features).toHaveLength(1)
+    expect(data.timelineEntries).toHaveLength(1)
+    expect(data.storyTimelineEntries).toHaveLength(1)
+    expect(data.overheadItems).toHaveLength(1)
+    expect(data.overheadItems[0].name).toBe('Governance')
+  })
+
+  it('mutates all domains then rollback restores exact original state', async () => {
+    // ── Mutate every captured domain ──────────────────────────────
+
+    // Delete ROLE segments, add new ones
+    await prisma.capacitySegment.deleteMany({ where: { capacityProfileId: profileRoleId } })
+    await createSegment(profileRoleId, 'seg-mutated-1', 10, 15, 30)
+
+    // Change NAMED_PERSON profile fields
+    await prisma.capacityProfile.update({
+      where: { id: profileNamedId },
+      data: { planningBasis: 'WHOLE_PROJECT_ALLOCATION', defaultPercent: 50 },
     })
-  }
 
-  return profile.id
-}
-
-async function createSegments(
-  profileId: string,
-  segments: Array<{ startWeek: number; endWeek: number; capacityPercent: number; source?: string }>,
-): Promise<void> {
-  for (const s of segments) {
-    await prisma.capacitySegment.create({
-      data: {
-        capacityProfile: { connect: { id: profileId } },
-        startWeek: s.startWeek,
-        endWeek: s.endWeek,
-        capacityPercent: s.capacityPercent,
-        source: s.source ?? 'MANUAL',
-      } as never,
+    // Delete PLANNED_RESOURCE profile entirely
+    await prisma.capacitySegment.deleteMany({
+      where: { capacityProfileId: profilePlannedId },
     })
-  }
-}
+    await prisma.capacityProfile.delete({ where: { id: profilePlannedId } })
 
-// ═════════════════════════════════════════════════════════════════════════════
-// Scenario A — exact v3 round trip (basic)
-// ═════════════════════════════════════════════════════════════════════════════
+    // Create an extra profile not in the snapshot
+    await createProfile(
+      projectId, 'prof-extra', 'ROLE', rtDesId, null,
+      { defaultPercent: 100 },
+      Prisma.DbNull,
+    )
 
-describeIf('Scenario A — v3 round trip', () => {
-  it('captures, mutates, and restores via buildSnapshot/recreateV3CapacityProfiles', async () => {
-    const projectId = await createProject()
-    const rtId = await createResourceType(projectId, 'Developer')
-    const nrId = await createNamedResource(projectId, rtId, 'Alice')
+    // Mutate backlog: delete and create new epics
+    await prisma.epic.deleteMany({ where: { projectId } })
+    const newEpic = await prisma.epic.create({
+      data: { name: 'Mutated Epic', projectId, order: 0 },
+    })
+    const newFeature = await prisma.feature.create({
+      data: { name: 'Mutated Feature', epicId: newEpic.id, order: 0 },
+    })
+    await prisma.userStory.create({
+      data: { name: 'Mutated Story', featureId: newFeature.id, order: 0 },
+    })
 
-    await createProfileWithSegments(projectId, rtId, null, 'ROLE', {
-      planningBasis: 'DEMAND_FOLLOWING',
-      source: 'FIXED',
-      defaultPercent: null,
-      startWeek: null,
-      endWeek: null,
-      legacy: Prisma.DbNull,
-    }, [
+    // Clear timelines
+    await prisma.timelineEntry.deleteMany({ where: { projectId } })
+    await prisma.storyTimelineEntry.deleteMany({ where: { projectId } })
+
+    // Clear overhead
+    await prisma.projectOverhead.deleteMany({ where: { projectId } })
+
+    // Rename resource type
+    await prisma.resourceType.update({
+      where: { id: rtDevId },
+      data: { name: 'Dev Mutated' },
+    })
+
+    // ── Mutate Alice allocation compatibility fields for B-state ──
+    await prisma.namedResource.update({
+      where: { id: nrAliceId },
+      data: {
+        allocationMode: 'TIMELINE',
+        allocationPercent: 50,
+        allocationStartWeek: 1,
+        allocationEndWeek: 6,
+      },
+    })
+
+    // ── Capture B-state HTTP responses (after mutations, before rollback) ──
+    const rpB = await request(app)
+      .get(`/api/projects/${projectId}/resource-profile`)
+      .set('Authorization', authHeader)
+      .expect(200)
+    resourceProfileAfterMutation = rpB.body
+    const tlB = await request(app)
+      .get(`/api/projects/${projectId}/timeline`)
+      .set('Authorization', authHeader)
+      .expect(200)
+    timelineAfterMutation = tlB.body
+    // Assert B-state timeline shows mutated Alice allocation
+    const tlBNamedResources = (timelineAfterMutation as Record<string, unknown>).namedResources as Array<Record<string, unknown>>
+    const aliceTLB = tlBNamedResources.find(nr => nr.id === nrAliceId)!
+    expect(aliceTLB.allocationMode).toBe('TIMELINE')
+    expect(aliceTLB.allocationPercent).toBe(50)
+    expect(aliceTLB.allocationStartWeek).toBe(1)
+    expect(aliceTLB.allocationEndWeek).toBe(6)
+    // Assert B-state Resource Profile shows mutated Alice allocation
+    const rpBRows = (resourceProfileAfterMutation as Record<string, unknown>).resourceRows as Array<Record<string, unknown>>
+    const rpBDevRow = rpBRows.find((r: Record<string, unknown>) => r.resourceTypeId === rtDevId)!
+    const rpBDevNrs = rpBDevRow.namedResources as Array<Record<string, unknown>>
+    const aliceRPB = rpBDevNrs.find((nr: Record<string, unknown>) => nr.id === nrAliceId)!
+    expect(aliceRPB.allocationMode).toBe('TIMELINE')
+    expect(aliceRPB.allocationPercent).toBe(50)
+    expect(aliceRPB.allocationStartWeek).toBe(1)
+    expect(aliceRPB.allocationEndWeek).toBe(6)
+
+    // ── Rollback ──────────────────────────────────────────────────
+    await rollbackProjectSnapshot({ projectId, snapshotId, userId, db: prisma })
+
+    // ── Verify exact restoration ──────────────────────────────────
+
+    // RTs: IDs preserved, original names restored
+    const rts = await prisma.resourceType.findMany({
+      where: { projectId },
+      orderBy: { name: 'asc' },
+    })
+    expect(rts).toHaveLength(2)
+    expect(rts.find(r => r.id === rtDevId)!.name).toBe('Developer')
+
+    // NRs: IDs preserved
+    const nrs = await prisma.namedResource.findMany({
+      where: { resourceType: { projectId } },
+    })
+    expect(nrs).toHaveLength(3)
+    expect(nrs.find(n => n.id === nrAliceId)!.pricingModel).toBe('ACTUAL_DAYS')
+
+    // Exactly 4 profiles restored, no extras
+    const profiles = await prisma.capacityProfile.findMany({
+      where: { projectId },
+      include: { segments: { orderBy: { startWeek: 'asc' as const } } },
+      orderBy: { ownerKind: 'asc' as const },
+    })
+    expect(profiles).toHaveLength(4)
+
+    // ROLE profile: exact original values
+    const roleRow = profiles.find(p => p.id === profileRoleId)!
+    expect(roleRow.ownerKind).toBe('ROLE')
+    expect(roleRow.resourceTypeId).toBe(rtDevId)
+    expect(roleRow.planningBasis).toBe('DEMAND_FOLLOWING')
+    expect(roleRow.source).toBe('MANUAL')
+    expect(roleRow.defaultPercent).toBeNull()
+    expect(roleRow.segments).toHaveLength(2)
+    expect(roleRow.segments[0].startWeek).toBe(0)
+    expect(roleRow.segments[0].capacityPercent).toBe(100)
+    expect(roleRow.segments[1].startWeek).toBe(5)
+
+    // NAMED_PERSON profile
+    const namedRow = profiles.find(p => p.id === profileNamedId)!
+    expect(namedRow.ownerKind).toBe('NAMED_PERSON')
+    expect(namedRow.namedResourceId).toBe(nrAliceId)
+    expect(namedRow.planningBasis).toBe('AVAILABILITY_WINDOW')
+    expect(namedRow.defaultPercent).toBe(100)
+    expect(namedRow.segments).toHaveLength(1)
+
+    // PLANNED_RESOURCE profile: exact segments restored
+    const plannedRow = profiles.find(p => p.id === profilePlannedId)!
+    expect(plannedRow.ownerKind).toBe('PLANNED_RESOURCE')
+    expect(plannedRow.segments).toHaveLength(3)
+    expect(plannedRow.segments[0].capacityPercent).toBe(200)
+    expect(plannedRow.segments[2].startWeek).toBe(8)
+    expect(plannedRow.segments[2].endWeek).toBe(8)
+
+    // PLANNED_RESOURCE profile with named resource (Charlie): exact segments restored
+    const plannedNrRow = profiles.find(p => p.id === profilePlannedNrId)!
+    expect(plannedNrRow.ownerKind).toBe('PLANNED_RESOURCE')
+    expect(plannedNrRow.namedResourceId).toBe(nrCharlieId)
+    expect(plannedNrRow.segments).toHaveLength(3)
+    expect(plannedNrRow.segments[0].startWeek).toBe(0)
+    expect(plannedNrRow.segments[0].capacityPercent).toBe(100)
+    expect(plannedNrRow.segments[2].endWeek).toBe(10)
+    expect(plannedNrRow.segments[2].capacityPercent).toBe(50)
+
+    // DB_NULL legacy preserved at storage level
+    const dbNullIds = await detectDbNullProfileIds(projectId)
+    expect(dbNullIds.has(profileRoleId)).toBe(true)
+    expect(dbNullIds.has(profileNamedId)).toBe(false)
+    expect(dbNullIds.has(profilePlannedId)).toBe(false)
+    expect(dbNullIds.has(profilePlannedNrId)).toBe(true)
+
+    // Backlog restored
+    const epics = await prisma.epic.findMany({ where: { projectId } })
+    expect(epics).toHaveLength(1)
+    expect(epics[0].name).toBe('Epic Alpha')
+
+    // Timeline entries restored
+    const tles = await prisma.timelineEntry.findMany({ where: { projectId } })
+    expect(tles).toHaveLength(1)
+
+    const stles = await prisma.storyTimelineEntry.findMany({ where: { projectId } })
+    expect(stles).toHaveLength(1)
+    expect(stles[0].durationWeeks).toBe(5)
+
+    // Overhead restored
+    const overheads = await prisma.projectOverhead.findMany({ where: { projectId } })
+    expect(overheads).toHaveLength(1)
+    expect(overheads[0].value).toBe(15)
+
+    // ── Canonical deep comparison: every field matches pre-mutation state ──
+    const canonicalAfter = await captureCanonicalState(projectId)
+    expect(canonicalAfter.resourceTypes).toEqual(canonicalBefore.resourceTypes)
+    expect(canonicalAfter.namedResources).toEqual(canonicalBefore.namedResources)
+    expect(canonicalAfter.capacityProfiles).toEqual(canonicalBefore.capacityProfiles)
+    expect(canonicalAfter.timelineEntries).toEqual(canonicalBefore.timelineEntries)
+    expect(canonicalAfter.storyTimelineEntries).toEqual(canonicalBefore.storyTimelineEntries)
+    expect(canonicalAfter.overheadItems).toEqual(canonicalBefore.overheadItems)
+    expect(canonicalAfter.dbNullProfileIds.sort()).toEqual(canonicalBefore.dbNullProfileIds.sort())
+
+    // ── HTTP read-parity assertions (real auth, real ownership, real PostgreSQL) ──
+    // Re-fetch Resource Profile after rollback
+    const rpAfter = await request(app)
+      .get(`/api/projects/${projectId}/resource-profile`)
+      .set('Authorization', authHeader)
+      .expect(200)
+    const profileAfter: Record<string, unknown> = rpAfter.body
+
+    // Re-fetch Timeline after rollback
+    const tlAfter = await request(app)
+      .get(`/api/projects/${projectId}/timeline`)
+      .set('Authorization', authHeader)
+      .expect(200)
+    const timelineAfter: Record<string, unknown> = tlAfter.body
+
+    // Narrow before-captured responses for comparison
+    const beforeRP = resourceProfileBefore as Record<string, unknown>
+    const beforeTL = timelineBefore as Record<string, unknown>
+    const afterRows = profileAfter.resourceRows as Array<Record<string, unknown>>
+    const beforeRows = beforeRP.resourceRows as Array<Record<string, unknown>>
+
+    // ── Role profile: PROFILE resolutionSource, exact restored segments, null fields ──
+    const devRow = afterRows.find(r => r.resourceTypeId === rtDevId)!
+    const devCp = devRow.capacityProfile as Record<string, unknown>
+    expect(devCp.resolutionSource).toBe('PROFILE')
+    expect(devCp.planningBasis).toBe('DEMAND_FOLLOWING')
+    expect(devCp.source).toBe('MANUAL')
+    expect(devCp.defaultPercent).toBeNull()
+    expect(devCp.startWeek).toBeNull()
+    expect(devCp.endWeek).toBeNull()
+    expect(devCp.segments).toEqual([
       { startWeek: 0, endWeek: 4, capacityPercent: 100 },
       { startWeek: 5, endWeek: 10, capacityPercent: 50 },
     ])
 
-    await createProfileWithSegments(projectId, null, nrId, 'NAMED_PERSON', {
-      planningBasis: 'AVAILABILITY_WINDOW',
-      source: 'SQUAD_PLANNER',
-      defaultPercent: 100,
-      startWeek: 2,
-      endWeek: 8,
-      legacy: { allocationMode: 'EFFORT' },
-    }, [
+    // ── Named-person identity, PROFILE resolutionSource, exact segments ──
+    const devNrs = devRow.namedResources as Array<Record<string, unknown>>
+    const aliceRow = devNrs.find(nr => nr.id === nrAliceId)!
+    expect(aliceRow.resourceIdentity).toBe('NAMED_PERSON')
+    const aliceCp = aliceRow.capacityProfile as Record<string, unknown>
+    expect(aliceCp.resolutionSource).toBe('PROFILE')
+    expect(aliceCp.planningBasis).toBe('AVAILABILITY_WINDOW')
+    expect(aliceCp.source).toBe('SQUAD_PLANNER')
+    expect(aliceCp.defaultPercent).toBe(100)
+    expect(aliceCp.startWeek).toBe(2)
+    expect(aliceCp.endWeek).toBe(8)
+    expect(aliceCp.segments).toEqual([
       { startWeek: 2, endWeek: 5, capacityPercent: 100 },
     ])
 
-    const initialProfiles = await prisma.capacityProfile.findMany({
-      where: { projectId },
-      include: { segments: { orderBy: { startWeek: 'asc' } } },
-    })
-    expect(initialProfiles.length).toBe(2)
+    // ── Designer RT: now has a task, appears with legacy-derived capacityProfile ──
+    const desRow = afterRows.find(r => r.resourceTypeId === rtDesId)!
+    expect(desRow.resourceTypeId).toBe(rtDesId)
+    // No ROLE profile persisted → capacityProfile comes from LEGACY fallback
+    const desCp = desRow.capacityProfile as Record<string, unknown> | undefined
+    expect(desCp).toBeDefined()
+    expect(desCp!.resolutionSource).toBe('LEGACY')
 
-    // Build snapshot
-    const { buildSnapshot } = await import('../routes/snapshots.js')
-    const snapshot = await buildSnapshot(projectId, prisma)
-    expect(snapshot.schemaVersion).toBe(3)
-    expect(snapshot.capacityProfiles.length).toBe(2)
+    // ── Bob (no persisted profile) under Designer RT: LEGACY resolutionSource ──
+    const desNrs = desRow.namedResources as Array<Record<string, unknown>>
+    const bobRow = desNrs.find(nr => nr.name === 'Bob')!
+    const bobCp = bobRow.capacityProfile as Record<string, unknown>
+    expect(bobCp.resolutionSource).toBe('LEGACY')
+    expect(bobRow.resourceIdentity).toBe('NAMED_PERSON')
 
-    // Verify SnapshotJsonValue
-    const roleProfile = snapshot.capacityProfiles.find(p => p.ownerKind === 'ROLE')
-    expect(roleProfile?.legacy.kind).toBe('DB_NULL')
-    const personProfile = snapshot.capacityProfiles.find(p => p.ownerKind === 'NAMED_PERSON')
-    expect(personProfile?.legacy.kind).toBe('VALUE')
-
-    // Mutate
-    const roleDb = initialProfiles.find(p => p.ownerKind === 'ROLE')!
-    await createSegments(roleDb.id, [
-      { startWeek: 11, endWeek: 14, capacityPercent: 25 },
+    // ── Charlie: PLANNED_RESOURCE identity, PROFILE resolutionSource, 3 segments ──
+    const charlieRow = devNrs.find(nr => nr.id === nrCharlieId)!
+    expect(charlieRow.resourceIdentity).toBe('PLANNED_RESOURCE')
+    const charlieCp = charlieRow.capacityProfile as Record<string, unknown>
+    expect(charlieCp.resolutionSource).toBe('PROFILE')
+    expect(charlieCp.planningBasis).toBe('capacityProfile')
+    expect(charlieCp.defaultPercent).toBeNull()
+    expect(charlieCp.startWeek).toBeNull()
+    expect(charlieCp.endWeek).toBeNull()
+    expect(charlieCp.segments).toEqual([
+      { startWeek: 0, endWeek: 2, capacityPercent: 100 },
+      { startWeek: 3, endWeek: 5, capacityPercent: 75 },
+      { startWeek: 6, endWeek: 10, capacityPercent: 50 },
     ])
-    const mutatedSegments = await prisma.capacitySegment.count({
-      where: { capacityProfileId: roleDb.id },
-    })
-    expect(mutatedSegments).toBe(3)
 
-    // Restore
-    const { recreateV3CapacityProfiles } = await import('../lib/projectSnapshotCapacity.js')
-    await prisma.$transaction(async tx => {
-      await recreateV3CapacityProfiles(tx, projectId, snapshot)
-    })
+    // ── Capacity profile segments are identical to pre-mutation response ──
+    const beforeDevCp = (beforeRows.find(r => r.resourceTypeId === rtDevId)!.capacityProfile as Record<string, unknown>)
+    expect(devCp.segments).toEqual(beforeDevCp.segments)
 
-    // Verify restoration
-    const restoredProfiles = await prisma.capacityProfile.findMany({
-      where: { projectId },
-      include: { segments: { orderBy: { startWeek: 'asc' } } },
-    })
-    expect(restoredProfiles.length).toBe(2)
-    const restoredRole = restoredProfiles.find(p => p.ownerKind === 'ROLE')
-    expect(restoredRole).toBeDefined()
-    expect(restoredRole!.segments.length).toBe(2)
-    expect(restoredRole!.segments[0].startWeek).toBe(0)
-    expect(restoredRole!.segments[1].startWeek).toBe(5)
-    const restoredPerson = restoredProfiles.find(p => p.ownerKind === 'NAMED_PERSON')
-    expect(restoredPerson).toBeDefined()
-    expect(restoredPerson!.segments.length).toBe(1)
-    expect(restoredPerson!.defaultPercent).toBe(100)
+    // ── Resource Profile allocation fields: every field matches A exactly (including nulls) ──
+    const devNrsTyped = devRow.namedResources as Array<Record<string, unknown>>
+    const afterAliceRow = devNrsTyped.find((nr: Record<string, unknown>) => nr.id === nrAliceId)!
+    const beforeDevRow = beforeRows.find((r: Record<string, unknown>) => r.resourceTypeId === rtDevId)!
+    const beforeDevNrsTyped = beforeDevRow.namedResources as Array<Record<string, unknown>>
+    const beforeAliceRow = beforeDevNrsTyped.find((nr: Record<string, unknown>) => nr.id === nrAliceId)!
+    ;['allocationMode', 'allocationPercent', 'allocationStartWeek', 'allocationEndWeek', 'startWeek', 'endWeek']
+      .forEach(field => {
+        expect(afterAliceRow[field]).toBe(beforeAliceRow[field])
+      })
+    // Dev row level: allocation fields including nulls
+    expect(devRow.allocationMode).toBe(beforeDevCp.allocationMode ?? beforeRows.find((r: Record<string, unknown>) => r.resourceTypeId === rtDevId)!.allocationMode)
+    const afterCharlieRow = devNrsTyped.find((nr: Record<string, unknown>) => nr.id === nrCharlieId)!
+    const beforeCharlieRow = beforeDevNrsTyped.find((nr: Record<string, unknown>) => nr.id === nrCharlieId)!
+    expect(afterCharlieRow.allocationMode).toBe(beforeCharlieRow.allocationMode)
+    expect(afterCharlieRow.allocationPercent).toBe(beforeCharlieRow.allocationPercent)
+    expect(afterCharlieRow.allocationStartWeek).toBe(beforeCharlieRow.allocationStartWeek)
+    expect(afterCharlieRow.allocationEndWeek).toBe(beforeCharlieRow.allocationEndWeek)
 
-    // Clean up
-    await prisma.capacitySegment.deleteMany({ where: { capacityProfile: { projectId } } })
-    await prisma.capacityProfile.deleteMany({ where: { projectId } })
-    await prisma.namedResource.deleteMany({ where: { resourceType: { projectId } } })
-    await prisma.resourceType.deleteMany({ where: { projectId } })
-    await prisma.project.delete({ where: { id: projectId } })
+    // ── Timeline parity: named-resource allocation fields equal A ──
+    const afterNRs = timelineAfter.namedResources as Array<Record<string, unknown>>
+    const beforeNRs = beforeTL.namedResources as Array<Record<string, unknown>>
+    const aliceTLAfter = afterNRs.find(nr => nr.id === nrAliceId)!
+    const aliceTLBefore = beforeNRs.find(nr => nr.id === nrAliceId)!
+    expect(aliceTLAfter.allocationMode).toBe(aliceTLBefore.allocationMode)
+    expect(aliceTLAfter.allocationPercent).toBe(aliceTLBefore.allocationPercent)
+    expect(aliceTLAfter.startWeek).toBe(aliceTLBefore.startWeek)
+    expect(aliceTLAfter.endWeek).toBe(aliceTLBefore.endWeek)
+    expect(aliceTLAfter.allocationStartWeek).toBe(aliceTLBefore.allocationStartWeek)
+    expect(aliceTLAfter.allocationEndWeek).toBe(aliceTLBefore.allocationEndWeek)
+
+    // ── Timeline entries (features + stories) match A exactly ──
+    expect(timelineAfter.entries).toEqual(beforeTL.entries)
+    const afterStoryEntries = (timelineAfter.storyEntries ?? []) as Array<unknown>
+    const beforeStoryEntries = (beforeTL.storyEntries ?? []) as Array<unknown>
+    expect(afterStoryEntries).toEqual(beforeStoryEntries)
   })
 })
 
 // ═════════════════════════════════════════════════════════════════════════════
-// Scenario D — invalid v3 validation is non-destructive
+// Scenario B — rollback-to-rollback chaining
 // ═════════════════════════════════════════════════════════════════════════════
 
-describeIf('Scenario D — invalid v3 validation', () => {
-  it('rejects duplicate profile IDs without modifying project state', async () => {
-    const projectId = await createProject()
-    const rtId = await createResourceType(projectId, 'Developer')
+describeIf('Scenario B — rollback chaining (A→B→rollback A→pre_rollback B→rollback)', () => {
+  let projectId: string
+  let rtId: string
+  let snapA: string
+  let preRollbackSnapId: string
 
-    await createProfileWithSegments(projectId, rtId, null, 'ROLE', {}, [
-      { startWeek: 0, endWeek: 10, capacityPercent: 100 },
+  beforeAll(async () => {
+    if (!runIntegration) return
+    projectId = await createProject()
+    rtId = await createResourceType(projectId, 'rt-b-chain', 'Engineer')
+    await createNamedResource(projectId, rtId, 'nr-b-chain', 'Eve')
+
+    // State A: ROLE profile, 100% TIMELINE, no segments
+    await createProfile(
+      projectId, 'prof-b-a', 'ROLE', rtId, null,
+      {
+        planningBasis: 'DEMAND_FOLLOWING',
+        source: 'MANUAL',
+        defaultPercent: 100,
+        startWeek: 0,
+        endWeek: 10,
+      },
+      Prisma.DbNull,
+    )
+
+    // Snapshot A
+    const dataA = await buildSnapshot(projectId, prisma)
+    const snapARec = await prisma.backlogSnapshot.create({
+      data: {
+        projectId, label: 'State A', trigger: 'manual',
+        snapshot: dataA as unknown as object, createdById: userId,
+      },
+    })
+    snapA = snapARec.id
+
+    // State B: change profile to 75% AVAILABILITY_WINDOW, add segments
+    await prisma.capacityProfile.update({
+      where: { id: 'prof-b-a' },
+      data: {
+        planningBasis: 'AVAILABILITY_WINDOW',
+        defaultPercent: 75,
+        startWeek: 1,
+        endWeek: 8,
+      },
+    })
+    const seg = await prisma.capacitySegment.findFirst({
+      where: { capacityProfileId: 'prof-b-a' },
+    })
+    if (seg) {
+      await prisma.capacitySegment.delete({ where: { id: seg.id } })
+    }
+    await createSegment('prof-b-a', 'seg-b-1', 1, 4, 75)
+    await createSegment('prof-b-a', 'seg-b-2', 5, 8, 50)
+  })
+
+  it('rollback to A, verify pre_rollback captures B, rollback pre_rollback to restore B', async () => {
+    // ── Capture B-state HTTP responses (before rollback) ──────────
+    const rpB = await request(app)
+      .get(`/api/projects/${projectId}/resource-profile`)
+      .set('Authorization', authHeader)
+      .expect(200)
+    // B-state ROLE profile: AVAILABILITY_WINDOW, 75%, with segments
+    const bRoleRow = (rpB.body.resourceRows as Array<Record<string, unknown>>).find(r => r.resourceTypeId === rtId)!
+    const bRoleCp = bRoleRow.capacityProfile as Record<string, unknown>
+    expect(bRoleCp.planningBasis).toBe('AVAILABILITY_WINDOW')
+    expect(bRoleCp.defaultPercent).toBe(75)
+    expect(bRoleCp.segments).toHaveLength(2)
+    const tlB = await request(app)
+      .get(`/api/projects/${projectId}/timeline`)
+      .set('Authorization', authHeader)
+      .expect(200)
+    expect(tlB.body).toHaveProperty('entries')
+    // ── Rollback to A ─────────────────────────────────────────────
+    await rollbackProjectSnapshot({ projectId, snapshotId: snapA, userId, db: prisma })
+
+    // Profile restored to A state
+    const profileA = await prisma.capacityProfile.findFirst({
+      where: { projectId, id: 'prof-b-a' },
+      include: { segments: { orderBy: { startWeek: 'asc' as const } } },
+    })
+    expect(profileA).not.toBeNull()
+    expect(profileA!.planningBasis).toBe('DEMAND_FOLLOWING')
+    expect(profileA!.defaultPercent).toBe(100)
+    expect(profileA!.segments).toHaveLength(0)
+
+    // Pre_rollback snapshot was created inside the transaction
+    const preSnaps = await prisma.backlogSnapshot.findMany({
+      where: { projectId, trigger: 'pre_rollback' },
+      orderBy: { createdAt: 'desc' as const },
+      take: 1,
+    })
+    expect(preSnaps).toHaveLength(1)
+    preRollbackSnapId = preSnaps[0].id
+
+    // Its label includes reference to the rolled-back snapshot
+    expect(preSnaps[0].label).toContain('State A')
+
+    // Pre_rollback data contains B's state at v3
+    const preData = preSnaps[0].snapshot as unknown as SnapshotV3
+    expect(preData.schemaVersion).toBe(3)
+    const bProfile = preData.capacityProfiles.find(p => p.id === 'prof-b-a')
+    expect(bProfile).toBeDefined()
+    expect(bProfile!.planningBasis).toBe('AVAILABILITY_WINDOW')
+    expect(bProfile!.defaultPercent).toBe(75)
+    expect(bProfile!.segments).toHaveLength(2)
+    expect(bProfile!.segments[0].capacityPercent).toBe(75)
+
+    // ── Rollback to pre_rollback (restore B) ──────────────────────
+    await rollbackProjectSnapshot({
+      projectId, snapshotId: preRollbackSnapId, userId, db: prisma,
+    })
+
+    // B state restored exactly
+    const profileB = await prisma.capacityProfile.findFirst({
+      where: { projectId, id: 'prof-b-a' },
+      include: { segments: { orderBy: { startWeek: 'asc' as const } } },
+    })
+    expect(profileB).not.toBeNull()
+    expect(profileB!.planningBasis).toBe('AVAILABILITY_WINDOW')
+    expect(profileB!.defaultPercent).toBe(75)
+    expect(profileB!.segments).toHaveLength(2)
+    expect(profileB!.segments[0].startWeek).toBe(1)
+    expect(profileB!.segments[1].capacityPercent).toBe(50)
+
+    // No duplicate profiles
+    const allProfiles = await prisma.capacityProfile.findMany({
+      where: { projectId },
+    })
+    expect(allProfiles).toHaveLength(1)
+    expect(allProfiles[0].id).toBe('prof-b-a')
+
+    // DB_NULL semantics preserved
+    const dbNullIds = await detectDbNullProfileIds(projectId)
+    expect(dbNullIds.has('prof-b-a')).toBe(true)
+
+    // Pre_rollback snapshots survive retention pruning
+    const finalPreRollbacks = await prisma.backlogSnapshot.count({
+      where: { projectId, trigger: 'pre_rollback' },
+    })
+    expect(finalPreRollbacks).toBeGreaterThanOrEqual(1)
+  })
+})
+
+// ═════════════════════════════════════════════════════════════════════════════
+// Scenario C — transactional FK failure after pre_rollback creation
+// ═════════════════════════════════════════════════════════════════════════════
+
+describeIf('Scenario C — transactional FK failure after pre_rollback creation', () => {
+  let projectId: string
+  let rtId: string
+  let snapshotId: string
+  let snapsBefore: number
+  let ftId: string
+
+  beforeAll(async () => {
+    if (!runIntegration) return
+    projectId = await createProject()
+    rtId = await createResourceType(projectId, 'rt-c-fail', 'Tester')
+
+    // Create a FeatureTemplate that the story will reference
+    ftId = (
+      await prisma.featureTemplate.create({
+        data: {
+          name: `RollbackTestTemplate-${Date.now()}`,
+          category: 'DEV',
+        },
+      })
+    ).id
+
+    // Create backlog with a story that has appliedTemplateId set
+    await createEpicBacklog(projectId, rtId, ftId)
+
+    // Create a profile
+    await createProfile(
+      projectId, 'prof-c', 'ROLE', rtId, null,
+      {},
+      Prisma.DbNull,
+    )
+
+    // Build and persist v3 snapshot
+    const data = await buildSnapshot(projectId, prisma)
+    const snap = await prisma.backlogSnapshot.create({
+      data: {
+        projectId, label: 'Scenario C', trigger: 'manual',
+        snapshot: data as unknown as object, createdById: userId,
+      },
+    })
+    snapshotId = snap.id
+    snapsBefore = await prisma.backlogSnapshot.count({ where: { projectId } })
+
+    // Delete the FeatureTemplate — the snapshot's story has appliedTemplateId=ftId.
+    // The rollback's restoreSnapshotCommonState will try to recreate the story with
+    // the stale FK, triggering a FK violation AFTER the pre_rollback snapshot is
+    // created inside the transaction.
+    await prisma.featureTemplate.delete({ where: { id: ftId } })
+  })
+
+  it('rollback fails with P2003 (FK violation), state unchanged, no new snapshot committed', async () => {
+    let caught: unknown
+    try {
+      await rollbackProjectSnapshot({ projectId, snapshotId, userId, db: prisma })
+    } catch (e) {
+      caught = e
+    }
+    expect(caught).toBeDefined()
+    expect(caught).toBeInstanceOf(Prisma.PrismaClientKnownRequestError)
+    expect((caught as Prisma.PrismaClientKnownRequestError).code).toBe('P2003')
+
+    // Snapshot count unchanged (pre_rollback was rolled back)
+    const snapsAfter = await prisma.backlogSnapshot.count({ where: { projectId } })
+    expect(snapsAfter).toBe(snapsBefore)
+
+    // Resource types still exist
+    const rtCount = await prisma.resourceType.count({ where: { projectId } })
+    expect(rtCount).toBe(1)
+
+    // Backlog unchanged (mutated or original — rollback didn't apply)
+    const epics = await prisma.epic.findMany({ where: { projectId } })
+    expect(epics).toHaveLength(1)
+    expect(epics[0].name).toBe('Epic Alpha')
+
+    // Profile still exists
+    const profile = await prisma.capacityProfile.findFirst({ where: { projectId } })
+    expect(profile).not.toBeNull()
+    expect(profile!.ownerKind).toBe('ROLE')
+  })
+})
+
+// ═════════════════════════════════════════════════════════════════════════════
+// Scenario D — pre-transaction validation failures are non-destructive
+// ═════════════════════════════════════════════════════════════════════════════
+
+describeIf('Scenario D — invalid v3 validation is non-destructive', () => {
+  let projectId: string
+  let rtId: string
+  let profileCountBefore: number
+
+  beforeEach(async () => {
+    if (!runIntegration) return
+    projectId = await createProject()
+    rtId = await createResourceType(projectId, 'rt-d-valid', 'Valid Role')
+    await createProfile(
+      projectId, 'prof-d-valid', 'ROLE', rtId, null,
+      {},
+      Prisma.DbNull,
+    )
+    const counts = await Promise.all([
+      prisma.capacityProfile.count({ where: { projectId } }),
+      prisma.backlogSnapshot.count({ where: { projectId } }),
     ])
+    profileCountBefore = counts[0]
+  })
 
-    const profilesBefore = await prisma.capacityProfile.count({ where: { projectId } })
-    expect(profilesBefore).toBe(1)
+  afterEach(async () => {
+    if (!runIntegration) return
+    await prisma.capacitySegment.deleteMany({
+      where: { capacityProfile: { projectId } },
+    })
+    await prisma.capacityProfile.deleteMany({ where: { projectId } })
+    await prisma.resourceType.deleteMany({ where: { projectId } })
+    await prisma.project.delete({ where: { id: projectId } })
+  })
 
-    const { validateSnapshotV3, SnapshotValidationError } = await import('../lib/projectSnapshotValidation.js')
+  it('rejects unknown schemaVersion (malformed discriminator)', async () => {
+    const badSnap = await prisma.backlogSnapshot.create({
+      data: {
+        projectId,
+        label: 'bad version',
+        trigger: 'manual',
+        snapshot: {
+          schemaVersion: 4,
+          epics: [],
+          resourceTypes: [],
+          namedResources: [],
+          timelineEntries: [],
+          storyTimelineEntries: [],
+          epicDependencies: [],
+          featureDependencies: [],
+          overheadItems: [],
+        } as unknown as object,
+        createdById: userId,
+      },
+    })
+    await expect(
+      rollbackProjectSnapshot({
+        projectId, snapshotId: badSnap.id, userId, db: prisma,
+      }),
+    ).rejects.toThrow(SnapshotSchemaError)
 
-    const badSnapshot = {
+    const profilesAfter = await prisma.capacityProfile.count({ where: { projectId } })
+    expect(profilesAfter).toBe(profileCountBefore)
+  })
+
+  it('rejects duplicate profile IDs without modifying state', async () => {
+    const badV3: SnapshotV3 = {
       schemaVersion: 3,
       epics: [],
       project: null,
-      resourceTypes: [
-        { id: 'rt-dev', name: 'Dev', category: null, count: null, hoursPerDay: null, dayRate: null, globalTypeId: null, allocationMode: null, allocationPercent: null, allocationStartWeek: null, allocationEndWeek: null },
-      ],
+      resourceTypes: [{
+        id: 'rt-d-dup', name: 'Dup', category: 'ENGINEERING',
+        count: 1, hoursPerDay: null, dayRate: null, globalTypeId: null,
+        allocationMode: 'TIMELINE', allocationPercent: 100,
+        allocationStartWeek: null, allocationEndWeek: null,
+      }],
       namedResources: [],
       timelineEntries: [],
       storyTimelineEntries: [],
@@ -293,9 +1247,9 @@ describeIf('Scenario D — invalid v3 validation', () => {
       overheadItems: [],
       capacityProfiles: [
         {
-          id: 'same-id',
+          id: 'dup-id',
           ownerKind: 'ROLE',
-          resourceTypeId: 'rt-dev',
+          resourceTypeId: 'rt-d-dup',
           namedResourceId: null,
           planningBasis: 'DEMAND_FOLLOWING',
           source: 'MANUAL',
@@ -306,10 +1260,10 @@ describeIf('Scenario D — invalid v3 validation', () => {
           segments: [],
         },
         {
-          id: 'same-id',
+          id: 'dup-id',
           ownerKind: 'NAMED_PERSON',
           resourceTypeId: null,
-          namedResourceId: 'missing-nr',
+          namedResourceId: null,
           planningBasis: 'DEMAND_FOLLOWING',
           source: 'MANUAL',
           defaultPercent: null,
@@ -320,71 +1274,696 @@ describeIf('Scenario D — invalid v3 validation', () => {
         },
       ],
     }
-
-    expect(() => validateSnapshotV3(badSnapshot as never)).toThrow(SnapshotValidationError)
+    const badSnap = await prisma.backlogSnapshot.create({
+      data: {
+        projectId, label: 'dup profiles', trigger: 'manual',
+        snapshot: badV3 as unknown as object, createdById: userId,
+      },
+    })
+    await expect(
+      rollbackProjectSnapshot({
+        projectId, snapshotId: badSnap.id, userId, db: prisma,
+      }),
+    ).rejects.toThrow(SnapshotValidationError)
 
     const profilesAfter = await prisma.capacityProfile.count({ where: { projectId } })
-    expect(profilesAfter).toBe(1)
+    expect(profilesAfter).toBe(profileCountBefore)
+  })
 
-    await prisma.capacitySegment.deleteMany({ where: { capacityProfile: { projectId } } })
-    await prisma.capacityProfile.deleteMany({ where: { projectId } })
-    await prisma.resourceType.deleteMany({ where: { projectId } })
-    await prisma.project.delete({ where: { id: projectId } })
+  it('rejects duplicate segment IDs', async () => {
+    const badV3: SnapshotV3 = {
+      schemaVersion: 3,
+      epics: [],
+      project: null,
+      resourceTypes: [{
+        id: 'rt-d-segdup', name: 'SegDup', category: 'ENGINEERING',
+        count: 1, hoursPerDay: null, dayRate: null, globalTypeId: null,
+        allocationMode: 'TIMELINE', allocationPercent: 100,
+        allocationStartWeek: null, allocationEndWeek: null,
+      }],
+      namedResources: [],
+      timelineEntries: [],
+      storyTimelineEntries: [],
+      epicDependencies: [],
+      featureDependencies: [],
+      overheadItems: [],
+      capacityProfiles: [{
+        id: 'prof-segdup',
+        ownerKind: 'ROLE',
+        resourceTypeId: 'rt-d-segdup',
+        namedResourceId: null,
+        planningBasis: 'DEMAND_FOLLOWING',
+        source: 'MANUAL',
+        defaultPercent: null,
+        startWeek: null,
+        endWeek: null,
+        legacy: { kind: 'DB_NULL' as const },
+        segments: [
+          { id: 'seg-same', startWeek: 0, endWeek: 5, capacityPercent: 100, source: 'MANUAL' },
+          { id: 'seg-same', startWeek: 6, endWeek: 10, capacityPercent: 50, source: 'MANUAL' },
+        ],
+      }],
+    }
+    const badSnap = await prisma.backlogSnapshot.create({
+      data: {
+        projectId, label: 'dup segments', trigger: 'manual',
+        snapshot: badV3 as unknown as object, createdById: userId,
+      },
+    })
+    await expect(
+      rollbackProjectSnapshot({
+        projectId, snapshotId: badSnap.id, userId, db: prisma,
+      }),
+    ).rejects.toThrow(SnapshotValidationError)
+
+    const profilesAfter = await prisma.capacityProfile.count({ where: { projectId } })
+    expect(profilesAfter).toBe(profileCountBefore)
+  })
+
+  it('rejects ROLE with missing resourceTypeId (not in snapshot resourceTypes)', async () => {
+    const badV3: SnapshotV3 = {
+      schemaVersion: 3,
+      epics: [],
+      project: null,
+      resourceTypes: [],
+      namedResources: [],
+      timelineEntries: [],
+      storyTimelineEntries: [],
+      epicDependencies: [],
+      featureDependencies: [],
+      overheadItems: [],
+      capacityProfiles: [{
+        id: 'prof-missing-owner',
+        ownerKind: 'ROLE',
+        resourceTypeId: 'rt-nonexistent',
+        namedResourceId: null,
+        planningBasis: 'DEMAND_FOLLOWING',
+        source: 'MANUAL',
+        defaultPercent: null,
+        startWeek: null,
+        endWeek: null,
+        legacy: { kind: 'DB_NULL' as const },
+        segments: [],
+      }],
+    }
+    const badSnap = await prisma.backlogSnapshot.create({
+      data: {
+        projectId, label: 'missing owner', trigger: 'manual',
+        snapshot: badV3 as unknown as object, createdById: userId,
+      },
+    })
+    await expect(
+      rollbackProjectSnapshot({
+        projectId, snapshotId: badSnap.id, userId, db: prisma,
+      }),
+    ).rejects.toThrow(SnapshotValidationError)
+
+    const profilesAfter = await prisma.capacityProfile.count({ where: { projectId } })
+    expect(profilesAfter).toBe(profileCountBefore)
+  })
+
+  it('rejects segment with startWeek > endWeek (invalid range)', async () => {
+    const badV3: SnapshotV3 = {
+      schemaVersion: 3,
+      epics: [],
+      project: null,
+      resourceTypes: [{
+        id: 'rt-d-range', name: 'Range', category: 'ENGINEERING',
+        count: 1, hoursPerDay: null, dayRate: null, globalTypeId: null,
+        allocationMode: 'TIMELINE', allocationPercent: 100,
+        allocationStartWeek: null, allocationEndWeek: null,
+      }],
+      namedResources: [],
+      timelineEntries: [],
+      storyTimelineEntries: [],
+      epicDependencies: [],
+      featureDependencies: [],
+      overheadItems: [],
+      capacityProfiles: [{
+        id: 'prof-range',
+        ownerKind: 'ROLE',
+        resourceTypeId: 'rt-d-range',
+        namedResourceId: null,
+        planningBasis: 'DEMAND_FOLLOWING',
+        source: 'MANUAL',
+        defaultPercent: null,
+        startWeek: null,
+        endWeek: null,
+        legacy: { kind: 'DB_NULL' as const },
+        segments: [{
+          id: 'seg-bad-range',
+          startWeek: 10,
+          endWeek: 5,
+          capacityPercent: 100,
+          source: 'MANUAL',
+        }],
+      }],
+    }
+    const badSnap = await prisma.backlogSnapshot.create({
+      data: {
+        projectId, label: 'bad range', trigger: 'manual',
+        snapshot: badV3 as unknown as object, createdById: userId,
+      },
+    })
+    await expect(
+      rollbackProjectSnapshot({
+        projectId, snapshotId: badSnap.id, userId, db: prisma,
+      }),
+    ).rejects.toThrow(SnapshotValidationError)
+
+    const profilesAfter = await prisma.capacityProfile.count({ where: { projectId } })
+    expect(profilesAfter).toBe(profileCountBefore)
+  })
+
+  it('rejects unsupported ownerKind, planningBasis, and source enums with no state change', async () => {
+    const validRT = { id: 'rt-d-valid', name: 'Valid', category: 'ENGINEERING' as const,
+      count: 1, hoursPerDay: null, dayRate: null, globalTypeId: null,
+      allocationMode: 'TIMELINE' as const, allocationPercent: 100,
+      allocationStartWeek: null, allocationEndWeek: null }
+
+    // Three snapshots each with a different invalid enum
+    const badConfigs: Array<{
+      label: string
+      overrides: Partial<{
+        ownerKind: string
+        planningBasis: string
+        source: string
+      }>
+    }> = [
+      { label: 'invalid ownerKind', overrides: { ownerKind: 'INVALID' } },
+      { label: 'invalid planningBasis', overrides: { ownerKind: 'ROLE', planningBasis: 'INVALID' } },
+      { label: 'invalid source', overrides: { ownerKind: 'ROLE', planningBasis: 'DEMAND_FOLLOWING', source: 'INVALID' } },
+    ]
+
+    for (const { label, overrides } of badConfigs) {
+      const badV3: SnapshotV3 = {
+        schemaVersion: 3,
+        epics: [],
+        project: null,
+        resourceTypes: [validRT],
+        namedResources: [],
+        timelineEntries: [],
+        storyTimelineEntries: [],
+        epicDependencies: [],
+        featureDependencies: [],
+        overheadItems: [],
+        capacityProfiles: [{
+          id: `prof-bad-enum-${label.replace(/\s+/g, '-')}`,
+          ownerKind: overrides.ownerKind ?? 'ROLE',
+          resourceTypeId: 'rt-d-valid',
+          namedResourceId: null,
+          planningBasis: overrides.planningBasis ?? 'DEMAND_FOLLOWING',
+          source: overrides.source ?? 'MANUAL',
+          defaultPercent: null,
+          startWeek: null,
+          endWeek: null,
+          legacy: { kind: 'DB_NULL' as const },
+          segments: [],
+        }] as unknown as SnapshotV3['capacityProfiles'],
+      }
+      const badSnap = await prisma.backlogSnapshot.create({
+        data: {
+          projectId, label, trigger: 'manual',
+          snapshot: badV3 as unknown as object, createdById: userId,
+        },
+      })
+      await expect(
+        rollbackProjectSnapshot({ projectId, snapshotId: badSnap.id, userId, db: prisma }),
+      ).rejects.toThrow(SnapshotValidationError)
+
+      const profilesAfter = await prisma.capacityProfile.count({ where: { projectId } })
+      expect(profilesAfter).toBe(profileCountBefore)
+    }
   })
 })
 
 // ═════════════════════════════════════════════════════════════════════════════
-// Scenario F — v1 leaves profiles untouched
+// Scenario E — real v2 rollback replaces stale persisted profiles
 // ═════════════════════════════════════════════════════════════════════════════
 
-describeIf('Scenario F — v1 leaves profiles untouched', () => {
-  it('restores epics only, does not modify existing profiles', async () => {
-    const projectId = await createProject()
-    const rtId = await createResourceType(projectId, 'Developer')
+describeIf('Scenario E — v2 rollback replaces stale persisted profiles', () => {
+  let projectId: string
+  let rtId: string
+  let nrId: string
+  let v2SnapshotId: string
 
-    await prisma.epic.create({
-      data: { name: 'Original Epic', projectId, order: 0 },
+  beforeAll(async () => {
+    if (!runIntegration) return
+    projectId = await createProject()
+
+    // Create RT with TIMELINE mode at 60%
+    rtId = await createResourceType(projectId, 'rt-e-dev', 'Engineer', {
+      allocationMode: 'TIMELINE',
+      allocationPercent: 60,
+      allocationStartWeek: 0,
+      allocationEndWeek: 10,
     })
 
-    await createProfileWithSegments(projectId, rtId, null, 'ROLE', {
-      planningBasis: 'DEMAND_FOLLOWING',
-      source: 'MANUAL',
-      defaultPercent: 100,
-      startWeek: 0,
-      endWeek: 10,
-      legacy: Prisma.DbNull,
-    }, [
-      { startWeek: 0, endWeek: 10, capacityPercent: 100 },
-    ])
-
-    // Simulate v1 rollback: delete epics only
-    await prisma.epic.deleteMany({ where: { projectId } })
-    await prisma.epic.create({
-      data: { name: 'Restored Epic', projectId, order: 0 },
+    // Create NR inheriting TIMELINE mode at 60%
+    nrId = await createNamedResource(projectId, rtId, 'nr-eve', 'Eve', {
+      allocationMode: 'TIMELINE',
+      allocationPercent: 60,
+      startWeek: 2,
+      endWeek: 8,
     })
 
-    // Verify profiles untouched
-    const profilesAfter = await prisma.capacityProfile.count({ where: { projectId } })
-    expect(profilesAfter).toBe(1)
+    // Create stale persisted profiles that DIFFER from v2-derived state
+    await createProfile(
+      projectId, 'prof-e-stale-role', 'ROLE', rtId, null,
+      {
+        planningBasis: 'AVAILABILITY_WINDOW',
+        source: 'SQUAD_PLANNER',
+        defaultPercent: 100,
+        startWeek: 0,
+        endWeek: 5,
+      },
+      Prisma.DbNull,
+    )
+    await createSegment('prof-e-stale-role', 'seg-e-stale', 0, 5, 100)
 
-    const profile = await prisma.capacityProfile.findFirst({ where: { projectId } })
-    expect(profile).not.toBeNull()
-    expect(profile!.defaultPercent).toBe(100)
+    await createProfile(
+      projectId, 'prof-e-stale-nr', 'NAMED_PERSON', null, nrId,
+      {
+        planningBasis: 'WHOLE_PROJECT_ALLOCATION',
+        source: 'MANUAL',
+        defaultPercent: 80,
+        startWeek: 1,
+        endWeek: 6,
+      },
+      { allocationMode: 'EFFORT' },
+    )
 
-    const segCount = await prisma.capacitySegment.count({
-      where: { capacityProfile: { projectId } },
+    // Add a PLANNED_RESOURCE that should NOT survive v2 rollback
+    await createProfile(
+      projectId, 'prof-e-planned', 'PLANNED_RESOURCE', null, null,
+      { planningBasis: 'CAPACITY_PROFILE', source: 'DERIVED' },
+      Prisma.DbNull,
+    )
+
+    // Build v2 snapshot from current state, downgrade schemaVersion to 2
+    const v3Data = await buildSnapshot(projectId, prisma)
+    const v2Data: SnapshotV2 = { ...v3Data, schemaVersion: 2 }
+    v2SnapshotId = (
+      await prisma.backlogSnapshot.create({
+        data: {
+          projectId,
+          label: 'v2 snapshot for Scenario E',
+          trigger: 'manual',
+          snapshot: v2Data as unknown as object,
+          createdById: userId,
+        },
+      })
+    ).id
+  })
+
+  it('v2 rollback replaces stale profiles with v2-derived ones', async () => {
+    // Validate stale profiles exist before call
+    const staleBefore = await prisma.capacityProfile.findMany({
+      where: { projectId },
     })
-    expect(segCount).toBe(1)
+    expect(staleBefore).toHaveLength(3)
 
-    // Verify epics changed
-    const epics = await prisma.epic.findMany({ where: { projectId } })
-    expect(epics.length).toBe(1)
-    expect(epics[0].name).toBe('Restored Epic')
+    // Rollback to v2 snapshot
+    await rollbackProjectSnapshot({
+      projectId, snapshotId: v2SnapshotId, userId, db: prisma,
+    })
 
-    await prisma.epic.deleteMany({ where: { projectId } })
-    await prisma.capacitySegment.deleteMany({ where: { capacityProfile: { projectId } } })
-    await prisma.capacityProfile.deleteMany({ where: { projectId } })
-    await prisma.resourceType.deleteMany({ where: { projectId } })
-    await prisma.project.delete({ where: { id: projectId } })
+    // After v2 rollback: 2 profiles (role + named), planned is removed
+    const profilesAfter = await prisma.capacityProfile.findMany({
+      where: { projectId },
+      orderBy: { createdAt: 'asc' as const },
+    })
+    expect(profilesAfter).toHaveLength(2)
+
+    const roleProfile = profilesAfter.find(p => p.ownerKind === 'ROLE')
+    const namedProfile = profilesAfter.find(p => p.ownerKind === 'NAMED_PERSON')
+    expect(roleProfile).toBeDefined()
+    expect(namedProfile).toBeDefined()
+
+    // Role profile derived from RT fields: 60%, AVAILABILITY_WINDOW planning & source
+    expect(roleProfile!.defaultPercent).toBe(60)
+    expect(roleProfile!.planningBasis).toBe('AVAILABILITY_WINDOW')
+    expect(roleProfile!.source).toBe('AVAILABILITY_WINDOW')
+
+    // Named profile derived from NR fields: same TIMELINE→AVAILABILITY_WINDOW mapping
+    expect(namedProfile!.defaultPercent).toBe(60)
+    expect(namedProfile!.namedResourceId).toBe(nrId)
+    expect(namedProfile!.planningBasis).toBe('AVAILABILITY_WINDOW')
+    expect(namedProfile!.source).toBe('AVAILABILITY_WINDOW')
+
+
+    // No PLANNED_RESOURCE survives v2
+    const plannedCount = await prisma.capacityProfile.count({
+      where: { projectId, ownerKind: 'PLANNED_RESOURCE' },
+    })
+    expect(plannedCount).toBe(0)
+
+    // No CAPACITY_PLAN segments
+    const planSegments = await prisma.capacitySegment.count({
+      where: {
+        capacityProfile: { projectId },
+        source: 'LEGACY',
+      },
+    })
+    expect(planSegments).toBe(0)
+
+    // Persisted resolution source: legacy contains the v2-derived values
+    const rawRole = await prisma.capacityProfile.findFirst({
+      where: { id: roleProfile!.id },
+    })
+    const roleLegacy = rawRole!.legacy as Record<string, unknown>
+    expect(roleLegacy).not.toBeNull()
+    // Legacy contains the exact RT fields that were captured in the v2 snapshot
+    expect(roleLegacy.allocationMode).toBe('TIMELINE')
+    expect(roleLegacy.allocationPercent).toBe(60)
+    expect(roleLegacy.allocationStartWeek).toBe(0)
+    expect(roleLegacy.allocationEndWeek).toBe(10)
   })
 })
+
+// ═════════════════════════════════════════════════════════════════════════════
+// Scenario F — v1 rollback (backlog only, profiles untouched, raw SQL legacy)
+// ═════════════════════════════════════════════════════════════════════════════
+
+describeIf('Scenario F — v1 rollback preserves profiles, restores backlog', () => {
+  let projectId: string
+  let rtId: string
+  let nrId: string
+  let profileRoleId: string
+  let profileNamedId: string
+  let profileJsonNullId: string
+  let profileObjWithNullId: string
+  let profileArrayWithNullId: string
+  let profileStringId: string
+  let profileNumberId: string
+  let profileBooleanId: string
+  let v1SnapshotId: string
+
+  beforeAll(async () => {
+    if (!runIntegration) return
+    projectId = await createProject()
+    rtId = await createResourceType(projectId, 'rt-f-dev', 'Developer')
+    nrId = await createNamedResource(projectId, rtId, 'nr-frank', 'Frank')
+
+    // ROLE profile — DB_NULL legacy
+    profileRoleId = await createProfile(
+      projectId, 'prof-f-role', 'ROLE', rtId, null,
+      {
+        planningBasis: 'DEMAND_FOLLOWING',
+        source: 'MANUAL',
+        defaultPercent: 100,
+        startWeek: 0,
+        endWeek: 10,
+      },
+      Prisma.DbNull,
+    )
+    await createSegment(profileRoleId, 'seg-f-1', 0, 4, 100)
+    await createSegment(profileRoleId, 'seg-f-2', 5, 10, 50)
+
+    // NAMED_PERSON profile — VALUE(object) legacy
+    profileNamedId = await createProfile(
+      projectId, 'prof-f-named', 'NAMED_PERSON', null, nrId,
+      {
+        planningBasis: 'AVAILABILITY_WINDOW',
+        source: 'SQUAD_PLANNER',
+        defaultPercent: 80,
+        startWeek: 2,
+        endWeek: 8,
+      },
+      { allocationMode: 'EFFORT' },
+    )
+
+    // ── 6 extra ROLE profiles covering all Prisma JSON null states ──
+    profileJsonNullId = await createProfile(
+      projectId, 'prof-f-jsonnull', 'ROLE', rtId, null,
+      { planningBasis: 'DEMAND_FOLLOWING', source: 'MANUAL', defaultPercent: 50 },
+      Prisma.JsonNull,
+    )
+    profileObjWithNullId = await createProfile(
+      projectId, 'prof-f-obj-null', 'ROLE', rtId, null,
+      { planningBasis: 'DEMAND_FOLLOWING', source: 'MANUAL', defaultPercent: 50 },
+      { outer: 'value', inner: null, nested: { deep: null } },
+    )
+    profileArrayWithNullId = await createProfile(
+      projectId, 'prof-f-arr-null', 'ROLE', rtId, null,
+      { planningBasis: 'DEMAND_FOLLOWING', source: 'MANUAL', defaultPercent: 50 },
+      ['a', null, 'c'],
+    )
+    profileStringId = await createProfile(
+      projectId, 'prof-f-string', 'ROLE', rtId, null,
+      { planningBasis: 'DEMAND_FOLLOWING', source: 'MANUAL', defaultPercent: 50 },
+      'hello-legacy',
+    )
+    profileNumberId = await createProfile(
+      projectId, 'prof-f-number', 'ROLE', rtId, null,
+      { planningBasis: 'DEMAND_FOLLOWING', source: 'MANUAL', defaultPercent: 50 },
+      12345,
+    )
+    profileBooleanId = await createProfile(
+      projectId, 'prof-f-bool', 'ROLE', rtId, null,
+      { planningBasis: 'DEMAND_FOLLOWING', source: 'MANUAL', defaultPercent: 50 },
+      true,
+    )
+
+    // Backlog for v1 snapshot
+    await createEpicBacklog(projectId, rtId, null)
+
+    // Add timeline entry
+    const epics = await prisma.epic.findMany({
+      where: { projectId },
+      include: { features: { include: { userStories: true } } },
+    })
+    const feature = epics[0].features[0]
+    const story = feature.userStories[0]
+    await prisma.timelineEntry.create({
+      data: {
+        projectId, featureId: feature.id,
+        startWeek: 1, durationWeeks: 6, isManual: true,
+      },
+    })
+    await prisma.storyTimelineEntry.create({
+      data: {
+        projectId, storyId: story.id,
+        startWeek: 2, durationWeeks: 4, isManual: false,
+      },
+    })
+
+    // Build v1 snapshot from current state (epic array only)
+    const v3Data = await buildSnapshot(projectId, prisma)
+    const v1: SnapshotV1 = v3Data.epics.map(e => ({
+      ...e,
+      id: e.id,
+      name: e.name,
+      description: e.description,
+      assumptions: e.assumptions,
+      order: e.order,
+      features: e.features.map(f => ({
+        ...f,
+        id: f.id,
+        name: f.name,
+        description: f.description,
+        assumptions: f.assumptions,
+        order: f.order,
+        userStories: f.userStories.map(s => ({
+          ...s,
+          id: s.id,
+          name: s.name,
+          description: s.description,
+          assumptions: s.assumptions,
+          order: s.order,
+          appliedTemplateId: s.appliedTemplateId,
+          tasks: s.tasks.map(t => ({
+            ...t,
+            name: t.name,
+            description: t.description,
+            assumptions: t.assumptions,
+            hoursEffort: t.hoursEffort,
+            durationDays: t.durationDays,
+            order: t.order,
+            resourceType: t.resourceType,
+          })),
+        })),
+      })),
+    }))
+
+    v1SnapshotId = await createV1Snapshot(projectId, v1)
+
+    // After taking the v1 snapshot, mutate the backlog
+    await prisma.epic.deleteMany({ where: { projectId } })
+    const newEpic = await prisma.epic.create({
+      data: { name: 'Mutated Epic After V1 Snap', projectId, order: 0 },
+    })
+    const newFeature = await prisma.feature.create({
+      data: { name: 'Mutated Feature', epicId: newEpic.id, order: 0 },
+    })
+    await prisma.userStory.create({
+      data: { name: 'Mutated Story', featureId: newFeature.id, order: 0 },
+    })
+  })
+
+  it('v1 rollback restores backlog, preserves profiles/RT/NR, creates pre_rollback', async () => {
+    // Confirm backlog is mutated before rollback
+    const epicsBefore = await prisma.epic.findMany({ where: { projectId } })
+    expect(epicsBefore).toHaveLength(1)
+    expect(epicsBefore[0].name).toBe('Mutated Epic After V1 Snap')
+
+    // Capture profile state before rollback (with segments for comparison)
+    const profilesBefore = await prisma.capacityProfile.findMany({
+      where: { projectId },
+      include: { segments: { orderBy: { startWeek: 'asc' as const } } },
+      orderBy: [{ ownerKind: 'asc' as const }, { id: 'asc' as const }],
+    })
+
+    // Rollback (v1 path)
+    await rollbackProjectSnapshot({
+      projectId, snapshotId: v1SnapshotId, userId, db: prisma,
+    })
+
+    // ── Backlog restored ──────────────────────────────────────────
+    const epicsAfter = await prisma.epic.findMany({ where: { projectId } })
+    expect(epicsAfter).toHaveLength(1)
+    expect(epicsAfter[0].name).toBe('Epic Alpha')
+
+    const featAfter = await prisma.feature.findMany({
+      where: { epicId: epicsAfter[0].id },
+    })
+    expect(featAfter).toHaveLength(1)
+    expect(featAfter[0].name).toBe('Feature One')
+
+    const storyAfter = await prisma.userStory.findMany({
+      where: { featureId: featAfter[0].id },
+    })
+    expect(storyAfter).toHaveLength(1)
+    expect(storyAfter[0].name).toBe('Story A')
+
+    // ── RT/NR untouched ───────────────────────────────────────────
+    const rtsAfter = await prisma.resourceType.findMany({ where: { projectId } })
+    expect(rtsAfter).toHaveLength(1)
+    expect(rtsAfter[0].id).toBe(rtId)
+
+    const nrsAfter = await prisma.namedResource.findMany({
+      where: { resourceType: { projectId } },
+    })
+    expect(nrsAfter).toHaveLength(1)
+    expect(nrsAfter[0].id).toBe(nrId)
+
+    // ── Profiles/segments unchanged ────────────────────────────────
+    const profilesAfter = await prisma.capacityProfile.findMany({
+      where: { projectId },
+      include: { segments: { orderBy: { startWeek: 'asc' as const } } },
+      orderBy: [{ ownerKind: 'asc' as const }, { id: 'asc' as const }],
+    })
+    expect(profilesAfter).toHaveLength(profilesBefore.length)
+
+    for (let i = 0; i < profilesBefore.length; i++) {
+      expect(profilesAfter[i].id).toBe(profilesBefore[i].id)
+      expect(profilesAfter[i].ownerKind).toBe(profilesBefore[i].ownerKind)
+      expect(profilesAfter[i].planningBasis).toBe(profilesBefore[i].planningBasis)
+      expect(profilesAfter[i].segments).toHaveLength(profilesBefore[i].segments.length)
+    }
+
+
+    // ── Pre_rollback snapshot created with trigger 'pre_rollback' ──
+    const preSnaps = await prisma.backlogSnapshot.findMany({
+      where: { projectId, trigger: 'pre_rollback' },
+    })
+    expect(preSnaps.length).toBeGreaterThanOrEqual(1)
+    const newest = preSnaps[preSnaps.length - 1]
+    expect(newest.trigger).toBe('pre_rollback')
+    const preData = newest.snapshot as unknown as { schemaVersion: number }
+    expect(preData.schemaVersion).toBe(3)
+    // ── Timeline entries — cascade-deleted when epics recreated ────
+    const tles = await prisma.timelineEntry.findMany({ where: { projectId } })
+    const stles = await prisma.storyTimelineEntry.findMany({ where: { projectId } })
+    // V1 rollback deletes all epics (cascade deletes features/stories/timeline entries),
+    // then recreates backlog without timeline entries, so count is zero.
+    expect(tles).toHaveLength(0)
+    expect(stles).toHaveLength(0)
+
+    // ── Raw SQL: comprehensive legacy null-type coverage ───────────
+    const rawRows = await prisma.$queryRawUnsafe<
+      Array<{ id: string; legacy_is_null: boolean; jsonb_typeof: string | null }>
+    >(
+      `SELECT
+         cp.id,
+         cp.legacy IS NULL AS legacy_is_null,
+         jsonb_typeof(cp.legacy) AS jsonb_typeof
+       FROM "CapacityProfile" cp
+       WHERE cp."projectId" = $1
+       ORDER BY cp.id`,
+      projectId,
+    )
+
+    // All 8 profiles verified by raw SQL
+    // 1. ROLE — Prisma.DbNull → SQL NULL, jsonb_typeof NULL
+    const roleRow = rawRows.find(r => r.id === profileRoleId)
+    expect(roleRow).toBeDefined()
+    expect(roleRow!.legacy_is_null).toBe(true)
+    expect(roleRow!.jsonb_typeof).toBeNull()
+
+    // 2. NAMED_PERSON — JSON object, jsonb_typeof 'object'
+    const namedRow = rawRows.find(r => r.id === profileNamedId)
+    expect(namedRow).toBeDefined()
+    expect(namedRow!.legacy_is_null).toBe(false)
+    expect(namedRow!.jsonb_typeof).toBe('object')
+
+    // 3. Prisma.JsonNull → legacy IS NULL = false, jsonb_typeof = 'null'
+    const jnRow = rawRows.find(r => r.id === profileJsonNullId)
+    expect(jnRow).toBeDefined()
+    expect(jnRow!.legacy_is_null).toBe(false)
+    expect(jnRow!.jsonb_typeof).toBe('null')
+
+    // 4. Object with nested null → jsonb_typeof = 'object'
+    const objRow = rawRows.find(r => r.id === profileObjWithNullId)
+    expect(objRow).toBeDefined()
+    expect(objRow!.legacy_is_null).toBe(false)
+    expect(objRow!.jsonb_typeof).toBe('object')
+    // Also verify the nested null is preserved via Prisma read
+    const objProfile = await prisma.capacityProfile.findUnique({ where: { id: profileObjWithNullId } })
+    const objLegacy = objProfile!.legacy as Record<string, unknown> | null
+    expect(objLegacy).not.toBeNull()
+    expect(objLegacy!.outer).toBe('value')
+    expect(objLegacy!.inner).toBeNull()
+    expect((objLegacy!.nested as Record<string, unknown>).deep).toBeNull()
+
+    // 5. Array with null → jsonb_typeof = 'array', element preserved
+    const arrRow = rawRows.find(r => r.id === profileArrayWithNullId)
+    expect(arrRow).toBeDefined()
+    expect(arrRow!.legacy_is_null).toBe(false)
+    expect(arrRow!.jsonb_typeof).toBe('array')
+    const arrProfile = await prisma.capacityProfile.findUnique({ where: { id: profileArrayWithNullId } })
+    const arrLegacy = arrProfile!.legacy as unknown[] | null
+    expect(arrLegacy).not.toBeNull()
+    expect(arrLegacy![0]).toBe('a')
+    expect(arrLegacy![1]).toBeNull()
+    expect(arrLegacy![2]).toBe('c')
+
+    // 6. String → jsonb_typeof = 'string', content preserved
+    const strRow = rawRows.find(r => r.id === profileStringId)
+    expect(strRow).toBeDefined()
+    expect(strRow!.legacy_is_null).toBe(false)
+    expect(strRow!.jsonb_typeof).toBe('string')
+    const strProfile = await prisma.capacityProfile.findUnique({ where: { id: profileStringId } })
+    expect(strProfile!.legacy).toBe('hello-legacy')
+
+    // 7. Finite number → jsonb_typeof = 'number', value preserved
+    const numRow = rawRows.find(r => r.id === profileNumberId)
+    expect(numRow).toBeDefined()
+    expect(numRow!.legacy_is_null).toBe(false)
+    expect(numRow!.jsonb_typeof).toBe('number')
+    const numProfile = await prisma.capacityProfile.findUnique({ where: { id: profileNumberId } })
+    expect(numProfile!.legacy).toBe(12345)
+
+    // 8. Boolean → jsonb_typeof = 'boolean', value preserved
+    const boolRow = rawRows.find(r => r.id === profileBooleanId)
+    expect(boolRow).toBeDefined()
+    expect(boolRow!.legacy_is_null).toBe(false)
+    expect(boolRow!.jsonb_typeof).toBe('boolean')
+    const boolProfile = await prisma.capacityProfile.findUnique({ where: { id: profileBooleanId } })
+    expect(boolProfile!.legacy).toBe(true)
+  })
+})
+
+// ═════════════════════════════════════════════════════════════════════════════
+// Test count: 12 total (A:2, B:1, C:1, D:6, E:1, F:1)
+// All under describeIf — skipped when INTEGRATION_TEST is not 'true'.

--- a/server/src/test/snapshotRollback.integration.test.ts
+++ b/server/src/test/snapshotRollback.integration.test.ts
@@ -60,6 +60,7 @@ let prisma: PrismaClient
 let userId: string
 let token: string
 let authHeader: string
+let extraTemplateId: string | undefined
 beforeAll(async () => {
   if (!runIntegration) return
   prisma = new PrismaClient({
@@ -105,6 +106,9 @@ afterAll(async () => {
   await prisma.namedResource.deleteMany({
     where: { resourceType: { project: { ownerId: userId } } },
   })
+  if (extraTemplateId) {
+    await prisma.featureTemplate.delete({ where: { id: extraTemplateId } })
+  }
   await prisma.resourceType.deleteMany({ where: { project: { ownerId: userId } } })
   await prisma.project.deleteMany({ where: { ownerId: userId } })
   await prisma.user.delete({ where: { id: userId } })
@@ -915,8 +919,8 @@ describeIf('Scenario A — v3 round trip with full canonical state', () => {
   it('mutates all domains then rollback restores exact original state', async () => {
     // ── Mutate every captured domain ──────────────────────────────
 
-    // Add a post-snapshot role owner, named resource, compatibility allocation,
-    // and persisted profile. V3 rollback must remove this owner set entirely.
+    // Add post-snapshot owners, compatibility metadata, a profile, and a discount.
+    // V3 rollback must preserve these rows while replacing only captured profiles.
     extraRtId = await createResourceType(projectId, 'rt-extra', 'Post-snapshot role', {
       count: 1,
       hoursPerDay: 8,
@@ -948,6 +952,25 @@ describeIf('Scenario A — v3 round trip with full canonical state', () => {
     extraRoleDiscountId = await createDiscount(
       projectId, extraRtId, 'PERCENTAGE', 20, 'Post-snapshot role discount', 2,
     )
+    const extraTemplate = await prisma.featureTemplate.create({
+      data: {
+        name: `Snapshot extra owner template ${Date.now()}`,
+        category: 'DEV',
+      },
+    })
+    extraTemplateId = extraTemplate.id
+    await prisma.templateTask.create({
+      data: {
+        name: 'Post-snapshot template task',
+        order: 0,
+        hoursSmall: 8,
+        hoursMedium: 8,
+        hoursLarge: 8,
+        resourceTypeName: 'Post-snapshot role',
+        templateId: extraTemplate.id,
+        resourceTypeId: extraRtId,
+      },
+    })
 
     // Delete ROLE segments, add new ones
     await prisma.capacitySegment.deleteMany({ where: { capacityProfileId: profileRoleId } })
@@ -1120,15 +1143,29 @@ describeIf('Scenario A — v3 round trip with full canonical state', () => {
       where: { projectId },
       orderBy: { order: 'asc' },
     })
-    expect(discountsAfterRollback).toHaveLength(2)
-    expect(discountsAfterRollback.map(d => d.id)).toEqual([projectDiscountId, targetRoleDiscountId])
+    expect(discountsAfterRollback).toHaveLength(3)
+    expect(discountsAfterRollback.map(d => d.id)).toEqual([
+      projectDiscountId,
+      targetRoleDiscountId,
+      extraRoleDiscountId,
+    ])
     const restoredProjectDiscount = discountsAfterRollback.find(d => d.id === projectDiscountId)!
     expect(restoredProjectDiscount.resourceTypeId).toBeNull()
     expect(restoredProjectDiscount.label).toBe('Project-wide baseline')
     const restoredTargetDiscount = discountsAfterRollback.find(d => d.id === targetRoleDiscountId)!
     expect(restoredTargetDiscount.resourceTypeId).toBe(rtDevId)
     expect(restoredTargetDiscount.label).toBe('Developer baseline')
-    expect(discountsAfterRollback.find(d => d.id === extraRoleDiscountId)).toBeUndefined()
+    const restoredExtraDiscount = discountsAfterRollback.find(d => d.id === extraRoleDiscountId)!
+    expect(restoredExtraDiscount.resourceTypeId).toBe(extraRtId)
+    expect(restoredExtraDiscount.label).toBe('Post-snapshot role discount')
+    if (!extraTemplateId) throw new Error('Scenario A template fixture missing')
+    const preservedTemplateTask = await prisma.templateTask.findFirst({
+      where: { templateId: extraTemplateId },
+    })
+    expect(preservedTemplateTask).toMatchObject({
+      resourceTypeId: extraRtId,
+      resourceTypeName: 'Post-snapshot role',
+    })
 
     const rpAfterRollback = await request(app)
       .get(`/api/projects/${projectId}/resource-profile`)
@@ -1151,17 +1188,33 @@ describeIf('Scenario A — v3 round trip with full canonical state', () => {
       where: { projectId },
       orderBy: { name: 'asc' },
     })
-    expect(rts).toHaveLength(2)
+    expect(rts).toHaveLength(3)
     expect(rts.find(r => r.id === rtDevId)!.name).toBe('Developer')
-
-    // NRs: IDs preserved
+    expect(rts.find(r => r.id === extraRtId)).toMatchObject({
+      name: 'Post-snapshot role',
+      count: 1,
+      hoursPerDay: 8,
+      dayRate: 700,
+      allocationMode: 'TIMELINE',
+      allocationPercent: 45,
+      allocationStartWeek: 2,
+      allocationEndWeek: 7,
+    })
     const nrs = await prisma.namedResource.findMany({
       where: { resourceType: { projectId } },
     })
-    expect(nrs).toHaveLength(8)
+
+    // Named-resource ownership and allocation metadata are not pruned.
+    expect(nrs).toHaveLength(9)
     expect(nrs.find(n => n.id === nrAliceId)!.pricingModel).toBe('ACTUAL_DAYS')
-    expect(rts.find(r => r.id === extraRtId)).toBeUndefined()
-    expect(nrs.find(n => n.id === extraNrId)).toBeUndefined()
+    expect(nrs.find(n => n.id === extraNrId)).toMatchObject({
+      resourceTypeId: extraRtId,
+      name: 'Post-snapshot person',
+      allocationMode: 'TIMELINE',
+      allocationPercent: 45,
+      allocationStartWeek: 2,
+      allocationEndWeek: 7,
+    })
 
 
     const profiles = await prisma.capacityProfile.findMany({
@@ -1372,10 +1425,28 @@ describeIf('Scenario A — v3 round trip with full canonical state', () => {
     expect(overheads).toHaveLength(1)
     expect(overheads[0].value).toBe(15)
 
-    // ── Canonical deep comparison: every field matches pre-mutation state ──
+    // ── Canonical deep comparison: captured state restored, extra owners retained ──
     const canonicalAfter = await captureCanonicalState(projectId)
-    expect(canonicalAfter.resourceTypes).toEqual(canonicalBefore.resourceTypes)
-    expect(canonicalAfter.namedResources).toEqual(canonicalBefore.namedResources)
+    expect(canonicalAfter.resourceTypes.filter(r => r.id !== extraRtId))
+      .toEqual(canonicalBefore.resourceTypes)
+    expect(canonicalAfter.namedResources.filter(n => n.id !== extraNrId))
+      .toEqual(canonicalBefore.namedResources)
+    expect(canonicalAfter.resourceTypes).toHaveLength(canonicalBefore.resourceTypes.length + 1)
+    expect(canonicalAfter.namedResources).toHaveLength(canonicalBefore.namedResources.length + 1)
+    expect(canonicalAfter.resourceTypes.find(r => r.id === extraRtId)).toMatchObject({
+      name: 'Post-snapshot role',
+      dayRate: 700,
+      allocationPercent: 45,
+      allocationStartWeek: 2,
+      allocationEndWeek: 7,
+    })
+    expect(canonicalAfter.namedResources.find(n => n.id === extraNrId)).toMatchObject({
+      resourceTypeId: extraRtId,
+      name: 'Post-snapshot person',
+      allocationPercent: 45,
+      allocationStartWeek: 2,
+      allocationEndWeek: 7,
+    })
     expect(canonicalAfter.capacityProfiles).toEqual(canonicalBefore.capacityProfiles)
     expect(canonicalAfter.timelineEntries).toEqual(canonicalBefore.timelineEntries)
     expect(canonicalAfter.storyTimelineEntries).toEqual(canonicalBefore.storyTimelineEntries)
@@ -1402,11 +1473,6 @@ describeIf('Scenario A — v3 round trip with full canonical state', () => {
     const beforeTL = timelineBefore as Record<string, unknown>
     const afterRows = profileAfter.resourceRows as Array<Record<string, unknown>>
     const beforeRows = beforeRP.resourceRows as Array<Record<string, unknown>>
-    // The restored Resource Profile and Timeline DTOs must not resolve deleted
-    // post-snapshot owners through legacy fallback.
-    expect(afterRows.find(r => r.resourceTypeId === extraRtId)).toBeUndefined()
-    const afterTimelineNRs = timelineAfter.namedResources as Array<Record<string, unknown>>
-    expect(afterTimelineNRs.find(nr => nr.id === extraNrId)).toBeUndefined()
 
 
     // ── Role profile: PROFILE resolutionSource, exact restored segments, null fields ──

--- a/server/src/test/snapshotRollback.integration.test.ts
+++ b/server/src/test/snapshotRollback.integration.test.ts
@@ -702,7 +702,7 @@ describeIf('Scenario A — v3 round trip with full canonical state', () => {
     expect(data.capacityProfiles).toHaveLength(9)
 
     // ROLE — DB_NULL, 2 segments
-    const roleP = data.capacityProfiles.find(p => p.ownerKind === 'ROLE')
+    const roleP = data.capacityProfiles.find(p => p.id === profileRoleId)
     expect(roleP).toBeDefined()
     expect(roleP!.id).toBe(profileRoleId)
     expect(roleP!.resourceTypeId).toBe(rtDevId)
@@ -715,7 +715,7 @@ describeIf('Scenario A — v3 round trip with full canonical state', () => {
     expect(roleP!.segments[1].capacityPercent).toBe(50)
 
     // NAMED_PERSON — VALUE(object), 1 segment
-    const namedP = data.capacityProfiles.find(p => p.ownerKind === 'NAMED_PERSON')
+    const namedP = data.capacityProfiles.find(p => p.id === profileNamedId)
     expect(namedP).toBeDefined()
     expect(namedP!.id).toBe(profileNamedId)
     expect(namedP!.namedResourceId).toBe(nrAliceId)
@@ -1895,7 +1895,7 @@ describeIf('Scenario E — v2 rollback replaces stale persisted profiles', () =>
     })
 
     // Create NR inheriting TIMELINE mode at 60%
-    nrId = await createNamedResource(projectId, rtId, 'nr-eve', 'Eve', {
+    nrId = await createNamedResource(projectId, rtId, 'nr-eve-scenario-e', 'Eve', {
       allocationMode: 'TIMELINE',
       allocationPercent: 60,
       startWeek: 2,
@@ -2038,7 +2038,7 @@ describeIf('Scenario F — v1 rollback preserves profiles, restores backlog', ()
     if (!runIntegration) return
     projectId = await createProject()
     rtId = await createResourceType(projectId, 'rt-f-dev', 'Developer')
-    nrId = await createNamedResource(projectId, rtId, 'nr-frank', 'Frank')
+    nrId = await createNamedResource(projectId, rtId, 'nr-frank-scenario-f', 'Frank')
 
     // ROLE profile — DB_NULL legacy
     profileRoleId = await createProfile(

--- a/server/src/test/snapshotRollback.integration.test.ts
+++ b/server/src/test/snapshotRollback.integration.test.ts
@@ -87,6 +87,7 @@ afterAll(async () => {
   })
   await prisma.capacityProfile.deleteMany({ where: { project: { ownerId: userId } } })
   await prisma.projectOverhead.deleteMany({ where: { project: { ownerId: userId } } })
+  await prisma.projectDiscount.deleteMany({ where: { project: { ownerId: userId } } })
   await prisma.timelineEntry.deleteMany({ where: { project: { ownerId: userId } } })
   await prisma.storyTimelineEntry.deleteMany({ where: { project: { ownerId: userId } } })
   await prisma.epicDependency.deleteMany({ where: { epic: { project: { ownerId: userId } } } })
@@ -238,6 +239,58 @@ async function createSegment(
     },
   })
 }
+
+async function createDiscount(
+  projectId: string,
+  resourceTypeId: string | null,
+  type: 'PERCENTAGE' | 'FIXED_AMOUNT',
+  value: number,
+  label: string,
+  order: number,
+): Promise<string> {
+  const discount = await prisma.projectDiscount.create({
+    data: { projectId, resourceTypeId, type, value, label, order },
+  })
+  return discount.id
+}
+
+interface CommercialParity {
+  rows: Array<{
+    id: string
+    resourceTypeId: string
+    subtotal: number
+    netSubtotal: number
+    appliedDiscounts: Array<{
+      id: string
+      resourceTypeId: string | null
+      calculatedAmount: number
+    }>
+  }>
+  subtotal: number
+  projectDiscounts: Array<{
+    id: string
+    resourceTypeId: string | null
+    calculatedAmount: number
+  }>
+  totalProjectDiscount: number
+  afterDiscounts: number
+  grandTotal: number
+}
+
+async function computeCommercialData(
+  profile: unknown,
+  discounts: unknown[],
+  project: { taxRate: number | null; taxLabel: string },
+): Promise<CommercialParity> {
+  const modulePath = new URL('../../../client/src/utils/financialCalculations.ts', import.meta.url).href
+  const clientCalculations = await import(modulePath)
+  return clientCalculations.computeCommercialData(
+    profile as never,
+    discounts as never,
+    project,
+  ) as CommercialParity
+}
+
 /**
  * Canonical state type for deep comparison after v3 rollback.
  */
@@ -408,6 +461,10 @@ describeIf('Scenario A — v3 round trip with full canonical state', () => {
   let segmentArrayNull1: string
   let segmentString1: string
   let segmentBool1: string
+  let projectDiscountId: string
+  let targetRoleDiscountId: string
+  let extraRoleDiscountId: string
+  let commercialBefore: CommercialParity
   let canonicalBefore: CanonicalProjectState
   // HTTP response snapshots for read-parity assertions
   let resourceProfileBefore: unknown
@@ -653,6 +710,14 @@ describeIf('Scenario A — v3 round trip with full canonical state', () => {
       },
     })
 
+    // ── Baseline discounts: project-wide plus target-role ─────────
+    projectDiscountId = await createDiscount(
+      projectId, null, 'PERCENTAGE', 5, 'Project-wide baseline', 0,
+    )
+    targetRoleDiscountId = await createDiscount(
+      projectId, rtDevId, 'PERCENTAGE', 10, 'Developer baseline', 1,
+    )
+
     // ── Build and persist snapshot ────────────────────────────────
     const data = await buildSnapshot(projectId, prisma)
     const snap = await prisma.backlogSnapshot.create({
@@ -682,6 +747,20 @@ describeIf('Scenario A — v3 round trip with full canonical state', () => {
     timelineBefore = tlBefore.body
     expect(resourceProfileBefore).toHaveProperty('resourceRows')
     expect(timelineBefore).toHaveProperty('entries')
+
+    const projectTax = await prisma.project.findUnique({
+      where: { id: projectId },
+      select: { taxRate: true, taxLabel: true },
+    })
+    if (!projectTax) throw new Error('Scenario A project missing tax settings')
+    const discountsBefore = await prisma.projectDiscount.findMany({
+      where: { projectId },
+      orderBy: { order: 'asc' },
+    })
+    commercialBefore = await computeCommercialData(resourceProfileBefore, discountsBefore, projectTax)
+    expect(commercialBefore.projectDiscounts.map(d => d.id)).toEqual([projectDiscountId])
+    const baselineTargetRow = commercialBefore.rows.find(r => r.resourceTypeId === rtDevId)
+    expect(baselineTargetRow?.appliedDiscounts.map(d => d.id)).toContain(targetRoleDiscountId)
   })
 
   it('captured snapshot has all domains and exact values', async () => {
@@ -820,6 +899,9 @@ describeIf('Scenario A — v3 round trip with full canonical state', () => {
     // Add a post-snapshot role owner, named resource, compatibility allocation,
     // and persisted profile. V3 rollback must remove this owner set entirely.
     extraRtId = await createResourceType(projectId, 'rt-extra', 'Post-snapshot role', {
+      count: 1,
+      hoursPerDay: 8,
+      dayRate: 700,
       allocationMode: 'TIMELINE',
       allocationPercent: 45,
       allocationStartWeek: 2,
@@ -843,6 +925,24 @@ describeIf('Scenario A — v3 round trip with full canonical state', () => {
       Prisma.DbNull,
     )
     await createSegment(extraProfileId, 'seg-extra-owner', 2, 7, 45)
+
+    extraRoleDiscountId = await createDiscount(
+      projectId, extraRtId, 'PERCENTAGE', 20, 'Post-snapshot role discount', 2,
+    )
+    const existingStory = await prisma.userStory.findFirst({
+      where: { feature: { epic: { projectId } } },
+      select: { id: true },
+    })
+    if (!existingStory) throw new Error('Scenario A fixture story missing')
+    await prisma.task.create({
+      data: {
+        name: 'Post-snapshot role task',
+        userStoryId: existingStory.id,
+        order: 99,
+        hoursEffort: 8,
+        resourceTypeId: extraRtId,
+      },
+    })
 
     // Delete ROLE segments, add new ones
     await prisma.capacitySegment.deleteMany({ where: { capacityProfileId: profileRoleId } })
@@ -981,11 +1081,56 @@ describeIf('Scenario A — v3 round trip with full canonical state', () => {
     expect(aliceRPB.allocationStartWeek).toBe(1)
     expect(aliceRPB.allocationEndWeek).toBe(6)
 
+    const discountsB = await prisma.projectDiscount.findMany({
+      where: { projectId },
+      orderBy: { order: 'asc' },
+    })
+    const projectTaxB = await prisma.project.findUnique({
+      where: { id: projectId },
+      select: { taxRate: true, taxLabel: true },
+    })
+    if (!projectTaxB) throw new Error('Scenario A project missing tax settings in B-state')
+    const commercialB = await computeCommercialData(resourceProfileAfterMutation, discountsB, projectTaxB)
+    const extraCommercialRow = commercialB.rows.find(r => r.resourceTypeId === extraRtId)
+    expect(extraCommercialRow).toBeDefined()
+    expect(extraCommercialRow!.appliedDiscounts.map(d => d.id)).toContain(extraRoleDiscountId)
+    expect(commercialB.projectDiscounts.map(d => d.id)).not.toContain(extraRoleDiscountId)
+    expect(commercialB.grandTotal).not.toBe(commercialBefore.grandTotal)
+
     // ── Rollback ──────────────────────────────────────────────────
     await rollbackProjectSnapshot({ projectId, snapshotId, userId, db: prisma })
 
     // ── Verify exact restoration ──────────────────────────────────
 
+    const discountsAfterRollback = await prisma.projectDiscount.findMany({
+      where: { projectId },
+      orderBy: { order: 'asc' },
+    })
+    expect(discountsAfterRollback).toHaveLength(2)
+    expect(discountsAfterRollback.map(d => d.id)).toEqual([projectDiscountId, targetRoleDiscountId])
+    const restoredProjectDiscount = discountsAfterRollback.find(d => d.id === projectDiscountId)!
+    expect(restoredProjectDiscount.resourceTypeId).toBeNull()
+    expect(restoredProjectDiscount.label).toBe('Project-wide baseline')
+    const restoredTargetDiscount = discountsAfterRollback.find(d => d.id === targetRoleDiscountId)!
+    expect(restoredTargetDiscount.resourceTypeId).toBe(rtDevId)
+    expect(restoredTargetDiscount.label).toBe('Developer baseline')
+    expect(discountsAfterRollback.find(d => d.id === extraRoleDiscountId)).toBeUndefined()
+
+    const rpAfterRollback = await request(app)
+      .get(`/api/projects/${projectId}/resource-profile`)
+      .set('Authorization', authHeader)
+      .expect(200)
+    const projectTaxAfterRollback = await prisma.project.findUnique({
+      where: { id: projectId },
+      select: { taxRate: true, taxLabel: true },
+    })
+    if (!projectTaxAfterRollback) throw new Error('Scenario A project missing tax settings after rollback')
+    const commercialAfterRollback = await computeCommercialData(
+      rpAfterRollback.body,
+      discountsAfterRollback,
+      projectTaxAfterRollback,
+    )
+    expect(commercialAfterRollback).toEqual(commercialBefore)
     // RTs: IDs preserved, original names restored
     const rts = await prisma.resourceType.findMany({
       where: { projectId },

--- a/server/src/test/snapshotRollback.integration.test.ts
+++ b/server/src/test/snapshotRollback.integration.test.ts
@@ -271,7 +271,7 @@ interface CanonicalProjectState {
  * comparisons compare only restorable business fields.
  */
 function stripTimestamps<T extends Record<string, unknown>>(row: T): Omit<T, 'createdAt' | 'updatedAt'> {
-  const { createdAt, updatedAt, ...rest } = row
+  const { createdAt: _createdAt, updatedAt: _updatedAt, ...rest } = row
   return rest as Omit<T, 'createdAt' | 'updatedAt'>
 }
 

--- a/server/src/test/snapshotRollback.integration.test.ts
+++ b/server/src/test/snapshotRollback.integration.test.ts
@@ -361,6 +361,7 @@ describeIf('Scenario A — v3 round trip with full canonical state', () => {
   let rtDesId: string
   let nrAliceId: string
   let nrCharlieId: string
+  let nrDaveId: string
   let profileRoleId: string
   let profileNamedId: string
   let profilePlannedId: string
@@ -409,6 +410,11 @@ describeIf('Scenario A — v3 round trip with full canonical state', () => {
       projectId, rtDevId, 'nr-charlie', 'Charlie',
       { allocationMode: 'TIMELINE', allocationPercent: 100, pricingModel: 'FIXED_PRICE' },
     )
+    // ── 4th named resource for synthetic PLANNED_RESOURCE ownership ──
+    nrDaveId = await createNamedResource(
+      projectId, rtDevId, 'nr-dave', 'Dave',
+      { allocationMode: 'TIMELINE', allocationPercent: 100, pricingModel: 'FIXED_PRICE' },
+    )
 
     // ── ROLE profile for Developer — DB_NULL legacy ───────────────
     profileRoleId = await createProfile(
@@ -445,7 +451,7 @@ describeIf('Scenario A — v3 round trip with full canonical state', () => {
     // ── PLANNED_RESOURCE (synthetic) — VALUE(number) legacy ───────
     // Discontinuous, overlapping, and >100% segments to test fidelity
     profilePlannedId = await createProfile(
-      projectId, 'prof-planned', 'PLANNED_RESOURCE', null, null,
+      projectId, 'prof-planned', 'PLANNED_RESOURCE', null, nrDaveId,
       {
         planningBasis: 'CAPACITY_PROFILE',
         source: 'DERIVED',
@@ -562,7 +568,7 @@ describeIf('Scenario A — v3 round trip with full canonical state', () => {
     expect(data.resourceTypes[0].id).toBe(rtDevId)
 
     // Named resources
-    expect(data.namedResources).toHaveLength(3)
+    expect(data.namedResources).toHaveLength(4)
     const alice = data.namedResources.find(n => n.name === 'Alice')
     expect(alice).toBeDefined()
     expect(alice!.pricingModel).toBe('ACTUAL_DAYS')
@@ -735,7 +741,7 @@ describeIf('Scenario A — v3 round trip with full canonical state', () => {
     const nrs = await prisma.namedResource.findMany({
       where: { resourceType: { projectId } },
     })
-    expect(nrs).toHaveLength(3)
+    expect(nrs).toHaveLength(4)
     expect(nrs.find(n => n.id === nrAliceId)!.pricingModel).toBe('ACTUAL_DAYS')
 
     // Exactly 4 profiles restored, no extras

--- a/server/src/test/snapshotRollback.integration.test.ts
+++ b/server/src/test/snapshotRollback.integration.test.ts
@@ -870,8 +870,8 @@ describeIf('Scenario A — v3 round trip with full canonical state', () => {
     const devRow = afterRows.find(r => r.resourceTypeId === rtDevId)!
     const devCp = devRow.capacityProfile as Record<string, unknown>
     expect(devCp.resolutionSource).toBe('PROFILE')
-    expect(devCp.planningBasis).toBe('DEMAND_FOLLOWING')
-    expect(devCp.source).toBe('MANUAL')
+    expect(devCp.planningBasis).toBe('demandFollowing')
+    expect(devCp.source).toBe('manual')
     expect(devCp.defaultPercent).toBeNull()
     expect(devCp.startWeek).toBeNull()
     expect(devCp.endWeek).toBeNull()
@@ -886,8 +886,8 @@ describeIf('Scenario A — v3 round trip with full canonical state', () => {
     expect(aliceRow.resourceIdentity).toBe('NAMED_PERSON')
     const aliceCp = aliceRow.capacityProfile as Record<string, unknown>
     expect(aliceCp.resolutionSource).toBe('PROFILE')
-    expect(aliceCp.planningBasis).toBe('AVAILABILITY_WINDOW')
-    expect(aliceCp.source).toBe('SQUAD_PLANNER')
+    expect(aliceCp.planningBasis).toBe('availabilityWindow')
+    expect(aliceCp.source).toBe('squadPlanner')
     expect(aliceCp.defaultPercent).toBe(100)
     expect(aliceCp.startWeek).toBe(2)
     expect(aliceCp.endWeek).toBe(8)

--- a/server/src/test/snapshotRollback.integration.test.ts
+++ b/server/src/test/snapshotRollback.integration.test.ts
@@ -624,10 +624,14 @@ describeIf('Scenario A — v3 round trip with full canonical state', () => {
     await prisma.capacitySegment.deleteMany({ where: { capacityProfileId: profileRoleId } })
     await createSegment(profileRoleId, 'seg-mutated-1', 10, 15, 30)
 
-    // Change NAMED_PERSON profile fields
+    // Change NAMED_PERSON profile fields for B-state (different startWeek/endWeek, 50% segment)
     await prisma.capacityProfile.update({
       where: { id: profileNamedId },
-      data: { planningBasis: 'WHOLE_PROJECT_ALLOCATION', defaultPercent: 50 },
+      data: { defaultPercent: 50, startWeek: 1, endWeek: 6 },
+    })
+    await prisma.capacitySegment.update({
+      where: { id: segmentNamed1 },
+      data: { startWeek: 1, endWeek: 6, capacityPercent: 50 },
     })
 
     // Delete PLANNED_RESOURCE profile entirely
@@ -651,11 +655,18 @@ describeIf('Scenario A — v3 round trip with full canonical state', () => {
     const newFeature = await prisma.feature.create({
       data: { name: 'Mutated Feature', epicId: newEpic.id, order: 0 },
     })
-    await prisma.userStory.create({
+    const newStory = await prisma.userStory.create({
       data: { name: 'Mutated Story', featureId: newFeature.id, order: 0 },
     })
-
-    // Clear timelines
+    await prisma.task.create({
+      data: {
+        name: 'Mutated Task',
+        userStoryId: newStory.id,
+        order: 0,
+        hoursEffort: 8,
+        resourceTypeId: rtDevId,
+      },
+    })
     await prisma.timelineEntry.deleteMany({ where: { projectId } })
     await prisma.storyTimelineEntry.deleteMany({ where: { projectId } })
 
@@ -988,6 +999,13 @@ describeIf('Scenario B — rollback chaining (A→B→rollback A→pre_rollback 
     }
     await createSegment('prof-b-a', 'seg-b-1', 1, 4, 75)
     await createSegment('prof-b-a', 'seg-b-2', 5, 8, 50)
+    // ── Backlog for route rendering (not part of snapshot, just for HTTP response) ──
+    const bEpic = await prisma.epic.create({ data: { name: 'B Epic', projectId, order: 0 } })
+    const bFeature = await prisma.feature.create({ data: { name: 'B Feature', epicId: bEpic.id, order: 0 } })
+    const bStory = await prisma.userStory.create({ data: { name: 'B Story', featureId: bFeature.id, order: 0 } })
+    await prisma.task.create({
+      data: { name: 'B Task', userStoryId: bStory.id, order: 0, hoursEffort: 8, resourceTypeId: rtId },
+    })
   })
 
   it('rollback to A, verify pre_rollback captures B, rollback pre_rollback to restore B', async () => {
@@ -999,7 +1017,7 @@ describeIf('Scenario B — rollback chaining (A→B→rollback A→pre_rollback 
     // B-state ROLE profile: AVAILABILITY_WINDOW, 75%, with segments
     const bRoleRow = (rpB.body.resourceRows as Array<Record<string, unknown>>).find(r => r.resourceTypeId === rtId)!
     const bRoleCp = bRoleRow.capacityProfile as Record<string, unknown>
-    expect(bRoleCp.planningBasis).toBe('AVAILABILITY_WINDOW')
+    expect(bRoleCp.planningBasis).toBe('availabilityWindow')
     expect(bRoleCp.defaultPercent).toBe(75)
     expect(bRoleCp.segments).toHaveLength(2)
     const tlB = await request(app)

--- a/server/src/test/snapshotRollback.integration.test.ts
+++ b/server/src/test/snapshotRollback.integration.test.ts
@@ -266,6 +266,15 @@ interface CanonicalProjectState {
   dbNullProfileIds: string[]
 }
 
+/**
+ * Strip database-managed timestamps from raw Prisma rows so canonical
+ * comparisons compare only restorable business fields.
+ */
+function stripTimestamps<T extends Record<string, unknown>>(row: T): Omit<T, 'createdAt' | 'updatedAt'> {
+  const { createdAt, updatedAt, ...rest } = row
+  return rest as Omit<T, 'createdAt' | 'updatedAt'>
+}
+
 async function captureCanonicalState(projectId: string): Promise<CanonicalProjectState> {
   const [resourceTypes, namedResources, capacityProfiles, timelineEntries, storyTimelineEntries, overheadItems] = await Promise.all([
     prisma.resourceType.findMany({ where: { projectId }, orderBy: { id: 'asc' } }),
@@ -280,7 +289,18 @@ async function captureCanonicalState(projectId: string): Promise<CanonicalProjec
     prisma.projectOverhead.findMany({ where: { projectId }, orderBy: { id: 'asc' } }),
   ])
   const dbNullIds = Array.from(await detectDbNullProfileIds(projectId))
-  return { resourceTypes, namedResources, capacityProfiles, timelineEntries, storyTimelineEntries, overheadItems, dbNullProfileIds: dbNullIds }
+  return {
+    resourceTypes,
+    namedResources: namedResources.map(stripTimestamps),
+    capacityProfiles: capacityProfiles.map(p => ({
+      ...stripTimestamps(p),
+      segments: p.segments.map(s => stripTimestamps(s)),
+    })),
+    timelineEntries: timelineEntries.map(stripTimestamps),
+    storyTimelineEntries: storyTimelineEntries.map(stripTimestamps),
+    overheadItems: overheadItems.map(stripTimestamps),
+    dbNullProfileIds: dbNullIds,
+  }
 }
 
 
@@ -602,9 +622,9 @@ describeIf('Scenario A — v3 round trip with full canonical state', () => {
     expect(namedP!.segments).toHaveLength(1)
 
     // PLANNED_RESOURCE — VALUE(number), 3 segments
-    const plannedP = data.capacityProfiles.find(p => p.ownerKind === 'PLANNED_RESOURCE')
+    const plannedP = data.capacityProfiles.find(p => p.id === profilePlannedId)
     expect(plannedP).toBeDefined()
-    expect(plannedP!.id).toBe(profilePlannedId)
+    expect(plannedP!.ownerKind).toBe('PLANNED_RESOURCE')
     expect(plannedP!.legacy.kind).toBe('VALUE')
     if (plannedP!.legacy.kind === 'VALUE') {
       expect(plannedP!.legacy.value).toBe(42)

--- a/server/src/test/snapshotRollback.integration.test.ts
+++ b/server/src/test/snapshotRollback.integration.test.ts
@@ -257,6 +257,8 @@ async function createDiscount(
 interface CommercialParity {
   rows: Array<{
     id: string
+    name: string
+    kind: 'resource' | 'named-resource' | 'overhead'
     resourceTypeId: string
     subtotal: number
     netSubtotal: number
@@ -275,6 +277,21 @@ interface CommercialParity {
   totalProjectDiscount: number
   afterDiscounts: number
   grandTotal: number
+}
+
+function normalizeCommercialParity(data: CommercialParity): CommercialParity {
+  return {
+    ...data,
+    rows: data.rows.map(row => row.kind === 'overhead'
+      ? {
+          ...row,
+          // V3 snapshots intentionally omit ProjectOverhead IDs, so rollback
+          // recreates this row with a new ID. Compare overheads by stable name.
+          id: `overhead:${row.name}`,
+          resourceTypeId: `overhead:${row.name}`,
+        }
+      : row),
+  }
 }
 
 async function computeCommercialData(
@@ -1127,7 +1144,8 @@ describeIf('Scenario A — v3 round trip with full canonical state', () => {
       discountsAfterRollback,
       projectTaxAfterRollback,
     )
-    expect(commercialAfterRollback).toEqual(commercialBefore)
+    expect(normalizeCommercialParity(commercialAfterRollback))
+      .toEqual(normalizeCommercialParity(commercialBefore))
     // RTs: IDs preserved, original names restored
     const rts = await prisma.resourceType.findMany({
       where: { projectId },

--- a/server/src/test/snapshots.test.ts
+++ b/server/src/test/snapshots.test.ts
@@ -973,12 +973,28 @@ describe('POST /api/projects/:projectId/snapshots/:snapshotId/rollback', () => {
     const cpCreate = vi.fn().mockResolvedValue({})
     const segCreate = vi.fn().mockResolvedValue({})
     const bsCreate = vi.fn().mockResolvedValue({})
+    const resourceTypeDelete = vi.fn()
+    const namedResourceDelete = vi.fn()
+    const discountDelete = vi.fn()
+    const templateTaskUpdate = vi.fn()
 
     vi.mocked(prisma.$transaction).mockImplementation(async (fn: unknown) => {
       const tx = makeRouteTx({
         capacityProfile: { findMany: vi.fn().mockResolvedValue([]), deleteMany: cpDelete, create: cpCreate },
         capacitySegment: { deleteMany: segDelete, create: segCreate },
         backlogSnapshot: { create: bsCreate, findMany: vi.fn().mockResolvedValue([]), deleteMany: vi.fn().mockResolvedValue({ count: 0 }) },
+        resourceType: {
+          findMany: vi.fn().mockResolvedValue([]),
+          upsert: vi.fn().mockResolvedValue({}),
+          deleteMany: resourceTypeDelete,
+        },
+        namedResource: {
+          findMany: vi.fn().mockResolvedValue([]),
+          upsert: vi.fn().mockResolvedValue({}),
+          deleteMany: namedResourceDelete,
+        },
+        projectDiscount: { findMany: vi.fn().mockResolvedValue([]), deleteMany: discountDelete },
+        templateTask: { updateMany: templateTaskUpdate },
       })
       return typeof fn === 'function'
         ? (fn as (t: unknown) => Promise<unknown>)(tx)
@@ -997,6 +1013,11 @@ describe('POST /api/projects/:projectId/snapshots/:snapshotId/rollback', () => {
     // Existing profiles/segments deleted
     expect(cpDelete.mock.calls.length).toBeGreaterThanOrEqual(1)
     expect(segDelete.mock.calls.length).toBeGreaterThanOrEqual(1)
+    // V3 never prunes owners or mutates uncaptured commercial/template state.
+    expect(resourceTypeDelete).not.toHaveBeenCalled()
+    expect(namedResourceDelete).not.toHaveBeenCalled()
+    expect(discountDelete).not.toHaveBeenCalled()
+    expect(templateTaskUpdate).not.toHaveBeenCalled()
 
     // Target profiles recreated with exact IDs and fields
     expect(cpCreate.mock.calls.length).toBe(2)
@@ -1037,172 +1058,6 @@ describe('POST /api/projects/:projectId/snapshots/:snapshotId/rollback', () => {
     expect(seg1.source).toBe('SQUAD_PLANNER')
   })
 
-  interface PruningDiscountRow {
-    id: string
-    projectId: string
-    resourceTypeId: string | null
-  }
-
-
-  async function runPruningRollback(
-    existingResourceTypes: Array<{ id: string; projectId: string }>,
-    namedResources: Array<{ id: string; resourceType: { projectId: string } }> = [],
-    failDiscountDelete = false,
-    discountRows: PruningDiscountRow[] = [],
-  ) {
-    const v3Target: SnapshotV3 = {
-      schemaVersion: 3, epics: [], project: null,
-      resourceTypes: [{
-        id: 'rt-target', name: 'Developer', category: 'ENGINEERING', count: 1,
-        hoursPerDay: 8, dayRate: 500, globalTypeId: null,
-        allocationMode: 'TIMELINE', allocationPercent: 100,
-        allocationStartWeek: 0, allocationEndWeek: 10,
-      }],
-      namedResources: [],
-      timelineEntries: [], storyTimelineEntries: [],
-      epicDependencies: [], featureDependencies: [], overheadItems: [],
-      capacityProfiles: [],
-    }
-
-    vi.mocked(prisma.project.findFirst).mockResolvedValue({ id: projId, ownerId: userId } as never)
-    vi.mocked(prisma.backlogSnapshot.findFirst).mockResolvedValue({
-      id: 'snap-v3-pruning', projectId: projId, label: 'V3 pruning',
-      trigger: 'manual', snapshot: v3Target as unknown as never,
-      createdById: userId, createdAt: new Date(),
-    } as never)
-    vi.mocked(prisma.resourceType.findMany).mockResolvedValue(existingResourceTypes as never)
-    vi.mocked(prisma.namedResource.findMany).mockResolvedValue(namedResources as never)
-
-    const remainingDiscounts = [...discountRows]
-    const discountDelete = vi.fn()
-    if (failDiscountDelete) {
-      discountDelete.mockRejectedValue(new Error('discount deletion failed'))
-    } else {
-      discountDelete.mockImplementation(async (args: {
-        where: { projectId: string; resourceTypeId: { in: string[] } }
-      }) => {
-        const deleted = remainingDiscounts.filter(discount =>
-          discount.projectId === args.where.projectId
-          && typeof discount.resourceTypeId === 'string'
-          && args.where.resourceTypeId.in.includes(discount.resourceTypeId),
-        )
-        for (const discount of deleted) {
-          const index = remainingDiscounts.indexOf(discount)
-          if (index >= 0) remainingDiscounts.splice(index, 1)
-        }
-        return { count: deleted.length }
-      })
-    }
-    const resourceTypeDelete = vi.fn().mockResolvedValue({ count: 0 })
-    const txResourceTypeFindMany = vi.fn().mockImplementation((args: {
-      where?: { id?: { notIn?: string[] } }
-    }) => {
-      const excludedIds = args.where?.id?.notIn ?? []
-      return Promise.resolve(existingResourceTypes.filter(rt => !excludedIds.includes(rt.id)))
-    })
-    vi.mocked(prisma.$transaction).mockImplementation(async (fn: unknown) => {
-      const tx = makeRouteTx({
-        resourceType: {
-          findMany: txResourceTypeFindMany,
-          upsert: vi.fn().mockResolvedValue({}),
-          deleteMany: resourceTypeDelete,
-        },
-        namedResource: {
-          findMany: vi.fn().mockResolvedValue(namedResources),
-          upsert: vi.fn().mockResolvedValue({}),
-        },
-        projectDiscount: { findMany: vi.fn().mockResolvedValue([]), deleteMany: discountDelete },
-      })
-      return typeof fn === 'function'
-        ? (fn as (t: unknown) => Promise<unknown>)(tx)
-        : Promise.resolve(fn)
-    })
-
-    const response = await request(app)
-      .post(`/api/projects/${projId}/snapshots/snap-v3-pruning/rollback`)
-      .set('Authorization', authHeader)
-
-    return { response, discountDelete, resourceTypeDelete, remainingDiscounts }
-  }
-
-  it('V3 pruning deletes role discounts for non-target ResourceTypes', async () => {
-    const { response, discountDelete, remainingDiscounts } = await runPruningRollback([
-      { id: 'rt-target', projectId: projId },
-      { id: 'rt-extra', projectId: projId },
-    ], [], false, [
-      { id: 'discount-extra', projectId: projId, resourceTypeId: 'rt-extra' },
-      { id: 'discount-foreign', projectId: 'project-other', resourceTypeId: 'rt-extra' },
-    ])
-
-    expect(response.status).toBe(200)
-    expect(discountDelete).toHaveBeenCalledWith({
-      where: {
-        projectId: projId,
-        resourceTypeId: { in: ['rt-extra'] },
-      },
-    })
-    expect(remainingDiscounts).toEqual([
-      { id: 'discount-foreign', projectId: 'project-other', resourceTypeId: 'rt-extra' },
-    ])
-  })
-
-  it('V3 pruning preserves target-role discounts', async () => {
-    const { response, discountDelete, remainingDiscounts } = await runPruningRollback([
-      { id: 'rt-target', projectId: projId },
-    ], [], false, [
-      { id: 'discount-target', projectId: projId, resourceTypeId: 'rt-target' },
-    ])
-
-    expect(response.status).toBe(200)
-    expect(discountDelete).not.toHaveBeenCalled()
-    expect(remainingDiscounts).toEqual([
-      { id: 'discount-target', projectId: projId, resourceTypeId: 'rt-target' },
-    ])
-  })
-
-  it('V3 pruning preserves project-wide discounts', async () => {
-    const { response, discountDelete, remainingDiscounts } = await runPruningRollback([
-      { id: 'rt-target', projectId: projId },
-    ], [], false, [
-      { id: 'discount-project', projectId: projId, resourceTypeId: null },
-    ])
-
-    expect(response.status).toBe(200)
-    expect(discountDelete).not.toHaveBeenCalled()
-    expect(remainingDiscounts).toEqual([
-      { id: 'discount-project', projectId: projId, resourceTypeId: null },
-    ])
-  })
-
-  it('V3 pruning scopes discount deletion to the rolled-back project', async () => {
-    const { response, discountDelete } = await runPruningRollback([
-      { id: 'rt-target', projectId: projId },
-      { id: 'rt-extra', projectId: projId },
-    ])
-
-    expect(response.status).toBe(200)
-    expect(discountDelete.mock.calls[0][0].where.projectId).toBe(projId)
-    expect(discountDelete.mock.calls[0][0].where.resourceTypeId).toEqual({ in: ['rt-extra'] })
-  })
-
-  it('V3 pruning performs no discount deletion when no ResourceTypes are pruned', async () => {
-    const { response, discountDelete } = await runPruningRollback([
-      { id: 'rt-target', projectId: projId },
-    ])
-
-    expect(response.status).toBe(200)
-    expect(discountDelete).not.toHaveBeenCalled()
-  })
-
-  it('V3 pruning aborts the rollback when discount deletion fails', async () => {
-    const { response, resourceTypeDelete } = await runPruningRollback([
-      { id: 'rt-target', projectId: projId },
-      { id: 'rt-extra', projectId: projId },
-    ], [], true)
-
-    expect(response.status).toBe(500)
-    expect(resourceTypeDelete).not.toHaveBeenCalled()
-  })
 
   // ═════════════════════════════════════════════════════════════════════════
   // 6. Pre-flight validation (before transaction)

--- a/server/src/test/snapshots.test.ts
+++ b/server/src/test/snapshots.test.ts
@@ -1,0 +1,1115 @@
+/**
+ * snapshots.test.ts — Server tests for snapshot creation and rollback.
+ *
+ * Tests v3 buildSnapshot, pure v3 helpers, and the rollback route's
+ * v1/v2/v3 paths including pre-flight validation, cross-project checks,
+ * and atomic transaction rollback.
+ *
+ * Covers:
+ *  - Pure parser tests (parseSnapshotData, type guards)
+ *  - Pure validation tests (validateSnapshotV3, sort helpers)
+ *  - buildSnapshot v3 creation with mock db parameter (returns schemaVersion 3)
+ *  - V1/V2/V3 route rollback
+ *  - Pre-flight validation: invalid v3, unknown schema, cross-project IDs
+ *  - Transaction atomicity (failure rejects with 500)
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import request from 'supertest'
+import jwt from 'jsonwebtoken'
+import { app } from '../index.js'
+import { prisma } from '../lib/prisma.js'
+import {
+  parseSnapshotData,
+  SnapshotSchemaError,
+  isSnapshotV2,
+  isSnapshotV3,
+  type SnapshotV2,
+  type SnapshotV3,
+} from '../lib/projectSnapshotTypes.js'
+import {
+  validateSnapshotV3,
+  SnapshotValidationError,
+  sortSnapshotProfiles,
+  sortSnapshotSegments,
+} from '../lib/projectSnapshotValidation.js'
+import { buildSnapshot } from '../routes/snapshots.js'
+process.env.JWT_SECRET = 'test-secret'
+
+const userId = 'user-1'
+const token = jwt.sign({ userId }, 'test-secret')
+const authHeader = `Bearer ${token}`
+const projId = 'proj-1'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 1. Pure parser tests (from projectSnapshotTypes.ts)
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('parseSnapshotData', () => {
+  it('parses a bare array as V1', () => {
+    const data = parseSnapshotData([{ id: 'e1', name: 'Epic 1', features: [] }])
+    expect(Array.isArray(data)).toBe(true)
+  })
+
+  it('parses schemaVersion 2 explicitly', () => {
+    const v2: SnapshotV2 = {
+      schemaVersion: 2,
+      epics: [],
+      project: null,
+      resourceTypes: [],
+      namedResources: [],
+      timelineEntries: [],
+      storyTimelineEntries: [],
+      epicDependencies: [],
+      featureDependencies: [],
+      overheadItems: [],
+    }
+    const result = parseSnapshotData(v2 as unknown as Record<string, unknown>)
+    expect((result as SnapshotV2).schemaVersion).toBe(2)
+    expect(isSnapshotV2(result)).toBe(true)
+  })
+
+  it('parses schemaVersion 3 explicitly', () => {
+    const v3: SnapshotV3 = {
+      schemaVersion: 3,
+      epics: [],
+      project: null,
+      resourceTypes: [],
+      namedResources: [],
+      timelineEntries: [],
+      storyTimelineEntries: [],
+      epicDependencies: [],
+      featureDependencies: [],
+      overheadItems: [],
+      capacityProfiles: [],
+    }
+    const result = parseSnapshotData(v3 as unknown as Record<string, unknown>)
+    expect(isSnapshotV3(result)).toBe(true)
+    if (isSnapshotV3(result)) {
+      expect(result.schemaVersion).toBe(3)
+      expect(Array.isArray(result.capacityProfiles)).toBe(true)
+    }
+  })
+
+  it('throws SnapshotSchemaError for unknown schemaVersion 99', () => {
+    expect(() =>
+      parseSnapshotData({ schemaVersion: 99, epics: [], resourceTypes: [], namedResources: [], timelineEntries: [], storyTimelineEntries: [], epicDependencies: [], featureDependencies: [], overheadItems: [] }),
+    ).toThrow(SnapshotSchemaError)
+  })
+
+  it('throws SnapshotSchemaError for null input', () => {
+    expect(() => parseSnapshotData(null)).toThrow(SnapshotSchemaError)
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 2. Pure validation tests (from projectSnapshotValidation.ts)
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('validateSnapshotV3', () => {
+  /** Minimal valid V3 fixture for tests that mutate a copy. */
+  function makeBaseV3(): SnapshotV3 {
+    return {
+      schemaVersion: 3,
+      epics: [],
+      project: null,
+      resourceTypes: [
+        {
+          id: 'rt-dev', name: 'Developer', category: 'role', count: 2,
+          hoursPerDay: 8, dayRate: 500, globalTypeId: null,
+          allocationMode: 'TIMELINE', allocationPercent: 100,
+          allocationStartWeek: 0, allocationEndWeek: 10,
+        },
+      ],
+      namedResources: [
+        {
+          id: 'nr-alice', resourceTypeId: 'rt-dev', name: 'Alice',
+          startWeek: null, endWeek: null, allocationPct: 100,
+          allocationMode: 'EFFORT', allocationPercent: 100,
+          allocationStartWeek: null, allocationEndWeek: null,
+          pricingModel: 'ACTUAL_DAYS',
+        },
+      ],
+      timelineEntries: [],
+      storyTimelineEntries: [],
+      epicDependencies: [],
+      featureDependencies: [],
+      overheadItems: [],
+      capacityProfiles: [
+        {
+          id: 'cp-1',
+          ownerKind: 'ROLE',
+          resourceTypeId: 'rt-dev',
+          namedResourceId: null,
+          planningBasis: 'DEMAND_FOLLOWING',
+          source: 'FIXED',
+          defaultPercent: null,
+          startWeek: null,
+          endWeek: null,
+          legacy: null,
+          segments: [],
+        },
+        {
+          id: 'cp-2',
+          ownerKind: 'NAMED_PERSON',
+          resourceTypeId: null,
+          namedResourceId: 'nr-alice',
+          planningBasis: 'AVAILABILITY_WINDOW',
+          source: 'SQUAD_PLANNER',
+          defaultPercent: 100,
+          startWeek: 0,
+          endWeek: 10,
+          legacy: { allocationMode: 'EFFORT' },
+          segments: [
+            { id: 'seg-1', startWeek: 0, endWeek: 4, capacityPercent: 100, source: 'SQUAD_PLANNER' },
+          ],
+        },
+      ],
+    }
+  }
+
+  it('rejects missing ROLE resourceTypeId', () => {
+    const snap = makeBaseV3()
+    snap.capacityProfiles[0].resourceTypeId = null
+    expect(() => validateSnapshotV3(snap)).toThrow(SnapshotValidationError)
+  })
+
+  it('rejects missing NAMED_PERSON namedResourceId', () => {
+    const snap = makeBaseV3()
+    snap.capacityProfiles[1].namedResourceId = null
+    expect(() => validateSnapshotV3(snap)).toThrow(SnapshotValidationError)
+  })
+
+  it('rejects ROLE with non-null namedResourceId', () => {
+    const snap = makeBaseV3()
+    snap.capacityProfiles[0].namedResourceId = 'nr-alice'
+    expect(() => validateSnapshotV3(snap)).toThrow(SnapshotValidationError)
+  })
+
+  it('rejects unsupported planningBasis enum', () => {
+    const snap = makeBaseV3()
+    ;(snap.capacityProfiles[1] as Record<string, unknown>).planningBasis = 'UNSUPPORTED_BASIS'
+    expect(() => validateSnapshotV3(snap)).toThrow(SnapshotValidationError)
+  })
+
+  it('rejects invalid segment range (endWeek < startWeek)', () => {
+    const snap = makeBaseV3()
+    snap.capacityProfiles[1].segments[0].endWeek = -1
+    expect(() => validateSnapshotV3(snap)).toThrow(SnapshotValidationError)
+  })
+
+  it('rejects duplicate profile ID', () => {
+    const snap = makeBaseV3()
+    snap.capacityProfiles.push({ ...snap.capacityProfiles[0], id: 'cp-1', segments: [] })
+    expect(() => validateSnapshotV3(snap)).toThrow(/duplicate profile id/)
+  })
+
+  it('rejects duplicate segment ID', () => {
+    const snap = makeBaseV3()
+    const segs = snap.capacityProfiles[1].segments
+    segs.push({
+      id: segs[0].id,
+      startWeek: 10,
+      endWeek: 12,
+      capacityPercent: 50,
+      source: 'MANUAL',
+    })
+    expect(() => validateSnapshotV3(snap)).toThrow(/duplicate segment id/)
+  })
+
+  it('accepts duplicate owner identities', () => {
+    const snap = makeBaseV3()
+    snap.capacityProfiles.push({
+      id: 'cp-3',
+      ownerKind: 'ROLE',
+      resourceTypeId: 'rt-dev',
+      namedResourceId: null,
+      planningBasis: 'AVAILABILITY_WINDOW',
+      source: 'MANUAL',
+      defaultPercent: 50,
+      startWeek: 2,
+      endWeek: 6,
+      legacy: null,
+      segments: [],
+    })
+    // Two ROLE profiles with same resourceTypeId — allowed
+    expect(() => validateSnapshotV3(snap)).not.toThrow()
+  })
+
+  it('accepts discontinuous / overlapping segments', () => {
+    const snap = makeBaseV3()
+    snap.capacityProfiles[1].segments = [
+      { id: 's1', startWeek: 0, endWeek: 4, capacityPercent: 100, source: 'SQUAD_PLANNER' },
+      { id: 's2', startWeek: 8, endWeek: 12, capacityPercent: 80, source: 'SQUAD_PLANNER' },  // gap
+      { id: 's3', startWeek: 3, endWeek: 6, capacityPercent: 50, source: 'SQUAD_PLANNER' },  // overlap
+    ]
+    expect(() => validateSnapshotV3(snap)).not.toThrow()
+  })
+
+  it('accepts >100% capacity in segments', () => {
+    const snap = makeBaseV3()
+    snap.capacityProfiles[1].segments[0].capacityPercent = 150
+    expect(() => validateSnapshotV3(snap)).not.toThrow()
+  })
+
+  it('accepts null legacy field', () => {
+    const snap = makeBaseV3()
+    snap.capacityProfiles[0].legacy = null
+    expect(() => validateSnapshotV3(snap)).not.toThrow()
+  })
+
+  it('accepts fractional profile/segment weeks', () => {
+    const snap = makeBaseV3()
+    const cp = snap.capacityProfiles[1]
+    cp.startWeek = 1.5
+    cp.endWeek = 8.75
+    cp.segments = [
+      { id: 'seg-frac', startWeek: 2.5, endWeek: 7.25, capacityPercent: 100, source: 'SQUAD_PLANNER' },
+    ]
+    expect(() => validateSnapshotV3(snap)).not.toThrow()
+  })
+
+  it('rejects empty resourceType id', () => {
+    const snap = makeBaseV3()
+    snap.resourceTypes[0].id = ''
+    expect(() => validateSnapshotV3(snap)).toThrow(SnapshotValidationError)
+  })
+
+  it('rejects duplicate resourceType id', () => {
+    const snap = makeBaseV3()
+    snap.resourceTypes.push({ ...snap.resourceTypes[0], id: 'rt-dev', name: 'Duplicate' })
+    expect(() => validateSnapshotV3(snap)).toThrow(/duplicate resourceType id/)
+  })
+
+  it('rejects empty namedResource id', () => {
+    const snap = makeBaseV3()
+    snap.namedResources[0].id = ''
+    expect(() => validateSnapshotV3(snap)).toThrow(SnapshotValidationError)
+  })
+
+  it('rejects duplicate namedResource id', () => {
+    const snap = makeBaseV3()
+    snap.namedResources.push({ ...snap.namedResources[0], id: 'nr-alice', resourceTypeId: 'rt-dev', name: 'Duplicate' })
+    expect(() => validateSnapshotV3(snap)).toThrow(/duplicate namedResource id/)
+  })
+
+  it('rejects namedResource referencing missing resourceTypeId', () => {
+    const snap = makeBaseV3()
+    snap.namedResources[0].resourceTypeId = 'rt-nonexistent'
+    expect(() => validateSnapshotV3(snap)).toThrow(/not found in snapshot.resourceTypes/)
+  })
+
+  it('rejects overhead item referencing missing resourceTypeId', () => {
+    const snap = makeBaseV3()
+    snap.overheadItems.push({
+      name: 'PM', type: 'percent', value: 10, resourceTypeId: 'rt-nonexistent', order: 1,
+    })
+    expect(() => validateSnapshotV3(snap)).toThrow(/not found in snapshot.resourceTypes/)
+  })
+
+  it('accepts overhead item with null resourceTypeId', () => {
+    const snap = makeBaseV3()
+    snap.overheadItems.push({
+      name: 'Fixed', type: 'fixed', value: 1000, resourceTypeId: null, order: 1,
+    })
+    expect(() => validateSnapshotV3(snap)).not.toThrow()
+  })
+
+
+  it('rejects null entry in overheadItems (malformed row)', () => {
+    const snap = makeBaseV3()
+    snap.overheadItems.push(null as never)
+    expect(() => validateSnapshotV3(snap)).toThrow(SnapshotValidationError)
+  })
+
+  it('rejects null entry in resourceTypes (malformed row)', () => {
+    const snap = makeBaseV3()
+    snap.resourceTypes.push(null as never)
+    expect(() => validateSnapshotV3(snap)).toThrow(SnapshotValidationError)
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 3. Pure sort helpers
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('sort helpers', () => {
+  it('sortSnapshotProfiles: sorts by ownerKind, owner identity, profile ID', () => {
+    const unsorted = [
+      { id: 'z', ownerKind: 'PLANNED_RESOURCE', resourceTypeId: null, namedResourceId: 'a' },
+      { id: 'b', ownerKind: 'ROLE', resourceTypeId: 'rt-1', namedResourceId: null },
+      { id: 'a', ownerKind: 'ROLE', resourceTypeId: 'rt-1', namedResourceId: null },
+      { id: 'c', ownerKind: 'NAMED_PERSON', resourceTypeId: null, namedResourceId: 'b' },
+      { id: 'd', ownerKind: 'NAMED_PERSON', resourceTypeId: null, namedResourceId: 'a' },
+    ] as Parameters<typeof sortSnapshotProfiles>[0]
+
+    const sorted = sortSnapshotProfiles(unsorted)
+
+    // order: NAMED_PERSON < PLANNED_RESOURCE < ROLE (alphabetical)
+    const kinds = sorted.map(p => p.ownerKind)
+    expect(kinds).toEqual(['NAMED_PERSON', 'NAMED_PERSON', 'PLANNED_RESOURCE', 'ROLE', 'ROLE'])
+    // NAMED_PERSON sorted by namedResourceId: 'a' (d) < 'b' (c)
+    expect(sorted[0].id).toBe('d')
+    expect(sorted[1].id).toBe('c')
+    // PLANNED_RESOURCE
+    expect(sorted[2].id).toBe('z')
+    // ROLE sorted by resourceTypeId then id: 'a' < 'b'
+    expect(sorted[3].id).toBe('a')
+    expect(sorted[4].id).toBe('b')
+  })
+
+  it('sortSnapshotSegments: sorts by startWeek, endWeek, segment ID', () => {
+    const unsorted = [
+      { id: 'b', startWeek: 0, endWeek: 4, capacityPercent: 100, source: 'FIXED' as const },
+      { id: 'c', startWeek: 0, endWeek: 2, capacityPercent: 50, source: 'FIXED' as const },
+      { id: 'a', startWeek: 0, endWeek: 2, capacityPercent: 80, source: 'FIXED' as const },
+    ]
+    const sorted = sortSnapshotSegments(unsorted)
+    expect(sorted.map(s => s.id)).toEqual(['a', 'c', 'b'])
+    // All same startWeek (0). a: endWeek=2 < c: endWeek=2 (a<c by id), b: endWeek=4
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 4. buildSnapshot v3 creation (uses db parameter, returns schemaVersion 3)
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('buildSnapshot', () => {
+  it('captures capacity profiles with ordering and field preservation', async () => {
+    // Unsorted profiles/segments to verify stable ordering
+    const rawProfiles = [
+      {
+        id: 'cp-3', ownerKind: 'PLANNED_RESOURCE',
+        resourceTypeId: null, namedResourceId: 'nr-bob',
+        planningBasis: 'WHOLE_PROJECT_ALLOCATION', source: 'MANUAL',
+        defaultPercent: null, startWeek: null, endWeek: null,
+        legacy: { oldField: 'value' },
+        segments: [
+          { id: 'seg-3b', startWeek: 0, endWeek: 2, capacityPercent: 100, source: 'MANUAL' },
+          { id: 'seg-3a', startWeek: 0, endWeek: 2, capacityPercent: 50, source: 'MANUAL' },
+        ],
+      },
+      {
+        id: 'cp-1', ownerKind: 'ROLE',
+        resourceTypeId: 'rt-dev', namedResourceId: null,
+        planningBasis: 'DEMAND_FOLLOWING', source: 'FIXED',
+        defaultPercent: null, startWeek: null, endWeek: null, legacy: null,
+        segments: [],
+      },
+      {
+        id: 'cp-2', ownerKind: 'NAMED_PERSON',
+        resourceTypeId: null, namedResourceId: 'nr-alice',
+        planningBasis: 'AVAILABILITY_WINDOW', source: 'SQUAD_PLANNER',
+        defaultPercent: 100, startWeek: 0, endWeek: 10,
+        legacy: { allocationMode: 'EFFORT' },
+        segments: [
+          { id: 'seg-2c', startWeek: 8, endWeek: 12, capacityPercent: 80, source: 'SQUAD_PLANNER' },
+          { id: 'seg-2a', startWeek: 0, endWeek: 4, capacityPercent: 100, source: 'SQUAD_PLANNER' },
+          { id: 'seg-2b', startWeek: 4, endWeek: 8, capacityPercent: 100, source: 'SQUAD_PLANNER' },
+        ],
+      },
+    ]
+
+    const db = {
+      epic: { findMany: vi.fn().mockResolvedValue([]) },
+      project: {
+        findUnique: vi.fn().mockResolvedValue({
+          startDate: new Date('2025-01-15'),
+          onboardingWeeks: 1, bufferWeeks: 2, hoursPerDay: 8,
+        }),
+      },
+      resourceType: {
+        findMany: vi.fn().mockResolvedValue([
+          { id: 'rt-dev', name: 'Developer', category: 'role', count: 2,
+            hoursPerDay: 8, dayRate: 500, globalTypeId: null,
+            allocationMode: 'TIMELINE', allocationPercent: 100,
+            allocationStartWeek: 0, allocationEndWeek: 10 },
+          { id: 'rt-des', name: 'Designer', category: 'role', count: 1,
+            hoursPerDay: 8, dayRate: 450, globalTypeId: null,
+            allocationMode: 'EFFORT', allocationPercent: 100,
+            allocationStartWeek: null, allocationEndWeek: null },
+        ]),
+      },
+      namedResource: {
+        findMany: vi.fn().mockResolvedValue([
+          { id: 'nr-alice', resourceTypeId: 'rt-dev', name: 'Alice',
+            startWeek: null, endWeek: null, allocationPct: 100,
+            allocationMode: 'EFFORT', allocationPercent: 100,
+            allocationStartWeek: null, allocationEndWeek: null,
+            pricingModel: 'ACTUAL_DAYS' },
+          { id: 'nr-bob', resourceTypeId: 'rt-dev', name: 'Bob',
+            startWeek: 2, endWeek: 8, allocationPct: 50,
+            allocationMode: 'TIMELINE', allocationPercent: 50,
+            allocationStartWeek: 2, allocationEndWeek: 8,
+            pricingModel: 'ACTUAL_DAYS' },
+        ]),
+      },
+      timelineEntry: { findMany: vi.fn().mockResolvedValue([]) },
+      storyTimelineEntry: { findMany: vi.fn().mockResolvedValue([]) },
+      epicDependency: { findMany: vi.fn().mockResolvedValue([]) },
+      featureDependency: { findMany: vi.fn().mockResolvedValue([]) },
+      projectOverhead: { findMany: vi.fn().mockResolvedValue([]) },
+      capacityProfile: { findMany: vi.fn().mockResolvedValue(rawProfiles) },
+    }
+
+    const result = await buildSnapshot(projId, db as never)
+    // schemaVersion 3
+    expect(result.schemaVersion).toBe(3)
+
+    // Project startDate converted to ISO string
+    expect(result.project).not.toBeNull()
+    expect(result.project?.startDate).toBe('2025-01-15T00:00:00.000Z')
+    // Profiles sorted: NAMED_PERSON < PLANNED_RESOURCE < ROLE (alphabetical by ownerKind)
+    const profileKinds = result.capacityProfiles.map(p => p.ownerKind)
+    expect(profileKinds).toEqual(['NAMED_PERSON', 'PLANNED_RESOURCE', 'ROLE'])
+    expect(result.capacityProfiles.map(p => p.id)).toEqual(['cp-2', 'cp-3', 'cp-1'])
+
+    // cp-2 (index 0): NAMED_PERSON, object legacy, segments sorted by startWeek/endWeek/id
+    const cp2 = result.capacityProfiles[0]
+    expect(cp2.ownerKind).toBe('NAMED_PERSON')
+    expect(cp2.namedResourceId).toBe('nr-alice')
+    expect(cp2.planningBasis).toBe('AVAILABILITY_WINDOW')
+    expect(cp2.source).toBe('SQUAD_PLANNER')
+    expect(cp2.defaultPercent).toBe(100)
+    expect(cp2.startWeek).toBe(0)
+    expect(cp2.endWeek).toBe(10)
+    expect(cp2.legacy).toEqual({ allocationMode: 'EFFORT' })
+    expect(cp2.segments.map(s => s.id)).toEqual(['seg-2a', 'seg-2b', 'seg-2c'])
+    expect(cp2.segments[0]).toEqual({ id: 'seg-2a', startWeek: 0, endWeek: 4, capacityPercent: 100, source: 'SQUAD_PLANNER' })
+    expect(cp2.segments[1].startWeek).toBe(4)
+    expect(cp2.segments[2].startWeek).toBe(8)
+
+    // cp-3 (index 1): PLANNED_RESOURCE, object legacy, segments sorted
+    const cp3 = result.capacityProfiles[1]
+    expect(cp3.ownerKind).toBe('PLANNED_RESOURCE')
+    expect(cp3.namedResourceId).toBe('nr-bob')
+    expect(cp3.planningBasis).toBe('WHOLE_PROJECT_ALLOCATION')
+    expect(cp3.source).toBe('MANUAL')
+    expect(cp3.legacy).toEqual({ oldField: 'value' })
+    expect(cp3.segments.map(s => s.id)).toEqual(['seg-3a', 'seg-3b'])
+    expect(cp3.segments[0].capacityPercent).toBe(50)
+    expect(cp3.segments[1].capacityPercent).toBe(100)
+
+    // cp-1 (index 2): ROLE, null legacy, no segments
+    const cp1 = result.capacityProfiles[2]
+    expect(cp1.ownerKind).toBe('ROLE')
+    expect(cp1.resourceTypeId).toBe('rt-dev')
+    expect(cp1.namedResourceId).toBeNull()
+    expect(cp1.planningBasis).toBe('DEMAND_FOLLOWING')
+    expect(cp1.source).toBe('FIXED')
+    expect(cp1.defaultPercent).toBeNull()
+    expect(cp1.startWeek).toBeNull()
+    expect(cp1.endWeek).toBeNull()
+    expect(cp1.legacy).toBeNull()
+    expect(cp1.segments).toEqual([])
+  })
+})
+// ═══════════════════════════════════════════════════════════════════════════
+// 5. Route — V1/V2/V3 rollback
+// ═══════════════════════════════════════════════════════════════════════════
+
+/**
+ * Build a mock transaction client with all delegates needed by buildSnapshot,
+ * restoreSnapshotCommonState, recreateV2/V3CapacityProfiles, and pruneSnapshots.
+ */
+function makeRouteTx(overrides: Record<string, unknown> = {}) {
+  const base = {
+    epic: { findMany: vi.fn().mockResolvedValue([]), deleteMany: vi.fn().mockResolvedValue({ count: 0 }), create: vi.fn().mockResolvedValue({ id: 'new-epic' }) },
+    project: { findUnique: vi.fn().mockResolvedValue({ startDate: new Date(), onboardingWeeks: null, bufferWeeks: null, hoursPerDay: null }), update: vi.fn().mockResolvedValue({}) },
+    resourceType: { findMany: vi.fn().mockResolvedValue([]), upsert: vi.fn().mockResolvedValue({}) },
+    namedResource: { findMany: vi.fn().mockResolvedValue([]), upsert: vi.fn().mockResolvedValue({}) },
+    timelineEntry: { findMany: vi.fn().mockResolvedValue([]), deleteMany: vi.fn().mockResolvedValue({ count: 0 }), createMany: vi.fn().mockResolvedValue({ count: 0 }) },
+    storyTimelineEntry: { findMany: vi.fn().mockResolvedValue([]), deleteMany: vi.fn().mockResolvedValue({ count: 0 }), createMany: vi.fn().mockResolvedValue({ count: 0 }) },
+    epicDependency: { findMany: vi.fn().mockResolvedValue([]), deleteMany: vi.fn().mockResolvedValue({ count: 0 }), createMany: vi.fn().mockResolvedValue({ count: 0 }) },
+    featureDependency: { findMany: vi.fn().mockResolvedValue([]), deleteMany: vi.fn().mockResolvedValue({ count: 0 }), createMany: vi.fn().mockResolvedValue({ count: 0 }) },
+    projectOverhead: { findMany: vi.fn().mockResolvedValue([]), deleteMany: vi.fn().mockResolvedValue({ count: 0 }), createMany: vi.fn().mockResolvedValue({ count: 0 }) },
+    capacityProfile: { findMany: vi.fn().mockResolvedValue([]), deleteMany: vi.fn().mockResolvedValue({ count: 999 }), create: vi.fn().mockResolvedValue({}) },
+    capacitySegment: { deleteMany: vi.fn().mockResolvedValue({ count: 999 }), create: vi.fn().mockResolvedValue({}) },
+    feature: { create: vi.fn().mockResolvedValue({ id: 'new-feature' }) },
+    userStory: { create: vi.fn().mockResolvedValue({ id: 'new-story' }) },
+    task: { create: vi.fn() },
+    backlogSnapshot: { create: vi.fn().mockResolvedValue({}), findMany: vi.fn().mockResolvedValue([]), deleteMany: vi.fn().mockResolvedValue({ count: 0 }) },
+  }
+  return { ...base, ...overrides }
+}
+
+describe('POST /api/projects/:projectId/snapshots/:snapshotId/rollback', () => {
+  it('V1: bare epic array restores epics, no capacity operations', async () => {
+    vi.mocked(prisma.project.findFirst).mockResolvedValue({ id: projId, ownerId: userId } as never)
+    vi.mocked(prisma.backlogSnapshot.findFirst).mockResolvedValue({
+      id: 'snap-v1', projectId: projId, label: 'Legacy V1',
+      trigger: 'manual',
+      snapshot: [{ id: 'e1', name: 'Epic', description: null, assumptions: null, order: 0,
+        featureMode: 'FIFO', scheduleMode: 'ASAP', timelineStartWeek: null,
+        isActive: true, projectId: projId, features: [] }],
+      createdById: userId, createdAt: new Date(),
+    } as never)
+
+    const cpDelete = vi.fn().mockResolvedValue({ count: 0 })
+    const cpCreate = vi.fn().mockResolvedValue({})
+    const epicDel = vi.fn().mockResolvedValue({ count: 0 })
+
+    vi.mocked(prisma.$transaction).mockImplementation(async (fn: unknown) => {
+      const tx = makeRouteTx({
+        capacityProfile: { findMany: vi.fn().mockResolvedValue([]), deleteMany: cpDelete, create: cpCreate },
+        epic: { findMany: vi.fn().mockResolvedValue([]), deleteMany: epicDel, create: vi.fn().mockResolvedValue({ id: 'new-e1' }) },
+      })
+      return typeof fn === 'function'
+        ? (fn as (t: unknown) => Promise<unknown>)(tx)
+        : Promise.resolve(fn)
+    })
+
+    const res = await request(app)
+      .post(`/api/projects/${projId}/snapshots/snap-v1/rollback`)
+      .set('Authorization', authHeader)
+
+    expect(res.status).toBe(200)
+    expect(vi.mocked(prisma.$transaction)).toHaveBeenCalledTimes(1)
+    expect(cpDelete.mock.calls.length).toBe(0)
+    expect(cpCreate.mock.calls.length).toBe(0)
+    expect(epicDel.mock.calls.length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('V2: full-state restore via transaction, legacy-compatible profiles', async () => {
+    const v2Data = {
+      schemaVersion: 2, epics: [], project: null,
+      resourceTypes: [{
+        id: 'rt-1', name: 'Developer', category: 'role', count: 1,
+        hoursPerDay: null, dayRate: null, globalTypeId: null,
+        allocationMode: 'TIMELINE', allocationPercent: 60,
+        allocationStartWeek: 2, allocationEndWeek: 6,
+      }],
+      namedResources: [],
+      timelineEntries: [], storyTimelineEntries: [],
+      epicDependencies: [], featureDependencies: [], overheadItems: [],
+    }
+
+    vi.mocked(prisma.project.findFirst).mockResolvedValue({ id: projId, ownerId: userId } as never)
+    vi.mocked(prisma.backlogSnapshot.findFirst).mockResolvedValue({
+      id: 'snap-v2', projectId: projId, label: 'V2 full',
+      trigger: 'manual', snapshot: v2Data,
+      createdById: userId, createdAt: new Date(),
+    } as never)
+
+    const cpDelete = vi.fn().mockResolvedValue({ count: 999 })
+    const segDelete = vi.fn().mockResolvedValue({ count: 999 })
+    const cpCreate = vi.fn().mockResolvedValue({})
+
+    vi.mocked(prisma.$transaction).mockImplementation(async (fn: unknown) => {
+      const tx = makeRouteTx({
+        capacityProfile: { findMany: vi.fn().mockResolvedValue([]), deleteMany: cpDelete, create: cpCreate },
+        capacitySegment: { deleteMany: segDelete, create: vi.fn().mockResolvedValue({}) },
+      })
+      return typeof fn === 'function'
+        ? (fn as (t: unknown) => Promise<unknown>)(tx)
+        : Promise.resolve(fn)
+    })
+
+    const res = await request(app)
+      .post(`/api/projects/${projId}/snapshots/snap-v2/rollback`)
+      .set('Authorization', authHeader)
+
+    expect(res.status).toBe(200)
+    expect(vi.mocked(prisma.$transaction)).toHaveBeenCalledTimes(1)
+    expect(cpDelete.mock.calls.length).toBeGreaterThanOrEqual(1)
+    expect(segDelete.mock.calls.length).toBeGreaterThanOrEqual(1)
+    expect(cpCreate.mock.calls.length).toBe(1)
+
+    const created = cpCreate.mock.calls[0][0]?.data as Record<string, unknown>
+    expect(created.id).toBe('snapshot-v2-role-rt-1')
+    expect(created.projectId).toBe(projId)
+    expect(created.ownerKind).toBe('ROLE')
+    expect(created.planningBasis).toBe('AVAILABILITY_WINDOW')
+    expect(created.source).toBe('AVAILABILITY_WINDOW')
+    expect(created.defaultPercent).toBe(60)
+    expect(created.startWeek).toBe(2)
+    expect(created.endWeek).toBe(6)
+  })
+
+  it('V3: exact profile/segment replacement in transaction', async () => {
+    const v3Target: SnapshotV3 = {
+      schemaVersion: 3, epics: [], project: null,
+      resourceTypes: [
+        { id: 'rt-dev', name: 'Developer', category: 'role', count: 2,
+          hoursPerDay: 8, dayRate: 500, globalTypeId: null,
+          allocationMode: 'TIMELINE', allocationPercent: 100,
+          allocationStartWeek: 0, allocationEndWeek: 10 },
+      ],
+      namedResources: [
+        { id: 'nr-alice', resourceTypeId: 'rt-dev', name: 'Alice',
+          startWeek: null, endWeek: null, allocationPct: 100,
+          allocationMode: 'EFFORT', allocationPercent: 100,
+          allocationStartWeek: null, allocationEndWeek: null,
+          pricingModel: 'ACTUAL_DAYS' },
+      ],
+      timelineEntries: [], storyTimelineEntries: [],
+      epicDependencies: [], featureDependencies: [], overheadItems: [],
+      capacityProfiles: [
+        {
+          id: 'cp-1', ownerKind: 'ROLE', resourceTypeId: 'rt-dev', namedResourceId: null,
+          planningBasis: 'DEMAND_FOLLOWING', source: 'FIXED', defaultPercent: null,
+          startWeek: null, endWeek: null, legacy: null, segments: [],
+        },
+        {
+          id: 'cp-2', ownerKind: 'NAMED_PERSON', resourceTypeId: null, namedResourceId: 'nr-alice',
+          planningBasis: 'AVAILABILITY_WINDOW', source: 'SQUAD_PLANNER', defaultPercent: 100,
+          startWeek: 0, endWeek: 10, legacy: { mode: 'EFFORT' },
+          segments: [
+            { id: 'seg-a', startWeek: 0, endWeek: 4, capacityPercent: 100, source: 'SQUAD_PLANNER' },
+          ],
+        },
+      ],
+    }
+
+    vi.mocked(prisma.project.findFirst).mockResolvedValue({ id: projId, ownerId: userId } as never)
+    vi.mocked(prisma.backlogSnapshot.findFirst).mockResolvedValue({
+      id: 'snap-v3', projectId: projId, label: 'test-v3',
+      trigger: 'manual', snapshot: v3Target as unknown as never,
+      createdById: userId, createdAt: new Date(),
+    } as never)
+    vi.mocked(prisma.resourceType.findMany).mockResolvedValue([
+      { id: 'rt-dev', projectId: projId },
+    ] as never)
+    vi.mocked(prisma.namedResource.findMany).mockResolvedValue([
+      { id: 'nr-alice', resourceType: { projectId: projId } },
+    ] as never)
+
+    const cpDelete = vi.fn().mockResolvedValue({ count: 999 })
+    const segDelete = vi.fn().mockResolvedValue({ count: 999 })
+    const cpCreate = vi.fn().mockResolvedValue({})
+    const segCreate = vi.fn().mockResolvedValue({})
+    const bsCreate = vi.fn().mockResolvedValue({})
+
+    vi.mocked(prisma.$transaction).mockImplementation(async (fn: unknown) => {
+      const tx = makeRouteTx({
+        capacityProfile: { findMany: vi.fn().mockResolvedValue([]), deleteMany: cpDelete, create: cpCreate },
+        capacitySegment: { deleteMany: segDelete, create: segCreate },
+        backlogSnapshot: { create: bsCreate, findMany: vi.fn().mockResolvedValue([]), deleteMany: vi.fn().mockResolvedValue({ count: 0 }) },
+      })
+      return typeof fn === 'function'
+        ? (fn as (t: unknown) => Promise<unknown>)(tx)
+        : Promise.resolve(fn)
+    })
+
+    const res = await request(app)
+      .post(`/api/projects/${projId}/snapshots/snap-v3/rollback`)
+      .set('Authorization', authHeader)
+
+    expect(res.status).toBe(200)
+    expect(vi.mocked(prisma.$transaction)).toHaveBeenCalledTimes(1)
+    // Pre-rollback snapshot created inside transaction (tx mock, not global prisma)
+    expect(bsCreate.mock.calls.length).toBeGreaterThanOrEqual(1)
+
+    // Existing profiles/segments deleted
+    expect(cpDelete.mock.calls.length).toBeGreaterThanOrEqual(1)
+    expect(segDelete.mock.calls.length).toBeGreaterThanOrEqual(1)
+
+    // Target profiles recreated with exact IDs and fields
+    expect(cpCreate.mock.calls.length).toBe(2)
+
+    const cp1 = cpCreate.mock.calls[0][0]?.data as Record<string, unknown>
+    expect(cp1.id).toBe('cp-1')
+    expect(cp1.projectId).toBe(projId)
+    expect(cp1.ownerKind).toBe('ROLE')
+    expect(cp1.resourceTypeId).toBe('rt-dev')
+    expect(cp1.namedResourceId).toBeNull()
+    expect(cp1.legacy).toBeNull()
+    expect(cp1.planningBasis).toBe('DEMAND_FOLLOWING')
+    expect(cp1.source).toBe('FIXED')
+    expect(cp1.defaultPercent).toBeNull()
+    expect(cp1.startWeek).toBeNull()
+    expect(cp1.endWeek).toBeNull()
+
+    const cp2 = cpCreate.mock.calls[1][0]?.data as Record<string, unknown>
+    expect(cp2.id).toBe('cp-2')
+    expect(cp2.projectId).toBe(projId)
+    expect(cp2.ownerKind).toBe('NAMED_PERSON')
+    expect(cp2.namedResourceId).toBe('nr-alice')
+    expect(cp2.legacy).toEqual({ mode: 'EFFORT' })
+    expect(cp2.planningBasis).toBe('AVAILABILITY_WINDOW')
+    expect(cp2.source).toBe('SQUAD_PLANNER')
+    expect(cp2.defaultPercent).toBe(100)
+    expect(cp2.startWeek).toBe(0)
+    expect(cp2.endWeek).toBe(10)
+
+    // Segments recreated with exact IDs and values
+    expect(segCreate.mock.calls.length).toBe(1)
+    const seg1 = segCreate.mock.calls[0][0]?.data as Record<string, unknown>
+    expect(seg1.id).toBe('seg-a')
+    expect(seg1.capacityProfileId).toBe('cp-2')
+    expect(seg1.startWeek).toBe(0)
+    expect(seg1.endWeek).toBe(4)
+    expect(seg1.capacityPercent).toBe(100)
+    expect(seg1.source).toBe('SQUAD_PLANNER')
+  })
+
+  // ═════════════════════════════════════════════════════════════════════════
+  // 6. Pre-flight validation (before transaction)
+  // ═════════════════════════════════════════════════════════════════════════
+
+  it('V3: invalid profile data returns 400 before transaction', async () => {
+    const invalidV3 = {
+      schemaVersion: 3, epics: [], project: null,
+      resourceTypes: [{ id: 'rt-dev', name: 'Dev', category: 'role', count: 1,
+        hoursPerDay: 8, dayRate: 500, globalTypeId: null,
+        allocationMode: 'TIMELINE', allocationPercent: 100,
+        allocationStartWeek: 0, allocationEndWeek: 10 }],
+      namedResources: [{ id: 'nr-alice', resourceTypeId: 'rt-dev', name: 'Alice',
+        startWeek: null, endWeek: null, allocationPct: 100,
+        allocationMode: 'EFFORT', allocationPercent: 100,
+        allocationStartWeek: null, allocationEndWeek: null, pricingModel: 'ACTUAL_DAYS' }],
+      timelineEntries: [], storyTimelineEntries: [],
+      epicDependencies: [], featureDependencies: [], overheadItems: [],
+      capacityProfiles: [
+        { id: 'cp-1', ownerKind: 'ROLE', resourceTypeId: null, namedResourceId: null,
+          planningBasis: 'DEMAND_FOLLOWING', source: 'FIXED', defaultPercent: null,
+          startWeek: null, endWeek: null, legacy: null, segments: [] },
+      ],
+    }
+
+    vi.mocked(prisma.project.findFirst).mockResolvedValue({ id: projId, ownerId: userId } as never)
+    vi.mocked(prisma.backlogSnapshot.findFirst).mockResolvedValue({
+      id: 'snap-bad', projectId: projId, label: 'bad',
+      trigger: 'manual', snapshot: invalidV3,
+      createdById: userId, createdAt: new Date(),
+    } as never)
+
+    const txSpy = vi.mocked(prisma.$transaction)
+
+    const res = await request(app)
+      .post(`/api/projects/${projId}/snapshots/snap-bad/rollback`)
+      .set('Authorization', authHeader)
+
+    expect(res.status).toBe(400)
+    expect(txSpy).not.toHaveBeenCalled()
+  })
+
+  it('unknown schema version returns 400 before transaction', async () => {
+    vi.mocked(prisma.project.findFirst).mockResolvedValue({ id: projId, ownerId: userId } as never)
+    vi.mocked(prisma.backlogSnapshot.findFirst).mockResolvedValue({
+      id: 'snap-future', projectId: projId, label: 'future',
+      trigger: 'manual',
+      snapshot: { schemaVersion: 99, epics: [], resourceTypes: [], namedResources: [],
+        timelineEntries: [], storyTimelineEntries: [], epicDependencies: [],
+        featureDependencies: [], overheadItems: [], capacityProfiles: [] },
+      createdById: userId, createdAt: new Date(),
+    } as never)
+
+    const txSpy = vi.mocked(prisma.$transaction)
+
+    const res = await request(app)
+      .post(`/api/projects/${projId}/snapshots/snap-future/rollback`)
+      .set('Authorization', authHeader)
+
+    expect(res.status).toBe(400)
+    expect(txSpy).not.toHaveBeenCalled()
+  })
+
+  it('cross-project ID collision returns 400 before transaction', async () => {
+    const v3Target: SnapshotV3 = {
+      schemaVersion: 3, epics: [], project: null,
+      resourceTypes: [{ id: 'rt-dev', name: 'Dev', category: 'role', count: 1,
+        hoursPerDay: 8, dayRate: 500, globalTypeId: null,
+        allocationMode: 'TIMELINE', allocationPercent: 100,
+        allocationStartWeek: 0, allocationEndWeek: 10 }],
+      namedResources: [],
+      timelineEntries: [], storyTimelineEntries: [],
+      epicDependencies: [], featureDependencies: [], overheadItems: [],
+      capacityProfiles: [
+        { id: 'cp-1', ownerKind: 'ROLE', resourceTypeId: 'rt-dev', namedResourceId: null,
+          planningBasis: 'DEMAND_FOLLOWING', source: 'FIXED', defaultPercent: null,
+          startWeek: null, endWeek: null, legacy: null, segments: [] },
+      ],
+    }
+
+    vi.mocked(prisma.project.findFirst).mockResolvedValue({ id: projId, ownerId: userId } as never)
+    vi.mocked(prisma.backlogSnapshot.findFirst).mockResolvedValue({
+      id: 'snap-cross', projectId: projId, label: 'cross',
+      trigger: 'manual', snapshot: v3Target as unknown as never,
+      createdById: userId, createdAt: new Date(),
+    } as never)
+    vi.mocked(prisma.resourceType.findMany).mockResolvedValue([
+      { id: 'rt-dev', projectId: 'other-proj' },
+    ] as never)
+
+    const txSpy = vi.mocked(prisma.$transaction)
+
+    const res = await request(app)
+      .post(`/api/projects/${projId}/snapshots/snap-cross/rollback`)
+      .set('Authorization', authHeader)
+
+    expect(res.status).toBe(400)
+    expect(txSpy).not.toHaveBeenCalled()
+  })
+
+
+  it('V3: foreign resourceType from snapshot.resourceTypes rejected before transaction', async () => {
+    const v3Target: SnapshotV3 = {
+      schemaVersion: 3, epics: [], project: null,
+      resourceTypes: [{ id: 'rt-foreign', name: 'OtherTeam', category: 'role', count: 1,
+        hoursPerDay: 8, dayRate: 500, globalTypeId: null,
+        allocationMode: 'TIMELINE', allocationPercent: 100,
+        allocationStartWeek: 0, allocationEndWeek: 10 }],
+      namedResources: [],
+      timelineEntries: [], storyTimelineEntries: [],
+      epicDependencies: [], featureDependencies: [], overheadItems: [],
+      capacityProfiles: [],
+    }
+
+    vi.mocked(prisma.project.findFirst).mockResolvedValue({ id: projId, ownerId: userId } as never)
+    vi.mocked(prisma.backlogSnapshot.findFirst).mockResolvedValue({
+      id: 'snap-rt-foreign', projectId: projId, label: 'foreign-rt',
+      trigger: 'manual', snapshot: v3Target as unknown as never,
+      createdById: userId, createdAt: new Date(),
+    } as never)
+    vi.mocked(prisma.resourceType.findMany).mockResolvedValue([
+      { id: 'rt-foreign', projectId: 'other-proj' },
+    ] as never)
+
+    const txSpy = vi.mocked(prisma.$transaction)
+
+    const res = await request(app)
+      .post(`/api/projects/${projId}/snapshots/snap-rt-foreign/rollback`)
+      .set('Authorization', authHeader)
+
+    expect(res.status).toBe(400)
+    expect(txSpy).not.toHaveBeenCalled()
+  })
+
+  it('V3: foreign namedResource from snapshot.namedResources rejected before transaction', async () => {
+    const v3Target: SnapshotV3 = {
+      schemaVersion: 3, epics: [], project: null,
+      resourceTypes: [{ id: 'rt-dev', name: 'Dev', category: 'role', count: 1,
+        hoursPerDay: 8, dayRate: 500, globalTypeId: null,
+        allocationMode: 'TIMELINE', allocationPercent: 100,
+        allocationStartWeek: 0, allocationEndWeek: 10 }],
+      namedResources: [{ id: 'nr-foreign', resourceTypeId: 'rt-dev', name: 'Bob',
+        startWeek: null, endWeek: null, allocationPct: 100,
+        allocationMode: 'EFFORT', allocationPercent: 100,
+        allocationStartWeek: null, allocationEndWeek: null, pricingModel: 'ACTUAL_DAYS' }],
+      timelineEntries: [], storyTimelineEntries: [],
+      epicDependencies: [], featureDependencies: [], overheadItems: [],
+      capacityProfiles: [],
+    }
+
+    vi.mocked(prisma.project.findFirst).mockResolvedValue({ id: projId, ownerId: userId } as never)
+    vi.mocked(prisma.backlogSnapshot.findFirst).mockResolvedValue({
+      id: 'snap-nr-foreign', projectId: projId, label: 'foreign-nr',
+      trigger: 'manual', snapshot: v3Target as unknown as never,
+      createdById: userId, createdAt: new Date(),
+    } as never)
+    // resourceType ID is new (doesn't exist in DB) — allowed
+    vi.mocked(prisma.resourceType.findMany).mockResolvedValue([] as never)
+    vi.mocked(prisma.namedResource.findMany).mockResolvedValue([
+      { id: 'nr-foreign', resourceType: { projectId: 'other-proj' } },
+    ] as never)
+
+    const txSpy = vi.mocked(prisma.$transaction)
+
+    const res = await request(app)
+      .post(`/api/projects/${projId}/snapshots/snap-nr-foreign/rollback`)
+      .set('Authorization', authHeader)
+
+    expect(res.status).toBe(400)
+    expect(txSpy).not.toHaveBeenCalled()
+  })
+
+  it('V3: foreign overhead resourceType rejected before transaction', async () => {
+    const v3Target: SnapshotV3 = {
+      schemaVersion: 3, epics: [], project: null,
+      resourceTypes: [
+        { id: 'rt-dev', name: 'Dev', category: 'role', count: 1,
+          hoursPerDay: 8, dayRate: 500, globalTypeId: null,
+          allocationMode: 'TIMELINE', allocationPercent: 100,
+          allocationStartWeek: 0, allocationEndWeek: 10 },
+        { id: 'rt-foreign', name: 'Other', category: 'role', count: 1,
+          hoursPerDay: 8, dayRate: 500, globalTypeId: null,
+          allocationMode: 'TIMELINE', allocationPercent: 100,
+          allocationStartWeek: 0, allocationEndWeek: 10 },
+      ],
+      namedResources: [],
+      timelineEntries: [], storyTimelineEntries: [],
+      epicDependencies: [], featureDependencies: [],
+      overheadItems: [{ name: 'PM', type: 'percent', value: 10, resourceTypeId: 'rt-foreign', order: 1 }],
+      capacityProfiles: [],
+    }
+
+    vi.mocked(prisma.project.findFirst).mockResolvedValue({ id: projId, ownerId: userId } as never)
+    vi.mocked(prisma.backlogSnapshot.findFirst).mockResolvedValue({
+      id: 'snap-oh-foreign', projectId: projId, label: 'foreign-oh',
+      trigger: 'manual', snapshot: v3Target as unknown as never,
+      createdById: userId, createdAt: new Date(),
+    } as never)
+    // 'rt-dev' is a new ID (fine); 'rt-foreign' already exists in another project
+    vi.mocked(prisma.resourceType.findMany).mockResolvedValue([
+      { id: 'rt-foreign', projectId: 'other-proj' },
+    ] as never)
+
+    const txSpy = vi.mocked(prisma.$transaction)
+
+    const res = await request(app)
+      .post(`/api/projects/${projId}/snapshots/snap-oh-foreign/rollback`)
+      .set('Authorization', authHeader)
+
+    expect(res.status).toBe(400)
+    expect(txSpy).not.toHaveBeenCalled()
+  })
+
+  it('V3: new IDs not in DB are allowed (valid rollback)', async () => {
+    const v3Target: SnapshotV3 = {
+      schemaVersion: 3, epics: [], project: null,
+      resourceTypes: [{ id: 'rt-new', name: 'NewRole', category: 'role', count: 1,
+        hoursPerDay: 8, dayRate: 500, globalTypeId: null,
+        allocationMode: 'TIMELINE', allocationPercent: 100,
+        allocationStartWeek: 0, allocationEndWeek: 10 }],
+      namedResources: [{ id: 'nr-new', resourceTypeId: 'rt-new', name: 'NewPerson',
+        startWeek: null, endWeek: null, allocationPct: 100,
+        allocationMode: 'EFFORT', allocationPercent: 100,
+        allocationStartWeek: null, allocationEndWeek: null, pricingModel: 'ACTUAL_DAYS' }],
+      timelineEntries: [], storyTimelineEntries: [],
+      epicDependencies: [], featureDependencies: [], overheadItems: [],
+      capacityProfiles: [
+        { id: 'cp-new', ownerKind: 'ROLE', resourceTypeId: 'rt-new', namedResourceId: null,
+          planningBasis: 'DEMAND_FOLLOWING', source: 'FIXED', defaultPercent: null,
+          startWeek: null, endWeek: null, legacy: null, segments: [] },
+      ],
+    }
+
+    vi.mocked(prisma.project.findFirst).mockResolvedValue({ id: projId, ownerId: userId } as never)
+    vi.mocked(prisma.backlogSnapshot.findFirst).mockResolvedValue({
+      id: 'snap-newids', projectId: projId, label: 'new-ids',
+      trigger: 'manual', snapshot: v3Target as unknown as never,
+      createdById: userId, createdAt: new Date(),
+    } as never)
+    vi.mocked(prisma.resourceType.findMany).mockResolvedValue([] as never)
+    vi.mocked(prisma.namedResource.findMany).mockResolvedValue([] as never)
+
+    const cpDelete = vi.fn().mockResolvedValue({ count: 0 })
+    const segDelete = vi.fn().mockResolvedValue({ count: 0 })
+    const cpCreate = vi.fn().mockResolvedValue({})
+    const segCreate = vi.fn().mockResolvedValue({})
+    const bsCreate = vi.fn().mockResolvedValue({})
+
+    vi.mocked(prisma.$transaction).mockImplementation(async (fn: unknown) => {
+      const tx = makeRouteTx({
+        capacityProfile: { findMany: vi.fn().mockResolvedValue([]), deleteMany: cpDelete, create: cpCreate },
+        capacitySegment: { deleteMany: segDelete, create: segCreate },
+        backlogSnapshot: { create: bsCreate, findMany: vi.fn().mockResolvedValue([]), deleteMany: vi.fn().mockResolvedValue({ count: 0 }) },
+      })
+      return typeof fn === 'function'
+        ? (fn as (t: unknown) => Promise<unknown>)(tx)
+        : Promise.resolve(fn)
+    })
+
+    const txSpy = vi.mocked(prisma.$transaction)
+
+    const res = await request(app)
+      .post(`/api/projects/${projId}/snapshots/snap-newids/rollback`)
+      .set('Authorization', authHeader)
+
+    // No DB rows for these IDs, so cross-project checks pass → reaches transaction
+    expect(txSpy).toHaveBeenCalled()
+    expect(res.status).toBe(200)
+  })
+  // ═════════════════════════════════════════════════════════════════════════
+  // 7. 404 and transaction atomicity
+  // ═════════════════════════════════════════════════════════════════════════
+
+  it('returns 404 when snapshot is not found', async () => {
+    vi.mocked(prisma.project.findFirst).mockResolvedValue({ id: projId, ownerId: userId } as never)
+    vi.mocked(prisma.backlogSnapshot.findFirst).mockResolvedValue(null as never)
+
+    const res = await request(app)
+      .post(`/api/projects/${projId}/snapshots/nonexistent/rollback`)
+      .set('Authorization', authHeader)
+
+    expect(res.status).toBe(404)
+  })
+
+  it('returns 404 when project is not found / not owned', async () => {
+    vi.mocked(prisma.project.findFirst).mockResolvedValue(null as never)
+
+    const res = await request(app)
+      .post(`/api/projects/${projId}/snapshots/snap-1/rollback`)
+      .set('Authorization', authHeader)
+
+    expect(res.status).toBe(404)
+  })
+
+  it('$transaction rejection returns 500 with no external cleanup', async () => {
+    vi.mocked(prisma.project.findFirst).mockResolvedValue({ id: projId, ownerId: userId } as never)
+    vi.mocked(prisma.backlogSnapshot.findFirst).mockResolvedValue({
+      id: 'snap-fail', projectId: projId, label: 'fail',
+      trigger: 'manual',
+      snapshot: [{ id: 'e1', name: 'E', features: [] }],
+      createdById: userId, createdAt: new Date(),
+    } as never)
+
+    vi.mocked(prisma.$transaction).mockRejectedValue(new Error('DB timeout'))
+    const bsDeleteSpy = vi.mocked(prisma.backlogSnapshot.delete)
+
+    const res = await request(app)
+      .post(`/api/projects/${projId}/snapshots/snap-fail/rollback`)
+      .set('Authorization', authHeader)
+
+    expect(res.status).toBe(500)
+    // Transaction is the atomic boundary — no external cleanup
+    expect(bsDeleteSpy).not.toHaveBeenCalled()
+  })
+
+  it('V3 tx callback failure rejects with 500 (restore/write error)', async () => {
+    const v3Target: SnapshotV3 = {
+      schemaVersion: 3, epics: [], project: null,
+      resourceTypes: [{ id: 'rt-dev', name: 'Dev', category: 'role', count: 1,
+        hoursPerDay: 8, dayRate: 500, globalTypeId: null,
+        allocationMode: 'TIMELINE', allocationPercent: 100,
+        allocationStartWeek: 0, allocationEndWeek: 10 }],
+      namedResources: [],
+      timelineEntries: [], storyTimelineEntries: [],
+      epicDependencies: [], featureDependencies: [], overheadItems: [],
+      capacityProfiles: [
+        { id: 'cp-1', ownerKind: 'ROLE', resourceTypeId: 'rt-dev', namedResourceId: null,
+          planningBasis: 'DEMAND_FOLLOWING', source: 'FIXED', defaultPercent: null,
+          startWeek: null, endWeek: null, legacy: null, segments: [] },
+      ],
+    }
+
+    vi.mocked(prisma.project.findFirst).mockResolvedValue({ id: projId, ownerId: userId } as never)
+    vi.mocked(prisma.backlogSnapshot.findFirst).mockResolvedValue({
+      id: 'snap-failwrite', projectId: projId, label: 'failwrite',
+      trigger: 'manual', snapshot: v3Target as unknown as never,
+      createdById: userId, createdAt: new Date(),
+    } as never)
+    vi.mocked(prisma.resourceType.findMany).mockResolvedValue([
+      { id: 'rt-dev', projectId: projId },
+    ] as never)
+
+    // Make capacityProfile.create throw inside the callback
+    const cpCreate = vi.fn().mockRejectedValue(new Error('Write failure'))
+
+    vi.mocked(prisma.$transaction).mockImplementation(async (fn: unknown) => {
+      const tx = makeRouteTx({
+        capacityProfile: { findMany: vi.fn().mockResolvedValue([]), deleteMany: vi.fn().mockResolvedValue({ count: 0 }), create: cpCreate },
+      })
+      return typeof fn === 'function'
+        ? (fn as (t: unknown) => Promise<unknown>)(tx)
+        : Promise.resolve(fn)
+    })
+
+    const bsDeleteSpy = vi.mocked(prisma.backlogSnapshot.delete)
+
+    const res = await request(app)
+      .post(`/api/projects/${projId}/snapshots/snap-failwrite/rollback`)
+      .set('Authorization', authHeader)
+
+    expect(res.status).toBe(500)
+    // The callback threw, so it was attempted
+    expect(cpCreate.mock.calls.length).toBeGreaterThanOrEqual(1)
+    // No external cleanup — DB transaction provides atomicity
+    expect(bsDeleteSpy).not.toHaveBeenCalled()
+  })
+})

--- a/server/src/test/snapshots.test.ts
+++ b/server/src/test/snapshots.test.ts
@@ -9,9 +9,11 @@
  *  - Pure parser tests (parseSnapshotData, type guards)
  *  - Pure validation tests (validateSnapshotV3, sort helpers)
  *  - buildSnapshot v3 creation with mock db parameter (returns schemaVersion 3)
+ *  - rollbackProjectSnapshot service with v1/v2/v3/failure semantics
  *  - V1/V2/V3 route rollback
  *  - Pre-flight validation: invalid v3, unknown schema, cross-project IDs
  *  - Transaction atomicity (failure rejects with 500)
+ *  - Route persistence on buildSnapshot failure
  */
 
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -35,7 +37,7 @@ import {
   sortSnapshotProfiles,
   sortSnapshotSegments,
 } from '../lib/projectSnapshotValidation.js'
-import { buildSnapshot } from '../routes/snapshots.js'
+import { buildSnapshot, rollbackProjectSnapshot, SnapshotNotFoundError, RollbackPreflightError } from '../lib/projectSnapshotService.js'
 process.env.JWT_SECRET = 'test-secret'
 
 const userId = 'user-1'
@@ -121,7 +123,7 @@ describe('validateSnapshotV3', () => {
       project: null,
       resourceTypes: [
         {
-          id: 'rt-dev', name: 'Developer', category: 'role', count: 2,
+          id: 'rt-dev', name: 'Developer', category: 'ENGINEERING', count: 2,
           hoursPerDay: 8, dayRate: 500, globalTypeId: null,
           allocationMode: 'TIMELINE', allocationPercent: 100,
           allocationStartWeek: 0, allocationEndWeek: 10,
@@ -308,7 +310,7 @@ describe('validateSnapshotV3', () => {
   it('rejects overhead item referencing missing resourceTypeId', () => {
     const snap = makeBaseV3()
     snap.overheadItems.push({
-      name: 'PM', type: 'percent', value: 10, resourceTypeId: 'rt-nonexistent', order: 1,
+      name: 'PM', type: 'PERCENTAGE', value: 10, resourceTypeId: 'rt-nonexistent', order: 1,
     })
     expect(() => validateSnapshotV3(snap)).toThrow(/not found in snapshot.resourceTypes/)
   })
@@ -316,7 +318,7 @@ describe('validateSnapshotV3', () => {
   it('accepts overhead item with null resourceTypeId', () => {
     const snap = makeBaseV3()
     snap.overheadItems.push({
-      name: 'Fixed', type: 'fixed', value: 1000, resourceTypeId: null, order: 1,
+      name: 'Fixed', type: 'FIXED_DAYS', value: 1000, resourceTypeId: null, order: 1,
     })
     expect(() => validateSnapshotV3(snap)).not.toThrow()
   })
@@ -426,11 +428,11 @@ describe('buildSnapshot', () => {
       },
       resourceType: {
         findMany: vi.fn().mockResolvedValue([
-          { id: 'rt-dev', name: 'Developer', category: 'role', count: 2,
+          { id: 'rt-dev', name: 'Developer', category: 'ENGINEERING', count: 2,
             hoursPerDay: 8, dayRate: 500, globalTypeId: null,
             allocationMode: 'TIMELINE', allocationPercent: 100,
             allocationStartWeek: 0, allocationEndWeek: 10 },
-          { id: 'rt-des', name: 'Designer', category: 'role', count: 1,
+          { id: 'rt-des', name: 'Designer', category: 'ENGINEERING', count: 1,
             hoursPerDay: 8, dayRate: 450, globalTypeId: null,
             allocationMode: 'EFFORT', allocationPercent: 100,
             allocationStartWeek: null, allocationEndWeek: null },
@@ -456,6 +458,11 @@ describe('buildSnapshot', () => {
       featureDependency: { findMany: vi.fn().mockResolvedValue([]) },
       projectOverhead: { findMany: vi.fn().mockResolvedValue([]) },
       capacityProfile: { findMany: vi.fn().mockResolvedValue(rawProfiles) },
+      $queryRaw: vi.fn().mockResolvedValue([
+        { id: 'cp-3', legacy_is_null: false, legacy_typeof: 'object' },
+        { id: 'cp-1', legacy_is_null: false, legacy_typeof: 'null' },
+        { id: 'cp-2', legacy_is_null: false, legacy_typeof: 'object' },
+      ]),
     }
 
     const result = await buildSnapshot(projId, db as never)
@@ -509,6 +516,122 @@ describe('buildSnapshot', () => {
     expect(cp1.legacy).toEqual({ kind: 'JSON_NULL' })
     expect(cp1.segments).toEqual([])
   })
+  it('distinguishes DB_NULL from JSON_NULL via legacy_is_null query', async () => {
+    const rawProfiles = [
+      {
+        id: 'cp-dbn', ownerKind: 'ROLE',
+        resourceTypeId: 'rt-dev', namedResourceId: null,
+        planningBasis: 'DEMAND_FOLLOWING', source: 'FIXED',
+        defaultPercent: null, startWeek: null, endWeek: null,
+        legacy: null,
+        segments: [],
+      },
+      {
+        id: 'cp-jn', ownerKind: 'NAMED_PERSON',
+        resourceTypeId: null, namedResourceId: 'nr-alice',
+        planningBasis: 'AVAILABILITY_WINDOW', source: 'SQUAD_PLANNER',
+        defaultPercent: 100, startWeek: 0, endWeek: 10,
+        legacy: null,
+        segments: [],
+      },
+    ]
+
+    const db = {
+      epic: { findMany: vi.fn().mockResolvedValue([]) },
+      project: { findUnique: vi.fn().mockResolvedValue(null) },
+      resourceType: { findMany: vi.fn().mockResolvedValue([]) },
+      namedResource: {
+        findMany: vi.fn().mockResolvedValue([
+          { id: 'nr-alice', resourceTypeId: 'rt-dev', name: 'Alice',
+            startWeek: null, endWeek: null, allocationPct: 100,
+            allocationMode: 'EFFORT', allocationPercent: 100,
+            allocationStartWeek: null, allocationEndWeek: null,
+            pricingModel: 'ACTUAL_DAYS' },
+        ]),
+      },
+      timelineEntry: { findMany: vi.fn().mockResolvedValue([]) },
+      storyTimelineEntry: { findMany: vi.fn().mockResolvedValue([]) },
+      epicDependency: { findMany: vi.fn().mockResolvedValue([]) },
+      featureDependency: { findMany: vi.fn().mockResolvedValue([]) },
+      projectOverhead: { findMany: vi.fn().mockResolvedValue([]) },
+      capacityProfile: { findMany: vi.fn().mockResolvedValue(rawProfiles) },
+      // cp-dbn maps to DB_NULL (legacy_is_null=true), cp-jn to JSON_NULL (legacy_typeof='null')
+      $queryRaw: vi.fn().mockResolvedValue([
+        { id: 'cp-dbn', legacy_is_null: true, legacy_typeof: null },
+        { id: 'cp-jn', legacy_is_null: false, legacy_typeof: 'null' },
+      ]),
+    }
+
+    const result = await buildSnapshot(projId, db as never)
+
+    const cpDbn = result.capacityProfiles.find(p => p.id === 'cp-dbn')
+    expect(cpDbn).toBeDefined()
+    expect(cpDbn!.legacy).toEqual({ kind: 'DB_NULL' })
+
+    const cpJn = result.capacityProfiles.find(p => p.id === 'cp-jn')
+    expect(cpJn).toBeDefined()
+    expect(cpJn!.legacy).toEqual({ kind: 'JSON_NULL' })
+  })
+
+  it('rejects buildSnapshot on $queryRaw failure', async () => {
+    const db = {
+      epic: { findMany: vi.fn().mockResolvedValue([]) },
+      project: { findUnique: vi.fn().mockResolvedValue(null) },
+      resourceType: { findMany: vi.fn().mockResolvedValue([]) },
+      namedResource: { findMany: vi.fn().mockResolvedValue([]) },
+      timelineEntry: { findMany: vi.fn().mockResolvedValue([]) },
+      storyTimelineEntry: { findMany: vi.fn().mockResolvedValue([]) },
+      epicDependency: { findMany: vi.fn().mockResolvedValue([]) },
+      featureDependency: { findMany: vi.fn().mockResolvedValue([]) },
+      projectOverhead: { findMany: vi.fn().mockResolvedValue([]) },
+      capacityProfile: { findMany: vi.fn().mockResolvedValue([{
+        id: 'cp-1', ownerKind: 'ROLE',
+        resourceTypeId: 'rt-dev', namedResourceId: null,
+        planningBasis: 'DEMAND_FOLLOWING', source: 'FIXED',
+        defaultPercent: null, startWeek: null, endWeek: null,
+        legacy: null, segments: [],
+      }]) },
+      $queryRaw: vi.fn().mockRejectedValue(new Error('DB connection lost')),
+    }
+
+    await expect(buildSnapshot(projId, db as never)).rejects.toThrow('DB connection lost')
+  })
+
+  it('rejects buildSnapshot when null-state rows are fewer than profiles', async () => {
+    const db = {
+      epic: { findMany: vi.fn().mockResolvedValue([]) },
+      project: { findUnique: vi.fn().mockResolvedValue(null) },
+      resourceType: { findMany: vi.fn().mockResolvedValue([]) },
+      timelineEntry: { findMany: vi.fn().mockResolvedValue([]) },
+      storyTimelineEntry: { findMany: vi.fn().mockResolvedValue([]) },
+      epicDependency: { findMany: vi.fn().mockResolvedValue([]) },
+      featureDependency: { findMany: vi.fn().mockResolvedValue([]) },
+      projectOverhead: { findMany: vi.fn().mockResolvedValue([]) },
+      capacityProfile: { findMany: vi.fn().mockResolvedValue([
+        { id: 'cp-1', ownerKind: 'ROLE', resourceTypeId: 'rt-dev', namedResourceId: null,
+          planningBasis: 'DEMAND_FOLLOWING', source: 'FIXED',
+          defaultPercent: null, startWeek: null, endWeek: null,
+          legacy: null, segments: [] },
+        { id: 'cp-2', ownerKind: 'NAMED_PERSON', resourceTypeId: null, namedResourceId: 'nr-alice',
+          planningBasis: 'AVAILABILITY_WINDOW', source: 'SQUAD_PLANNER',
+          defaultPercent: 100, startWeek: 0, endWeek: 10,
+          legacy: null, segments: [] },
+      ]) },
+      namedResource: { findMany: vi.fn().mockResolvedValue([
+        { id: 'nr-alice', resourceTypeId: 'rt-dev', name: 'Alice',
+          startWeek: null, endWeek: null, allocationPct: 100,
+          allocationMode: 'EFFORT', allocationPercent: 100,
+          allocationStartWeek: null, allocationEndWeek: null,
+          pricingModel: 'ACTUAL_DAYS' },
+      ]) },
+      // Only 1 row for 2 profiles — triggers missing profile error
+      $queryRaw: vi.fn().mockResolvedValue([
+        { id: 'cp-1', legacy_is_null: false, legacy_typeof: 'null' },
+      ]),
+    }
+
+    await expect(buildSnapshot(projId, db as never)).rejects.toThrow('Missing null-state row')
+  })
 })
 // ═══════════════════════════════════════════════════════════════════════════
 // 5. Route — V1/V2/V3 rollback
@@ -529,6 +652,7 @@ function makeRouteTx(overrides: Record<string, unknown> = {}) {
     epicDependency: { findMany: vi.fn().mockResolvedValue([]), deleteMany: vi.fn().mockResolvedValue({ count: 0 }), createMany: vi.fn().mockResolvedValue({ count: 0 }) },
     featureDependency: { findMany: vi.fn().mockResolvedValue([]), deleteMany: vi.fn().mockResolvedValue({ count: 0 }), createMany: vi.fn().mockResolvedValue({ count: 0 }) },
     projectOverhead: { findMany: vi.fn().mockResolvedValue([]), deleteMany: vi.fn().mockResolvedValue({ count: 0 }), createMany: vi.fn().mockResolvedValue({ count: 0 }) },
+    $queryRaw: vi.fn().mockResolvedValue([]),
     capacityProfile: { findMany: vi.fn().mockResolvedValue([]), deleteMany: vi.fn().mockResolvedValue({ count: 999 }), create: vi.fn().mockResolvedValue({}) },
     capacitySegment: { deleteMany: vi.fn().mockResolvedValue({ count: 999 }), create: vi.fn().mockResolvedValue({}) },
     feature: { create: vi.fn().mockResolvedValue({ id: 'new-feature' }) },
@@ -580,7 +704,7 @@ describe('POST /api/projects/:projectId/snapshots/:snapshotId/rollback', () => {
     const v2Data = {
       schemaVersion: 2, epics: [], project: null,
       resourceTypes: [{
-        id: 'rt-1', name: 'Developer', category: 'role', count: 1,
+        id: 'rt-1', name: 'Developer', category: 'ENGINEERING', count: 1,
         hoursPerDay: null, dayRate: null, globalTypeId: null,
         allocationMode: 'TIMELINE', allocationPercent: 60,
         allocationStartWeek: 2, allocationEndWeek: 6,
@@ -636,7 +760,7 @@ describe('POST /api/projects/:projectId/snapshots/:snapshotId/rollback', () => {
     const v3Target: SnapshotV3 = {
       schemaVersion: 3, epics: [], project: null,
       resourceTypes: [
-        { id: 'rt-dev', name: 'Developer', category: 'role', count: 2,
+        { id: 'rt-dev', name: 'Developer', category: 'ENGINEERING', count: 2,
           hoursPerDay: 8, dayRate: 500, globalTypeId: null,
           allocationMode: 'TIMELINE', allocationPercent: 100,
           allocationStartWeek: 0, allocationEndWeek: 10 },
@@ -756,7 +880,7 @@ describe('POST /api/projects/:projectId/snapshots/:snapshotId/rollback', () => {
   it('V3: invalid profile data returns 400 before transaction', async () => {
     const invalidV3 = {
       schemaVersion: 3, epics: [], project: null,
-      resourceTypes: [{ id: 'rt-dev', name: 'Dev', category: 'role', count: 1,
+      resourceTypes: [{ id: 'rt-dev', name: 'Dev', category: 'ENGINEERING', count: 1,
         hoursPerDay: 8, dayRate: 500, globalTypeId: null,
         allocationMode: 'TIMELINE', allocationPercent: 100,
         allocationStartWeek: 0, allocationEndWeek: 10 }],
@@ -814,7 +938,7 @@ describe('POST /api/projects/:projectId/snapshots/:snapshotId/rollback', () => {
   it('cross-project ID collision returns 400 before transaction', async () => {
     const v3Target: SnapshotV3 = {
       schemaVersion: 3, epics: [], project: null,
-      resourceTypes: [{ id: 'rt-dev', name: 'Dev', category: 'role', count: 1,
+      resourceTypes: [{ id: 'rt-dev', name: 'Dev', category: 'ENGINEERING', count: 1,
         hoursPerDay: 8, dayRate: 500, globalTypeId: null,
         allocationMode: 'TIMELINE', allocationPercent: 100,
         allocationStartWeek: 0, allocationEndWeek: 10 }],
@@ -852,7 +976,7 @@ describe('POST /api/projects/:projectId/snapshots/:snapshotId/rollback', () => {
   it('V3: foreign resourceType from snapshot.resourceTypes rejected before transaction', async () => {
     const v3Target: SnapshotV3 = {
       schemaVersion: 3, epics: [], project: null,
-      resourceTypes: [{ id: 'rt-foreign', name: 'OtherTeam', category: 'role', count: 1,
+      resourceTypes: [{ id: 'rt-foreign', name: 'OtherTeam', category: 'ENGINEERING', count: 1,
         hoursPerDay: 8, dayRate: 500, globalTypeId: null,
         allocationMode: 'TIMELINE', allocationPercent: 100,
         allocationStartWeek: 0, allocationEndWeek: 10 }],
@@ -885,7 +1009,7 @@ describe('POST /api/projects/:projectId/snapshots/:snapshotId/rollback', () => {
   it('V3: foreign namedResource from snapshot.namedResources rejected before transaction', async () => {
     const v3Target: SnapshotV3 = {
       schemaVersion: 3, epics: [], project: null,
-      resourceTypes: [{ id: 'rt-dev', name: 'Dev', category: 'role', count: 1,
+      resourceTypes: [{ id: 'rt-dev', name: 'Dev', category: 'ENGINEERING', count: 1,
         hoursPerDay: 8, dayRate: 500, globalTypeId: null,
         allocationMode: 'TIMELINE', allocationPercent: 100,
         allocationStartWeek: 0, allocationEndWeek: 10 }],
@@ -924,11 +1048,11 @@ describe('POST /api/projects/:projectId/snapshots/:snapshotId/rollback', () => {
     const v3Target: SnapshotV3 = {
       schemaVersion: 3, epics: [], project: null,
       resourceTypes: [
-        { id: 'rt-dev', name: 'Dev', category: 'role', count: 1,
+        { id: 'rt-dev', name: 'Dev', category: 'ENGINEERING', count: 1,
           hoursPerDay: 8, dayRate: 500, globalTypeId: null,
           allocationMode: 'TIMELINE', allocationPercent: 100,
           allocationStartWeek: 0, allocationEndWeek: 10 },
-        { id: 'rt-foreign', name: 'Other', category: 'role', count: 1,
+        { id: 'rt-foreign', name: 'Other', category: 'ENGINEERING', count: 1,
           hoursPerDay: 8, dayRate: 500, globalTypeId: null,
           allocationMode: 'TIMELINE', allocationPercent: 100,
           allocationStartWeek: 0, allocationEndWeek: 10 },
@@ -936,7 +1060,7 @@ describe('POST /api/projects/:projectId/snapshots/:snapshotId/rollback', () => {
       namedResources: [],
       timelineEntries: [], storyTimelineEntries: [],
       epicDependencies: [], featureDependencies: [],
-      overheadItems: [{ name: 'PM', type: 'percent', value: 10, resourceTypeId: 'rt-foreign', order: 1 }],
+      overheadItems: [{ name: 'PM', type: 'PERCENTAGE', value: 10, resourceTypeId: 'rt-foreign', order: 1 }],
       capacityProfiles: [],
     }
 
@@ -964,7 +1088,7 @@ describe('POST /api/projects/:projectId/snapshots/:snapshotId/rollback', () => {
   it('V3: new IDs not in DB are allowed (valid rollback)', async () => {
     const v3Target: SnapshotV3 = {
       schemaVersion: 3, epics: [], project: null,
-      resourceTypes: [{ id: 'rt-new', name: 'NewRole', category: 'role', count: 1,
+      resourceTypes: [{ id: 'rt-new', name: 'NewRole', category: 'ENGINEERING', count: 1,
         hoursPerDay: 8, dayRate: 500, globalTypeId: null,
         allocationMode: 'TIMELINE', allocationPercent: 100,
         allocationStartWeek: 0, allocationEndWeek: 10 }],
@@ -1066,7 +1190,7 @@ describe('POST /api/projects/:projectId/snapshots/:snapshotId/rollback', () => {
   it('V3 tx callback failure rejects with 500 (restore/write error)', async () => {
     const v3Target: SnapshotV3 = {
       schemaVersion: 3, epics: [], project: null,
-      resourceTypes: [{ id: 'rt-dev', name: 'Dev', category: 'role', count: 1,
+      resourceTypes: [{ id: 'rt-dev', name: 'Dev', category: 'ENGINEERING', count: 1,
         hoursPerDay: 8, dayRate: 500, globalTypeId: null,
         allocationMode: 'TIMELINE', allocationPercent: 100,
         allocationStartWeek: 0, allocationEndWeek: 10 }],
@@ -1113,5 +1237,325 @@ describe('POST /api/projects/:projectId/snapshots/:snapshotId/rollback', () => {
     expect(cpCreate.mock.calls.length).toBeGreaterThanOrEqual(1)
     // No external cleanup — DB transaction provides atomicity
     expect(bsDeleteSpy).not.toHaveBeenCalled()
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 8. Route persistence on buildSnapshot failure
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('route persistence on buildSnapshot failure', () => {
+  it('manual POST persists nothing on $queryRaw failure', async () => {
+    vi.mocked(prisma.project.findFirst).mockResolvedValue({ id: projId, ownerId: userId } as never)
+    // Provide minimal data for buildSnapshot queries
+    vi.mocked(prisma.project.findUnique).mockResolvedValue({
+      startDate: new Date(), onboardingWeeks: 0, bufferWeeks: 0, hoursPerDay: 7.6,
+    } as never)
+    vi.mocked(prisma.resourceType.findMany).mockResolvedValue([])
+    vi.mocked(prisma.namedResource.findMany).mockResolvedValue([])
+    vi.mocked(prisma.timelineEntry.findMany).mockResolvedValue([])
+    vi.mocked(prisma.storyTimelineEntry.findMany).mockResolvedValue([])
+    vi.mocked(prisma.epicDependency.findMany).mockResolvedValue([])
+    vi.mocked(prisma.featureDependency.findMany).mockResolvedValue([])
+    vi.mocked(prisma.projectOverhead.findMany).mockResolvedValue([])
+    vi.mocked(prisma.capacityProfile.findMany).mockResolvedValue([
+      { id: 'cp-1', ownerKind: 'ROLE', resourceTypeId: null, namedResourceId: null,
+        legacy: null },
+    ] as never)
+    // $queryRaw rejects → buildSnapshot throws
+    const mockQueryRaw = vi.fn().mockRejectedValue(new Error('Query failure'))
+    ;(prisma as unknown as Record<string, unknown>).$queryRaw = mockQueryRaw
+
+    const bsCreate = vi.mocked(prisma.backlogSnapshot.create)
+    const bsDeleteMany = vi.mocked(prisma.backlogSnapshot.deleteMany)
+
+    const res = await request(app)
+      .post(`/api/projects/${projId}/snapshots`)
+      .set('Authorization', authHeader)
+      .send({ label: 'fail-test' })
+
+    expect(res.status).toBe(500)
+    expect(bsCreate).not.toHaveBeenCalled()
+    expect(bsDeleteMany).not.toHaveBeenCalled()
+
+    delete (prisma as unknown as Record<string, unknown>).$queryRaw
+  })
+
+  it('rollback transaction aborts before destructive restore on buildSnapshot failure', async () => {
+    const v3Target: SnapshotV3 = {
+      schemaVersion: 3, epics: [], project: null,
+      resourceTypes: [
+        { id: 'rt-dev', name: 'Dev', category: 'ENGINEERING', count: 1,
+          hoursPerDay: 8, dayRate: 500, globalTypeId: null,
+          allocationMode: 'TIMELINE', allocationPercent: 100,
+          allocationStartWeek: 0, allocationEndWeek: 10 },
+      ],
+      namedResources: [],
+      timelineEntries: [], storyTimelineEntries: [],
+      epicDependencies: [], featureDependencies: [], overheadItems: [],
+      capacityProfiles: [
+        { id: 'cp-1', ownerKind: 'ROLE', resourceTypeId: 'rt-dev', namedResourceId: null,
+          planningBasis: 'DEMAND_FOLLOWING', source: 'FIXED', defaultPercent: null,
+          startWeek: null, endWeek: null, legacy: { kind: 'DB_NULL' }, segments: [] },
+      ],
+    }
+
+    vi.mocked(prisma.project.findFirst).mockResolvedValue({ id: projId, ownerId: userId } as never)
+    vi.mocked(prisma.backlogSnapshot.findFirst).mockResolvedValue({
+      id: 'snap-fail-build', projectId: projId, label: 'fail-build',
+      trigger: 'manual', snapshot: v3Target as unknown as never,
+      createdById: userId, createdAt: new Date(),
+    } as never)
+    vi.mocked(prisma.resourceType.findMany).mockResolvedValue([] as never)
+    vi.mocked(prisma.namedResource.findMany).mockResolvedValue([] as never)
+
+    const bsCreate = vi.fn()
+    const cpDelete = vi.fn().mockResolvedValue({ count: 0 })
+    const epicDel = vi.fn().mockResolvedValue({ count: 0 })
+
+    vi.mocked(prisma.$transaction).mockImplementation(async (fn: unknown) => {
+      const tx = makeRouteTx({
+        $queryRaw: vi.fn().mockRejectedValue(new Error('Null-state query failure')),
+        backlogSnapshot: { create: bsCreate, findMany: vi.fn().mockResolvedValue([]), deleteMany: vi.fn().mockResolvedValue({ count: 0 }) },
+        capacityProfile: {
+          findMany: vi.fn().mockResolvedValue([
+            { id: 'cp-1', ownerKind: 'ROLE', resourceTypeId: null, namedResourceId: null,
+              planningBasis: 'DEMAND_FOLLOWING', source: 'FIXED',
+              defaultPercent: null, startWeek: null, endWeek: null,
+              legacy: null, segments: [] },
+          ]),
+          deleteMany: cpDelete, create: vi.fn(),
+        },
+        epic: { findMany: vi.fn().mockResolvedValue([]), deleteMany: epicDel },
+      })
+      return typeof fn === 'function'
+        ? (fn as (t: unknown) => Promise<unknown>)(tx)
+        : Promise.resolve(fn)
+    })
+
+    const res = await request(app)
+      .post(`/api/projects/${projId}/snapshots/snap-fail-build/rollback`)
+      .set('Authorization', authHeader)
+
+    expect(res.status).toBe(500)
+    // Pre-rollback snapshot NOT created
+    expect(bsCreate).not.toHaveBeenCalled()
+    // No destructive operations attempted
+    expect(cpDelete).not.toHaveBeenCalled()
+    expect(epicDel).not.toHaveBeenCalled()
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 9. rollbackProjectSnapshot service (direct unit tests)
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('rollbackProjectSnapshot', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('V1: rolls back bare epic array via service', async () => {
+    vi.mocked(prisma.backlogSnapshot.findFirst).mockResolvedValue({
+      id: 'snap-v1-svc', projectId: projId, label: 'V1 svc',
+      trigger: 'manual',
+      snapshot: [{ id: 'e1', name: 'Epic', description: null, assumptions: null, order: 0,
+        featureMode: 'FIFO', scheduleMode: 'ASAP', timelineStartWeek: null,
+        isActive: true, projectId: projId, features: [] }],
+      createdById: userId, createdAt: new Date(),
+    } as never)
+
+    const epicDel = vi.fn().mockResolvedValue({ count: 0 })
+    const bsCreate = vi.fn().mockResolvedValue({})
+
+    vi.mocked(prisma.$transaction).mockImplementation(async (fn: unknown) => {
+      const tx = makeRouteTx({
+        capacityProfile: { findMany: vi.fn().mockResolvedValue([]), deleteMany: vi.fn().mockResolvedValue({ count: 0 }), create: vi.fn().mockResolvedValue({}) },
+        epic: { findMany: vi.fn().mockResolvedValue([]), deleteMany: epicDel, create: vi.fn().mockResolvedValue({ id: 'new-e1' }) },
+        backlogSnapshot: { create: bsCreate, findMany: vi.fn().mockResolvedValue([]), deleteMany: vi.fn().mockResolvedValue({ count: 0 }) },
+      })
+      return typeof fn === 'function'
+        ? (fn as (t: unknown) => Promise<unknown>)(tx)
+        : Promise.resolve(fn)
+    })
+
+    await rollbackProjectSnapshot({ projectId: projId, snapshotId: 'snap-v1-svc', userId })
+    expect(vi.mocked(prisma.$transaction)).toHaveBeenCalledTimes(1)
+    expect(bsCreate).toHaveBeenCalled()
+    expect(epicDel).toHaveBeenCalled()
+  })
+
+  it('V2: full-state restore via service', async () => {
+    const v2Data = {
+      schemaVersion: 2, epics: [], project: null,
+      resourceTypes: [{
+        id: 'rt-1', name: 'Developer', category: 'ENGINEERING', count: 1,
+        hoursPerDay: null, dayRate: null, globalTypeId: null,
+        allocationMode: 'TIMELINE', allocationPercent: 60,
+        allocationStartWeek: 2, allocationEndWeek: 6,
+      }],
+      namedResources: [],
+      timelineEntries: [], storyTimelineEntries: [],
+      epicDependencies: [], featureDependencies: [], overheadItems: [],
+    }
+
+    vi.mocked(prisma.backlogSnapshot.findFirst).mockResolvedValue({
+      id: 'snap-v2-svc', projectId: projId, label: 'V2 svc',
+      trigger: 'manual', snapshot: v2Data,
+      createdById: userId, createdAt: new Date(),
+    } as never)
+
+    const cpDelete = vi.fn().mockResolvedValue({ count: 999 })
+    const segDelete = vi.fn().mockResolvedValue({ count: 999 })
+    const cpCreate = vi.fn().mockResolvedValue({})
+
+    vi.mocked(prisma.$transaction).mockImplementation(async (fn: unknown) => {
+      const tx = makeRouteTx({
+        capacityProfile: { findMany: vi.fn().mockResolvedValue([]), deleteMany: cpDelete, create: cpCreate },
+        capacitySegment: { deleteMany: segDelete, create: vi.fn().mockResolvedValue({}) },
+      })
+      return typeof fn === 'function'
+        ? (fn as (t: unknown) => Promise<unknown>)(tx)
+        : Promise.resolve(fn)
+    })
+
+    await rollbackProjectSnapshot({ projectId: projId, snapshotId: 'snap-v2-svc', userId })
+    expect(vi.mocked(prisma.$transaction)).toHaveBeenCalledTimes(1)
+    expect(cpDelete).toHaveBeenCalled()
+    expect(segDelete).toHaveBeenCalled()
+    expect(cpCreate).toHaveBeenCalled()
+  })
+
+  it('V3: exact profile/segment replacement via service', async () => {
+    const v3Target: SnapshotV3 = {
+      schemaVersion: 3, epics: [], project: null,
+      resourceTypes: [{ id: 'rt-dev', name: 'Dev', category: 'ENGINEERING', count: 2,
+        hoursPerDay: 8, dayRate: 500, globalTypeId: null,
+        allocationMode: 'TIMELINE', allocationPercent: 100,
+        allocationStartWeek: 0, allocationEndWeek: 10 }],
+      namedResources: [{ id: 'nr-alice', resourceTypeId: 'rt-dev', name: 'Alice',
+        startWeek: null, endWeek: null, allocationPct: 100,
+        allocationMode: 'EFFORT', allocationPercent: 100,
+        allocationStartWeek: null, allocationEndWeek: null, pricingModel: 'ACTUAL_DAYS' }],
+      timelineEntries: [], storyTimelineEntries: [],
+      epicDependencies: [], featureDependencies: [], overheadItems: [],
+      capacityProfiles: [
+        { id: 'cp-1', ownerKind: 'ROLE', resourceTypeId: 'rt-dev', namedResourceId: null,
+          planningBasis: 'DEMAND_FOLLOWING', source: 'FIXED', defaultPercent: null,
+          startWeek: null, endWeek: null, legacy: { kind: 'DB_NULL' }, segments: [] },
+        { id: 'cp-2', ownerKind: 'NAMED_PERSON', resourceTypeId: null, namedResourceId: 'nr-alice',
+          planningBasis: 'AVAILABILITY_WINDOW', source: 'SQUAD_PLANNER', defaultPercent: 100,
+          startWeek: 0, endWeek: 10, legacy: { kind: 'VALUE', value: { mode: 'EFFORT' } },
+          segments: [{ id: 'seg-a', startWeek: 0, endWeek: 4, capacityPercent: 100, source: 'SQUAD_PLANNER' }],
+        },
+      ],
+    }
+
+    vi.mocked(prisma.backlogSnapshot.findFirst).mockResolvedValue({
+      id: 'snap-v3-svc', projectId: projId, label: 'V3 svc',
+      trigger: 'manual', snapshot: v3Target as unknown as never,
+      createdById: userId, createdAt: new Date(),
+    } as never)
+    vi.mocked(prisma.resourceType.findMany).mockResolvedValue([
+      { id: 'rt-dev', projectId: projId },
+    ] as never)
+    vi.mocked(prisma.namedResource.findMany).mockResolvedValue([
+      { id: 'nr-alice', resourceType: { projectId: projId } },
+    ] as never)
+
+    const cpDelete = vi.fn().mockResolvedValue({ count: 999 })
+    const segDelete = vi.fn().mockResolvedValue({ count: 999 })
+    const cpCreate = vi.fn().mockResolvedValue({})
+    const bsCreate = vi.fn().mockResolvedValue({})
+
+    vi.mocked(prisma.$transaction).mockImplementation(async (fn: unknown) => {
+      const tx = makeRouteTx({
+        capacityProfile: { findMany: vi.fn().mockResolvedValue([]), deleteMany: cpDelete, create: cpCreate },
+        capacitySegment: { deleteMany: segDelete, create: vi.fn().mockResolvedValue({}) },
+        backlogSnapshot: { create: bsCreate, findMany: vi.fn().mockResolvedValue([]), deleteMany: vi.fn().mockResolvedValue({ count: 0 }) },
+      })
+      return typeof fn === 'function'
+        ? (fn as (t: unknown) => Promise<unknown>)(tx)
+        : Promise.resolve(fn)
+    })
+
+    await rollbackProjectSnapshot({ projectId: projId, snapshotId: 'snap-v3-svc', userId })
+    expect(vi.mocked(prisma.$transaction)).toHaveBeenCalledTimes(1)
+    expect(bsCreate).toHaveBeenCalled()
+    expect(cpDelete).toHaveBeenCalled()
+    expect(segDelete).toHaveBeenCalled()
+    expect(cpCreate.mock.calls.length).toBe(2)
+  })
+
+  it('throws SnapshotNotFoundError when snapshot missing', async () => {
+    vi.mocked(prisma.backlogSnapshot.findFirst).mockResolvedValue(null as never)
+
+    await expect(rollbackProjectSnapshot({
+      projectId: projId, snapshotId: 'missing', userId,
+    })).rejects.toThrow(SnapshotNotFoundError)
+
+    expect(vi.mocked(prisma.$transaction)).not.toHaveBeenCalled()
+  })
+
+  it('throws SnapshotSchemaError on unparseable snapshot JSON', async () => {
+    vi.mocked(prisma.backlogSnapshot.findFirst).mockResolvedValue({
+      id: 'snap-bad-json', projectId: projId, label: 'bad',
+      trigger: 'manual', snapshot: 'not-a-valid-snapshot',
+      createdById: userId, createdAt: new Date(),
+    } as never)
+
+    await expect(rollbackProjectSnapshot({
+      projectId: projId, snapshotId: 'snap-bad-json', userId,
+    })).rejects.toThrow(SnapshotSchemaError)
+
+    expect(vi.mocked(prisma.$transaction)).not.toHaveBeenCalled()
+  })
+
+  it('throws RollbackPreflightError on cross-project ID collision', async () => {
+    const v3Target: SnapshotV3 = {
+      schemaVersion: 3, epics: [], project: null,
+      resourceTypes: [{ id: 'rt-foreign', name: 'Foreign', category: 'ENGINEERING', count: 1,
+        hoursPerDay: 8, dayRate: 500, globalTypeId: null,
+        allocationMode: 'TIMELINE', allocationPercent: 100,
+        allocationStartWeek: 0, allocationEndWeek: 10 }],
+      namedResources: [],
+      timelineEntries: [], storyTimelineEntries: [],
+      epicDependencies: [], featureDependencies: [], overheadItems: [],
+      capacityProfiles: [
+        { id: 'cp-1', ownerKind: 'ROLE', resourceTypeId: 'rt-foreign', namedResourceId: null,
+          planningBasis: 'DEMAND_FOLLOWING', source: 'FIXED', defaultPercent: null,
+          startWeek: null, endWeek: null, legacy: { kind: 'DB_NULL' }, segments: [] },
+      ],
+    }
+
+    vi.mocked(prisma.backlogSnapshot.findFirst).mockResolvedValue({
+      id: 'snap-cross-svc', projectId: projId, label: 'cross-svc',
+      trigger: 'manual', snapshot: v3Target as unknown as never,
+      createdById: userId, createdAt: new Date(),
+    } as never)
+    vi.mocked(prisma.resourceType.findMany).mockResolvedValue([
+      { id: 'rt-foreign', projectId: 'other-project' },
+    ] as never)
+
+    await expect(rollbackProjectSnapshot({
+      projectId: projId, snapshotId: 'snap-cross-svc', userId,
+    })).rejects.toThrow(RollbackPreflightError)
+
+    expect(vi.mocked(prisma.$transaction)).not.toHaveBeenCalled()
+  })
+
+  it('propagates $transaction rejection with 500-equivalent error', async () => {
+    vi.mocked(prisma.backlogSnapshot.findFirst).mockResolvedValue({
+      id: 'snap-tx-fail', projectId: projId, label: 'tx-fail',
+      trigger: 'manual',
+      snapshot: [{ id: 'e1', name: 'E', features: [] }],
+      createdById: userId, createdAt: new Date(),
+    } as never)
+
+    vi.mocked(prisma.$transaction).mockRejectedValue(new Error('DB timeout'))
+
+    await expect(rollbackProjectSnapshot({
+      projectId: projId, snapshotId: 'snap-tx-fail', userId,
+    })).rejects.toThrow('DB timeout')
   })
 })

--- a/server/src/test/snapshots.test.ts
+++ b/server/src/test/snapshots.test.ts
@@ -16,6 +16,7 @@
 
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import request from 'supertest'
+import { Prisma } from '@prisma/client'
 import jwt from 'jsonwebtoken'
 import { app } from '../index.js'
 import { prisma } from '../lib/prisma.js'
@@ -24,6 +25,7 @@ import {
   SnapshotSchemaError,
   isSnapshotV2,
   isSnapshotV3,
+
   type SnapshotV2,
   type SnapshotV3,
 } from '../lib/projectSnapshotTypes.js'
@@ -150,7 +152,7 @@ describe('validateSnapshotV3', () => {
           defaultPercent: null,
           startWeek: null,
           endWeek: null,
-          legacy: null,
+          legacy: { kind: 'DB_NULL' },
           segments: [],
         },
         {
@@ -163,7 +165,7 @@ describe('validateSnapshotV3', () => {
           defaultPercent: 100,
           startWeek: 0,
           endWeek: 10,
-          legacy: { allocationMode: 'EFFORT' },
+          legacy: { kind: 'VALUE', value: { allocationMode: 'EFFORT' } },
           segments: [
             { id: 'seg-1', startWeek: 0, endWeek: 4, capacityPercent: 100, source: 'SQUAD_PLANNER' },
           ],
@@ -233,7 +235,7 @@ describe('validateSnapshotV3', () => {
       defaultPercent: 50,
       startWeek: 2,
       endWeek: 6,
-      legacy: null,
+      legacy: { kind: 'DB_NULL' },
       segments: [],
     })
     // Two ROLE profiles with same resourceTypeId — allowed
@@ -258,7 +260,7 @@ describe('validateSnapshotV3', () => {
 
   it('accepts null legacy field', () => {
     const snap = makeBaseV3()
-    snap.capacityProfiles[0].legacy = null
+    snap.capacityProfiles[0].legacy = { kind: 'DB_NULL' }
     expect(() => validateSnapshotV3(snap)).not.toThrow()
   })
 
@@ -477,7 +479,7 @@ describe('buildSnapshot', () => {
     expect(cp2.defaultPercent).toBe(100)
     expect(cp2.startWeek).toBe(0)
     expect(cp2.endWeek).toBe(10)
-    expect(cp2.legacy).toEqual({ allocationMode: 'EFFORT' })
+    expect(cp2.legacy).toEqual({ kind: 'VALUE', value: { allocationMode: 'EFFORT' } })
     expect(cp2.segments.map(s => s.id)).toEqual(['seg-2a', 'seg-2b', 'seg-2c'])
     expect(cp2.segments[0]).toEqual({ id: 'seg-2a', startWeek: 0, endWeek: 4, capacityPercent: 100, source: 'SQUAD_PLANNER' })
     expect(cp2.segments[1].startWeek).toBe(4)
@@ -489,7 +491,7 @@ describe('buildSnapshot', () => {
     expect(cp3.namedResourceId).toBe('nr-bob')
     expect(cp3.planningBasis).toBe('WHOLE_PROJECT_ALLOCATION')
     expect(cp3.source).toBe('MANUAL')
-    expect(cp3.legacy).toEqual({ oldField: 'value' })
+    expect(cp3.legacy).toEqual({ kind: 'VALUE', value: { oldField: 'value' } })
     expect(cp3.segments.map(s => s.id)).toEqual(['seg-3a', 'seg-3b'])
     expect(cp3.segments[0].capacityPercent).toBe(50)
     expect(cp3.segments[1].capacityPercent).toBe(100)
@@ -504,7 +506,7 @@ describe('buildSnapshot', () => {
     expect(cp1.defaultPercent).toBeNull()
     expect(cp1.startWeek).toBeNull()
     expect(cp1.endWeek).toBeNull()
-    expect(cp1.legacy).toBeNull()
+    expect(cp1.legacy).toEqual({ kind: 'JSON_NULL' })
     expect(cp1.segments).toEqual([])
   })
 })
@@ -621,7 +623,7 @@ describe('POST /api/projects/:projectId/snapshots/:snapshotId/rollback', () => {
 
     const created = cpCreate.mock.calls[0][0]?.data as Record<string, unknown>
     expect(created.id).toBe('snapshot-v2-role-rt-1')
-    expect(created.projectId).toBe(projId)
+    expect(created.project).toEqual({ connect: { id: projId } })
     expect(created.ownerKind).toBe('ROLE')
     expect(created.planningBasis).toBe('AVAILABILITY_WINDOW')
     expect(created.source).toBe('AVAILABILITY_WINDOW')
@@ -652,12 +654,12 @@ describe('POST /api/projects/:projectId/snapshots/:snapshotId/rollback', () => {
         {
           id: 'cp-1', ownerKind: 'ROLE', resourceTypeId: 'rt-dev', namedResourceId: null,
           planningBasis: 'DEMAND_FOLLOWING', source: 'FIXED', defaultPercent: null,
-          startWeek: null, endWeek: null, legacy: null, segments: [],
+          startWeek: null, endWeek: null, legacy: { kind: 'DB_NULL' }, segments: [],
         },
         {
           id: 'cp-2', ownerKind: 'NAMED_PERSON', resourceTypeId: null, namedResourceId: 'nr-alice',
           planningBasis: 'AVAILABILITY_WINDOW', source: 'SQUAD_PLANNER', defaultPercent: 100,
-          startWeek: 0, endWeek: 10, legacy: { mode: 'EFFORT' },
+          startWeek: 0, endWeek: 10, legacy: { kind: 'VALUE', value: { mode: 'EFFORT' } },
           segments: [
             { id: 'seg-a', startWeek: 0, endWeek: 4, capacityPercent: 100, source: 'SQUAD_PLANNER' },
           ],
@@ -713,11 +715,10 @@ describe('POST /api/projects/:projectId/snapshots/:snapshotId/rollback', () => {
 
     const cp1 = cpCreate.mock.calls[0][0]?.data as Record<string, unknown>
     expect(cp1.id).toBe('cp-1')
-    expect(cp1.projectId).toBe(projId)
+    expect(cp1.project).toEqual({ connect: { id: projId } })
     expect(cp1.ownerKind).toBe('ROLE')
-    expect(cp1.resourceTypeId).toBe('rt-dev')
-    expect(cp1.namedResourceId).toBeNull()
-    expect(cp1.legacy).toBeNull()
+    expect(cp1.resourceType).toEqual({ connect: { id: 'rt-dev' } })
+    expect(cp1.legacy).toBe(Prisma.DbNull)
     expect(cp1.planningBasis).toBe('DEMAND_FOLLOWING')
     expect(cp1.source).toBe('FIXED')
     expect(cp1.defaultPercent).toBeNull()
@@ -726,9 +727,10 @@ describe('POST /api/projects/:projectId/snapshots/:snapshotId/rollback', () => {
 
     const cp2 = cpCreate.mock.calls[1][0]?.data as Record<string, unknown>
     expect(cp2.id).toBe('cp-2')
-    expect(cp2.projectId).toBe(projId)
+    expect(cp2.project).toEqual({ connect: { id: projId } })
     expect(cp2.ownerKind).toBe('NAMED_PERSON')
-    expect(cp2.namedResourceId).toBe('nr-alice')
+    expect(cp2.resourceType).toBeUndefined()
+    expect(cp2.namedResource).toEqual({ connect: { id: 'nr-alice' } })
     expect(cp2.legacy).toEqual({ mode: 'EFFORT' })
     expect(cp2.planningBasis).toBe('AVAILABILITY_WINDOW')
     expect(cp2.source).toBe('SQUAD_PLANNER')
@@ -740,7 +742,7 @@ describe('POST /api/projects/:projectId/snapshots/:snapshotId/rollback', () => {
     expect(segCreate.mock.calls.length).toBe(1)
     const seg1 = segCreate.mock.calls[0][0]?.data as Record<string, unknown>
     expect(seg1.id).toBe('seg-a')
-    expect(seg1.capacityProfileId).toBe('cp-2')
+    expect(seg1.capacityProfile).toEqual({ connect: { id: 'cp-2' } })
     expect(seg1.startWeek).toBe(0)
     expect(seg1.endWeek).toBe(4)
     expect(seg1.capacityPercent).toBe(100)
@@ -767,7 +769,7 @@ describe('POST /api/projects/:projectId/snapshots/:snapshotId/rollback', () => {
       capacityProfiles: [
         { id: 'cp-1', ownerKind: 'ROLE', resourceTypeId: null, namedResourceId: null,
           planningBasis: 'DEMAND_FOLLOWING', source: 'FIXED', defaultPercent: null,
-          startWeek: null, endWeek: null, legacy: null, segments: [] },
+          startWeek: null, endWeek: null, legacy: { kind: 'DB_NULL' }, segments: [] },
       ],
     }
 
@@ -822,7 +824,7 @@ describe('POST /api/projects/:projectId/snapshots/:snapshotId/rollback', () => {
       capacityProfiles: [
         { id: 'cp-1', ownerKind: 'ROLE', resourceTypeId: 'rt-dev', namedResourceId: null,
           planningBasis: 'DEMAND_FOLLOWING', source: 'FIXED', defaultPercent: null,
-          startWeek: null, endWeek: null, legacy: null, segments: [] },
+          startWeek: null, endWeek: null, legacy: { kind: 'DB_NULL' }, segments: [] },
       ],
     }
 
@@ -975,7 +977,7 @@ describe('POST /api/projects/:projectId/snapshots/:snapshotId/rollback', () => {
       capacityProfiles: [
         { id: 'cp-new', ownerKind: 'ROLE', resourceTypeId: 'rt-new', namedResourceId: null,
           planningBasis: 'DEMAND_FOLLOWING', source: 'FIXED', defaultPercent: null,
-          startWeek: null, endWeek: null, legacy: null, segments: [] },
+          startWeek: null, endWeek: null, legacy: { kind: 'DB_NULL' }, segments: [] },
       ],
     }
 
@@ -1074,7 +1076,7 @@ describe('POST /api/projects/:projectId/snapshots/:snapshotId/rollback', () => {
       capacityProfiles: [
         { id: 'cp-1', ownerKind: 'ROLE', resourceTypeId: 'rt-dev', namedResourceId: null,
           planningBasis: 'DEMAND_FOLLOWING', source: 'FIXED', defaultPercent: null,
-          startWeek: null, endWeek: null, legacy: null, segments: [] },
+          startWeek: null, endWeek: null, legacy: { kind: 'DB_NULL' }, segments: [] },
       ],
     }
 

--- a/server/src/test/snapshots.test.ts
+++ b/server/src/test/snapshots.test.ts
@@ -808,13 +808,14 @@ function makeRouteTx(overrides: Record<string, unknown> = {}) {
   const base = {
     epic: { findMany: vi.fn().mockResolvedValue([]), deleteMany: vi.fn().mockResolvedValue({ count: 0 }), create: vi.fn().mockResolvedValue({ id: 'new-epic' }) },
     project: { findUnique: vi.fn().mockResolvedValue({ startDate: new Date(), onboardingWeeks: null, bufferWeeks: null, hoursPerDay: null }), update: vi.fn().mockResolvedValue({}) },
-    resourceType: { findMany: vi.fn().mockResolvedValue([]), upsert: vi.fn().mockResolvedValue({}) },
+    resourceType: { findMany: vi.fn().mockResolvedValue([]), upsert: vi.fn().mockResolvedValue({}), deleteMany: vi.fn().mockResolvedValue({ count: 0 }) },
     namedResource: { findMany: vi.fn().mockResolvedValue([]), upsert: vi.fn().mockResolvedValue({}) },
     timelineEntry: { findMany: vi.fn().mockResolvedValue([]), deleteMany: vi.fn().mockResolvedValue({ count: 0 }), createMany: vi.fn().mockResolvedValue({ count: 0 }) },
     storyTimelineEntry: { findMany: vi.fn().mockResolvedValue([]), deleteMany: vi.fn().mockResolvedValue({ count: 0 }), createMany: vi.fn().mockResolvedValue({ count: 0 }) },
     epicDependency: { findMany: vi.fn().mockResolvedValue([]), deleteMany: vi.fn().mockResolvedValue({ count: 0 }), createMany: vi.fn().mockResolvedValue({ count: 0 }) },
     featureDependency: { findMany: vi.fn().mockResolvedValue([]), deleteMany: vi.fn().mockResolvedValue({ count: 0 }), createMany: vi.fn().mockResolvedValue({ count: 0 }) },
     projectOverhead: { findMany: vi.fn().mockResolvedValue([]), deleteMany: vi.fn().mockResolvedValue({ count: 0 }), createMany: vi.fn().mockResolvedValue({ count: 0 }) },
+    projectDiscount: { findMany: vi.fn().mockResolvedValue([]), deleteMany: vi.fn().mockResolvedValue({ count: 0 }) },
     $queryRaw: vi.fn().mockResolvedValue([]),
     capacityProfile: { findMany: vi.fn().mockResolvedValue([]), deleteMany: vi.fn().mockResolvedValue({ count: 999 }), create: vi.fn().mockResolvedValue({}) },
     capacitySegment: { deleteMany: vi.fn().mockResolvedValue({ count: 999 }), create: vi.fn().mockResolvedValue({}) },
@@ -1034,6 +1035,173 @@ describe('POST /api/projects/:projectId/snapshots/:snapshotId/rollback', () => {
     expect(seg1.endWeek).toBe(4)
     expect(seg1.capacityPercent).toBe(100)
     expect(seg1.source).toBe('SQUAD_PLANNER')
+  })
+
+  interface PruningDiscountRow {
+    id: string
+    projectId: string
+    resourceTypeId: string | null
+  }
+
+
+  async function runPruningRollback(
+    existingResourceTypes: Array<{ id: string; projectId: string }>,
+    namedResources: Array<{ id: string; resourceType: { projectId: string } }> = [],
+    failDiscountDelete = false,
+    discountRows: PruningDiscountRow[] = [],
+  ) {
+    const v3Target: SnapshotV3 = {
+      schemaVersion: 3, epics: [], project: null,
+      resourceTypes: [{
+        id: 'rt-target', name: 'Developer', category: 'ENGINEERING', count: 1,
+        hoursPerDay: 8, dayRate: 500, globalTypeId: null,
+        allocationMode: 'TIMELINE', allocationPercent: 100,
+        allocationStartWeek: 0, allocationEndWeek: 10,
+      }],
+      namedResources: [],
+      timelineEntries: [], storyTimelineEntries: [],
+      epicDependencies: [], featureDependencies: [], overheadItems: [],
+      capacityProfiles: [],
+    }
+
+    vi.mocked(prisma.project.findFirst).mockResolvedValue({ id: projId, ownerId: userId } as never)
+    vi.mocked(prisma.backlogSnapshot.findFirst).mockResolvedValue({
+      id: 'snap-v3-pruning', projectId: projId, label: 'V3 pruning',
+      trigger: 'manual', snapshot: v3Target as unknown as never,
+      createdById: userId, createdAt: new Date(),
+    } as never)
+    vi.mocked(prisma.resourceType.findMany).mockResolvedValue(existingResourceTypes as never)
+    vi.mocked(prisma.namedResource.findMany).mockResolvedValue(namedResources as never)
+
+    const remainingDiscounts = [...discountRows]
+    const discountDelete = vi.fn()
+    if (failDiscountDelete) {
+      discountDelete.mockRejectedValue(new Error('discount deletion failed'))
+    } else {
+      discountDelete.mockImplementation(async (args: {
+        where: { projectId: string; resourceTypeId: { in: string[] } }
+      }) => {
+        const deleted = remainingDiscounts.filter(discount =>
+          discount.projectId === args.where.projectId
+          && typeof discount.resourceTypeId === 'string'
+          && args.where.resourceTypeId.in.includes(discount.resourceTypeId),
+        )
+        for (const discount of deleted) {
+          const index = remainingDiscounts.indexOf(discount)
+          if (index >= 0) remainingDiscounts.splice(index, 1)
+        }
+        return { count: deleted.length }
+      })
+    }
+    const resourceTypeDelete = vi.fn().mockResolvedValue({ count: 0 })
+    const txResourceTypeFindMany = vi.fn().mockImplementation((args: {
+      where?: { id?: { notIn?: string[] } }
+    }) => {
+      const excludedIds = args.where?.id?.notIn ?? []
+      return Promise.resolve(existingResourceTypes.filter(rt => !excludedIds.includes(rt.id)))
+    })
+    vi.mocked(prisma.$transaction).mockImplementation(async (fn: unknown) => {
+      const tx = makeRouteTx({
+        resourceType: {
+          findMany: txResourceTypeFindMany,
+          upsert: vi.fn().mockResolvedValue({}),
+          deleteMany: resourceTypeDelete,
+        },
+        namedResource: {
+          findMany: vi.fn().mockResolvedValue(namedResources),
+          upsert: vi.fn().mockResolvedValue({}),
+        },
+        projectDiscount: { findMany: vi.fn().mockResolvedValue([]), deleteMany: discountDelete },
+      })
+      return typeof fn === 'function'
+        ? (fn as (t: unknown) => Promise<unknown>)(tx)
+        : Promise.resolve(fn)
+    })
+
+    const response = await request(app)
+      .post(`/api/projects/${projId}/snapshots/snap-v3-pruning/rollback`)
+      .set('Authorization', authHeader)
+
+    return { response, discountDelete, resourceTypeDelete, remainingDiscounts }
+  }
+
+  it('V3 pruning deletes role discounts for non-target ResourceTypes', async () => {
+    const { response, discountDelete, remainingDiscounts } = await runPruningRollback([
+      { id: 'rt-target', projectId: projId },
+      { id: 'rt-extra', projectId: projId },
+    ], [], false, [
+      { id: 'discount-extra', projectId: projId, resourceTypeId: 'rt-extra' },
+      { id: 'discount-foreign', projectId: 'project-other', resourceTypeId: 'rt-extra' },
+    ])
+
+    expect(response.status).toBe(200)
+    expect(discountDelete).toHaveBeenCalledWith({
+      where: {
+        projectId: projId,
+        resourceTypeId: { in: ['rt-extra'] },
+      },
+    })
+    expect(remainingDiscounts).toEqual([
+      { id: 'discount-foreign', projectId: 'project-other', resourceTypeId: 'rt-extra' },
+    ])
+  })
+
+  it('V3 pruning preserves target-role discounts', async () => {
+    const { response, discountDelete, remainingDiscounts } = await runPruningRollback([
+      { id: 'rt-target', projectId: projId },
+    ], [], false, [
+      { id: 'discount-target', projectId: projId, resourceTypeId: 'rt-target' },
+    ])
+
+    expect(response.status).toBe(200)
+    expect(discountDelete).not.toHaveBeenCalled()
+    expect(remainingDiscounts).toEqual([
+      { id: 'discount-target', projectId: projId, resourceTypeId: 'rt-target' },
+    ])
+  })
+
+  it('V3 pruning preserves project-wide discounts', async () => {
+    const { response, discountDelete, remainingDiscounts } = await runPruningRollback([
+      { id: 'rt-target', projectId: projId },
+    ], [], false, [
+      { id: 'discount-project', projectId: projId, resourceTypeId: null },
+    ])
+
+    expect(response.status).toBe(200)
+    expect(discountDelete).not.toHaveBeenCalled()
+    expect(remainingDiscounts).toEqual([
+      { id: 'discount-project', projectId: projId, resourceTypeId: null },
+    ])
+  })
+
+  it('V3 pruning scopes discount deletion to the rolled-back project', async () => {
+    const { response, discountDelete } = await runPruningRollback([
+      { id: 'rt-target', projectId: projId },
+      { id: 'rt-extra', projectId: projId },
+    ])
+
+    expect(response.status).toBe(200)
+    expect(discountDelete.mock.calls[0][0].where.projectId).toBe(projId)
+    expect(discountDelete.mock.calls[0][0].where.resourceTypeId).toEqual({ in: ['rt-extra'] })
+  })
+
+  it('V3 pruning performs no discount deletion when no ResourceTypes are pruned', async () => {
+    const { response, discountDelete } = await runPruningRollback([
+      { id: 'rt-target', projectId: projId },
+    ])
+
+    expect(response.status).toBe(200)
+    expect(discountDelete).not.toHaveBeenCalled()
+  })
+
+  it('V3 pruning aborts the rollback when discount deletion fails', async () => {
+    const { response, resourceTypeDelete } = await runPruningRollback([
+      { id: 'rt-target', projectId: projId },
+      { id: 'rt-extra', projectId: projId },
+    ], [], true)
+
+    expect(response.status).toBe(500)
+    expect(resourceTypeDelete).not.toHaveBeenCalled()
   })
 
   // ═════════════════════════════════════════════════════════════════════════

--- a/server/src/test/snapshots.test.ts
+++ b/server/src/test/snapshots.test.ts
@@ -539,7 +539,14 @@ describe('buildSnapshot', () => {
     const db = {
       epic: { findMany: vi.fn().mockResolvedValue([]) },
       project: { findUnique: vi.fn().mockResolvedValue(null) },
-      resourceType: { findMany: vi.fn().mockResolvedValue([]) },
+      resourceType: {
+        findMany: vi.fn().mockResolvedValue([
+          { id: 'rt-dev', name: 'Developer', category: 'ENGINEERING', count: 2,
+            hoursPerDay: 8, dayRate: 500, globalTypeId: null,
+            allocationMode: 'TIMELINE', allocationPercent: 100,
+            allocationStartWeek: 0, allocationEndWeek: 10 },
+        ]),
+      },
       namedResource: {
         findMany: vi.fn().mockResolvedValue([
           { id: 'nr-alice', resourceTypeId: 'rt-dev', name: 'Alice',
@@ -631,6 +638,162 @@ describe('buildSnapshot', () => {
     }
 
     await expect(buildSnapshot(projId, db as never)).rejects.toThrow('Missing null-state row')
+  })
+  it('rejects ROLE with null resourceTypeId', async () => {
+    const rawProfiles = [
+      {
+        id: 'cp-1', ownerKind: 'ROLE',
+        resourceTypeId: null, namedResourceId: null,
+        planningBasis: 'DEMAND_FOLLOWING', source: 'FIXED',
+        defaultPercent: null, startWeek: null, endWeek: null,
+        legacy: null, segments: [],
+      },
+    ]
+    const db = {
+      epic: { findMany: vi.fn().mockResolvedValue([]) },
+      project: { findUnique: vi.fn().mockResolvedValue(null) },
+      resourceType: { findMany: vi.fn().mockResolvedValue([]) },
+      namedResource: { findMany: vi.fn().mockResolvedValue([]) },
+      timelineEntry: { findMany: vi.fn().mockResolvedValue([]) },
+      storyTimelineEntry: { findMany: vi.fn().mockResolvedValue([]) },
+      epicDependency: { findMany: vi.fn().mockResolvedValue([]) },
+      featureDependency: { findMany: vi.fn().mockResolvedValue([]) },
+      projectOverhead: { findMany: vi.fn().mockResolvedValue([]) },
+      capacityProfile: { findMany: vi.fn().mockResolvedValue(rawProfiles) },
+      $queryRaw: vi.fn().mockResolvedValue([
+        { id: 'cp-1', legacy_is_null: false, legacy_typeof: 'null' },
+      ]),
+    }
+    await expect(buildSnapshot(projId, db as never)).rejects.toThrow(SnapshotValidationError)
+  })
+  it('rejects NAMED_PERSON with null namedResourceId', async () => {
+    const rawProfiles = [
+      {
+        id: 'cp-npn', ownerKind: 'NAMED_PERSON',
+        resourceTypeId: null, namedResourceId: null,
+        planningBasis: 'AVAILABILITY_WINDOW', source: 'SQUAD_PLANNER',
+        defaultPercent: 100, startWeek: 0, endWeek: 10,
+        legacy: null, segments: [],
+      },
+    ]
+    const db = {
+      epic: { findMany: vi.fn().mockResolvedValue([]) },
+      project: { findUnique: vi.fn().mockResolvedValue(null) },
+      resourceType: { findMany: vi.fn().mockResolvedValue([]) },
+      namedResource: { findMany: vi.fn().mockResolvedValue([]) },
+      timelineEntry: { findMany: vi.fn().mockResolvedValue([]) },
+      storyTimelineEntry: { findMany: vi.fn().mockResolvedValue([]) },
+      epicDependency: { findMany: vi.fn().mockResolvedValue([]) },
+      featureDependency: { findMany: vi.fn().mockResolvedValue([]) },
+      projectOverhead: { findMany: vi.fn().mockResolvedValue([]) },
+      capacityProfile: { findMany: vi.fn().mockResolvedValue(rawProfiles) },
+      $queryRaw: vi.fn().mockResolvedValue([
+        { id: 'cp-npn', legacy_is_null: false, legacy_typeof: 'null' },
+      ]),
+    }
+    await expect(buildSnapshot(projId, db as never)).rejects.toThrow(SnapshotValidationError)
+  })
+  it('rejects PLANNED_RESOURCE with null namedResourceId', async () => {
+    const rawProfiles = [
+      {
+        id: 'cp-ppr', ownerKind: 'PLANNED_RESOURCE',
+        resourceTypeId: null, namedResourceId: null,
+        planningBasis: 'WHOLE_PROJECT_ALLOCATION', source: 'MANUAL',
+        defaultPercent: null, startWeek: null, endWeek: null,
+        legacy: null, segments: [],
+      },
+    ]
+    const db = {
+      epic: { findMany: vi.fn().mockResolvedValue([]) },
+      project: { findUnique: vi.fn().mockResolvedValue(null) },
+      resourceType: { findMany: vi.fn().mockResolvedValue([]) },
+      namedResource: { findMany: vi.fn().mockResolvedValue([]) },
+      timelineEntry: { findMany: vi.fn().mockResolvedValue([]) },
+      storyTimelineEntry: { findMany: vi.fn().mockResolvedValue([]) },
+      epicDependency: { findMany: vi.fn().mockResolvedValue([]) },
+      featureDependency: { findMany: vi.fn().mockResolvedValue([]) },
+      projectOverhead: { findMany: vi.fn().mockResolvedValue([]) },
+      capacityProfile: { findMany: vi.fn().mockResolvedValue(rawProfiles) },
+      $queryRaw: vi.fn().mockResolvedValue([
+        { id: 'cp-ppr', legacy_is_null: false, legacy_typeof: 'null' },
+      ]),
+    }
+    await expect(buildSnapshot(projId, db as never)).rejects.toThrow(SnapshotValidationError)
+  })
+  it('rejects cross-reference to missing named resource', async () => {
+    const rawProfiles = [
+      {
+        id: 'cp-xref', ownerKind: 'NAMED_PERSON',
+        resourceTypeId: null, namedResourceId: 'nr-nonexistent',
+        planningBasis: 'AVAILABILITY_WINDOW', source: 'SQUAD_PLANNER',
+        defaultPercent: 100, startWeek: 0, endWeek: 10,
+        legacy: null, segments: [],
+      },
+    ]
+    const db = {
+      epic: { findMany: vi.fn().mockResolvedValue([]) },
+      project: { findUnique: vi.fn().mockResolvedValue(null) },
+      resourceType: { findMany: vi.fn().mockResolvedValue([]) },
+      namedResource: { findMany: vi.fn().mockResolvedValue([]) },
+      timelineEntry: { findMany: vi.fn().mockResolvedValue([]) },
+      storyTimelineEntry: { findMany: vi.fn().mockResolvedValue([]) },
+      epicDependency: { findMany: vi.fn().mockResolvedValue([]) },
+      featureDependency: { findMany: vi.fn().mockResolvedValue([]) },
+      projectOverhead: { findMany: vi.fn().mockResolvedValue([]) },
+      capacityProfile: { findMany: vi.fn().mockResolvedValue(rawProfiles) },
+      $queryRaw: vi.fn().mockResolvedValue([
+        { id: 'cp-xref', legacy_is_null: false, legacy_typeof: 'null' },
+      ]),
+    }
+    await expect(buildSnapshot(projId, db as never)).rejects.toThrow(SnapshotValidationError)
+  })
+  it('preserves duplicate owner identities', async () => {
+    const rawProfiles = [
+      {
+        id: 'cp-d1', ownerKind: 'ROLE',
+        resourceTypeId: 'rt-dev', namedResourceId: null,
+        planningBasis: 'DEMAND_FOLLOWING', source: 'FIXED',
+        defaultPercent: null, startWeek: null, endWeek: null,
+        legacy: null, segments: [],
+      },
+      {
+        id: 'cp-d2', ownerKind: 'ROLE',
+        resourceTypeId: 'rt-dev', namedResourceId: null,
+        planningBasis: 'AVAILABILITY_WINDOW', source: 'MANUAL',
+        defaultPercent: 50, startWeek: 2, endWeek: 6,
+        legacy: null, segments: [],
+      },
+    ]
+    const db = {
+      epic: { findMany: vi.fn().mockResolvedValue([]) },
+      project: { findUnique: vi.fn().mockResolvedValue({
+        startDate: new Date('2025-01-15'),
+        onboardingWeeks: 1, bufferWeeks: 2, hoursPerDay: 8,
+      }) },
+      resourceType: { findMany: vi.fn().mockResolvedValue([
+        { id: 'rt-dev', name: 'Developer', category: 'ENGINEERING', count: 2,
+          hoursPerDay: 8, dayRate: 500, globalTypeId: null,
+          allocationMode: 'TIMELINE', allocationPercent: 100,
+          allocationStartWeek: 0, allocationEndWeek: 10 },
+      ]) },
+      namedResource: { findMany: vi.fn().mockResolvedValue([]) },
+      timelineEntry: { findMany: vi.fn().mockResolvedValue([]) },
+      storyTimelineEntry: { findMany: vi.fn().mockResolvedValue([]) },
+      epicDependency: { findMany: vi.fn().mockResolvedValue([]) },
+      featureDependency: { findMany: vi.fn().mockResolvedValue([]) },
+      projectOverhead: { findMany: vi.fn().mockResolvedValue([]) },
+      capacityProfile: { findMany: vi.fn().mockResolvedValue(rawProfiles) },
+      $queryRaw: vi.fn().mockResolvedValue([
+        { id: 'cp-d1', legacy_is_null: false, legacy_typeof: 'null' },
+        { id: 'cp-d2', legacy_is_null: false, legacy_typeof: 'null' },
+      ]),
+    }
+    const result = await buildSnapshot(projId, db as never)
+    expect(result.capacityProfiles).toHaveLength(2)
+    expect(result.capacityProfiles[0].ownerKind).toBe('ROLE')
+    expect(result.capacityProfiles[0].resourceTypeId).toBe('rt-dev')
+    expect(result.capacityProfiles[1].ownerKind).toBe('ROLE')
+    expect(result.capacityProfiles[1].resourceTypeId).toBe('rt-dev')
   })
 })
 // ═══════════════════════════════════════════════════════════════════════════
@@ -1344,6 +1507,73 @@ describe('route persistence on buildSnapshot failure', () => {
     expect(cpDelete).not.toHaveBeenCalled()
     expect(epicDel).not.toHaveBeenCalled()
   })
+  it('manual POST persists nothing on null-state row mismatch', async () => {
+    vi.mocked(prisma.project.findFirst).mockResolvedValue({ id: projId, ownerId: userId } as never)
+    vi.mocked(prisma.project.findUnique).mockResolvedValue({
+      startDate: new Date(), onboardingWeeks: 0, bufferWeeks: 0, hoursPerDay: 7.6,
+    } as never)
+    vi.mocked(prisma.resourceType.findMany).mockResolvedValue([])
+    vi.mocked(prisma.namedResource.findMany).mockResolvedValue([])
+    vi.mocked(prisma.timelineEntry.findMany).mockResolvedValue([])
+    vi.mocked(prisma.storyTimelineEntry.findMany).mockResolvedValue([])
+    vi.mocked(prisma.epicDependency.findMany).mockResolvedValue([])
+    vi.mocked(prisma.featureDependency.findMany).mockResolvedValue([])
+    vi.mocked(prisma.projectOverhead.findMany).mockResolvedValue([])
+    vi.mocked(prisma.capacityProfile.findMany).mockResolvedValue([
+      { id: 'cp-1', ownerKind: 'ROLE', resourceTypeId: null, namedResourceId: null,
+        legacy: null,
+        segments: [],
+        planningBasis: 'DEMAND_FOLLOWING', source: 'FIXED',
+        defaultPercent: null, startWeek: null, endWeek: null },
+    ] as never)
+    // Only 0 null-state rows for 1 profile → buildSnapshot throws "Missing null-state row"
+    const mockQueryRaw = vi.fn().mockResolvedValue([])
+    ;(prisma as unknown as Record<string, unknown>).$queryRaw = mockQueryRaw
+    const bsCreate = vi.mocked(prisma.backlogSnapshot.create)
+    const bsDeleteMany = vi.mocked(prisma.backlogSnapshot.deleteMany)
+    const res = await request(app)
+      .post(`/api/projects/${projId}/snapshots`)
+      .set('Authorization', authHeader)
+      .send({ label: 'fail-mismatch' })
+    expect(res.status).toBe(500)
+    expect(bsCreate).not.toHaveBeenCalled()
+    expect(bsDeleteMany).not.toHaveBeenCalled()
+    delete (prisma as unknown as Record<string, unknown>).$queryRaw
+  })
+  it('manual POST persists nothing on validation failure (invalid ROLE owner)', async () => {
+    vi.mocked(prisma.project.findFirst).mockResolvedValue({ id: projId, ownerId: userId } as never)
+    vi.mocked(prisma.project.findUnique).mockResolvedValue({
+      startDate: new Date(), onboardingWeeks: 0, bufferWeeks: 0, hoursPerDay: 7.6,
+    } as never)
+    vi.mocked(prisma.resourceType.findMany).mockResolvedValue([])
+    vi.mocked(prisma.namedResource.findMany).mockResolvedValue([])
+    vi.mocked(prisma.timelineEntry.findMany).mockResolvedValue([])
+    vi.mocked(prisma.storyTimelineEntry.findMany).mockResolvedValue([])
+    vi.mocked(prisma.epicDependency.findMany).mockResolvedValue([])
+    vi.mocked(prisma.featureDependency.findMany).mockResolvedValue([])
+    vi.mocked(prisma.projectOverhead.findMany).mockResolvedValue([])
+    vi.mocked(prisma.capacityProfile.findMany).mockResolvedValue([
+      { id: 'cp-1', ownerKind: 'ROLE', resourceTypeId: null, namedResourceId: null,
+        legacy: null, segments: [],
+        planningBasis: 'DEMAND_FOLLOWING', source: 'FIXED',
+        defaultPercent: null, startWeek: null, endWeek: null },
+    ] as never)
+    // $queryRaw returns matching row so fetch phase succeeds; validateSnapshotV3 rejects the null resourceTypeId
+    const mockQueryRaw = vi.fn().mockResolvedValue([
+      { id: 'cp-1', legacy_is_null: false, legacy_typeof: 'null' },
+    ])
+    ;(prisma as unknown as Record<string, unknown>).$queryRaw = mockQueryRaw
+    const bsCreate = vi.mocked(prisma.backlogSnapshot.create)
+    const bsDeleteMany = vi.mocked(prisma.backlogSnapshot.deleteMany)
+    const res = await request(app)
+      .post(`/api/projects/${projId}/snapshots`)
+      .set('Authorization', authHeader)
+      .send({ label: 'fail-validation' })
+    expect(res.status).toBe(500)
+    expect(bsCreate).not.toHaveBeenCalled()
+    expect(bsDeleteMany).not.toHaveBeenCalled()
+    delete (prisma as unknown as Record<string, unknown>).$queryRaw
+  })
 })
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -1557,5 +1787,34 @@ describe('rollbackProjectSnapshot', () => {
     await expect(rollbackProjectSnapshot({
       projectId: projId, snapshotId: 'snap-tx-fail', userId,
     })).rejects.toThrow('DB timeout')
+  })
+  it('throws SnapshotValidationError and aborts before transaction on invalid V3 snapshot', async () => {
+    const invalidV3: SnapshotV3 = {
+      schemaVersion: 3, epics: [], project: null,
+      resourceTypes: [{
+        id: 'rt-dev', name: 'Dev', category: 'ENGINEERING', count: 1,
+        hoursPerDay: 8, dayRate: 500, globalTypeId: null,
+        allocationMode: 'TIMELINE', allocationPercent: 100,
+        allocationStartWeek: 0, allocationEndWeek: 10,
+      }],
+      namedResources: [],
+      timelineEntries: [], storyTimelineEntries: [],
+      epicDependencies: [], featureDependencies: [], overheadItems: [],
+      capacityProfiles: [
+        { id: 'cp-bad', ownerKind: 'ROLE', resourceTypeId: null, namedResourceId: null,
+          planningBasis: 'DEMAND_FOLLOWING', source: 'FIXED', defaultPercent: null,
+          startWeek: null, endWeek: null, legacy: { kind: 'DB_NULL' }, segments: [] },
+      ],
+    }
+    vi.mocked(prisma.backlogSnapshot.findFirst).mockResolvedValue({
+      id: 'snap-invalid-v3', projectId: projId, label: 'invalid-v3',
+      trigger: 'manual', snapshot: invalidV3 as unknown as never,
+      createdById: userId, createdAt: new Date(),
+    } as never)
+    await expect(rollbackProjectSnapshot({
+      projectId: projId, snapshotId: 'snap-invalid-v3', userId,
+    })).rejects.toThrow(SnapshotValidationError)
+    // Validation before transaction — no destructive operations attempted
+    expect(vi.mocked(prisma.$transaction)).not.toHaveBeenCalled()
   })
 })

--- a/server/src/test/squadPlan.test.ts
+++ b/server/src/test/squadPlan.test.ts
@@ -24,6 +24,7 @@ import {
   deriveFeatureSpanFromWeeklyAllocations,
   stripCapacityPlanMaterialization,
 } from '../routes/squadPlan.js'
+import { buildSnapshot } from '../routes/snapshots.js'
 import type { SchedulerResourceType } from '../lib/scheduler.js'
 
 
@@ -571,5 +572,40 @@ describe('POST /api/projects/:projectId/squad-plan/apply', () => {
     expect(weeklyDemandCache['rt-dev|0']).toBeCloseTo(5, 6)
     expect(weeklyDemandCache['rt-dev|4']).toBeCloseTo(2.5, 6)
     expect(weeklyDemandCache['rt-dev|4']).toBeLessThan(5)
+  })
+
+  it('returns 500 when buildSnapshot rejects, preventing snapshot persistence and mutation', async () => {
+    vi.mocked(prisma.project.findFirst).mockResolvedValue(mockProject as never)
+    vi.mocked(prisma.resourceType.findMany).mockResolvedValue([{ id: 'rt-dev' }] as never)
+    vi.mocked(buildSnapshot).mockRejectedValueOnce(new Error('Snapshot null-state rejection'))
+
+    const res = await request(app)
+      .post('/api/projects/proj-1/squad-plan/apply')
+      .set('Authorization', authHeader)
+      .send({
+        name: 'Test plan',
+        targetWeeks: 10,
+        periodWeeks: 4,
+        maxDelta: 1,
+        periods: [
+          {
+            periodIndex: 0,
+            startWeek: 0,
+            endWeek: 4,
+            entries: [
+              {
+                resourceTypeId: 'rt-dev',
+                headcount: 1,
+                demandFTE: 0.8,
+                utilisationPct: 80,
+              },
+            ],
+          },
+        ],
+      })
+
+    expect(res.status).toBe(500)
+    expect(prisma.backlogSnapshot.create).not.toHaveBeenCalled()
+    expect(prisma.$transaction).not.toHaveBeenCalled()
   })
 })

--- a/server/src/test/timeline.test.ts
+++ b/server/src/test/timeline.test.ts
@@ -1,8 +1,26 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import request from 'supertest'
 import jwt from 'jsonwebtoken'
+
+vi.mock('../routes/snapshots.js', async importOriginal => {
+  const actual = await importOriginal<typeof import('../routes/snapshots.js')>()
+  return {
+    ...actual,
+    buildSnapshot: vi.fn().mockResolvedValue({}),
+  }
+})
+
+vi.mock('../lib/snapshotUtils.js', async importOriginal => {
+  const actual = await importOriginal<typeof import('../lib/snapshotUtils.js')>()
+  return {
+    ...actual,
+    pruneSnapshots: vi.fn().mockResolvedValue(undefined),
+  }
+})
+
 import { app } from '../index.js'
 import { prisma } from '../lib/prisma.js'
+import { buildSnapshot } from '../routes/snapshots.js'
 import { getWeeklyCapacity } from '../routes/timeline.js'
 
 process.env.JWT_SECRET = 'test-secret'
@@ -1389,5 +1407,26 @@ describe('getWeeklyCapacity', () => {
     // 2 named (100%) + 3 phantom slots → effective headcount = 5 = count
     // Total = 5 * 8 * 5 = 200
     expect(getWeeklyCapacity(rt, 0, 8)).toBe(200)
+  })
+})
+
+describe('POST /api/projects/:projectId/timeline/level — buildSnapshot rejection', () => {
+  it('returns 500 when buildSnapshot rejects, preventing snapshot persistence and mutation', async () => {
+    vi.mocked(prisma.project.findFirst).mockResolvedValue(mockProject as never)
+    vi.mocked(prisma.epic.findMany).mockResolvedValue([] as never)
+    vi.mocked(prisma.resourceType.findMany).mockResolvedValue([] as never)
+    vi.mocked(prisma.timelineEntry.findMany).mockResolvedValue([] as never)
+    vi.mocked(prisma.storyTimelineEntry.findMany).mockResolvedValue([] as never)
+    vi.mocked(prisma.epicDependency.findMany).mockResolvedValue([] as never)
+    vi.mocked(buildSnapshot).mockRejectedValueOnce(new Error('Snapshot null-state rejection'))
+
+    const res = await request(app)
+      .post('/api/projects/proj-1/timeline/level')
+      .set('Authorization', authHeader)
+      .send({})
+
+    expect(res.status).toBe(500)
+    expect(prisma.backlogSnapshot.create).not.toHaveBeenCalled()
+    expect(prisma.$transaction).not.toHaveBeenCalled()
   })
 })

--- a/server/vitest.integration.config.ts
+++ b/server/vitest.integration.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'vitest/config'
+import baseConfig from './vitest.config.js'
+
+export default defineConfig({
+  test: {
+    // Inherit all base settings
+    ...baseConfig.test,
+    // Override env to enable the integration-test guard
+    env: {
+      ...baseConfig.test?.env,
+      INTEGRATION_TEST: 'true',
+    },
+  },
+})


### PR DESCRIPTION
## Summary

Adds schema v3 project snapshots that preserve persisted `CapacityProfile` and `CapacitySegment` state, including stable IDs, owner metadata, planning fields, and lossless Prisma JSON-null semantics. Rollback restores supported project state atomically through the authoritative service.

## Related issue

Closes #357

## Final head

`eb85b92d71a920040af38de86c1bd1c8ddd70be9`

## Blocking-review remediation

- `buildSnapshot` validates the complete `SnapshotV3` before persistence or destructive apply when owner/cross-reference state is invalid.
- Production null-state capture uses parameterised `Prisma.sql` / `$queryRaw` and fails closed. V3 persistence maps `DB_NULL`, `JSON_NULL`, and value states through Prisma sentinels with a typed capacity persistence interface.
- V3 rollback exactly replaces the `CapacityProfile` and `CapacitySegment` rows represented by the snapshot. It upserts captured `ResourceType`/`NamedResource` metadata but does not prune owners created after the snapshot.
- Post-snapshot `ResourceType`, `NamedResource`, compatibility metadata, `TemplateTask.resourceTypeId` links, and `ProjectDiscount` rows remain intact. No discount can be promoted to project-wide scope by rollback.
- V2/V3 and V1 backlog restoration preserves captured assumptions, scope modes, timeline-start fields, colours, and active flags. Scenario G verifies scope/scheduling round trips and inactive-item behaviour.
- The PostgreSQL suite exercises destructive v3 rollback, generated `pre_rollback` reversal, transaction failure atomicity, v2 stale-profile replacement through the Resource Profile DTO, v1 profile preservation, non-destructive owner restoration, and all supported JSON storage states. Scenario A asserts exact Prisma values plus storage-level `legacy IS NULL` / `jsonb_typeof` results.
- Added required CI execution for the two changed client regression files: commercial consistency and resource-profile export.

## PostgreSQL rollback integration evidence

The required CI step runs after Prisma migration/generation with `INTEGRATION_TEST=true`; it is not skipped. The suite covers the real rollback service and transaction path, including profile replacement and preservation of post-snapshot owners and metadata.

## Verification

GitHub Actions run #29216189382: success
https://github.com/NickMonrad/monrad-estimator/actions/runs/29216189382

- Server unit suite: 801 passed, 13 skipped locally; the integration file is skipped only in the ordinary unit invocation.
- Required PostgreSQL snapshot integration suite: executed by the green CI workflow.
- Focused client regressions: 20 passed across `canonical-commercial-consistency.test.ts` and `resource-profile-export.test.ts`.
- Client production build passed.
- Server production build passed.
- Server and client TypeScript checks passed.
- Server lint passed with existing warnings and no errors; touched server files lint clean.
- Client lint passed with existing warnings and no errors.
- Local PostgreSQL is unavailable; the real database path is exercised by the required CI service-container run above.

## Scope and safety

- No Prisma schema or migration changes.
- No #358–#364 work included.
- Client regression tests are test-only evidence; production snapshot design remains server-owned.
- V3 profile replacement is intentionally non-destructive outside the profile/segment snapshot boundary.
- PR remains open and blocked for review. Do not merge.
