### PR TITLE
docs(#391): harden agent remediation and review workflow

### DIFF
--- a/.github/agents/codex-developer.agent.md
+++ b/.github/agents/codex-developer.agent.md
@@ -24,10 +24,14 @@ The repository-wide instructions are authoritative. Do not duplicate or override
 - Preserve security, authorisation, migration safety, accessibility, loading states, empty states, and visible error handling.
 - Run the relevant validation commands and report exact results.
 - Update documentation made inaccurate by the change.
-- Prepare the feature branch and pull request for human review.
+- Prepare the correct issue or existing PR branch for human review.
 
 ## Behaviour
 
+- Before editing, verify the dedicated worktree, current branch, tracked issue, and whether the task is new work or remediation of an existing PR.
+- For new work, create the issue branch from current `main` in a separate Git worktree.
+- For existing-PR remediation, fetch and inspect the latest PR head and continue on that PR's existing branch in its dedicated worktree. Do not create a replacement branch, retarget the PR, rebase, force-push, or rewrite shared history unless explicitly instructed.
+- Reuse an existing dedicated worktree when it already owns the branch. Never modify, clean, reset, delete, or otherwise disturb another agent's worktree.
 - Be autonomous on routine implementation decisions that can be resolved from repository patterns.
 - Be surgical: do not modify unrelated code or introduce speculative abstractions.
 - Prefer existing dependencies and platform features. Do not add a new dependency unless the issue requires it or explicit approval is obtained.
@@ -36,13 +40,22 @@ The repository-wide instructions are authoritative. Do not duplicate or override
 
 ## Completion report
 
+Before reporting completion:
+
+1. Review the final diff against the original issue, acceptance criteria, approved design, and exclusions.
+2. Commit only the intended changes and push the commit to the correct issue or existing PR branch.
+3. Confirm the remote branch contains the final commit and the worktree is clean.
+4. If any intended work is incomplete, uncommitted, or unpushed, report the task as incomplete rather than implying completion.
+
 Provide:
 
 1. a concise summary of what changed and why
 2. files changed
 3. validation commands and exact results
 4. E2E tests added or updated, or why E2E is not applicable
-5. risks, limitations, or follow-ups
-6. the branch and PR URL when created
+5. risks, limitations, and optional follow-ups kept separate from required work
+6. the worktree path and branch
+7. the final pushed commit SHA and PR URL
+8. confirmation that the worktree is clean
 
 End with: **Do not merge — wait for review.**

--- a/.github/instructions/project.instructions.md
+++ b/.github/instructions/project.instructions.md
@@ -47,17 +47,18 @@ An implementation agent may analyse, modify code, add appropriate tests, update 
 
 For each task:
 
-1. Read the issue, relevant code, tests, and applicable path-scoped instructions.
+1. Read the issue, acceptance criteria, approved design, agreed exclusions, relevant code, tests, and applicable path-scoped instructions.
 2. Identify the current source of truth and affected API/data/UI contracts.
 3. Prefer the smallest correct change that fully satisfies the acceptance criteria.
 4. Add focused tests at the lowest useful level and E2E coverage when user-visible behaviour changes.
 5. Run the relevant validation commands and report exact results.
 6. Update documentation that became inaccurate because of the change.
-7. Prepare the branch and pull request for human review.
+7. Review the final diff against the original issue and acceptance criteria.
+8. Commit and push the intended changes to the correct issue or existing PR branch, then prepare the pull request for human review.
 
 Do not ask for guidance on routine implementation choices that can be resolved from existing patterns. Escalate genuine ambiguity, destructive data impact, security trade-offs, or scope that materially exceeds the issue.
 
-## Git and human-review safety
+## Git, worktree, and human-review safety
 
 Agents must never:
 
@@ -68,13 +69,18 @@ Agents must never:
 - close the tracked issue manually when the PR should close it
 - force-push or rewrite shared history without explicit user approval
 - discard unrelated worktree changes
+- modify, clean, reset, delete, or otherwise disturb another agent's worktree
 - bypass failing required checks
 
-Branch from current `main` and use:
+Implementation and pull-request remediation must use a dedicated Git worktree. Before editing, verify the worktree path, current branch, tracked issue, and whether the task is new work or remediation of an existing PR. Reuse an existing dedicated worktree when it already owns the branch, and leave the selected worktree clean after the intended changes are committed and pushed.
+
+For new issue work, branch from current `main` and use:
 
 - `feature/<issue>-<slug>` for features and planned improvements
 - `fix/<issue>-<slug>` for defects
 - `docs/<issue>-<slug>` for documentation-only work
+
+For remediation of an existing pull request, fetch and inspect the latest PR head and continue on that PR's existing branch in its dedicated worktree. Do not create a replacement branch, retarget the PR, rebase, force-push, or rewrite shared history unless explicitly instructed.
 
 Commit messages use:
 
@@ -86,7 +92,7 @@ Valid types include `feat`, `fix`, `refactor`, `docs`, `test`, and `chore`.
 
 Do not add a hard-coded Copilot co-author trailer. Attribution must reflect the actual authoring workflow.
 
-Every implementation PR must include `Closes #N`, use the PR template, and end in a reviewable state. The final handoff must say: **Do not merge — wait for review.**
+Every implementation PR must include `Closes #N`, use the PR template, and end in a reviewable state. Work is not complete while intended changes are incomplete, uncommitted, or unpushed. The final handoff must report the final pushed commit SHA, PR URL, worktree and branch, validation and CI state, and confirmation that the worktree is clean. It must say: **Do not merge — wait for review.**
 
 ## Simplicity and review discipline
 
@@ -97,6 +103,7 @@ Follow `.github/instructions/simplicity-review.instructions.md` for all implemen
 - Do not create generic frameworks for a single current use case.
 - Keep calculation logic and state in the owning domain rather than mirroring it elsewhere.
 - Every review has a correctness pass followed by a simplicity/over-engineering pass.
+- Reviews must inspect the latest PR head, verify prior findings still exist, distinguish required work from optional follow-ups, and stop once the approved scope is correctly implemented and adequately tested.
 
 ## Domain ownership boundaries
 
@@ -322,9 +329,10 @@ The PR description must explain:
 - important design or migration decisions
 - validation commands and exact results
 - E2E tests added/updated, or why E2E is not applicable
-- risks, limitations, and follow-up work
+- risks, limitations, and optional follow-up work kept separate from required work
+- the final pushed commit SHA
 
-After every push, check required CI and report its current state. Do not merge even when all checks pass.
+After every push, confirm the remote branch contains the intended commit, check required CI, and report its current state. Before reporting completion, verify the worktree is clean. If intended work remains incomplete, uncommitted, or unpushed, report the task as incomplete. Do not merge even when all checks pass.
 
 ## Optional local accelerators
 

--- a/.github/instructions/simplicity-review.instructions.md
+++ b/.github/instructions/simplicity-review.instructions.md
@@ -51,11 +51,27 @@ Each domain must maintain a single source of truth for its data. Avoid mirrored 
 
 ## Review Procedure
 
+Before reviewing code:
+
+1. Inspect the latest pull-request head, not an earlier local checkout or prior review diff.
+2. Read the tracked issue, acceptance criteria, approved design, agreed exclusions, and prior required feedback.
+3. Inspect the changed code in system context and check the relevant CI and validation results.
+4. Verify that every previously reported finding still exists on the latest head before repeating it.
+
 Use two passes for every PR review:
 
 1. **Correctness pass** — behaviour, data model, API contracts, tests, migrations, safety, accessibility, cache invalidation, and UX. Correctness wins over simplicity.
-
 2. **Simplicity / over-engineering pass** — look for dead props, duplicated state, helpers with one caller, abstractions with one implementation, unused flexibility, hand-rolled platform features, unnecessary dependencies, and code that can be deleted.
+
+Classify every actionable finding as exactly one of:
+
+- **Blocking defect** — incorrect, unsafe, regressive, destructive, or violates an acceptance criterion.
+- **Required completion** — work explicitly required by the issue, approved design, or prior valid review feedback is missing.
+- **Optional follow-up** — useful improvement that is not required for this PR.
+
+Only blocking defects and required completion prevent merge. Keep optional follow-ups explicitly non-blocking, separate from required remediation, and out of remediation prompts unless the user separately approves them.
+
+For blocking or required findings, identify the affected component, the scope or contract violation, the impact, and the minimum remediation. Do not request broad cleanup when a targeted fix is sufficient. Do not introduce new requirements or hypothetical future needs.
 
 When reporting simplicity findings, use concise lines:
 
@@ -64,3 +80,13 @@ When reporting simplicity findings, use concise lines:
 ```
 
 If there is nothing meaningful to simplify, say: `Lean already. Ship.`
+
+Stop the review cycle once the approved scope is correctly implemented, adequately tested, CI is passing or has a clearly identified external limitation, and the changed structure is acceptably maintainable. Do not continue creating remediation work merely because another design might be preferable.
+
+End every review with exactly one verdict:
+
+- `Ready to merge`
+- `Ready to merge once CI passes`
+- `Changes required`
+
+When the verdict is `Changes required`, list only the minimum required remediation. Keep optional follow-ups separate and explicitly non-blocking.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,11 +5,12 @@ Repository-wide implementation and review rules are defined in `.github/instruct
 ## Branching strategy
 
 - `main` is the stable, reviewed branch.
-- Start each piece of work from the latest `main`.
+- For new issue work, start a new issue branch from the latest `main`.
+- For remediation of an existing pull request, fetch and inspect the latest PR head and continue on the existing PR branch. Do not create a replacement branch, retarget the PR, rebase, force-push, or rewrite shared history unless explicitly requested.
 - Target `main` directly; do not chain feature branches.
 - Use one branch per issue or independently reviewable work item.
 
-Branch names:
+Branch names for new work:
 
 ```text
 feature/<issue>-<slug>
@@ -24,18 +25,31 @@ feature/365-agent-instruction-hardening
 fix/353-windows-e2e-runner
 ```
 
+## Worktrees
+
+Implementation and pull-request remediation must use a dedicated Git worktree so concurrent work does not interfere.
+
+- Verify the selected worktree and branch before editing.
+- Reuse an existing dedicated worktree when it already owns the branch.
+- Do not modify, clean, reset, delete, or otherwise disturb another contributor's or agent's worktree.
+- Leave the worktree clean after the intended changes are committed and pushed.
+
 ## Pull-request process
 
-1. Confirm the issue scope and acceptance criteria.
-2. Implement the smallest complete change and add appropriate tests.
-3. Run the repository validation contract.
-4. Update affected documentation and screenshots.
-5. Raise a PR against `main` using `.github/pull_request_template.md`.
-6. Include `Closes #N` in the PR body.
-7. Wait for human review and approval.
-8. The repository owner merges the PR.
+1. Confirm the issue scope, acceptance criteria, approved design, and exclusions.
+2. Confirm whether the task is new work or remediation of an existing PR and select the correct branch and dedicated worktree.
+3. Implement the smallest complete change and add appropriate tests.
+4. Run the repository validation contract.
+5. Update affected documentation and screenshots.
+6. Review the final diff against the original issue and acceptance criteria.
+7. Commit only the intended changes and push them to the correct branch.
+8. Raise or update the PR against `main` using `.github/pull_request_template.md`.
+9. Include `Closes #N` in the PR body for new issue work.
+10. Confirm the remote branch contains the final commit, record the commit SHA and PR URL, and leave the worktree clean.
+11. Wait for human review and approval.
+12. The repository owner merges the PR.
 
-Contributors and agents must not push directly to `main`, merge their own PR, enable auto-merge, approve their own PR, or bypass required checks.
+Incomplete, uncommitted, or unpushed work must be reported as incomplete. Contributors and agents must not push directly to `main`, merge their own PR, enable auto-merge, approve their own PR, force-push shared history without explicit approval, or bypass required checks.
 
 ## Commit messages
 
@@ -131,9 +145,15 @@ Update documentation when behaviour, setup, architecture, commands, or supported
 
 ## Review standard
 
+Before reviewing, inspect the latest PR head and read the issue, acceptance criteria, approved design, agreed exclusions, prior required feedback, and relevant CI results. Verify that earlier findings still exist before repeating them.
+
 Every review includes:
 
 1. a correctness pass covering behaviour, security, data safety, tests, accessibility, UX, and API contracts
 2. a simplicity pass covering unnecessary abstraction, duplicated state, unused flexibility, new dependencies, and code that can be deleted
+
+Classify findings as `Blocking defect`, `Required completion`, or `Optional follow-up`. Only the first two block merge. Optional follow-ups must remain explicitly non-blocking and must not be included in required remediation or agent prompts.
+
+Stop once the approved scope is correctly implemented, adequately tested, and acceptably structured. End with exactly one verdict: `Ready to merge`, `Ready to merge once CI passes`, or `Changes required`.
 
 See `.github/instructions/simplicity-review.instructions.md` for the complete review procedure.


### PR DESCRIPTION
## Summary

Closes #391

Hardens the repository's agent instructions around existing-PR remediation, dedicated worktrees, completion/push reporting, and scope-disciplined reviews.

## Changes

- Distinguishes new issue branches from remediation on an existing PR branch and latest PR head.
- Requires implementation and remediation to use a dedicated worktree without disturbing other agents.
- Requires final issue-scope review, commit, push, final SHA/PR reporting, and a clean worktree before completion can be claimed.
- Expands the two-pass review procedure with latest-head and prior-finding verification, three finding classifications, a stopping rule, and exact verdicts.
- Keeps optional follow-ups non-blocking and out of required remediation prompts.

## Design, data, or migration notes

The existing instruction hierarchy remains unchanged. `.github/instructions/project.instructions.md` remains canonical; the developer-agent and contributor files only summarise or adapt that contract.

No application, database, CI, test-infrastructure, or migration behaviour changed.

## Validation

- Compared `main` (`49dc1d000a8c415959cd522159a3cd945083037e`) with the branch.
- Confirmed exactly four approved instruction files changed.
- Reviewed the draft diff against issue #391 and the existing instruction precedence model.
- Application tests and E2E: N/A — documentation/instruction-only change.
- CI state: pending after draft PR creation.

## Files changed

- `.github/instructions/project.instructions.md`
- `.github/instructions/simplicity-review.instructions.md`
- `.github/agents/codex-developer.agent.md`
- `CONTRIBUTING.md`

## Risks and follow-ups

None required. Moving PostgreSQL operational detail into path-scoped documentation remains explicitly out of scope.

## Review control

- Draft PR for human review.
- Auto-merge is not enabled.
- Do not merge until the final review is complete.

**Do not merge — wait for review.**