### PR TITLE
fix(#394): sequential-story phases and weekly-demand dedup

### DIFF
--- a/server/src/lib/projectPlanningModel.ts
+++ b/server/src/lib/projectPlanningModel.ts
@@ -427,10 +427,11 @@ export function mergeWeeklyDemand(
 
   for (const row of fallbackDemand) {
     const hasCached = cachedResourceTypes.has(row.resourceTypeName)
-    if (hasCached) {
-      const rtMaxWeek = cachedMaxWeekByRt.get(row.resourceTypeName)
-      if (rtMaxWeek != null && row.week <= rtMaxWeek) continue
-    }
+    // If a resource type has any cached scheduler demand, suppress every
+    // fallback row for that resource type across the entire horizon.
+    // This prevents duplicated demand from fallback rows after the final
+    // cached week.
+    if (hasCached) continue
     mergedDemand.set(weeklyDemandKey(row.week, row.resourceTypeName), row)
   }
 

--- a/server/src/lib/scheduler.ts
+++ b/server/src/lib/scheduler.ts
@@ -354,6 +354,11 @@ export function runScheduler(input: SchedulerInput): SchedulerOutput {
   const manualDurationWeeks = new Map(manualFeatureEntries.map(e => [e.featureId, e.durationWeeks]))
   const manualStoryWeeks = new Map(manualStoryEntries.map(e => [e.storyId, e.startWeek]))
 
+  // Story phase transition tracking (populated during levelling, used for
+  // levelled story bars). Maps storyId → simulation time for start/completion.
+  const storyPhaseStart = new Map<string, number>()
+  const storyPhaseDone = new Map<string, number>()
+
   // ── Flatten features across epics, attaching epic back-reference ─────────
   const allFeatures = epics.flatMap(epic =>
     epic.features.map(f => ({ ...f, epic }))
@@ -430,8 +435,10 @@ export function runScheduler(input: SchedulerInput): SchedulerOutput {
   }
 
   function storyPhaseSchedule(feature: typeof allFeatures[0]): Array<{ storyId: string; weeks: number }> {
-    const activeStories = feature.userStories.filter(s => s.isActive !== false)
-    const sorted = [...activeStories].sort((a, b) => (a.order ?? 0) - (b.order ?? 0))
+    // Exclude manually pinned stories — they are sequenced independently
+    // in the story bars pass and must not distort automatic phase durations.
+    const autoStories = feature.userStories.filter(s => s.isActive !== false && !manualStoryWeeks.has(s.id))
+    const sorted = [...autoStories].sort((a, b) => (a.order ?? 0) - (b.order ?? 0))
     return sorted.map(s => ({ storyId: s.id, weeks: storyBottleneckWeeks(s) }))
   }
 
@@ -439,6 +446,11 @@ export function runScheduler(input: SchedulerInput): SchedulerOutput {
   function featureDurationWeeks(feature: typeof allFeatures[0]): number {
     const phases = storyPhaseSchedule(feature)
     if (phases.length === 0) return 1
+    // Preserve 1-week default when no non-manual story has task effort.
+    const hasAnyAutoTasks = feature.userStories
+      .filter(s => s.isActive !== false && !manualStoryWeeks.has(s.id))
+      .some(s => s.tasks.length > 0)
+    if (!hasAnyAutoTasks) return 1
     const total = phases.reduce((sum, p) => sum + p.weeks, 0)
     // Apply parallel demand floor if this feature belongs to a parallel epic
     const floor = parallelEpicMinSpan.get(feature.epic.id)
@@ -646,7 +658,7 @@ export function runScheduler(input: SchedulerInput): SchedulerOutput {
     for (const fId of processed) {
       if (manualStartWeeks.has(fId)) continue
       const f = featureMap.get(fId)!
-      const activeStories = f.userStories.filter(s => s.isActive !== false)
+      const activeStories = f.userStories.filter(s => s.isActive !== false && !manualStoryWeeks.has(s.id))
       const sorted = [...activeStories].sort((a, b) => (a.order ?? 0) - (b.order ?? 0))
       const phases = sorted.map(s => {
         const byRt = new Map<string, number>()
@@ -699,6 +711,14 @@ export function runScheduler(input: SchedulerInput): SchedulerOutput {
             if (!hasCapacity) continue
           }
           simStart.set(fId, t)
+          // Record the first story phase's start time for levelled bar derivation
+          const startPhases = storyPhases.get(fId)
+          if (startPhases && startPhases.length > 0) {
+            const firstIdx = currentStoryIdx.get(fId) ?? 0
+            if (firstIdx < startPhases.length) {
+              storyPhaseStart.set(startPhases[firstIdx].storyId, t)
+            }
+          }
         }
       }
       const active = [...unfinished].filter(fId => simStart.has(fId))
@@ -776,16 +796,42 @@ export function runScheduler(input: SchedulerInput): SchedulerOutput {
       for (const fId of active) {
         const allDone = [...(remainingHours.get(fId)?.values() ?? [])].every(h => h <= 0.001)
         if (allDone) {
-          // Current story phase consumed — advance to next, or mark feature done
+          // Record current story phase completion for levelled bar derivation
+          const phases = storyPhases.get(fId)
+          if (phases) {
+            const prevIdx = currentStoryIdx.get(fId) ?? 0
+            if (prevIdx < phases.length) {
+              storyPhaseDone.set(phases[prevIdx].storyId, t)
+            }
+          }
+          // Advance to next story phase or mark feature done
           if (!advanceToNextStory(fId)) {
             simDone.set(fId, t + STEP)
             unfinished.delete(fId)
+          } else {
+            // Record the next story phase's start time
+            const phases = storyPhases.get(fId)!
+            const nextIdx = currentStoryIdx.get(fId) ?? 0
+            if (nextIdx < phases.length) {
+              storyPhaseStart.set(phases[nextIdx].storyId, t)
+            }
           }
         }
       }
 
       t += STEP
       t = Math.round(t * 5) / 5
+    }
+
+    // Record completion times for story phases whose completion coincides
+    // with the feature's simDone (last story done at the feature boundary).
+    for (const [fId, idx] of currentStoryIdx) {
+      const phases = storyPhases.get(fId)
+      if (!phases || idx < 0 || idx >= phases.length) continue
+      const lastStoryId = phases[idx].storyId
+      if (!storyPhaseDone.has(lastStoryId) && simDone.has(fId)) {
+        storyPhaseDone.set(lastStoryId, simDone.get(fId)!)
+      }
     }
 
     // Apply simulation results back to startWeeks/finishWeeks
@@ -835,10 +881,10 @@ export function runScheduler(input: SchedulerInput): SchedulerOutput {
   }
 
   // Pass 2: story-phase sequential scheduling per feature.
-  // Uses bottleneck-phase durations (not total hours) so story bars reflect
-  // the actual sequential task-phases rather than a proportional split.
-  // For levelled schedules the phase durations scale to fill the levelled
-  // feature span; for non-levelled schedules the phases stack directly.
+  // For levelled schedules with recorded phase transitions, story bars are
+  // derived directly from the simulation's actual start/completion times.
+  // For non-levelled schedules, bottleneck-phase durations are proportionally
+  // scaled to fill the feature span.
   const storiesByFeature = new Map<string, typeof allStories>()
   for (const story of allStories) {
     const fId = story.feature.id
@@ -850,25 +896,39 @@ export function runScheduler(input: SchedulerInput): SchedulerOutput {
   }
 
   for (const [fId, stories] of storiesByFeature) {
-    const featureStart = startWeeks.get(fId) ?? 0
-    const featureDuration = Math.max(0.2, (finishWeeks.get(fId) ?? featureStart + 1) - featureStart)
-
-    const f = featureMap.get(fId)!
-    const phases = storyPhaseSchedule(f)
-    const totalPhaseWeeks = phases.reduce((sum, p) => sum + p.weeks, 0)
-    const scale = totalPhaseWeeks > 0 ? featureDuration / totalPhaseWeeks : 1
-
     const siblings = stories.filter(s => !manualStoryWeeks.has(s.id))
     if (siblings.length === 0) continue
 
-    let cursor = featureStart
-    for (const sibling of siblings) {
-      const phase = phases.find(p => p.storyId === sibling.id)
-      const phaseWeeks = phase?.weeks ?? 0.2
-      const dur = phaseWeeks * scale
-      const safeDur = Math.max(0.2, dur)
-      storyScheduled.set(sibling.id, { startWeek: cursor, durationWeeks: safeDur, isManual: false })
-      cursor += safeDur
+    // Use recorded phase transitions from levelling when available
+    const allHaveRecorded = siblings.every(s => storyPhaseStart.has(s.id) && storyPhaseDone.has(s.id))
+    if (resourceLevel && allHaveRecorded && siblings.length > 0) {
+      for (const sibling of siblings) {
+        const start = storyPhaseStart.get(sibling.id)!
+        const done = storyPhaseDone.get(sibling.id)!
+        storyScheduled.set(sibling.id, {
+          startWeek: start,
+          durationWeeks: Math.max(0.2, done - start),
+          isManual: false,
+        })
+      }
+    } else {
+      // Non-levelled: bottleneck-phase calculation with proportional scaling
+      const featureStart = startWeeks.get(fId) ?? 0
+      const featureDuration = Math.max(0.2, (finishWeeks.get(fId) ?? featureStart + 1) - featureStart)
+      const f = featureMap.get(fId)!
+      const phases = storyPhaseSchedule(f)
+      const totalPhaseWeeks = phases.reduce((sum, p) => sum + p.weeks, 0)
+      const scale = totalPhaseWeeks > 0 ? featureDuration / totalPhaseWeeks : 1
+
+      let cursor = featureStart
+      for (const sibling of siblings) {
+        const phase = phases.find(p => p.storyId === sibling.id)
+        const phaseWeeks = phase?.weeks ?? 0.2
+        const dur = phaseWeeks * scale
+        const safeDur = Math.max(0.2, dur)
+        storyScheduled.set(sibling.id, { startWeek: cursor, durationWeeks: safeDur, isManual: false })
+        cursor += safeDur
+      }
     }
   }
 

--- a/server/src/lib/scheduler.ts
+++ b/server/src/lib/scheduler.ts
@@ -843,10 +843,12 @@ export function runScheduler(input: SchedulerInput): SchedulerOutput {
             const prevIdx = currentStoryIdx.get(fId) ?? 0
             if (prevIdx < phases.length) {
               const prevStoryId = phases[prevIdx].storyId
-              // Zero-effort phases never receive positive allocation,
-              // so their start is set here at the transition boundary.
+              // Zero-effort phases never receive positive allocation.
+              // Record start at the beginning of this step (t) and completion
+              // at the end (t+STEP) so story bars are contiguous — the next
+              // phase begins allocation at t+STEP in the following iteration.
               if (!storyPhaseStart.has(prevStoryId)) {
-                storyPhaseStart.set(prevStoryId, t + STEP)
+                storyPhaseStart.set(prevStoryId, t)
               }
               storyPhaseDone.set(prevStoryId, t + STEP)
             }
@@ -888,17 +890,17 @@ export function runScheduler(input: SchedulerInput): SchedulerOutput {
       }
     }
 
-    // Record completion times for story phases whose completion coincides
-    // with the feature's simDone (last story done at the feature boundary).
     for (const [fId, idx] of currentStoryIdx) {
       const phases = storyPhases.get(fId)
       if (!phases || idx < 0 || idx >= phases.length) continue
       const lastStoryId = phases[idx].storyId
       if (!storyPhaseDone.has(lastStoryId) && simDone.has(fId)) {
-        storyPhaseDone.set(lastStoryId, simDone.get(fId)!)
-        // Zero-effort last story: ensure start time is also recorded
+        const simDoneVal = simDone.get(fId)!
+        storyPhaseDone.set(lastStoryId, simDoneVal)
+        // Zero-effort last story: set start one scheduler step before
+        // simDone so the bar has a real STEP-width interval.
         if (!storyPhaseStart.has(lastStoryId)) {
-          storyPhaseStart.set(lastStoryId, simDone.get(fId)!)
+          storyPhaseStart.set(lastStoryId, Math.max(simDoneVal - STEP, 0))
         }
       }
     }

--- a/server/src/lib/scheduler.ts
+++ b/server/src/lib/scheduler.ts
@@ -614,6 +614,39 @@ export function runScheduler(input: SchedulerInput): SchedulerOutput {
 
   // ── Resource-levelling simulation ─────────────────────────────────────────
   const weeklyConsumptionMap = new Map<string, number>()
+  const rtById = new Map(resourceTypes.map(rt => [rt.id, rt]))
+
+  // Pre-compute pinned story resource demand for inclusion in weeklyConsumptionMap
+  // and capacity reservation during levelling. Pinned stories are excluded from
+  // automatic story phases but their demand must be represented.
+  const pinnedStoryDemand = new Map<string, number>()  // key: `${rtId}|${week}` → hours/week
+  for (const f of allFeatures) {
+    for (const story of f.userStories) {
+      if (!manualStoryWeeks.has(story.id)) continue
+      if (story.isActive === false) continue
+      const sw = manualStoryWeeks.get(story.id)!
+      const totalHours = story.tasks.reduce((sum, t) => {
+        const hpd = t.resourceType?.hoursPerDay ?? fallbackHoursPerDay
+        return sum + effectiveDays(t.durationDays, t.hoursEffort, hpd) * hpd
+      }, 0)
+      const dur = Math.max(0.2, totalHours / fallbackHoursPerDay / 5)
+
+      for (const task of story.tasks) {
+        const rtId = task.resourceTypeId ?? '_unassigned'
+        const hpd = task.resourceType?.hoursPerDay ?? fallbackHoursPerDay
+        const hours = effectiveDays(task.durationDays, task.hoursEffort, hpd) * hpd
+        const startW = Math.floor(sw)
+        const endWk = Math.ceil(sw + dur)
+        for (let w = startW; w < endWk; w++) {
+          const overlap = Math.min(w + 1, sw + dur) - Math.max(w, sw)
+          if (overlap <= 0) continue
+          const weeklyHours = hours * (overlap / dur)
+          const key = `${rtId}|${w}`
+          pinnedStoryDemand.set(key, (pinnedStoryDemand.get(key) ?? 0) + weeklyHours)
+        }
+      }
+    }
+  }
 
   if (resourceLevel) {
     function featureResourceHours(feature: typeof allFeatures[0]): Map<string, number> {
@@ -635,7 +668,6 @@ export function runScheduler(input: SchedulerInput): SchedulerOutput {
       featureResourceHoursCache.set(fId, featureResourceHours(featureMap.get(fId)!))
     }
 
-    const rtById = new Map(resourceTypes.map(rt => [rt.id, rt]))
     const allRtIds = [...resourceTypes.map(rt => rt.id), '_unassigned']
 
     // Story-phase tracking for per-story sequential demand exposure within
@@ -766,6 +798,17 @@ export function runScheduler(input: SchedulerInput): SchedulerOutput {
             }
           }
         }
+        // Subtract pinned story demand from available capacity and record it.
+        // Pinned demand is spread uniformly across all steps in each week.
+        const pinnedWeeklyHours = pinnedStoryDemand.get(`${rtId}|${currentWeek}`) ?? 0
+        if (pinnedWeeklyHours > 0) {
+          const pinnedStepHours = pinnedWeeklyHours * STEP
+          capPerStep = Math.max(0, capPerStep - pinnedStepHours)
+          weeklyConsumptionMap.set(
+            `${rtId}|${currentWeek}`,
+            (weeklyConsumptionMap.get(`${rtId}|${currentWeek}`) ?? 0) + pinnedStepHours / hpd,
+          )
+        }
         const competing = active.filter(fId => (remainingHours.get(fId)?.get(rtId) ?? 0) > 0.001)
         if (competing.length === 0) continue
 
@@ -801,7 +844,7 @@ export function runScheduler(input: SchedulerInput): SchedulerOutput {
           if (phases) {
             const prevIdx = currentStoryIdx.get(fId) ?? 0
             if (prevIdx < phases.length) {
-              storyPhaseDone.set(phases[prevIdx].storyId, t)
+              storyPhaseDone.set(phases[prevIdx].storyId, t + STEP)
             }
           }
           // Advance to next story phase or mark feature done
@@ -813,7 +856,7 @@ export function runScheduler(input: SchedulerInput): SchedulerOutput {
             const phases = storyPhases.get(fId)!
             const nextIdx = currentStoryIdx.get(fId) ?? 0
             if (nextIdx < phases.length) {
-              storyPhaseStart.set(phases[nextIdx].storyId, t)
+              storyPhaseStart.set(phases[nextIdx].storyId, t + STEP)
             }
           }
         }
@@ -841,6 +884,16 @@ export function runScheduler(input: SchedulerInput): SchedulerOutput {
       const dur = doneW !== undefined ? doneW - sw : featureDurationWeeks(featureMap.get(fId)!)
       startWeeks.set(fId, sw)
       finishWeeks.set(fId, sw + dur)
+    }
+  }
+
+  // Add pinned story demand to weeklyConsumptionMap for weeks not already
+  // represented (the simulation loop already adds these for the levelled path).
+  for (const [key, weeklyHours] of pinnedStoryDemand) {
+    if (!weeklyConsumptionMap.has(key)) {
+      const [rtId] = key.split('|')
+      const hpd = rtById.get(rtId)?.hoursPerDay ?? fallbackHoursPerDay
+      weeklyConsumptionMap.set(key, Math.round(weeklyHours / hpd * 100) / 100)
     }
   }
 

--- a/server/src/lib/scheduler.ts
+++ b/server/src/lib/scheduler.ts
@@ -404,20 +404,21 @@ export function runScheduler(input: SchedulerInput): SchedulerOutput {
   }
 
   // ── Helper: duration in weeks for a feature ───────────────────────────────
-  function featureDurationWeeks(feature: typeof allFeatures[0]): number {
-    const allTasks = feature.userStories.filter(s => s.isActive !== false).flatMap(s => s.tasks)
-    if (allTasks.length === 0) return 1
+  // ── Helper: story-phase bottleneck duration ─────────────────────────────
+  function storyBottleneckWeeks(story: SchedulerStory): number {
+    const tasks = story.tasks
+    if (tasks.length === 0) return 0.2
 
-    const byRt = new Map<string | null, typeof allTasks>()
-    for (const task of allTasks) {
+    const byRt = new Map<string | null, typeof tasks>()
+    for (const task of tasks) {
       const group = byRt.get(task.resourceTypeId) ?? []
       group.push(task)
       byRt.set(task.resourceTypeId, group)
     }
 
     let maxDays = 0
-    for (const [rtId, tasks] of byRt) {
-      const personDays = tasks.reduce((sum, t) => {
+    for (const [rtId, rtTasks] of byRt) {
+      const personDays = rtTasks.reduce((sum, t) => {
         const hpd = t.resourceType?.hoursPerDay ?? fallbackHoursPerDay
         return sum + effectiveDays(t.durationDays, t.hoursEffort, hpd)
       }, 0)
@@ -425,14 +426,26 @@ export function runScheduler(input: SchedulerInput): SchedulerOutput {
       const days = personDays / count
       if (days > maxDays) maxDays = days
     }
-    const individualResult = Math.max(0.2, maxDays / 5)
+    return Math.max(0.2, maxDays / 5)
+  }
 
+  function storyPhaseSchedule(feature: typeof allFeatures[0]): Array<{ storyId: string; weeks: number }> {
+    const activeStories = feature.userStories.filter(s => s.isActive !== false)
+    const sorted = [...activeStories].sort((a, b) => (a.order ?? 0) - (b.order ?? 0))
+    return sorted.map(s => ({ storyId: s.id, weeks: storyBottleneckWeeks(s) }))
+  }
+
+  // ── Helper: duration in weeks for a feature (sequential story phases) ──
+  function featureDurationWeeks(feature: typeof allFeatures[0]): number {
+    const phases = storyPhaseSchedule(feature)
+    if (phases.length === 0) return 1
+    const total = phases.reduce((sum, p) => sum + p.weeks, 0)
     // Apply parallel demand floor if this feature belongs to a parallel epic
     const floor = parallelEpicMinSpan.get(feature.epic.id)
     if (floor !== undefined) {
-      return Math.max(individualResult, floor)
+      return Math.max(total, floor)
     }
-    return individualResult
+    return total
   }
 
   // ── Kahn's topological sort over features ─────────────────────────────────
@@ -613,10 +626,40 @@ export function runScheduler(input: SchedulerInput): SchedulerOutput {
     const rtById = new Map(resourceTypes.map(rt => [rt.id, rt]))
     const allRtIds = [...resourceTypes.map(rt => rt.id), '_unassigned']
 
+    // Story-phase tracking for per-story sequential demand exposure within
+    // each feature.  Only the current story's resource demand is eligible
+    // for capacity allocation; when all demand for the current story is
+    // consumed, the next story phase begins.
+    const storyPhases = new Map<string, Array<{ storyId: string; byRt: Map<string, number> }>>()
+    const currentStoryIdx = new Map<string, number>()
+
+    function advanceToNextStory(fId: string): boolean {
+      const phases = storyPhases.get(fId)!
+      const idx = (currentStoryIdx.get(fId) ?? -1) + 1
+      if (idx >= phases.length) return false
+      currentStoryIdx.set(fId, idx)
+      remainingHours.set(fId, new Map(phases[idx].byRt))
+      return true
+    }
+
     const remainingHours = new Map<string, Map<string, number>>()
     for (const fId of processed) {
       if (manualStartWeeks.has(fId)) continue
-      remainingHours.set(fId, new Map(featureResourceHoursCache.get(fId)!))
+      const f = featureMap.get(fId)!
+      const activeStories = f.userStories.filter(s => s.isActive !== false)
+      const sorted = [...activeStories].sort((a, b) => (a.order ?? 0) - (b.order ?? 0))
+      const phases = sorted.map(s => {
+        const byRt = new Map<string, number>()
+        for (const task of s.tasks) {
+          const rtId = task.resourceTypeId ?? '_unassigned'
+          const hpd = task.resourceType?.hoursPerDay ?? fallbackHoursPerDay
+          const hours = effectiveDays(task.durationDays, task.hoursEffort, hpd) * hpd
+          byRt.set(rtId, (byRt.get(rtId) ?? 0) + hours)
+        }
+        return { storyId: s.id, byRt }
+      })
+      storyPhases.set(fId, phases)
+      advanceToNextStory(fId)
     }
 
     const simStart = new Map<string, number>()
@@ -658,7 +701,6 @@ export function runScheduler(input: SchedulerInput): SchedulerOutput {
           simStart.set(fId, t)
         }
       }
-
       const active = [...unfinished].filter(fId => simStart.has(fId))
 
       const currentWeek = Math.floor(t)
@@ -682,14 +724,7 @@ export function runScheduler(input: SchedulerInput): SchedulerOutput {
 
       if (active.length === 0) { t += STEP; continue }
 
-      for (const fId of active) {
-        if (remainingHours.get(fId)?.size === 0) {
-          if (!simDone.has(fId)) {
-            simDone.set(fId, t + STEP)
-            unfinished.delete(fId)
-          }
-        }
-      }
+      // (size-zero handled by the all-values-zero check below with story advance)
 
       for (const rtId of allRtIds) {
         const rt = rtById.get(rtId)
@@ -741,8 +776,11 @@ export function runScheduler(input: SchedulerInput): SchedulerOutput {
       for (const fId of active) {
         const allDone = [...(remainingHours.get(fId)?.values() ?? [])].every(h => h <= 0.001)
         if (allDone) {
-          simDone.set(fId, t + STEP)
-          unfinished.delete(fId)
+          // Current story phase consumed — advance to next, or mark feature done
+          if (!advanceToNextStory(fId)) {
+            simDone.set(fId, t + STEP)
+            unfinished.delete(fId)
+          }
         }
       }
 
@@ -796,7 +834,11 @@ export function runScheduler(input: SchedulerInput): SchedulerOutput {
     }
   }
 
-  // Pass 2: proportional sequential scheduling per feature
+  // Pass 2: story-phase sequential scheduling per feature.
+  // Uses bottleneck-phase durations (not total hours) so story bars reflect
+  // the actual sequential task-phases rather than a proportional split.
+  // For levelled schedules the phase durations scale to fill the levelled
+  // feature span; for non-levelled schedules the phases stack directly.
   const storiesByFeature = new Map<string, typeof allStories>()
   for (const story of allStories) {
     const fId = story.feature.id
@@ -809,20 +851,21 @@ export function runScheduler(input: SchedulerInput): SchedulerOutput {
 
   for (const [fId, stories] of storiesByFeature) {
     const featureStart = startWeeks.get(fId) ?? 0
-    const featureDone = finishWeeks.get(fId) ?? (featureStart + 1)
-    const featureDuration = Math.max(0.2, featureDone - featureStart)
+    const featureDuration = Math.max(0.2, (finishWeeks.get(fId) ?? featureStart + 1) - featureStart)
+
+    const f = featureMap.get(fId)!
+    const phases = storyPhaseSchedule(f)
+    const totalPhaseWeeks = phases.reduce((sum, p) => sum + p.weeks, 0)
+    const scale = totalPhaseWeeks > 0 ? featureDuration / totalPhaseWeeks : 1
 
     const siblings = stories.filter(s => !manualStoryWeeks.has(s.id))
     if (siblings.length === 0) continue
 
-    const totalFeatureHours = siblings.reduce((sum, s) => sum + storyTotalHours(s), 0)
-
     let cursor = featureStart
     for (const sibling of siblings) {
-      const hrs = storyTotalHours(sibling)
-      const dur = totalFeatureHours > 0
-        ? (hrs / totalFeatureHours) * featureDuration
-        : featureDuration / Math.max(1, siblings.length)
+      const phase = phases.find(p => p.storyId === sibling.id)
+      const phaseWeeks = phase?.weeks ?? 0.2
+      const dur = phaseWeeks * scale
       const safeDur = Math.max(0.2, dur)
       storyScheduled.set(sibling.id, { startWeek: cursor, durationWeeks: safeDur, isManual: false })
       cursor += safeDur

--- a/server/src/lib/scheduler.ts
+++ b/server/src/lib/scheduler.ts
@@ -616,10 +616,11 @@ export function runScheduler(input: SchedulerInput): SchedulerOutput {
   const weeklyConsumptionMap = new Map<string, number>()
   const rtById = new Map(resourceTypes.map(rt => [rt.id, rt]))
 
-  // Pre-compute pinned story resource demand for inclusion in weeklyConsumptionMap
-  // and capacity reservation during levelling. Pinned stories are excluded from
-  // automatic story phases but their demand must be represented.
-  const pinnedStoryDemand = new Map<string, number>()  // key: `${rtId}|${week}` → hours/week
+  // Pre-compute pinned story resource demand for both weekly output accounting
+  // and precise step-overlap capacity reservation. Pinned stories are excluded
+  // from automatic story phases but their demand must be represented.
+  const pinnedStoryDemand = new Map<string, number>()  // key: `${rtId}|${week}` → hours/week (output)
+  const pinnedIntervals: Array<{ rtId: string; hpd: number; totalHours: number; dur: number; startWeek: number; endWeek: number }> = []
   for (const f of allFeatures) {
     for (const story of f.userStories) {
       if (!manualStoryWeeks.has(story.id)) continue
@@ -630,15 +631,18 @@ export function runScheduler(input: SchedulerInput): SchedulerOutput {
         return sum + effectiveDays(t.durationDays, t.hoursEffort, hpd) * hpd
       }, 0)
       const dur = Math.max(0.2, totalHours / fallbackHoursPerDay / 5)
+      const endWeek = sw + dur
 
       for (const task of story.tasks) {
         const rtId = task.resourceTypeId ?? '_unassigned'
         const hpd = task.resourceType?.hoursPerDay ?? fallbackHoursPerDay
         const hours = effectiveDays(task.durationDays, task.hoursEffort, hpd) * hpd
+        pinnedIntervals.push({ rtId, hpd, totalHours: hours, dur, startWeek: sw, endWeek })
+        // Weekly totals for output accounting
         const startW = Math.floor(sw)
-        const endWk = Math.ceil(sw + dur)
+        const endWk = Math.ceil(endWeek)
         for (let w = startW; w < endWk; w++) {
-          const overlap = Math.min(w + 1, sw + dur) - Math.max(w, sw)
+          const overlap = Math.min(w + 1, endWeek) - Math.max(w, sw)
           if (overlap <= 0) continue
           const weeklyHours = hours * (overlap / dur)
           const key = `${rtId}|${w}`
@@ -746,36 +750,13 @@ export function runScheduler(input: SchedulerInput): SchedulerOutput {
             if (!hasCapacity) continue
           }
           simStart.set(fId, t)
-          // Record the first story phase's start time for levelled bar derivation
-          const startPhases = storyPhases.get(fId)
-          if (startPhases && startPhases.length > 0) {
-            const firstIdx = currentStoryIdx.get(fId) ?? 0
-            if (firstIdx < startPhases.length) {
-              storyPhaseStart.set(startPhases[firstIdx].storyId, t)
-            }
-          }
+          // (story phase start is recorded at first allocation, not at simStart)
         }
       }
       const active = [...unfinished].filter(fId => simStart.has(fId))
 
       const currentWeek = Math.floor(t)
-      for (const rtId of allRtIds) {
-        const rt = rtById.get(rtId)
-        const hpd = rt?.hoursPerDay ?? fallbackHoursPerDay
-        for (const [fId] of manualStartWeeks) {
-          const fStart = simStart.get(fId)
-          const fDone = simDone.get(fId)
-          if (fStart === undefined || fDone === undefined || fDone <= fStart) continue
-          if (t >= fStart && t < fDone) {
-            const rtHours = featureResourceHoursCache.get(fId)!.get(rtId) ?? 0
-            if (rtHours > 0) {
-              const perStep = (rtHours / (fDone - fStart)) * STEP
-              const consumptionKey = `${rtId}|${currentWeek}`
-              weeklyConsumptionMap.set(consumptionKey, (weeklyConsumptionMap.get(consumptionKey) ?? 0) + perStep / hpd)
-            }
-          }
-        }
-      }
+      // (manual-feature consumption output is handled post-loop)
 
       if (active.length === 0) { t += STEP; continue }
 
@@ -801,13 +782,15 @@ export function runScheduler(input: SchedulerInput): SchedulerOutput {
             }
           }
         }
-        // Subtract pinned story demand from available capacity per step.
-        // Output accounting for pinned demand is handled separately below
-        // (outside the step-by-step loop) to ensure complete weekly totals.
-        const pinnedWeeklyHours = pinnedStoryDemand.get(`${rtId}|${currentWeek}`) ?? 0
-        if (pinnedWeeklyHours > 0) {
-          const pinnedStepHours = pinnedWeeklyHours * STEP
-          capPerStep = Math.max(0, capPerStep - pinnedStepHours)
+        // Subtract pinned story demand from available capacity using exact
+        // step-overlap with each pinned interval, not a uniform weekly spread.
+        // A pinned story at week 0.8 should only reserve capacity from 0.8 onward.
+        for (const pin of pinnedIntervals) {
+          if (pin.rtId !== rtId) continue
+          if (t + STEP <= pin.startWeek || t >= pin.endWeek) continue
+          const overlap = Math.min(t + STEP, pin.endWeek) - Math.max(t, pin.startWeek)
+          if (overlap <= 0) continue
+          capPerStep = Math.max(0, capPerStep - pin.totalHours * (overlap / pin.dur))
         }
         const competing = active.filter(fId => (remainingHours.get(fId)?.get(rtId) ?? 0) > 0.001)
         if (competing.length === 0) continue
@@ -833,6 +816,21 @@ export function runScheduler(input: SchedulerInput): SchedulerOutput {
           const consumptionKey = `${rtId}|${currentWeek}`
           weeklyConsumptionMap.set(consumptionKey, (weeklyConsumptionMap.get(consumptionKey) ?? 0) + actualAllocated / hpd)
           remainingHours.get(fId)!.set(rtId, Math.max(0, rem - actualAllocated))
+          // Record the current story phase's start time at first positive allocation,
+          // not when the feature became eligible. This aligns story bars with actual
+          // consumption rather than eligibility.
+          if (actualAllocated > 0) {
+            const phases = storyPhases.get(fId)
+            if (phases) {
+              const idx = currentStoryIdx.get(fId) ?? 0
+              if (idx < phases.length) {
+                const storyId = phases[idx].storyId
+                if (!storyPhaseStart.has(storyId)) {
+                  storyPhaseStart.set(storyId, t)
+                }
+              }
+            }
+          }
         }
       }
 
@@ -864,6 +862,29 @@ export function runScheduler(input: SchedulerInput): SchedulerOutput {
 
       t += STEP
       t = Math.round(t * 5) / 5
+    }
+
+    // Add complete manual-feature consumption to weeklyConsumptionMap.
+    // This runs outside the while loop so it is independent of whether any
+    // automatic features exist.
+    for (const [fId, sw] of manualStartWeeks) {
+      const fEnd = simDone.get(fId) ?? (sw + 1)
+      if (sw >= fEnd) continue
+      const fHours = featureResourceHoursCache.get(fId)
+      if (!fHours) continue
+      const fDur = fEnd - sw
+      for (const [rtId, rtHours] of fHours) {
+        const hpd = rtById.get(rtId)?.hoursPerDay ?? fallbackHoursPerDay
+        const startW = Math.floor(sw)
+        const endWk = Math.ceil(fEnd)
+        for (let w = startW; w < endWk; w++) {
+          const overlap = Math.min(w + 1, fEnd) - Math.max(w, sw)
+          if (overlap <= 0) continue
+          const weeklyDays = rtHours * (overlap / fDur)
+          const key = `${rtId}|${w}`
+          weeklyConsumptionMap.set(key, (weeklyConsumptionMap.get(key) ?? 0) + Math.round(weeklyDays / hpd * 100) / 100)
+        }
+      }
     }
 
     // Record completion times for story phases whose completion coincides

--- a/server/src/lib/scheduler.ts
+++ b/server/src/lib/scheduler.ts
@@ -842,20 +842,21 @@ export function runScheduler(input: SchedulerInput): SchedulerOutput {
           if (phases) {
             const prevIdx = currentStoryIdx.get(fId) ?? 0
             if (prevIdx < phases.length) {
-              storyPhaseDone.set(phases[prevIdx].storyId, t + STEP)
+              const prevStoryId = phases[prevIdx].storyId
+              // Zero-effort phases never receive positive allocation,
+              // so their start is set here at the transition boundary.
+              if (!storyPhaseStart.has(prevStoryId)) {
+                storyPhaseStart.set(prevStoryId, t + STEP)
+              }
+              storyPhaseDone.set(prevStoryId, t + STEP)
             }
           }
-          // Advance to next story phase or mark feature done
+          // Advance to next story phase or mark feature done.
+          // The next phase's start is NOT recorded here — the
+          // allocation path sets it at first positive allocation.
           if (!advanceToNextStory(fId)) {
             simDone.set(fId, t + STEP)
             unfinished.delete(fId)
-          } else {
-            // Record the next story phase's start time
-            const phases = storyPhases.get(fId)!
-            const nextIdx = currentStoryIdx.get(fId) ?? 0
-            if (nextIdx < phases.length) {
-              storyPhaseStart.set(phases[nextIdx].storyId, t + STEP)
-            }
           }
         }
       }
@@ -895,6 +896,10 @@ export function runScheduler(input: SchedulerInput): SchedulerOutput {
       const lastStoryId = phases[idx].storyId
       if (!storyPhaseDone.has(lastStoryId) && simDone.has(fId)) {
         storyPhaseDone.set(lastStoryId, simDone.get(fId)!)
+        // Zero-effort last story: ensure start time is also recorded
+        if (!storyPhaseStart.has(lastStoryId)) {
+          storyPhaseStart.set(lastStoryId, simDone.get(fId)!)
+        }
       }
     }
 

--- a/server/src/lib/scheduler.ts
+++ b/server/src/lib/scheduler.ts
@@ -653,6 +653,9 @@ export function runScheduler(input: SchedulerInput): SchedulerOutput {
       const result = new Map<string, number>()
       for (const story of feature.userStories) {
         if (story.isActive === false) continue
+        // Pinned stories have independent demand accounting; exclude them from
+        // the manual-feature aggregate to prevent double-counting.
+        if (manualStoryWeeks.has(story.id)) continue
         for (const task of story.tasks) {
           const rtId = task.resourceTypeId ?? '_unassigned'
           const hpd = task.resourceType?.hoursPerDay ?? fallbackHoursPerDay
@@ -798,16 +801,13 @@ export function runScheduler(input: SchedulerInput): SchedulerOutput {
             }
           }
         }
-        // Subtract pinned story demand from available capacity and record it.
-        // Pinned demand is spread uniformly across all steps in each week.
+        // Subtract pinned story demand from available capacity per step.
+        // Output accounting for pinned demand is handled separately below
+        // (outside the step-by-step loop) to ensure complete weekly totals.
         const pinnedWeeklyHours = pinnedStoryDemand.get(`${rtId}|${currentWeek}`) ?? 0
         if (pinnedWeeklyHours > 0) {
           const pinnedStepHours = pinnedWeeklyHours * STEP
           capPerStep = Math.max(0, capPerStep - pinnedStepHours)
-          weeklyConsumptionMap.set(
-            `${rtId}|${currentWeek}`,
-            (weeklyConsumptionMap.get(`${rtId}|${currentWeek}`) ?? 0) + pinnedStepHours / hpd,
-          )
         }
         const competing = active.filter(fId => (remainingHours.get(fId)?.get(rtId) ?? 0) > 0.001)
         if (competing.length === 0) continue
@@ -887,13 +887,17 @@ export function runScheduler(input: SchedulerInput): SchedulerOutput {
     }
   }
 
-  // Add pinned story demand to weeklyConsumptionMap for weeks not already
-  // represented (the simulation loop already adds these for the levelled path).
-  for (const [key, weeklyHours] of pinnedStoryDemand) {
-    if (!weeklyConsumptionMap.has(key)) {
+  // Add complete pinned story demand to weeklyConsumptionMap for the levelled
+  // path (outside the step loop so weeks with partial automatic coverage still
+  // record the full pinned total).  The non-levelled path does NOT emit a
+  // partial scheduler cache — fallback demand already covers all resource types.
+  if (resourceLevel) {
+    for (const [key, weeklyHours] of pinnedStoryDemand) {
       const [rtId] = key.split('|')
       const hpd = rtById.get(rtId)?.hoursPerDay ?? fallbackHoursPerDay
-      weeklyConsumptionMap.set(key, Math.round(weeklyHours / hpd * 100) / 100)
+      // Add the complete pinned weekly total; the simulation loop only used
+      // pinned demand for capacity reservation, not output accounting.
+      weeklyConsumptionMap.set(key, (weeklyConsumptionMap.get(key) ?? 0) + Math.round(weeklyHours / hpd * 100) / 100)
     }
   }
 

--- a/server/src/routes/timeline.ts
+++ b/server/src/routes/timeline.ts
@@ -217,11 +217,11 @@ function buildResponse(
 
     for (const row of fallbackDemand) {
       const hasCachedDemand = cachedResourceTypes.has(row.resourceTypeName)
-      if (hasCachedDemand) {
-        const rtMaxWeek = cachedMaxWeekByRt.get(row.resourceTypeName)
-        if (rtMaxWeek != null && row.week <= rtMaxWeek) continue
-      }
-
+      // If a resource type has any cached scheduler demand, suppress every
+      // fallback row for that resource type across the entire horizon.
+      // This prevents duplicated demand from fallback rows after the final
+      // cached week.
+      if (hasCachedDemand) continue
       mergedDemand.set(weeklyDemandKey(row.week, row.resourceTypeName), row)
     }
 

--- a/server/src/test/projectPlanningModel.test.ts
+++ b/server/src/test/projectPlanningModel.test.ts
@@ -397,9 +397,8 @@ describe('buildFallbackWeeklyDemand', () => {
 // ─────────────────────────────────────────────────────────────────────────────
 // mergeWeeklyDemand
 // ─────────────────────────────────────────────────────────────────────────────
-
 describe('mergeWeeklyDemand', () => {
-  it('uses simulated demand for cached RT within horizon, fallback beyond', () => {
+  it('suppresses all fallback when resource type has any cached demand', () => {
     const fallback = [
       { week: 0, resourceTypeName: 'Dev', demandDays: 2, capacityDays: 10 },
       { week: 1, resourceTypeName: 'Dev', demandDays: 2, capacityDays: 10 },
@@ -407,17 +406,15 @@ describe('mergeWeeklyDemand', () => {
       { week: 3, resourceTypeName: 'Dev', demandDays: 2, capacityDays: 10 },
     ]
     const simulated = new Map<string, number>([
-      ['Dev|0', 5],
-      ['Dev|1', 5],
+      ['Dev|0', 4],
+      ['Dev|1', 4],
     ])
+    // Cached RT → all fallback suppressed, even weeks past the cached horizon
     const result = mergeWeeklyDemand(fallback, simulated)
-    // Cache covers weeks 0-1 (max week 1), so fallback for those weeks is suppressed
-    // Week 0,1 use simulated (5 each), weeks 2,3 use fallback (2 each)
-    expect(result).toHaveLength(4)
-    expect(result.find(r => r.week === 0)?.demandDays).toBe(5)
-    expect(result.find(r => r.week === 1)?.demandDays).toBe(5)
-    expect(result.find(r => r.week === 2)?.demandDays).toBe(2)
-    expect(result.find(r => r.week === 3)?.demandDays).toBe(2)
+    expect(result.find(r => r.week === 0)?.demandDays).toBe(4)
+    expect(result.find(r => r.week === 1)?.demandDays).toBe(4)
+    expect(result.find(r => r.week === 2)).toBeUndefined()
+    expect(result.find(r => r.week === 3)).toBeUndefined()
   })
 
   it('suppresses fallback for cached RT weeks even when simulated has gaps', () => {
@@ -457,20 +454,18 @@ describe('mergeWeeklyDemand', () => {
     // Only Dev has cached demand
     const simulated = new Map<string, number>([['Dev|0', 5]])
     const result = mergeWeeklyDemand(fallback, simulated)
-    // Dev week 0 uses simulated (5), Dev week 1 uses fallback (2), QA week 0 uses fallback (1)
+    // Dev has cached demand → all Dev fallback suppressed, even week 1 (past cached horizon)
+    // QA has no cached demand → QA fallback week 0 is retained
     expect(result.find(r => r.week === 0 && r.resourceTypeName === 'Dev')?.demandDays).toBe(5)
-    expect(result.find(r => r.week === 1 && r.resourceTypeName === 'Dev')?.demandDays).toBe(2)
+    expect(result.find(r => r.week === 1 && r.resourceTypeName === 'Dev')).toBeUndefined()
     expect(result.find(r => r.week === 0 && r.resourceTypeName === 'QA')?.demandDays).toBe(1)
   })
-
   it('filters out zero-demand rows', () => {
     const fallback: Array<{ week: number; resourceTypeName: string; demandDays: number; capacityDays: number }> = []
     const simulated = new Map<string, number>([
-      ['Dev|0', -1], // negative should be filtered... actually checked as demandDays <= 0 after rounding
+      ['Dev|0', -1],
     ])
     const result = mergeWeeklyDemand(fallback, simulated)
-    // -1 rounds to -1, so it passes the demandDays > 0 filter...
-    // Actually Math.round(-1*100)/100 = -1, which is not > 0, so it's filtered
     expect(result).toHaveLength(0)
   })
 })
@@ -558,15 +553,16 @@ describe('weekly demand integration', () => {
     expect(fallback).toHaveLength(4)
     expect(fallback[0].demandDays).toBe(2)
 
-    // Merge with cached demand (simulated replaces weeks 0-1)
+    // Merge with cached demand (simulated replaces ALL Dev demand)
     const simulated = new Map<string, number>([
       ['Developer|0', 4],
       ['Developer|1', 4],
     ])
     const merged = mergeWeeklyDemand(fallback, simulated)
-    expect(merged).toHaveLength(4)
+    // Only the 2 cached weeks survive; fallback weeks 2-3 are suppressed
+    expect(merged).toHaveLength(2)
     expect(merged.find(r => r.week === 0)?.demandDays).toBe(4)
-    expect(merged.find(r => r.week === 2)?.demandDays).toBe(2)
+    expect(merged.find(r => r.week === 2)).toBeUndefined()
   })
 })
 

--- a/server/src/test/resourceProfile.test.ts
+++ b/server/src/test/resourceProfile.test.ts
@@ -741,7 +741,7 @@ describe('GET /api/projects/:projectId/resource-profile', () => {
     ])
   })
 
-  it('uses per-resource-type cached horizon: fallback re-emerges for an RT after its own cache max week, even when another RT has a longer horizon', async () => {
+  it('suppresses all fallback when resource type has any cached data, regardless of horizon', async () => {
     vi.mocked(prisma.project.findFirst).mockResolvedValue({
       id: 'proj-1',
       ownerId: userId,
@@ -861,13 +861,11 @@ describe('GET /api/projects/:projectId/resource-profile', () => {
 
     const devRow = res.body.resourceRows.find((row: any) => row.resourceTypeId === 'rt-dev')
     const qaRow = res.body.resourceRows.find((row: any) => row.resourceTypeId === 'rt-qa')
-
-    // Developer is cached for weeks 0-1, so fallback at week 0-1 is suppressed
+    // Developer is cached for weeks 0-1, so all Dev fallback suppressed
     expect(devRow.namedResources[0].actualAllocatedWeeks.map((w: any) => w.week)).toEqual([0, 1])
 
-    // QA is only cached for week 0, so fallback at week 1 is NOT suppressed
-    // (per-RT max is 0, so week 1 > 0 and fallback re-emerges)
-    expect(qaRow.namedResources[0].actualAllocatedWeeks.map((w: any) => w.week)).toEqual([0, 1])
+    // QA is only cached for week 0 — all QA fallback suppressed, so QA only appears for week 0
+    expect(qaRow.namedResources[0].actualAllocatedWeeks.map((w: any) => w.week)).toEqual([0])
   })
 
   it('does not cross-bind actual allocations when named resources share the same name', async () => {

--- a/server/src/test/scheduler.test.ts
+++ b/server/src/test/scheduler.test.ts
@@ -1076,6 +1076,60 @@ describe('sequential story phases', () => {
       .reduce((sum, [, v]) => sum + v, 0)
     expect(s2Total2).toBeCloseTo(11.0, 1)
   })
+
+  it('work → zero-effort → work: levelled story bars are contiguous', () => {
+    // Three ordered automatic stories: story1 (80 Dev hours), story2 (no tasks),
+    // story3 (80 QA hours). Zero-effort story2 must have real STEP-width bar
+    // without overlapping story1 or story3.
+    const dev = makeRt('rt-dev', 'Dev', 1, 8)
+    const qa = makeRt('rt-qa', 'QA', 1, 8)
+    const s1 = makeStory('s1', [makeTask(80, 'rt-dev', 'Dev')], 0)
+    const s2 = makeStory('s2', [], 1)
+    const s3 = makeStory('s3', [makeTask(80, 'rt-qa', 'QA')], 2)
+    const f1 = makeFeature('f1', [s1, s2, s3])
+    const epic = makeEpic('ep1', [f1])
+    const result = runScheduler(baseInput({
+      epics: [epic],
+      resourceTypes: [dev, qa],
+      resourceLevel: true,
+    }))
+    const STEP = 0.2
+    const s1Bar = result.storySchedule.find(s => s.storyId === 's1')!
+    const s2Bar = result.storySchedule.find(s => s.storyId === 's2')!
+    const s3Bar = result.storySchedule.find(s => s.storyId === 's3')!
+    // Story 1 completes at t+STEP
+    const s1End = s1Bar.startWeek + s1Bar.durationWeeks
+    // Story 2 starts exactly when story 1 completes
+    expect(s2Bar.startWeek).toBe(s1End)
+    // Story 2 duration is exactly one scheduler step
+    expect(s2Bar.durationWeeks).toBeCloseTo(STEP, 3)
+    // Story 3 starts exactly when story 2 completes
+    expect(s3Bar.startWeek).toBe(s2Bar.startWeek + s2Bar.durationWeeks)
+    // Bars are contiguous and non-overlapping
+    expect(s3Bar.startWeek).toBeGreaterThanOrEqual(s2Bar.startWeek + s2Bar.durationWeeks - 0.001)
+    // Story 2 adds no rows to weeklyConsumptionMap
+    // Dev total = 80h/8hpd = 10pd, QA total = 80h/8hpd = 10pd
+    const devTotal = [...result.weeklyConsumptionMap.entries()]
+      .filter(([k]) => k.startsWith('rt-dev|'))
+      .reduce((sum, [, v]) => sum + v, 0)
+    expect(devTotal).toBeCloseTo(10.0, 1)
+    const qaTotal = [...result.weeklyConsumptionMap.entries()]
+      .filter(([k]) => k.startsWith('rt-qa|'))
+      .reduce((sum, [, v]) => sum + v, 0)
+    expect(qaTotal).toBeCloseTo(10.0, 1)
+    // Feature finish aligns with story 3's completion
+    const fEntry = result.featureSchedule.find(e => e.featureId === 'f1')!
+    expect(fEntry.startWeek + fEntry.durationWeeks).toBeGreaterThanOrEqual(s3Bar.startWeek + s3Bar.durationWeeks - 0.01)
+    // Idempotent rerun
+    const result2 = runScheduler(baseInput({
+      epics: [epic],
+      resourceTypes: [dev, qa],
+      resourceLevel: true,
+    }))
+    const s2Bar2 = result2.storySchedule.find(s => s.storyId === 's2')!
+    expect(s2Bar2.startWeek).toBe(s2Bar.startWeek)
+    expect(s2Bar2.durationWeeks).toBeCloseTo(STEP, 3)
+  })
   it('acceptance: 17.5d Security + 5.0d Principal Engineer (non-levelled)', () => {
     const hpd = 7.6
     const security = makeRt('rt-sec', 'Principal Consultant - Security', 1, hpd)

--- a/server/src/test/scheduler.test.ts
+++ b/server/src/test/scheduler.test.ts
@@ -619,6 +619,130 @@ describe('runScheduler', () => {
 })
 
 // ─────────────────────────────────────────────────────────────────────────────
+// Sequential story-phase scheduling (#394)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('sequential story phases', () => {
+  it('stories with different resource types do not overlap within a feature', () => {
+    // Story 1: 40 Dev hours (5 days → 1 week)
+    // Story 2: 40 QA hours (5 days → 1 week)
+    // Sequential phases → feature = 2 weeks, story 1 starts week 0, story 2 starts week 1
+    const dev = makeRt('rt-dev', 'Dev', 1, 8)
+    const qa = makeRt('rt-qa', 'QA', 1, 8)
+    const s1 = makeStory('s1', [makeTask(40, 'rt-dev', 'Dev')], 0)
+    const s2 = makeStory('s2', [makeTask(40, 'rt-qa', 'QA')], 1)
+    const f1 = makeFeature('f1', [s1, s2])
+    const epic = makeEpic('ep1', [f1])
+    const result = runScheduler(baseInput({ epics: [epic], resourceTypes: [dev, qa] }))
+
+    const featureEntry = result.featureSchedule.find(e => e.featureId === 'f1')!
+    expect(featureEntry.durationWeeks).toBeCloseTo(2, 1)
+    expect(featureEntry.startWeek).toBe(0)
+
+    const bar1 = result.storySchedule.find(s => s.storyId === 's1')!
+    const bar2 = result.storySchedule.find(s => s.storyId === 's2')!
+    expect(bar1.startWeek).toBe(0)
+    expect(bar1.durationWeeks).toBeCloseTo(1, 1)
+    expect(bar2.startWeek).toBeGreaterThanOrEqual(bar1.startWeek + bar1.durationWeeks - 0.01)
+    expect(bar2.durationWeeks).toBeCloseTo(1, 1)
+  })
+
+  it('within-story tasks with different RTs overlap (same story start)', () => {
+    // Single story with both Dev (40h) and QA (40h) tasks
+    // Both run concurrently within the same story phase
+    // Bottleneck: 5 days → 1 week
+    const dev = makeRt('rt-dev', 'Dev', 1, 8)
+    const qa = makeRt('rt-qa', 'QA', 1, 8)
+    const s1 = makeStory('s1', [
+      makeTask(40, 'rt-dev', 'Dev'),
+      makeTask(40, 'rt-qa', 'QA'),
+    ], 0)
+    const f1 = makeFeature('f1', [s1])
+    const epic = makeEpic('ep1', [f1])
+    const result = runScheduler(baseInput({ epics: [epic], resourceTypes: [dev, qa] }))
+
+    const bar = result.storySchedule.find(s => s.storyId === 's1')!
+    expect(bar.durationWeeks).toBeCloseTo(1, 1)
+    expect(bar.startWeek).toBe(0)
+  })
+
+  it('feature duration equals sum of story-phase bottleneck weeks', () => {
+    // Story 1: 80 Dev hours (10 days → 2 weeks bottleneck)
+    // Story 2: 40 QA hours (5 days → 1 week bottleneck)
+    // Sequential phases → feature = 3 weeks
+    const dev = makeRt('rt-dev', 'Dev', 1, 8)
+    const qa = makeRt('rt-qa', 'QA', 1, 8)
+    const s1 = makeStory('s1', [makeTask(80, 'rt-dev', 'Dev')], 0)
+    const s2 = makeStory('s2', [makeTask(40, 'rt-qa', 'QA')], 1)
+    const f1 = makeFeature('f1', [s1, s2])
+    const epic = makeEpic('ep1', [f1])
+    const result = runScheduler(baseInput({ epics: [epic], resourceTypes: [dev, qa] }))
+
+    const featureEntry = result.featureSchedule.find(e => e.featureId === 'f1')!
+    expect(featureEntry.durationWeeks).toBeCloseTo(3, 1)
+  })
+
+  it('parallel epic features are unaffected by story-phase ordering', () => {
+    // Two features in a parallel epic, each with 2 stories
+    // Parallel epic means features run simultaneously
+    // Story phasing only affects intra-feature ordering
+    const dev = makeRt('rt-dev', 'Dev', 1, 8)
+    const f1 = makeFeature('f1', [
+      makeStory('s1a', [makeTask(40, 'rt-dev', 'Dev')], 0),
+      makeStory('s1b', [makeTask(40, 'rt-dev', 'Dev')], 1),
+    ])
+    const f2 = makeFeature('f2', [
+      makeStory('s2a', [makeTask(40, 'rt-dev', 'Dev')], 0),
+      makeStory('s2b', [makeTask(40, 'rt-dev', 'Dev')], 1),
+    ])
+    const epic = makeEpic('ep1', [f1, f2], { featureMode: 'parallel' })
+    const result = runScheduler(baseInput({ epics: [epic], resourceTypes: [dev] }))
+
+    // Both features start at week 0 (parallel)
+    const entry1 = result.featureSchedule.find(e => e.featureId === 'f1')!
+    const entry2 = result.featureSchedule.find(e => e.featureId === 'f2')!
+    expect(entry1.startWeek).toBe(0)
+    expect(entry2.startWeek).toBe(0)
+    // Parallel demand floor: total demand = 160h = 20 person-days over 1 Dev (5d/wk)
+    // MinSpan = 20/5 = 4 weeks. Feature duration = max(2, 4) = 4 weeks.
+    expect(entry1.durationWeeks).toBeCloseTo(4, 1)
+    expect(entry2.durationWeeks).toBeCloseTo(4, 1)
+  })
+
+  it('resource levelling preserves story-phase ordering with capacity contention', () => {
+    // Two features sharing one Dev (count=1), each with story phases
+    // Feature 1: story1 (80 Dev hours = 2 weeks), story2 (80 Dev hours = 2 weeks)
+    // Feature 2: story1 (40 Dev hours = 1 week), story2 (40 Dev hours = 1 week)
+    // With resourceLevel=true, features compete for capacity
+    const dev = makeRt('rt-dev', 'Dev', 1, 8)
+
+    const f1 = makeFeature('f1', [
+      makeStory('f1s1', [makeTask(80, 'rt-dev', 'Dev')], 0),
+      makeStory('f1s2', [makeTask(80, 'rt-dev', 'Dev')], 1),
+    ])
+    const f2 = makeFeature('f2', [
+      makeStory('f2s1', [makeTask(40, 'rt-dev', 'Dev')], 0),
+      makeStory('f2s2', [makeTask(40, 'rt-dev', 'Dev')], 1),
+    ])
+    const epic = makeEpic('ep1', [f1, f2])
+    const result = runScheduler(baseInput({
+      epics: [epic],
+      resourceTypes: [dev],
+      resourceLevel: true,
+    }))
+
+    const f1s1 = result.storySchedule.find(s => s.storyId === 'f1s1')!
+    const f1s2 = result.storySchedule.find(s => s.storyId === 'f1s2')!
+    const f2s1 = result.storySchedule.find(s => s.storyId === 'f2s1')!
+    const f2s2 = result.storySchedule.find(s => s.storyId === 'f2s2')!
+
+    // Each feature's stories are sequential (start week increases)
+    expect(f1s2.startWeek).toBeGreaterThanOrEqual(f1s1.startWeek + f1s1.durationWeeks - 0.01)
+    expect(f2s2.startWeek).toBeGreaterThanOrEqual(f2s1.startWeek + f2s1.durationWeeks - 0.01)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
 // Parallel demand floor tests
 // ─────────────────────────────────────────────────────────────────────────────
 

--- a/server/src/test/scheduler.test.ts
+++ b/server/src/test/scheduler.test.ts
@@ -804,29 +804,21 @@ describe('sequential story phases', () => {
     expect(s2Bar.isManual).toBe(false)
   })
 
-  it('pinned story demand appears in weeklyConsumptionMap (non-levelled)', () => {
+  it('non-levelled does not emit partial pinned-only cache', () => {
+    // Pinned and automatic stories share the same resource type (Dev).
+    // Non-levelled must NOT produce a partial scheduler cache that would
+    // suppress fallback demand for the automatic portion downstream.
     const dev = makeRt('rt-dev', 'Dev', 1, 8)
-    const qa = makeRt('rt-qa', 'QA', 1, 8)
-    const s1 = makeStory('s1', [makeTask(40, 'rt-dev', 'Dev')], 0) // manual
-    const s2 = makeStory('s2', [makeTask(40, 'rt-qa', 'QA')], 1)  // auto
+    const s1 = makeStory('s1', [makeTask(40, 'rt-dev', 'Dev')], 0)
+    const s2 = makeStory('s2', [makeTask(40, 'rt-dev', 'Dev')], 1)
     const f1 = makeFeature('f1', [s1, s2])
     const epic = makeEpic('ep1', [f1])
     const result = runScheduler(baseInput({
       epics: [epic],
-      resourceTypes: [dev, qa],
+      resourceTypes: [dev],
       manualStoryEntries: [{ storyId: 's1', startWeek: 0 }],
     }))
-    // Non-levelled: weeklyConsumptionMap contains pinned demand (Dev) only.
-    // Automatic story (QA) demand is not in the map without the simulation.
-    const devTotal = [...result.weeklyConsumptionMap.entries()]
-      .filter(([k]) => k.startsWith('rt-dev|'))
-      .reduce((sum, [, v]) => sum + v, 0)
-    expect(devTotal).toBeCloseTo(5.0, 1)
-    // QA (automatic) is absent from the non-levelled map
-    const qaTotal = [...result.weeklyConsumptionMap.entries()]
-      .filter(([k]) => k.startsWith('rt-qa|'))
-      .reduce((sum, [, v]) => sum + v, 0)
-    expect(qaTotal).toBe(0)
+    expect(result.weeklyConsumptionMap.size).toBe(0)
   })
 
   it('pinned story demand appears in weeklyConsumptionMap (resource-levelled)', () => {
@@ -886,12 +878,75 @@ describe('sequential story phases', () => {
     expect(s2Bar.isManual).toBe(false)
   })
 
-  // ── Issue #394 acceptance fixture ──────────────────────────────────────────
+  it('manual feature + manual story: pinned demand is not double-counted', () => {
+    const dev = makeRt('rt-dev', 'Dev', 1, 8)
+    const s1 = makeStory('s1', [makeTask(40, 'rt-dev', 'Dev')], 0)
+    const f1 = makeFeature('f1', [s1])
+    const epic = makeEpic('ep1', [f1])
+    const result = runScheduler(baseInput({
+      epics: [epic],
+      resourceTypes: [dev],
+      manualFeatureEntries: [{ featureId: 'f1', startWeek: 0, durationWeeks: 4 }],
+      manualStoryEntries: [{ storyId: 's1', startWeek: 0 }],
+      resourceLevel: true,
+    }))
+    const devTotal = [...result.weeklyConsumptionMap.entries()]
+      .filter(([k]) => k.startsWith('rt-dev|'))
+      .reduce((sum, [, v]) => sum + v, 0)
+    expect(devTotal).toBeCloseTo(5.0, 1)
+  })
+
+  it('pinned story spans week where auto work is only partially active', () => {
+    // Pinned s1 at week 0 with 80 Dev hours → spans weeks 0-1.
+    // Auto feature f1 finishes in week 0.1 (< 1 step → still within week 0).
+    // Pinned weekly demand for Dev must be the full 5pd, not just the fraction
+    // coincident with the auto feature's active simulation steps.
+    const dev = makeRt('rt-dev', 'Dev', 1, 8)
+    const s1 = makeStory('s1', [makeTask(80, 'rt-dev', 'Dev')], 0)
+    const s2 = makeStory('s2', [makeTask(8, 'rt-dev', 'Dev')], 1)
+    const f1 = makeFeature('f1', [s1, s2])
+    const epic = makeEpic('ep1', [f1])
+    const result = runScheduler(baseInput({
+      epics: [epic],
+      resourceTypes: [dev],
+      manualStoryEntries: [{ storyId: 's1', startWeek: 0 }],
+      resourceLevel: true,
+    }))
+
+    // Pinned Dev: 80h/8hpd = 10 person-days over dur = 80/8/5 = 2 weeks → 5pd/week
+    const pinnedDevWeeks = [...result.weeklyConsumptionMap.entries()]
+      .filter(([k]) => k.startsWith('rt-dev|'))
+      .map(([k, v]) => ({ week: parseInt(k.split('|')[1], 10), days: v }))
+      .filter(({ days }) => days > 0)
+    // Week 0 should have exactly the pinned share (~5pd) plus any auto share
+    const wk0 = pinnedDevWeeks.find(w => w.week === 0)
+    expect(wk0).toBeDefined()
+    expect(wk0!.days).toBeGreaterThan(4)
+  })
+
+  it('pinned-only week with no active automatic features', () => {
+    // Single feature with a single pinned story at week 5.
+    // No automatic features or stories — pinned demand must still appear.
+    const dev = makeRt('rt-dev', 'Dev', 1, 8)
+    const s1 = makeStory('s1', [makeTask(40, 'rt-dev', 'Dev')], 0)
+    const f1 = makeFeature('f1', [s1])
+    const epic = makeEpic('ep1', [f1])
+    const result = runScheduler(baseInput({
+      epics: [epic],
+      resourceTypes: [dev],
+      manualStoryEntries: [{ storyId: 's1', startWeek: 5 }],
+      resourceLevel: true,
+    }))
+    // Pinned: 40h/8hpd = 5pd, all in week 5 (pinned story duration = 1 week)
+    const devWk5 = [...result.weeklyConsumptionMap.entries()]
+      .filter(([k]) => k === 'rt-dev|5')
+      .reduce((sum, [, v]) => sum + v, 0)
+    expect(devWk5).toBeCloseTo(5.0, 1)
+  })
   it('acceptance: 17.5d Security + 5.0d Principal Engineer (non-levelled)', () => {
     const hpd = 7.6
     const security = makeRt('rt-sec', 'Principal Consultant - Security', 1, hpd)
     const engineer = makeRt('rt-pe', 'Principal Engineer - Cloud & DevOps', 1, hpd)
-
     // 17.5 days of Security effort → 17.5 * 7.6 = 133 hours
     const s1 = makeStory('s1', [makeTask(133, 'rt-sec', 'Principal Consultant - Security', hpd)], 0)
     // 38 hours / 5.0 days of Principal Engineer effort → 38 hours

--- a/server/src/test/scheduler.test.ts
+++ b/server/src/test/scheduler.test.ts
@@ -709,11 +709,12 @@ describe('sequential story phases', () => {
     expect(entry2.durationWeeks).toBeCloseTo(4, 1)
   })
 
-  it('resource levelling preserves story-phase ordering with capacity contention', () => {
-    // Two features sharing one Dev (count=1), each with story phases
-    // Feature 1: story1 (80 Dev hours = 2 weeks), story2 (80 Dev hours = 2 weeks)
-    // Feature 2: story1 (40 Dev hours = 1 week), story2 (40 Dev hours = 1 week)
-    // With resourceLevel=true, features compete for capacity
+  it('resource levelling preserves story-phase ordering under genuine capacity contention', () => {
+    // Two features in a PARALLEL epic share one Dev (count=1).
+    // Feature 1: f1s1 (80 Dev hours = ~2 wk), f1s2 (80 Dev hours = ~2 wk)
+    // Feature 2: f2s1 (40 Dev hours = ~1 wk), f2s2 (40 Dev hours = ~1 wk)
+    // With resourceLevel=true and parallel epic, both features are eligible
+    // concurrently and compete for the same Dev capacity.
     const dev = makeRt('rt-dev', 'Dev', 1, 8)
 
     const f1 = makeFeature('f1', [
@@ -724,7 +725,7 @@ describe('sequential story phases', () => {
       makeStory('f2s1', [makeTask(40, 'rt-dev', 'Dev')], 0),
       makeStory('f2s2', [makeTask(40, 'rt-dev', 'Dev')], 1),
     ])
-    const epic = makeEpic('ep1', [f1, f2])
+    const epic = makeEpic('ep1', [f1, f2], { featureMode: 'parallel' })
     const result = runScheduler(baseInput({
       epics: [epic],
       resourceTypes: [dev],
@@ -736,9 +737,164 @@ describe('sequential story phases', () => {
     const f2s1 = result.storySchedule.find(s => s.storyId === 'f2s1')!
     const f2s2 = result.storySchedule.find(s => s.storyId === 'f2s2')!
 
+    // Both features in a parallel epic start concurrently (week 0)
+    const f1Entry = result.featureSchedule.find(e => e.featureId === 'f1')!
+    const f2Entry = result.featureSchedule.find(e => e.featureId === 'f2')!
+    expect(f1Entry.startWeek).toBe(0)
+    expect(f2Entry.startWeek).toBe(0)
+
     // Each feature's stories are sequential (start week increases)
     expect(f1s2.startWeek).toBeGreaterThanOrEqual(f1s1.startWeek + f1s1.durationWeeks - 0.01)
     expect(f2s2.startWeek).toBeGreaterThanOrEqual(f2s1.startWeek + f2s1.durationWeeks - 0.01)
+
+    // No story from feature 2 precedes the previous phase within feature 2
+    // (intra-feature ordering is preserved regardless of inter-feature contention)
+  })
+
+  it('empty feature with one taskless story retains 1-week default', () => {
+    const dev = makeRt('rt-dev', 'Dev', 1, 8)
+    const s1 = makeStory('s1', [], 0)
+    const f1 = makeFeature('f1', [s1])
+    const epic = makeEpic('ep1', [f1])
+    const result = runScheduler(baseInput({ epics: [epic], resourceTypes: [dev] }))
+    const entry = result.featureSchedule.find(e => e.featureId === 'f1')!
+    expect(entry.durationWeeks).toBeCloseTo(1, 1)
+  })
+
+  it('empty feature with multiple taskless stories retains 1-week default', () => {
+    const dev = makeRt('rt-dev', 'Dev', 1, 8)
+    const s1 = makeStory('s1', [], 0)
+    const s2 = makeStory('s2', [], 1)
+    const s3 = makeStory('s3', [], 2)
+    const f1 = makeFeature('f1', [s1, s2, s3])
+    const epic = makeEpic('ep1', [f1])
+    const result = runScheduler(baseInput({ epics: [epic], resourceTypes: [dev] }))
+    const entry = result.featureSchedule.find(e => e.featureId === 'f1')!
+    // Number of empty stories does not stretch feature duration
+    expect(entry.durationWeeks).toBeCloseTo(1, 1)
+  })
+
+  it('manually pinned story is not consumed as an automatic phase', () => {
+    // Story 1 is manual (pinned at week 0), story 2 is automatic
+    // The automatic phase should only include story 2's duration.
+    // Feature duration should be story 2's bottleneck (1 week), plus the
+    // manual story's existence should not affect automatic duration.
+    const dev = makeRt('rt-dev', 'Dev', 1, 8)
+    const s1 = makeStory('s1', [makeTask(80, 'rt-dev', 'Dev')], 0)  // manual
+    const s2 = makeStory('s2', [makeTask(40, 'rt-dev', 'Dev')], 1)  // auto
+    const f1 = makeFeature('f1', [s1, s2])
+    const epic = makeEpic('ep1', [f1])
+    const result = runScheduler(baseInput({
+      epics: [epic],
+      resourceTypes: [dev],
+      manualStoryEntries: [{ storyId: 's1', startWeek: 0 }],
+    }))
+
+    const featureEntry = result.featureSchedule.find(e => e.featureId === 'f1')!
+    // Automatic phase is only story 2 (1 week bottleneck), so feature = ~1 week
+    // Manual story does not extend or shrink automatic duration
+    expect(featureEntry.durationWeeks).toBeCloseTo(1, 1)
+
+    const s1Bar = result.storySchedule.find(s => s.storyId === 's1')!
+    expect(s1Bar.startWeek).toBe(0)
+    expect(s1Bar.isManual).toBe(true)
+
+    const s2Bar = result.storySchedule.find(s => s.storyId === 's2')!
+    expect(s2Bar.startWeek).toBe(0)
+    expect(s2Bar.isManual).toBe(false)
+  })
+
+  // ── Issue #394 acceptance fixture ──────────────────────────────────────────
+  it('acceptance: 17.5d Security + 5.0d Principal Engineer (non-levelled)', () => {
+    const hpd = 7.6
+    const security = makeRt('rt-sec', 'Principal Consultant - Security', 1, hpd)
+    const engineer = makeRt('rt-pe', 'Principal Engineer - Cloud & DevOps', 1, hpd)
+
+    // 17.5 days of Security effort → 17.5 * 7.6 = 133 hours
+    const s1 = makeStory('s1', [makeTask(133, 'rt-sec', 'Principal Consultant - Security', hpd)], 0)
+    // 38 hours / 5.0 days of Principal Engineer effort → 38 hours
+    const s2 = makeStory('s2', [makeTask(38, 'rt-pe', 'Principal Engineer - Cloud & DevOps', hpd)], 1)
+    const f1 = makeFeature('f1', [s1, s2])
+    const epic = makeEpic('ep1', [f1])
+
+    const result = runScheduler(baseInput({ epics: [epic], resourceTypes: [security, engineer] }))
+
+    const fEntry = result.featureSchedule.find(e => e.featureId === 'f1')!
+    // Feature duration >= 4.5 weeks (17.5d + 5.0d = 22.5 working days / 5 = 4.5 weeks)
+    expect(fEntry.durationWeeks).toBeGreaterThanOrEqual(4.5)
+
+    const s1Bar = result.storySchedule.find(s => s.storyId === 's1')!
+    const s2Bar = result.storySchedule.find(s => s.storyId === 's2')!
+
+    // Stories follow story order
+    expect(s1Bar.startWeek).toBe(0)
+    expect(s2Bar.startWeek).toBeGreaterThanOrEqual(s1Bar.startWeek + s1Bar.durationWeeks - 0.01)
+
+    // (weeklyConsumptionMap is only populated with resourceLevel=true,
+    //  so total-demand assertions are in the levelled variant below)
+    expect(fEntry.durationWeeks).toBeGreaterThanOrEqual(4.5)
+  })
+
+  it('acceptance: 17.5d Security + 5.0d Principal Engineer (resource-levelled)', () => {
+    const hpd = 7.6
+    const security = makeRt('rt-sec', 'Principal Consultant - Security', 1, hpd)
+    const engineer = makeRt('rt-pe', 'Principal Engineer - Cloud & DevOps', 1, hpd)
+
+    const s1 = makeStory('s1', [makeTask(133, 'rt-sec', 'Principal Consultant - Security', hpd)], 0)
+    const s2 = makeStory('s2', [makeTask(38, 'rt-pe', 'Principal Engineer - Cloud & DevOps', hpd)], 1)
+    const f1 = makeFeature('f1', [s1, s2])
+    const epic = makeEpic('ep1', [f1])
+
+    const result = runScheduler(baseInput({
+      epics: [epic],
+      resourceTypes: [security, engineer],
+      resourceLevel: true,
+    }))
+
+    const fEntry = result.featureSchedule.find(e => e.featureId === 'f1')!
+    // Feature duration >= 4.5 weeks
+    expect(fEntry.durationWeeks).toBeGreaterThanOrEqual(4.5)
+
+    const s1Bar = result.storySchedule.find(s => s.storyId === 's1')!
+    const s2Bar = result.storySchedule.find(s => s.storyId === 's2')!
+
+    // Stories follow story order and do not overlap
+    expect(s1Bar.startWeek).toBe(0)
+    expect(s2Bar.startWeek).toBeGreaterThanOrEqual(s1Bar.startWeek + s1Bar.durationWeeks - 0.01)
+
+    // Principal Engineer total = exactly 5.0 days
+    const peTotal = [...result.weeklyConsumptionMap.entries()]
+      .filter(([key]) => key.startsWith('rt-pe|'))
+      .reduce((sum, [, days]) => sum + days, 0)
+    expect(peTotal).toBeCloseTo(5.0, 1)
+
+    // PE consumption starts only after Security phase completes
+    const peWeeks = [...result.weeklyConsumptionMap.entries()]
+      .filter(([key]) => key.startsWith('rt-pe|'))
+      .map(([key]) => parseInt(key.split('|')[1], 10))
+    const minPeWeek = Math.min(...peWeeks)
+    const secDoneWeek = Math.floor(s1Bar.startWeek + s1Bar.durationWeeks)
+    expect(minPeWeek).toBeGreaterThanOrEqual(secDoneWeek - 1) // within scheduler precision
+
+    // Security total = exactly 17.5 days
+    const secTotal = [...result.weeklyConsumptionMap.entries()]
+      .filter(([key]) => key.startsWith('rt-sec|'))
+      .reduce((sum, [, days]) => sum + days, 0)
+    expect(secTotal).toBeCloseTo(17.5, 1)
+
+    // Idempotency: re-running produces the same totals
+    const result2 = runScheduler(baseInput({
+      epics: [epic],
+      resourceTypes: [security, engineer],
+      resourceLevel: true,
+    }))
+    const peTotal2 = [...result2.weeklyConsumptionMap.entries()]
+      .filter(([key]) => key.startsWith('rt-pe|'))
+      .reduce((sum, [, days]) => sum + days, 0)
+    expect(peTotal2).toBeCloseTo(5.0, 1)
+
+    const fEntry2 = result2.featureSchedule.find(e => e.featureId === 'f1')!
+    expect(fEntry2.durationWeeks).toBe(fEntry.durationWeeks)
   })
 })
 

--- a/server/src/test/scheduler.test.ts
+++ b/server/src/test/scheduler.test.ts
@@ -943,6 +943,71 @@ describe('sequential story phases', () => {
       .reduce((sum, [, v]) => sum + v, 0)
     expect(devWk5).toBeCloseTo(5.0, 1)
   })
+
+  it('manual feature with no auto features reports complete demand', () => {
+    const dev = makeRt('rt-dev', 'Dev', 1, 8)
+    const s1 = makeStory('s1', [makeTask(40, 'rt-dev', 'Dev')], 0)
+    const s2 = makeStory('s2', [makeTask(40, 'rt-dev', 'Dev')], 1)
+    const f1 = makeFeature('f1', [s1, s2])
+    const epic = makeEpic('ep1', [f1])
+    const result = runScheduler(baseInput({
+      epics: [epic],
+      resourceTypes: [dev],
+      manualFeatureEntries: [{ featureId: 'f1', startWeek: 0, durationWeeks: 4 }],
+      manualStoryEntries: [{ storyId: 's1', startWeek: 0 }],
+      resourceLevel: true,
+    }))
+    const devTotal = [...result.weeklyConsumptionMap.entries()]
+      .filter(([k]) => k.startsWith('rt-dev|'))
+      .reduce((sum, [, v]) => sum + v, 0)
+    expect(devTotal).toBeCloseTo(10.0, 1)
+  })
+
+  it('fractional pinned position reserves capacity at exact step overlap', () => {
+    const dev = makeRt('rt-dev', 'Dev', 1, 8)
+    const sPin = makeStory('s-pin', [makeTask(8, 'rt-dev', 'Dev')], 0)
+    const sAuto = makeStory('s-auto', [makeTask(40, 'rt-dev', 'Dev')], 1)
+    const f1 = makeFeature('f1', [sPin, sAuto])
+    const epic = makeEpic('ep1', [f1])
+    const result = runScheduler(baseInput({
+      epics: [epic],
+      resourceTypes: [dev],
+      manualStoryEntries: [{ storyId: 's-pin', startWeek: 0.8 }],
+      resourceLevel: true,
+    }))
+    const devTotal = [...result.weeklyConsumptionMap.entries()]
+      .filter(([k]) => k.startsWith('rt-dev|'))
+      .reduce((sum, [, v]) => sum + v, 0)
+    expect(devTotal).toBeCloseTo(6.0, 1)
+    const autoBar = result.storySchedule.find(s => s.storyId === 's-auto')!
+    expect(autoBar.startWeek).toBeLessThan(0.8)
+  })
+
+  it('story phase start aligns with first allocation, not eligibility', () => {
+    const dev = makeRt('rt-dev', 'Dev', 1, 8)
+    const f1s1 = makeStory('f1s1', [makeTask(80, 'rt-dev', 'Dev')], 0)
+    const f1 = makeFeature('f1', [f1s1])
+    const f2s1 = makeStory('f2s1', [makeTask(40, 'rt-dev', 'Dev')], 0)
+    const f2 = makeFeature('f2', [f2s1])
+    const epic = makeEpic('ep1', [f1, f2], { featureMode: 'parallel' })
+    const result = runScheduler(baseInput({
+      epics: [epic],
+      resourceTypes: [dev],
+      resourceLevel: true,
+    }))
+    const f1Bar = result.storySchedule.find(s => s.storyId === 'f1s1')!
+    const f2Bar = result.storySchedule.find(s => s.storyId === 'f2s1')!
+    const f1Entry = result.featureSchedule.find(e => e.featureId === 'f1')!
+    const f2Entry = result.featureSchedule.find(e => e.featureId === 'f2')!
+    expect(f1Entry.startWeek).toBe(0)
+    expect(f2Entry.startWeek).toBe(0)
+    expect(f1Bar.startWeek).toBeGreaterThanOrEqual(0)
+    expect(f2Bar.startWeek).toBeGreaterThanOrEqual(0)
+    const devTotal = [...result.weeklyConsumptionMap.entries()]
+      .filter(([k]) => k.startsWith('rt-dev|'))
+      .reduce((sum, [, v]) => sum + v, 0)
+    expect(devTotal).toBeCloseTo(15.0, 1)
+  })
   it('acceptance: 17.5d Security + 5.0d Principal Engineer (non-levelled)', () => {
     const hpd = 7.6
     const security = makeRt('rt-sec', 'Principal Consultant - Security', 1, hpd)

--- a/server/src/test/scheduler.test.ts
+++ b/server/src/test/scheduler.test.ts
@@ -804,6 +804,88 @@ describe('sequential story phases', () => {
     expect(s2Bar.isManual).toBe(false)
   })
 
+  it('pinned story demand appears in weeklyConsumptionMap (non-levelled)', () => {
+    const dev = makeRt('rt-dev', 'Dev', 1, 8)
+    const qa = makeRt('rt-qa', 'QA', 1, 8)
+    const s1 = makeStory('s1', [makeTask(40, 'rt-dev', 'Dev')], 0) // manual
+    const s2 = makeStory('s2', [makeTask(40, 'rt-qa', 'QA')], 1)  // auto
+    const f1 = makeFeature('f1', [s1, s2])
+    const epic = makeEpic('ep1', [f1])
+    const result = runScheduler(baseInput({
+      epics: [epic],
+      resourceTypes: [dev, qa],
+      manualStoryEntries: [{ storyId: 's1', startWeek: 0 }],
+    }))
+    // Non-levelled: weeklyConsumptionMap contains pinned demand (Dev) only.
+    // Automatic story (QA) demand is not in the map without the simulation.
+    const devTotal = [...result.weeklyConsumptionMap.entries()]
+      .filter(([k]) => k.startsWith('rt-dev|'))
+      .reduce((sum, [, v]) => sum + v, 0)
+    expect(devTotal).toBeCloseTo(5.0, 1)
+    // QA (automatic) is absent from the non-levelled map
+    const qaTotal = [...result.weeklyConsumptionMap.entries()]
+      .filter(([k]) => k.startsWith('rt-qa|'))
+      .reduce((sum, [, v]) => sum + v, 0)
+    expect(qaTotal).toBe(0)
+  })
+
+  it('pinned story demand appears in weeklyConsumptionMap (resource-levelled)', () => {
+    const dev = makeRt('rt-dev', 'Dev', 1, 8)
+    const qa = makeRt('rt-qa', 'QA', 1, 8)
+    const s1 = makeStory('s1', [makeTask(40, 'rt-dev', 'Dev')], 0)
+    const s2 = makeStory('s2', [makeTask(40, 'rt-qa', 'QA')], 1)
+    const f1 = makeFeature('f1', [s1, s2])
+    const epic = makeEpic('ep1', [f1])
+    const result = runScheduler(baseInput({
+      epics: [epic],
+      resourceTypes: [dev, qa],
+      manualStoryEntries: [{ storyId: 's1', startWeek: 0 }],
+      resourceLevel: true,
+    }))
+
+    const devTotal = [...result.weeklyConsumptionMap.entries()]
+      .filter(([k]) => k.startsWith('rt-dev|'))
+      .reduce((sum, [, v]) => sum + v, 0)
+    expect(devTotal).toBeCloseTo(5.0, 1)
+
+    const qaTotal = [...result.weeklyConsumptionMap.entries()]
+      .filter(([k]) => k.startsWith('rt-qa|'))
+      .reduce((sum, [, v]) => sum + v, 0)
+    expect(qaTotal).toBeCloseTo(5.0, 1)
+  })
+
+  it('pinned demand reserves capacity; auto story does not consume pinned slot', () => {
+    // One Dev (count=1), one feature: s1 manual (80h), s2 auto (80h), same RT
+    // Pinned s1 at week 0 consumes all Dev capacity for ~2 weeks.
+    // Auto s2 must wait until pinned story completes.
+    const dev = makeRt('rt-dev', 'Dev', 1, 8)
+    const s1 = makeStory('s1', [makeTask(80, 'rt-dev', 'Dev')], 0)
+    const s2 = makeStory('s2', [makeTask(80, 'rt-dev', 'Dev')], 1)
+    const f1 = makeFeature('f1', [s1, s2])
+    const epic = makeEpic('ep1', [f1])
+    const result = runScheduler(baseInput({
+      epics: [epic],
+      resourceTypes: [dev],
+      manualStoryEntries: [{ storyId: 's1', startWeek: 0 }],
+      resourceLevel: true,
+    }))
+
+    // Total Dev demand = 160h / 8 = 20 person-days (pinned 10pd + auto 10pd)
+    const devTotal = [...result.weeklyConsumptionMap.entries()]
+      .filter(([k]) => k.startsWith('rt-dev|'))
+      .reduce((sum, [, v]) => sum + v, 0)
+    expect(devTotal).toBeCloseTo(20.0, 1)
+
+    // Pinned story bar is at week 0
+    const s1Bar = result.storySchedule.find(s => s.storyId === 's1')!
+    expect(s1Bar.startWeek).toBe(0)
+    expect(s1Bar.isManual).toBe(true)
+
+    // Auto story placement is not distorted by the manual story
+    const s2Bar = result.storySchedule.find(s => s.storyId === 's2')!
+    expect(s2Bar.isManual).toBe(false)
+  })
+
   // ── Issue #394 acceptance fixture ──────────────────────────────────────────
   it('acceptance: 17.5d Security + 5.0d Principal Engineer (non-levelled)', () => {
     const hpd = 7.6

--- a/server/src/test/scheduler.test.ts
+++ b/server/src/test/scheduler.test.ts
@@ -982,8 +982,10 @@ describe('sequential story phases', () => {
     const autoBar = result.storySchedule.find(s => s.storyId === 's-auto')!
     expect(autoBar.startWeek).toBeLessThan(0.8)
   })
-
-  it('story phase start aligns with first allocation, not eligibility', () => {
+  it('story phase start aligns with first allocation, not eligibility (strengthened)', () => {
+    // Parallel epic: f1 (80 Dev) and f2 (40 Dev) share one Dev.
+    // Greedy scheduler allocates to f2 first (smaller). f1's story
+    // must not start before it receives positive Dev allocation.
     const dev = makeRt('rt-dev', 'Dev', 1, 8)
     const f1s1 = makeStory('f1s1', [makeTask(80, 'rt-dev', 'Dev')], 0)
     const f1 = makeFeature('f1', [f1s1])
@@ -999,14 +1001,80 @@ describe('sequential story phases', () => {
     const f2Bar = result.storySchedule.find(s => s.storyId === 'f2s1')!
     const f1Entry = result.featureSchedule.find(e => e.featureId === 'f1')!
     const f2Entry = result.featureSchedule.find(e => e.featureId === 'f2')!
+    // Both features eligible concurrently in parallel epic
     expect(f1Entry.startWeek).toBe(0)
     expect(f2Entry.startWeek).toBe(0)
-    expect(f1Bar.startWeek).toBeGreaterThanOrEqual(0)
-    expect(f2Bar.startWeek).toBeGreaterThanOrEqual(0)
+    // f2 (40h) gets allocation first (greedy by remaining ascending)
+    expect(f2Bar.startWeek).toBe(0)
+    // f1 (80h) must start LATER, after f2 has received some allocation
+    expect(f1Bar.startWeek).toBeGreaterThan(0)
+    // Bars are sequential and non-overlapping
+    expect(f1Bar.startWeek).toBeGreaterThanOrEqual(f2Bar.startWeek + f2Bar.durationWeeks - 0.01)
+    // Total Dev = 120h/8hpd = 15pd
     const devTotal = [...result.weeklyConsumptionMap.entries()]
       .filter(([k]) => k.startsWith('rt-dev|'))
       .reduce((sum, [, v]) => sum + v, 0)
     expect(devTotal).toBeCloseTo(15.0, 1)
+  })
+
+  it('sequential story 2 delayed by pinned reservation starts at first allocation', () => {
+    // Feature: story1 (80 Dev hours) → story2 (80 QA hours).
+    // A pinned QA story at week 2.0 (8h, dur=0.2w) blocks QA capacity
+    // at the transition. story2 must not start until it receives
+    // allocation after the pin interval ends.
+    const dev = makeRt('rt-dev', 'Dev', 1, 8)
+    const qa = makeRt('rt-qa', 'QA', 1, 8)
+    const s1 = makeStory('s1', [makeTask(80, 'rt-dev', 'Dev')], 0)
+    const s2 = makeStory('s2', [makeTask(80, 'rt-qa', 'QA')], 1)
+    const sPin = makeStory('s-pin', [makeTask(8, 'rt-qa', 'QA')], 2)
+    const f1 = makeFeature('f1', [s1, s2, sPin])
+    const epic = makeEpic('ep1', [f1])
+    const result = runScheduler(baseInput({
+      epics: [epic],
+      resourceTypes: [dev, qa],
+      manualStoryEntries: [{ storyId: 's-pin', startWeek: 2.0 }],
+      resourceLevel: true,
+    }))
+    // Test with exact scheduler STEP (0.2) precision where possible
+    const s1Bar = result.storySchedule.find(s => s.storyId === 's1')!
+    const s2Bar = result.storySchedule.find(s => s.storyId === 's2')!
+    // Story 1 completes at t+STEP from its last allocation step
+    // story2 must NOT start at the story1 completion timestamp
+    expect(s2Bar.startWeek).toBeGreaterThan(s1Bar.startWeek + s1Bar.durationWeeks - 0.01)
+    // story2's first allocation is at or after the pinned interval (2.0-2.2)
+    // With STEP=0.2, story2 starts no earlier than 2.0+STEP=2.2
+    const minAlloc = s1Bar.startWeek + s1Bar.durationWeeks
+    expect(s2Bar.startWeek).toBeGreaterThanOrEqual(minAlloc)
+    // No story2 consumption before its bar starts
+    const s2Before = [...result.weeklyConsumptionMap.entries()]
+      .filter(([k]) => k.startsWith('rt-qa|'))
+      .filter(([k]) => parseInt(k.split('|')[1], 10) < Math.floor(s2Bar.startWeek))
+    expect(s2Before.length).toBe(0)
+    // Bars are sequential
+    expect(s2Bar.startWeek).toBeGreaterThanOrEqual(s1Bar.startWeek + s1Bar.durationWeeks - 0.01)
+    // story2 total QA demand = 80h/8hpd = 10pd
+    const s2Total = [...result.weeklyConsumptionMap.entries()]
+      .filter(([k]) => k.startsWith('rt-qa|'))
+      .reduce((sum, [, v]) => sum + v, 0)
+    expect(s2Total).toBeCloseTo(11.0, 1) // 10 auto + 1 pinned
+    // Total Dev = 80h/8hpd = 10pd
+    const devTotal = [...result.weeklyConsumptionMap.entries()]
+      .filter(([k]) => k.startsWith('rt-dev|'))
+      .reduce((sum, [, v]) => sum + v, 0)
+    expect(devTotal).toBeCloseTo(10.0, 1)
+    // Idempotent rerun
+    const result2 = runScheduler(baseInput({
+      epics: [epic],
+      resourceTypes: [dev, qa],
+      manualStoryEntries: [{ storyId: 's-pin', startWeek: 2.0 }],
+      resourceLevel: true,
+    }))
+    const s2Bar2 = result2.storySchedule.find(s => s.storyId === 's2')!
+    expect(s2Bar2.startWeek).toBe(s2Bar.startWeek)
+    const s2Total2 = [...result2.weeklyConsumptionMap.entries()]
+      .filter(([k]) => k.startsWith('rt-qa|'))
+      .reduce((sum, [, v]) => sum + v, 0)
+    expect(s2Total2).toBeCloseTo(11.0, 1)
   })
   it('acceptance: 17.5d Security + 5.0d Principal Engineer (non-levelled)', () => {
     const hpd = 7.6

--- a/server/src/test/timeline.test.ts
+++ b/server/src/test/timeline.test.ts
@@ -657,6 +657,161 @@ describe('GET /api/projects/:projectId/timeline', () => {
     expect(securityDemand[16]).toBeUndefined()
   })
 
+  it('cross-surface: schedule cache produces 5.0 PE days in timeline response', async () => {
+    // Simulate scheduler output for the 17.5d Security + 5.0d PE fixture (hpd=7.6)
+    // Security: 133h / 7.6 = 17.5 person-days, spread over 4+ weeks = 3.5-4.5 d/wk
+    // PE: 38h / 7.6 = 5.0 person-days
+    vi.mocked(prisma.project.findFirst).mockResolvedValue({
+      ...mockProject,
+      hoursPerDay: 7.6,
+      weeklyDemandCache: {
+        'rt-sec|0': 3.5,
+        'rt-sec|1': 3.5,
+        'rt-sec|2': 3.5,
+        'rt-sec|3': 3.5,
+        'rt-sec|4': 3.5,
+        'rt-pe|5': 5.0,
+      },
+    } as any)
+    vi.mocked(prisma.timelineEntry.findMany).mockResolvedValue([
+      {
+        id: 'entry-1',
+        projectId: 'proj-1',
+        featureId: 'feat-1',
+        startWeek: 0,
+        durationWeeks: 6,
+        isManual: false,
+        feature: {
+          id: 'feat-1',
+          name: 'Security & Engineering',
+          order: 0,
+          isActive: true,
+          epic: {
+            id: 'epic-1',
+            name: 'Delivery',
+            order: 0,
+            isActive: true,
+            featureMode: 'SEQUENTIAL',
+            scheduleMode: 'AUTO',
+            timelineStartWeek: null,
+          },
+          userStories: [{
+            isActive: true,
+            tasks: [{
+              resourceTypeId: 'rt-sec',
+              hoursEffort: 133,
+              durationDays: null,
+              resourceType: { id: 'rt-sec', name: 'Principal Consultant - Security', hoursPerDay: 7.6 },
+            }],
+          }],
+        },
+      },
+    ] as any)
+    vi.mocked(prisma.resourceType.findMany).mockResolvedValue([
+      { id: 'rt-sec', name: 'Principal Consultant - Security', category: 'ENGINEERING', count: 1, hoursPerDay: 7.6, allocationMode: 'EFFORT', namedResources: [] },
+      { id: 'rt-pe', name: 'Principal Engineer - Cloud & DevOps', category: 'ENGINEERING', count: 1, hoursPerDay: 7.6, allocationMode: 'EFFORT', namedResources: [] },
+    ] as any)
+    vi.mocked(prisma.capacityPlan.findFirst).mockResolvedValue(null as any)
+
+    const res = await request(app)
+      .get('/api/projects/proj-1/timeline')
+      .set('Authorization', authHeader)
+
+    expect(res.status).toBe(200)
+
+    // PE demand in weeklyDemand = exactly 5.0 days (from cache, no fallback)
+    const peDemand = res.body.weeklyDemand
+      .filter((row: any) => row.resourceTypeName === 'Principal Engineer - Cloud & DevOps')
+      .reduce((sum: number, row: any) => sum + row.demandDays, 0)
+    expect(peDemand).toBeCloseTo(5.0, 1)
+
+    // Security demand = 17.5 days (from cache, no fallback)
+    const secDemand = res.body.weeklyDemand
+      .filter((row: any) => row.resourceTypeName === 'Principal Consultant - Security')
+      .reduce((sum: number, row: any) => sum + row.demandDays, 0)
+    expect(secDemand).toBeCloseTo(17.5, 1)
+
+    // Re-fetch (simulate second GET) — same totals
+    vi.mocked(prisma.project.findFirst).mockResolvedValue({
+      ...mockProject,
+      hoursPerDay: 7.6,
+      weeklyDemandCache: {
+        'rt-sec|0': 3.5,
+        'rt-sec|1': 3.5,
+        'rt-sec|2': 3.5,
+        'rt-sec|3': 3.5,
+        'rt-sec|4': 3.5,
+        'rt-pe|5': 5.0,
+      },
+    } as any)
+    const res2 = await request(app)
+      .get('/api/projects/proj-1/timeline')
+      .set('Authorization', authHeader)
+    const peDemand2 = res2.body.weeklyDemand
+      .filter((row: any) => row.resourceTypeName === 'Principal Engineer - Cloud & DevOps')
+      .reduce((sum: number, row: any) => sum + row.demandDays, 0)
+    expect(peDemand2).toBeCloseTo(5.0, 1)
+  })
+
+  it('cross-surface: resource type absent from cache still receives fallback demand', async () => {
+    // Developer in cache, QA absent from cache
+    vi.mocked(prisma.project.findFirst).mockResolvedValue({
+      ...mockProject,
+      weeklyDemandCache: {
+        'rt-dev|0': 5,
+      },
+    } as any)
+    vi.mocked(prisma.timelineEntry.findMany).mockResolvedValue([{
+      id: 'entry-1',
+      projectId: 'proj-1',
+      featureId: 'feat-1',
+      startWeek: 0,
+      durationWeeks: 2,
+      isManual: false,
+      feature: {
+        id: 'feat-1',
+        name: 'Dev Work',
+        order: 0,
+        isActive: true,
+        epic: {
+          id: 'epic-1',
+          name: 'Delivery',
+          order: 0,
+          isActive: true,
+          featureMode: 'SEQUENTIAL',
+          scheduleMode: 'AUTO',
+          timelineStartWeek: null,
+        },
+        userStories: [{
+          isActive: true,
+          tasks: [
+            { resourceTypeId: 'rt-dev', hoursEffort: 40, durationDays: null, resourceType: { id: 'rt-dev', name: 'Developer', hoursPerDay: 8 } },
+            { resourceTypeId: 'rt-qa', hoursEffort: 20, durationDays: null, resourceType: { id: 'rt-qa', name: 'QA', hoursPerDay: 8 } },
+          ],
+        }],
+      },
+    }] as any)
+    vi.mocked(prisma.resourceType.findMany).mockResolvedValue([
+      { id: 'rt-dev', name: 'Developer', category: 'ENGINEERING', count: 1, hoursPerDay: 8, allocationMode: 'EFFORT', namedResources: [] },
+      { id: 'rt-qa', name: 'QA', category: 'ENGINEERING', count: 1, hoursPerDay: 8, allocationMode: 'EFFORT', namedResources: [] },
+    ] as any)
+    vi.mocked(prisma.capacityPlan.findFirst).mockResolvedValue(null as any)
+
+    const res = await request(app)
+      .get('/api/projects/proj-1/timeline')
+      .set('Authorization', authHeader)
+
+    expect(res.status).toBe(200)
+
+    // Developer has cached demand — all Dev fallback suppressed (only week 0 from cache)
+    const devDemand = res.body.weeklyDemand.filter((row: any) => row.resourceTypeName === 'Developer')
+    expect(devDemand).toHaveLength(1)
+
+    // QA has no cached demand — QA fallback retained
+    const qaDemand = res.body.weeklyDemand.filter((row: any) => row.resourceTypeName === 'QA')
+    expect(qaDemand.length).toBeGreaterThan(0)
+  })
+
   it('uses materialized CAPACITY_PLAN split capacity for parallel warnings', async () => {
     vi.mocked(prisma.project.findFirst).mockResolvedValue({
       ...mockProject,

--- a/server/src/test/timeline.test.ts
+++ b/server/src/test/timeline.test.ts
@@ -408,7 +408,7 @@ describe('GET /api/projects/:projectId/timeline', () => {
     ]))
   })
 
-  it('backfills weeklyDemand beyond cached horizon from scheduled entries', async () => {
+  it('suppresses all fallback when resource type has any cached data, regardless of horizon', async () => {
     vi.mocked(prisma.project.findFirst).mockResolvedValue({
       ...mockProject,
       weeklyDemandCache: {
@@ -463,16 +463,15 @@ describe('GET /api/projects/:projectId/timeline', () => {
 
     expect(res.status).toBe(200)
 
+    // Developer has cached data (week 0) → all Developer fallback suppressed,
+    // including weeks 60-70 from the long-tail entry
     const developerDemand = res.body.weeklyDemand.filter((row: any) => row.resourceTypeName === 'Developer')
-    const weeks = developerDemand.map((row: any) => row.week)
-    const uniqueKeys = new Set(developerDemand.map((row: any) => `${row.week}|${row.resourceTypeName}`))
-
-    expect(weeks).toContain(65)
-    expect(weeks).toContain(69)
-    expect(uniqueKeys.size).toBe(developerDemand.length)
+    expect(developerDemand).toHaveLength(1)
+    expect(developerDemand[0].week).toBe(0)
+    expect(developerDemand[0].demandDays).toBe(1.25)
   })
 
-  it('does not backfill a missing interior cached week, but still backfills beyond the cached horizon', async () => {
+  it('suppresses all fallback when resource type has cached data, including weeks beyond cached horizon', async () => {
     vi.mocked(prisma.project.findFirst).mockResolvedValue({
       ...mockProject,
       weeklyDemandCache: {
@@ -532,14 +531,14 @@ describe('GET /api/projects/:projectId/timeline', () => {
       .filter((row: any) => row.resourceTypeName === 'Developer')
       .reduce((acc: Record<number, number>, row: any) => ({ ...acc, [row.week]: row.demandDays }), {})
 
+    // Developer has cache → all fallback suppressed. Only cached weeks survive.
     expect(developerDemand[55]).toBe(2.5)
     expect(developerDemand[56]).toBeUndefined()
     expect(developerDemand[57]).toBe(2.5)
-    expect(developerDemand[58]).toBe(5)
-    expect(developerDemand[59]).toBe(5)
+    expect(developerDemand[58]).toBeUndefined()
+    expect(developerDemand[59]).toBeUndefined()
   })
-
-  it('uses per-resource-type cached horizon: cached demand suppresses fallback only for the same RT within its own cache range', async () => {
+  it('suppresses all fallback when resource type has any cached data: Security only in cache weeks', async () => {
     vi.mocked(prisma.project.findFirst).mockResolvedValue({
       ...mockProject,
       weeklyDemandCache: {
@@ -647,14 +646,15 @@ describe('GET /api/projects/:projectId/timeline', () => {
       .filter((row: any) => row.resourceTypeName === 'Principal Consultant - Security')
       .reduce((acc: Record<number, number>, row: any) => ({ ...acc, [row.week]: row.demandDays }), {})
 
-    // Security is only cached for weeks 10-11, so fallback re-emerges at week 12
+    // Security has cached data (weeks 10-11) → all Security fallback suppressed.
+    // Only cached weeks survive; weeks 12-16 are absent (no fallback re-emergence).
     expect(securityDemand[10]).toBe(2.5)
     expect(securityDemand[11]).toBe(2.5)
-    expect(securityDemand[12]).toBe(5)
-    expect(securityDemand[13]).toBe(5)
-    expect(securityDemand[14]).toBe(5)
-    expect(securityDemand[15]).toBe(5)
-    expect(securityDemand[16]).toBe(5)
+    expect(securityDemand[12]).toBeUndefined()
+    expect(securityDemand[13]).toBeUndefined()
+    expect(securityDemand[14]).toBeUndefined()
+    expect(securityDemand[15]).toBeUndefined()
+    expect(securityDemand[16]).toBeUndefined()
   })
 
   it('uses materialized CAPACITY_PLAN split capacity for parallel warnings', async () => {


### PR DESCRIPTION
## Summary
Fix #394 — sequential-story phases and weekly-demand deduplication.

## Changes

### Scheduler — sequential story phases (`server/src/lib/scheduler.ts`)
- **`storyBottleneckWeeks()`** — new helper computing per-story duration from its bottleneck resource type
- **`storyPhaseSchedule()`** — new helper returning ordered story phases for a feature
- **`featureDurationWeeks()`** — now returns the sum of story-phase bottleneck durations instead of the max-RT aggregate across all stories. Stories with different resource types no longer overlap within a feature.
- **Levelling simulation** — tracks story phases per feature; exposes only the current story phase's resource demand for capacity allocation. Advances to the next story when the current phase is fully consumed.
- **Story bars** — use phase-based durations (scaled proportionally to the feature's actual span) instead of a proportional split by total hours.

### Weekly-demand merge — deduplication (`server/src/lib/projectPlanningModel.ts`, `server/src/routes/timeline.ts`)
- **`mergeWeeklyDemand()`** — suppresses ALL fallback rows for a resource type that has any cached scheduler demand, not just rows within the cached horizon. This prevents duplicated demand when fallback re-emerges past the scheduler's coverage.
- **Timeline route** — same fix applied to the inline merge logic.

### Tests
- **5 new scheduler tests** covering: RT-separation (different RTs don't overlap), within-story concurrency (same RT tasks overlap), phase-sum duration, parallel-epic regression, and levelled phase ordering
- **Updated timeline/resource-profile/planning-model tests** — 7 tests updated for new merge behaviour (fallback fully suppressed for cached resource types)

## Validation
- `npm run validate` — all checks pass
  - Server: 1144 tests passed, 156 skipped
  - Client: 301 tests passed
  - Lint, type-check, build: clean

## Risks and Limitations
- When the weekly demand cache is stale (timeline entries added after last scheduler run), the new merge logic suppresses fallback for a cached resource type entirely, potentially hiding unprocessed demand. The user should re-run the scheduler to refresh the cache.
- Sequential story phasing affects the default (non-parallel) epic mode. Parallel epic features are unaffected.

## E2E
Not applicable — pure server changes covered by existing unit tests and 5 new regression tests.
