### PR TITLE
fix(#414): increase document-generation timeouts to prevent timeout errors

### DIFF
--- a/client/src/pages/DocumentsPage.tsx
+++ b/client/src/pages/DocumentsPage.tsx
@@ -118,6 +118,9 @@ export default function DocumentsPage() {
           generatedBy: user?.name ?? user?.email ?? 'Monrad Estimator',
           documentLabel: label,
         },
+      }, {
+        // PDF generation can take 30-60s for complex documents
+        timeout: 120_000,
       })
       queryClient.invalidateQueries({ queryKey: ['generated-docs', projectId] })
       setLabel(defaultLabel(project?.name))

--- a/server/src/lib/pdfRenderer.ts
+++ b/server/src/lib/pdfRenderer.ts
@@ -54,12 +54,12 @@ export async function generatePdfFromHtml(html: string): Promise<Buffer> {
       },
       allowedSchemes: ['http', 'https', 'data'],
     })
-    await page.setContent(safeHtml, { waitUntil: 'load', timeout: 30_000 })
+    await page.setContent(safeHtml, { waitUntil: 'load', timeout: 60_000 })
     const pdfBuffer = await page.pdf({
       format: 'A4',
       printBackground: true,
       margin: { top: '40px', bottom: '40px', left: '48px', right: '48px' },
-      timeout: 30_000,
+      timeout: 60_000,
     })
     return Buffer.from(pdfBuffer)
   } finally {


### PR DESCRIPTION
## Problem

The Generate & Save button on the Documents page times out after 30 seconds when generating PDF scope documents. This happens because:

1. **Client-side**: The axios instance has a global 30-second timeout (`timeout: 30000`)
2. **Server-side**: Puppeteer PDF generation can take 30-60s (page content rendering + PDF generation each have 30s timeouts)
3. **Combined**: The client kills the request 30s in, before Puppeteer finishes rendering the PDF

## Changes

- **`server/src/lib/pdfRenderer.ts`**: Increased Puppeteer `page.setContent` and `page.pdf` timeouts from 30s to 60s each
- **`client/src/pages/DocumentsPage.tsx`**: Extended the document generation POST request timeout to 120s (per-request override, up from the global 30s default)

## Validation

- Lint: 0 errors
- TypeScript: passes
- Server tests: 1356 passed
- Client tests: 310 passed

Closes #414