### PR TITLE
chore(#421): add reviewed production readiness remediation

### DIFF
--- a/docs/domain/capacity-profile-readiness-remediation.md
+++ b/docs/domain/capacity-profile-readiness-remediation.md
@@ -1,0 +1,341 @@
+# Capacity-Profile Readiness Remediation (Issue #421)
+
+## Purpose
+
+PR #419 (`chore(#418): retire runtime legacy capacity-column compatibility`)
+installed the permanent read-only readiness gate
+(`npm run capacity-profiles:readiness`). The production database
+substantially predates the profile-first population work, so the gate fails
+with deterministic and ambiguous blockers. This document specifies the
+reviewed pre-PR-2 remediation command that lets #404:
+
+1. produce an exact read-only remediation plan;
+2. distinguish deterministic corrections from decisions that require explicit
+   approval;
+3. apply only an approved, unchanged plan transactionally;
+4. rerun the permanent readiness gate;
+5. stop safely on ambiguity or drift.
+
+This PR performs **no production data changes**. Execution is owned by #404.
+
+## Command
+
+One cohesive, explicitly invoked command with two modes:
+
+```bash
+# Dry-run (default; zero writes)
+npm run capacity-profiles:remediate-readiness -- --dry-run
+npm run capacity-profiles:remediate-readiness -- --dry-run --json reviewed-plan.json
+npm run capacity-profiles:remediate-readiness -- --dry-run --json reviewed-plan.json --manifest approved-decisions.json
+
+# Apply (writes ONLY the reviewed plan, inside one transaction)
+npm run capacity-profiles:remediate-readiness -- --apply --plan reviewed-plan.json
+npm run capacity-profiles:remediate-readiness -- --apply --plan reviewed-plan.json --manifest approved-decisions.json
+```
+
+Equivalent standalone invocation from `server/`:
+
+```bash
+npx tsx src/scripts/remediateProductionReadiness.ts [--dry-run] [--json <path>] [--manifest <path>]
+npx tsx src/scripts/remediateProductionReadiness.ts --apply --plan <path> [--manifest <path>]
+```
+
+The command never runs at startup, exposes no API/UI, performs no writes in
+dry-run mode, and never prints credentials or complete database URLs.
+
+### Exit contract
+
+| Code | Meaning |
+|------|---------|
+| `0` | Plan is valid and has **no unresolved decisions** (apply mode: every operation applied or already applied, and the post-apply readiness + planner checks are clean). |
+| `1` | Operational, structural or drift failure — malformed plan/manifest, unsupported findings, fingerprint mismatch, state changed since dry-run, transaction failure, post-apply regression. In apply mode nothing was written when the failure occurred before commit. |
+| `2` | Plan is valid but **explicit decisions remain unresolved** — apply is refused. |
+
+Dry-run exit code reflects the plan's classification only; the permanent
+readiness gate (`npm run capacity-profiles:readiness`) is a separate command
+and is never weakened.
+
+## Deterministic transformation matrix (live state)
+
+Only transformations whose intended profile state is proven by existing
+persisted evidence and established repository rules are deterministic. The
+approved `capacityProfileMapping.ts` mapper and the current Squad Planner ROLE
+writer (`buildRoleProfileData`) are reused; no new semantics are invented.
+
+### ResourceTypes without any profile (role owners)
+
+| Legacy `allocationMode` | Target profile | Evidence |
+|---|---|---|
+| `TIMELINE` | `AVAILABILITY_WINDOW` / `AVAILABILITY_WINDOW`, `defaultPercent = allocationPercent ?? null`, window preserved (`allocationStartWeek`/`allocationEndWeek`) | mode + window aliases |
+| `EFFORT` / absent | `DEMAND_FOLLOWING` / `FIXED`, `defaultPercent = allocationPercent ?? null`; stale windows discarded | mode |
+| `FULL_PROJECT` | `WHOLE_PROJECT_ALLOCATION` / `FIXED`, `defaultPercent = allocationPercent ?? null`; stale windows discarded | mode |
+| `CAPACITY_PLAN` **with valid persisted active-plan entries** | `CAPACITY_PROFILE` / `SQUAD_PLANNER` via `buildRoleProfileData` (aggregate weekly-headcount segments, planner provenance preserved) | active-plan periods/entries |
+| `CAPACITY_PLAN` without usable window or plan evidence | **decision required** — never guessed | — |
+
+### NamedResources without any profile
+
+Mode is the named resource's OWN `allocationMode` (the legacy scheduler never
+inherited the parent role's mode).
+
+| Legacy `allocationMode` | Target profile | Evidence |
+|---|---|---|
+| `TIMELINE` | `AVAILABILITY_WINDOW` / `AVAILABILITY_WINDOW`, `defaultPercent = allocationPercent ?? allocationPct ?? 100`, window preserved (precedence `allocationStartWeek ?? startWeek`) | mode + window aliases |
+| `FULL_PROJECT` | `WHOLE_PROJECT_ALLOCATION` / `FIXED`, same percent; stale windows discarded | mode |
+| `EFFORT` / absent | `DEMAND_FOLLOWING` / `FIXED`, same percent; stale windows discarded (same stale-alias policy as v2 translation) | mode |
+| `CAPACITY_PLAN` **with captured window** | `AVAILABILITY_WINDOW` / `LEGACY`, same percent, window preserved — the exact v2 snapshot translation policy | mode + window |
+| `CAPACITY_PLAN` without captured window | **decision required** | — |
+| never-active window (`(-1,-1)` pair or inverted `start > end`) | `AVAILABILITY_WINDOW` at `defaultPercent 0`, null window | policy below |
+
+### Persisted profile shape defects
+
+| Defect | Correction | Classification |
+|---|---|---|
+| `DEMAND_FOLLOWING` / `WHOLE_PROJECT_ALLOCATION` with `startWeek`/`endWeek` set | clear the window fields (basis forbids them; the legacy mode never used them) | deterministic |
+| overlapping segments on a `CAPACITY_PROFILE` | exact sum-preserving non-overlapping decomposition; existing segment IDs preserved; surplus intervals get deterministic IDs and inherit the covering segment's provenance | deterministic |
+| segmentless non-canonical `CAPACITY_PROFILE` (e.g. 13 legacy ROLE rows with `defaultPercent 100`, no segments, windowless `CAPACITY_PLAN` legacy JSON) | **decision required** (owner intent; no capacity can be proven) | decision |
+| `AVAILABILITY_WINDOW` with invalid/inverted week fields | **decision required** | decision |
+| anything else (both/neither owner FK, bad enums, negative segment weeks, …) | **unsupported** — dry-run exits `1`, apply refuses | unsupported |
+
+### Preservation guarantees
+
+- Effective weekly capacity is preserved exactly (proposed profile ↔ mapper /
+  planner-writer derived DTO equality is asserted per operation; the runtime
+  scheduler resolver consumes only profile state after apply).
+- Project and owner identity preserved; pricing and independent metadata never
+  touched (candidate ResourceType/NamedResource columns are read-only here).
+- Existing valid profile IDs and segment IDs preserved where no replacement is
+  required; created profiles use deterministic IDs
+  (`remediation-role-<ownerId>` / `remediation-named-<ownerId>`) and
+  mapper-shaped `legacy` JSON capturing the original values.
+- Squad Planner / optimiser / transfer provenance preserved (updates never
+  rewrite `CapacityProfile.legacy`; the deterministic planner reconstruction
+  writes `SQUAD_PLANNER` provenance via the current planner writer).
+- No blanket default is applied to zero-profile projects; windowless
+  `CAPACITY_PLAN` owners stay untouched until an explicit decision exists.
+
+## Cases requiring explicit decisions
+
+Unless a reviewed manifest decision resolves them:
+
+- ResourceTypes with `CAPACITY_PLAN` state but no usable window/plan evidence
+  (production: 104 of the 106 — the 2 planner-owned Supply Chain roles are
+  proven deterministic by their persisted active-plan entries and 4/4
+  profile-backed named resources);
+- NamedResources with `CAPACITY_PLAN` state but no captured window (9);
+- the 13 segmentless legacy ROLE `CAPACITY_PROFILE` rows;
+- v2 snapshot entries with `CAPACITY_PLAN` and no captured window (933);
+- v2 snapshot entries with a single `-1` edge (no established meaning);
+- any owner whose kind, source, percentage, window, segments or provenance
+  cannot be determined exactly.
+
+## Historical v2 snapshot policy
+
+Readiness and rollback share the same translation helper
+(`translateV2SnapshotProfiles`), so the policy below applies to both, and the
+remediation planner classifies every v2 entry with the same rules.
+
+### `-1` sentinel windows
+
+**Proven meaning: "never active" (zero capacity).** Evidence:
+
+- The legacy Squad Planner apply path wrote
+  `{ startWeek: -1, endWeek: -1, allocationPercent: 100 }` as the fallback for
+  named resources without an assigned slot window
+  (`server/src/routes/squadPlan.ts`, pre-#359, `slotWindows[idx] ?? {…-1…}`).
+- The legacy scheduler window gate (`week >= start && week <= end`, with
+  `start = nr.startWeek ?? 0`, `end = nr.endWeek ?? Infinity`) never matches
+  for `(-1, -1)`, so the entry contributed zero capacity.
+- `server/src/test/scheduler.test.ts` codifies this:
+  "slot never active → endWeek=-1 → does not contribute capacity".
+- `null` (not `-1`) was the "unbounded" representation (`endWeek ?? Infinity`).
+
+Deterministic normalization: a `(-1, -1)` captured window pair translates to a
+zero-capacity profile (`defaultPercent 0`, null window) — the exact historical
+effective capacity, never a guess. A single `-1` edge has no established
+meaning and requires an explicit `snapshot-window-interpretation` decision.
+
+### Inverted windows (`start > end`)
+
+The legacy scheduler tolerated inverted windows without clamping; no week can
+match `week >= start && week <= end`, so the entry contributed zero capacity.
+Deterministic normalization: same zero-capacity representation as `(-1, -1)`.
+
+### `CAPACITY_PLAN` entries without captured windows
+
+Never translated to full-project or unbounded capacity. If the entry's
+captured payload cannot prove the exact window, an explicit
+`snapshot-window-interpretation` decision is required. Decisions are applied
+as minimal snapshot rewrites: only `allocationStartWeek`/`allocationEndWeek`
+are written (negative fallback aliases cleared), all unrelated snapshot
+content and metadata are preserved, and the complete resulting snapshot is
+re-validated through the shared translation before writing. Reruns are no-ops.
+
+Malformed snapshots are never deleted to pass readiness — they are reported as
+unsupported and block apply.
+
+## Plan and manifest format
+
+The dry-run emits a versioned JSON plan (`formatVersion: 1`) containing every
+finding (classified `deterministic` / `decisionRequired` / `unsupported` /
+`alreadyValid`), concrete operations, unresolved decision entries with their
+allowed resolution shapes, and the current-state evidence hash per entry.
+
+Fingerprint contract:
+
+- `plan.fingerprint` = SHA-256 over the canonical JSON (sorted keys) of the
+  plan's actionable content (summary, findings, operations, decisions).
+  `generatedAt` is excluded so repeated dry-runs on unchanged state produce
+  identical fingerprints.
+- `manifest.planFingerprint` must equal the referenced plan's fingerprint;
+  any alteration of reviewed plan content invalidates the fingerprint and
+  apply refuses.
+- Every operation/decision carries `evidenceHash` = SHA-256 of the canonical
+  current-state evidence used at plan time. Apply re-reads every affected row
+  and refuses execution when the hash differs or the proposed state is not
+  already persisted.
+
+Manifest (`formatVersion: 1`): per-decision entries referencing plan decision
+ids with an explicit reviewed resolution. Supported resolution shapes (only
+those required by #421):
+
+- `scalar-profile` (`DEMAND_FOLLOWING` / `WHOLE_PROJECT_ALLOCATION` + percent);
+- `availability-window` (percent + window);
+- `segmented-capacity-profile` (percent + explicit segments);
+- `owner-kind-decision` (`NAMED_PERSON` / `PLANNED_RESOURCE` + capacity shape);
+- `snapshot-window-interpretation` (window for windowless / single-`-1`
+  snapshot entries).
+
+Unresolved decisions prevent apply; malformed or disallowed resolutions are
+rejected; no generic migration DSL is introduced. Production-specific
+decisions are never embedded in repository source or tests.
+
+## Transaction and drift strategy
+
+Apply runs inside **one PostgreSQL transaction** for the bounded production
+data size (a few thousand rows):
+
+1. plan + manifest validation (fingerprint, formats, resolution shapes);
+2. refusal when any decision is unresolved or any unsupported finding exists;
+3. inside the transaction: re-read every affected owner/profile/snapshot,
+   verify evidence hashes (or that the proposed state is already persisted →
+   no-op), validate every proposed profile against the authoritative
+   structural rules, write, then re-verify every write;
+4. any failure rolls back everything — no partially repaired project is ever
+   reported as successful;
+5. after commit: re-run the planner and the permanent readiness gate; exit `1`
+   with a full report if any non-policy blocker remains.
+
+No distributed or resumable migration infrastructure is introduced. The
+command is idempotent: applying the same reviewed plan twice is a no-op.
+
+## Ownership-invariant migration sequencing
+
+`20260721000001_enforce_capacity_profile_ownership_invariants` is a
+constraint/index-only migration (CHECK constraints + partial unique indexes)
+with its own SQL preflight checks. Production currently has 36 applied
+migrations; this migration is pending and **must remain unapplied until the
+database passes the profile ownership/completeness preconditions** (the
+readiness gate).
+
+**Recommended sequencing (primary):** after #421 remediation is installed and
+the live readiness gate passes, and after the fresh backup + restore
+verification of #404 Phase 2 is recorded, apply this migration as **its own
+controlled step** with the application in maintenance mode:
+
+```bash
+npx prisma migrate deploy   # from the reviewed commit; applies only 20260721000001
+```
+
+Applying it separately keeps the later PR 2 deploy a single-migration deploy
+(the drop-column migration), so constraint-enforcement failures can never be
+entangled with the destructive step. Prisma applies pending migrations in
+directory order, so if it is left pending it WILL be applied together with the
+PR 2 migration during the Phase 4 `prisma migrate deploy` — acceptable but
+couples the steps; the separate step is preferred. This PR does not modify,
+apply or fold in that migration.
+
+## #404 Production handoff procedure
+
+The production machine must execute exactly these steps; stop on any failure
+or drift. No step asks the production agent to invent data values.
+
+1. **Install the reviewed #421 commit.** Check out the exact reviewed commit
+   on `main`; confirm `git status --short` is clean and `git rev-parse HEAD`
+   matches the recorded commit.
+2. **Confirm the physical candidate columns still exist** (they do — no
+   schema change is part of this release).
+3. **Create a fresh backup before any remediation write**
+   (`npm run db:backup`); record path, timestamp and database identity.
+4. **Run dry-run against production:**
+
+   ```bash
+   npm run capacity-profiles:remediate-readiness -- --dry-run --json /tmp/plan.json
+   ```
+
+   Expect exit `2` (decisions remain) with the deterministic and
+   decision-required counts matching the reviewed expectations.
+5. **Save the plan outside the repository** (`/tmp/plan.json` above) — never
+   commit plan or manifest files.
+6. **Compare plan counts and fingerprint with the reviewed expectations.**
+   Any mismatch stops the process.
+7. **Obtain explicit decisions for every unresolved entry.** Each decision
+   must be reviewed and recorded in the manifest format
+   (`formatVersion: 1`, `planFingerprint` = plan fingerprint). The production
+   agent must not edit JSON values on its own judgement.
+8. **Rerun dry-run with the approved manifest:**
+
+   ```bash
+   npm run capacity-profiles:remediate-readiness -- --dry-run --json /tmp/plan-resolved.json --manifest /tmp/decisions.json
+   ```
+
+   Expect exit `0` and zero unresolved decisions.
+9. **Apply the exact unchanged plan:**
+
+   ```bash
+   npm run capacity-profiles:remediate-readiness -- --apply --plan /tmp/plan-resolved.json
+   ```
+
+   (or `--apply --plan /tmp/plan.json --manifest /tmp/decisions.json`). Expect
+   exit `0` with a complete applied/skipped report.
+10. **Rerun the permanent readiness gate and the audit:**
+
+    ```bash
+    npm run capacity-profiles:readiness
+    npm run capacity-profiles:audit
+    ```
+
+    Both must pass. Stop on any failure or drift.
+11. **Create and restore-test a fresh post-remediation backup** (#404 Phase 2):
+    backup, restore into a disposable database, run readiness + audit + the
+    representative project checks on the restored copy, remove the disposable
+    database and leave no `monrad_pg_` resources.
+12. **Apply the ownership-invariant migration as its own controlled step**
+    (see sequencing above) once the Phase 2 evidence is recorded.
+13. **Authorize #418 PR 2 only after #404 records both successful gates**
+    (readiness passing on the exact reviewed commit AND a restore-tested
+    fresh backup).
+
+Stop conditions: any non-zero exit, fingerprint/count mismatch, unexpected
+drift, readiness failure, audit failure, backup/restore failure, or any
+remaining ambiguous owner. **PR 2 remains blocked** until the gates pass.
+
+## Tests
+
+- `server/src/test/productionRemediationPlan.test.ts` — pure planner unit
+  tests (classification matrix, never-active policy, overlap decomposition,
+  fingerprint stability/tamper detection, manifest merge/refusals, exit
+  classification).
+- `server/src/test/productionRemediation.integration.test.ts` — Linux
+  PostgreSQL suite covering dry-run (zero writes, stable fingerprints,
+  credentials absent, production-scale counts), deterministic apply (all
+  matrix rows, capacity/identity preservation, candidate columns frozen,
+  runtime resolver profile-first), manifest decisions (unresolved/malformed/
+  fingerprint/drift refusals, exact resolution, rerun no-op), transaction
+  safety (mid-transaction rollback, no partial success), historical snapshots
+  (all policy cases, minimal rewrites, readiness/rollback agreement, malformed
+  refusal) and the end-to-end blocker-class database (readiness fails →
+  dry-run → approved apply → audit + readiness pass → runtime loads →
+  representative rollback → candidate columns remain).
+
+Run via the Docker-backed local runner (`npm run test:integration:local`) or
+directly with `INTEGRATION_TEST=true` against a disposable PostgreSQL 15.

--- a/docs/domain/capacity-profile-readiness-remediation.md
+++ b/docs/domain/capacity-profile-readiness-remediation.md
@@ -145,6 +145,27 @@ named person or a planner-created resource. Such decisions are emitted with
   completeness requires exactly one ROLE profile for planner-owned roles);
   when the parent ROLE profile cannot be derived deterministically, the
   `PLANNED_RESOURCE` selection is rejected rather than guessed;
+
+### Shared-parent ROLE coordination
+
+Parent ROLE ownership is coordinated **once per ResourceType** across the
+complete resolved plan:
+
+- a valid existing parent ROLE profile (exactly one, structurally valid) is
+  **retained as-is** — no create/update operation is emitted and no
+  replacement happens when a child becomes `PLANNED_RESOURCE`;
+- a compatible baseline ROLE operation for the parent (same reviewed
+  proposed owner, profile ID and shape) is **reused** — no duplicate is
+  emitted;
+- multiple `PLANNED_RESOURCE` children under the same parent collapse into
+  **one** deterministic parent ROLE operation (grouped by parent ResourceType
+  id); output is independent of manifest decision ordering;
+- conflicting parent ROLE proposals (incompatible requirements or a
+  requirement incompatible with a baseline operation) **reject the resolved
+  plan before any write**, reporting the parent ResourceType and the
+  conflicting decision/operation IDs;
+- when no valid ROLE profile exists and no deterministic proposal can be
+  proven, `PLANNED_RESOURCE` stays fail-closed;
 - the selected owner kind and nested capacity are validated through the
   authoritative structural and ownership rules before any write;
 - deterministic NamedResource mappings (where existing evidence proves a

--- a/docs/domain/capacity-profile-readiness-remediation.md
+++ b/docs/domain/capacity-profile-readiness-remediation.md
@@ -128,6 +128,28 @@ Unless a reviewed manifest decision resolves them:
 - any owner whose kind, source, percentage, window, segments or provenance
   cannot be determined exactly.
 
+### Owner-kind decisions for ambiguous NamedResources
+
+A missing NamedResource whose capacity cannot be proven (windowless
+`CAPACITY_PLAN`, single `-1`) has an **unproven owner kind** — it may be a
+named person or a planner-created resource. Such decisions are emitted with
+`allowedResolutions: ["owner-kind-decision"]` only:
+
+- a **direct** scalar / window / segmented capacity resolution is rejected
+  (it would silently default the owner to `NAMED_PERSON`);
+- an explicit `owner-kind-decision` selects `NAMED_PERSON` **or**
+  `PLANNED_RESOURCE`, followed by one of the nested capacity shapes
+  (`scalar-profile`, `availability-window`, `segmented-capacity-profile`);
+- selecting `PLANNED_RESOURCE` also creates the parent role's ROLE profile
+  from the reviewed deterministic derivation captured at dry-run (readiness
+  completeness requires exactly one ROLE profile for planner-owned roles);
+  when the parent ROLE profile cannot be derived deterministically, the
+  `PLANNED_RESOURCE` selection is rejected rather than guessed;
+- the selected owner kind and nested capacity are validated through the
+  authoritative structural and ownership rules before any write;
+- deterministic NamedResource mappings (where existing evidence proves a
+  named person) are unchanged and never require an owner-kind decision.
+
 ## Historical v2 snapshot policy
 
 Readiness and rollback share the same translation helper
@@ -183,9 +205,14 @@ allowed resolution shapes, and the current-state evidence hash per entry.
 Fingerprint contract:
 
 - `plan.fingerprint` = SHA-256 over the canonical JSON (sorted keys) of the
-  plan's actionable content (summary, findings, operations, decisions).
-  `generatedAt` is excluded so repeated dry-runs on unchanged state produce
-  identical fingerprints.
+  plan's actionable content (summary, findings, operations, decisions)
+  **plus `baselineStateHash`**. `generatedAt` is excluded so repeated
+  dry-runs on unchanged state produce identical fingerprints.
+- `plan.baselineStateHash` = SHA-256 over the canonical **complete
+  remediation state** the dry-run inspected: all projects, ResourceTypes,
+  NamedResources, CapacityProfiles, CapacitySegments, active CapacityPlan
+  periods/entries and all BacklogSnapshots. It is covered by the reviewed
+  fingerprint, so tampering with it invalidates the plan.
 - `manifest.planFingerprint` must equal the referenced plan's fingerprint;
   any alteration of reviewed plan content invalidates the fingerprint and
   apply refuses.
@@ -194,6 +221,33 @@ Fingerprint contract:
   and refuses execution when the hash differs or the proposed state is not
   already persisted.
 
+### Full-scope drift refusal (before any write)
+
+Inside the same transaction and before the first write, apply re-loads the
+complete remediation state with the same loader the dry-run uses, recomputes
+`baselineStateHash`, and compares it with the reviewed plan. Any unplanned
+change — a new unprofiled ResourceType or NamedResource, a previously valid
+profile becoming malformed, a duplicate or cross-project ownership defect, a
+new or changed BacklogSnapshot, an active CapacityPlan change, or any other
+state difference — refuses execution with exit `1` and **zero writes**,
+regardless of whether the existing operations' local evidence still matches.
+The per-operation evidence checks remain as a second layer.
+
+### Idempotent rerun contract
+
+An apply whose complete state no longer equals the reviewed baseline is
+accepted as a no-op **only** when BOTH hold:
+
+1. every reviewed operation already matches its exact proposed state; and
+2. the planner rebuilt from the current state contains no remaining
+   operations, unresolved decisions or unsupported findings.
+
+The apply then returns success with all operations skipped (the permanent
+readiness check still re-runs after the empty transaction as defence in
+depth). Any mixed, partially applied or otherwise different state refuses
+before writes. The contract is identical for the baseline-plan-plus-manifest
+and resolved-plan invocation forms.
+
 Manifest (`formatVersion: 1`): per-decision entries referencing plan decision
 ids with an explicit reviewed resolution. Supported resolution shapes (only
 those required by #421):
@@ -201,7 +255,11 @@ those required by #421):
 - `scalar-profile` (`DEMAND_FOLLOWING` / `WHOLE_PROJECT_ALLOCATION` + percent);
 - `availability-window` (percent + window);
 - `segmented-capacity-profile` (percent + explicit segments);
-- `owner-kind-decision` (`NAMED_PERSON` / `PLANNED_RESOURCE` + capacity shape);
+- `owner-kind-decision` (`NAMED_PERSON` / `PLANNED_RESOURCE` + nested
+  capacity shape) — required for ambiguous missing NamedResources, whose
+  owner kind is unproven; selecting `PLANNED_RESOURCE` additionally creates
+  the parent role's deterministically derived ROLE profile (or is rejected
+  when the parent ROLE cannot be proven);
 - `snapshot-window-interpretation` (window for windowless / single-`-1`
   snapshot entries).
 
@@ -216,13 +274,17 @@ data size (a few thousand rows):
 
 1. plan + manifest validation (fingerprint, formats, resolution shapes);
 2. refusal when any decision is unresolved or any unsupported finding exists;
-3. inside the transaction: re-read every affected owner/profile/snapshot,
-   verify evidence hashes (or that the proposed state is already persisted →
-   no-op), validate every proposed profile against the authoritative
-   structural rules, write, then re-verify every write;
-4. any failure rolls back everything — no partially repaired project is ever
+3. inside the transaction, before any write: reload the complete remediation
+   state and compare its canonical hash with the reviewed `baselineStateHash`
+   — any difference refuses with zero writes (full-scope drift); an exact
+   post-apply rerun (all operations already in proposed state, planner clean)
+   returns success with everything skipped;
+4. re-read every affected owner/profile/snapshot and verify the operation's
+   evidence hash (second layer), validate every proposed profile against the
+   authoritative structural rules, write, then re-verify every write;
+5. any failure rolls back everything — no partially repaired project is ever
    reported as successful;
-5. after commit: re-run the planner and the permanent readiness gate; exit `1`
+6. after commit: re-run the planner and the permanent readiness gate; exit `1`
    with a full report if any non-policy blocker remains.
 
 No distributed or resumable migration infrastructure is introduced. The
@@ -324,14 +386,22 @@ remaining ambiguous owner. **PR 2 remains blocked** until the gates pass.
 - `server/src/test/productionRemediationPlan.test.ts` — pure planner unit
   tests (classification matrix, never-active policy, overlap decomposition,
   fingerprint stability/tamper detection, manifest merge/refusals, exit
-  classification).
+  classification, owner-kind decision contract incl. PLANNED_RESOURCE parent
+  role derivation, baselineStateHash stability/tamper coverage).
 - `server/src/test/productionRemediation.integration.test.ts` — Linux
   PostgreSQL suite covering dry-run (zero writes, stable fingerprints,
   credentials absent, production-scale counts), deterministic apply (all
   matrix rows, capacity/identity preservation, candidate columns frozen,
   runtime resolver profile-first), manifest decisions (unresolved/malformed/
-  fingerprint/drift refusals, exact resolution, rerun no-op), transaction
-  safety (mid-transaction rollback, no partial success), historical snapshots
+  fingerprint refusals, exact NAMED_PERSON and PLANNED_RESOURCE owner-kind
+  resolutions passing structural/ownership/readiness/resolver checks,
+  unknown nested shapes rejected before writes, rerun no-op), full-scope
+  drift (new unprofiled RT/NR, malformed profile, new untranslatable
+  snapshot, changed unplanned snapshot entry, active-plan change outside
+  operation evidence, cross-project ownership, mixed partial state — all
+  refuse with zero writes; exact rerun no-op and identical drift contract for
+  both invocation forms), transaction safety (mid-transaction rollback, no
+  partial success), historical snapshots
   (all policy cases, minimal rewrites, readiness/rollback agreement, malformed
   refusal) and the end-to-end blocker-class database (readiness fails →
   dry-run → approved apply → audit + readiness pass → runtime loads →

--- a/docs/domain/legacy-capacity-column-runtime-cutover.md
+++ b/docs/domain/legacy-capacity-column-runtime-cutover.md
@@ -154,3 +154,17 @@ For each readiness run, the production machine records:
 - **PR 1 performs no production migration.** All database and migration
   testing in PR 1 uses disposable PostgreSQL databases on the development
   machine.
+
+## Pre-PR-2 remediation (Issue #421)
+
+The first production readiness run failed with deterministic and ambiguous
+blockers (missing profiles, malformed persisted profiles, untranslatable
+historical v2 snapshots). The reviewed remediation command
+(`npm run capacity-profiles:remediate-readiness`, explicit dry-run/apply
+modes) is specified in
+[`docs/domain/capacity-profile-readiness-remediation.md`](capacity-profile-readiness-remediation.md),
+including the deterministic transformation matrix, the historical v2 snapshot
+policy (never-active `-1`/inverted-window normalisation shared by readiness
+and rollback), the decision manifest contract, the ownership-invariant
+migration sequencing, and the exact #404 production handoff. PR 2 remains
+blocked until #404 executes that procedure and records both gates.

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "capacity-profiles:audit:json": "npm run capacity-profiles:audit:json --workspace=server",
     "capacity-profiles:audit:repair": "npm run capacity-profiles:audit:repair --workspace=server",
     "capacity-profiles:readiness": "npm run capacity-profiles:readiness --workspace=server",
+    "capacity-profiles:remediate-readiness": "npm run capacity-profiles:remediate-readiness --workspace=server",
     "capacity-profiles:backfill": "npm run capacity-profiles:backfill --workspace=server",
     "capacity-profiles:reconcile": "npm run capacity-profiles:reconcile --workspace=server"
   },

--- a/scripts/run-integration-local.mjs
+++ b/scripts/run-integration-local.mjs
@@ -19,6 +19,7 @@ try {
       'test:runtime-cutover-integration',
       'test:transfer-integration',
       'test:legacy-alias-removal-integration',
+      'test:remediation-integration',
     ]) {
       if (guard.triggered) break
       await runCommand('npm', ['run', script, '--workspace=server'], { cwd: root, env: environment, signal: guard.abortSignal })

--- a/server/package.json
+++ b/server/package.json
@@ -26,11 +26,13 @@
     "capacity-profiles:audit:repair": "tsx src/scripts/auditCapacityProfileOwnership.ts --repair-identical",
     "capacity-profiles:audit:repair:json": "tsx src/scripts/auditCapacityProfileOwnership.ts --repair-identical --json",
     "capacity-profiles:readiness": "tsx src/scripts/checkProductionMigrationReadiness.ts",
+    "capacity-profiles:remediate-readiness": "tsx src/scripts/remediateProductionReadiness.ts",
     "test:ownership-invariants-integration": "vitest run --config vitest.integration.config.ts src/test/capacityProfileOwnershipInvariants.integration.test.ts",
     "test:runtime-cutover-integration": "vitest run --config vitest.integration.config.ts src/test/runtimeCutoverProfileFirst.integration.test.ts",
     "test:transfer-integration": "vitest run --config vitest.integration.config.ts src/test/capacityProfileTransfer.integration.test.ts",
     "postinstall": "prisma generate",
-    "test:legacy-alias-removal-integration": "vitest run --config vitest.integration.config.ts src/test/legacyCapacityAliasRemoval.integration.test.ts"
+    "test:legacy-alias-removal-integration": "vitest run --config vitest.integration.config.ts src/test/legacyCapacityAliasRemoval.integration.test.ts",
+    "test:remediation-integration": "vitest run --config vitest.integration.config.ts src/test/productionRemediation.integration.test.ts"
   },
   "prisma": {
     "seed": "tsx prisma/seed.ts"

--- a/server/src/lib/productionRemediationApply.ts
+++ b/server/src/lib/productionRemediationApply.ts
@@ -34,6 +34,7 @@ import {
   classifyPlanExit,
   resolvePlanWithManifest,
   parsePlanJson,
+  computeStateHash,
   buildRtEvidence,
   buildNrEvidence,
   buildProfileEvidence,
@@ -689,6 +690,51 @@ export async function applyRemediationPlan(
 
   try {
     await prisma.$transaction(async tx => {
+      // ── Full-scope drift check: the COMPLETE remediation state must match
+      // the reviewed dry-run baseline before any write (issue #421 review
+      // round 2). The state hash covers projects, resource types, named
+      // resources, profiles, segments, active plan periods/entries and all
+      // backlog snapshots — anything outside the per-operation evidence.
+      const currentState = await loadRemediationState(tx)
+      const currentStateHash = computeStateHash(currentState)
+      const baselineIntact = currentStateHash === plan.baselineStateHash
+
+      if (!baselineIntact) {
+        // ── Exact-rerun acceptance ───────────────────────────────────────
+        // A rerun after a fully successful application must be a no-op: every
+        // reviewed operation already matches its exact proposed state, and
+        // the complete current planner contains no remaining operations,
+        // unresolved decisions or unsupported findings. Any mixed, partially
+        // applied or otherwise different state is refused BEFORE the first
+        // write.
+        const rerunVerdicts: VerificationResult[] = []
+        let rerunRefusals = 0
+        let rerunWrites = 0
+        for (const op of plan.operations) {
+          const current = await loadCurrentState(tx, op)
+          const verdict = verifyOperation(op, current)
+          rerunVerdicts.push(verdict)
+          if (verdict.verdict === 'write') rerunWrites++
+          if (verdict.verdict === 'refuse') rerunRefusals++
+        }
+        const rerunPlan = buildRemediationPlan(currentState, plan.applicationCommit)
+        const fullyRemediated =
+          rerunPlan.summary.operations === 0 &&
+          rerunPlan.summary.decisionsRequired === 0 &&
+          rerunPlan.summary.findings.unsupported === 0
+        if (rerunWrites === 0 && rerunRefusals === 0 && fullyRemediated) {
+          // Exact rerun: every operation already in proposed state; nothing
+          // to write. The post-commit readiness check still runs as defence
+          // in depth.
+          skipped = plan.operations.length
+          return
+        }
+        throw new RemediationDriftError(
+          'complete remediation state changed since dry-run — the reviewed baseline no longer matches. ' +
+          'No write was performed. Regenerate the plan with a fresh dry-run and re-review before applying.',
+        )
+      }
+
       // ── Pre-flight: re-read every affected row and verify evidence ──────
       const verdicts: VerificationResult[] = []
       for (const op of plan.operations) {

--- a/server/src/lib/productionRemediationApply.ts
+++ b/server/src/lib/productionRemediationApply.ts
@@ -1,0 +1,901 @@
+/**
+ * productionRemediationApply.ts — Issue #421: transactional apply of the
+ * reviewed readiness-remediation plan.
+ *
+ * Apply guarantees (mirrored by the CLI contract):
+ *  - requires an explicit `--apply` invocation with the exact reviewed plan
+ *    (and optional approved manifest);
+ *  - refuses a missing, malformed, fingerprint-mismatched or unresolved plan;
+ *  - re-reads every affected row before writing and verifies the exact
+ *    current-state evidence hash from the plan (drift protection);
+ *  - performs no best-effort guessing — every write is either a deterministic
+ *    operation from the plan or an explicit manifest-resolved operation;
+ *  - runs inside ONE database transaction; any failure rolls back all writes;
+ *  - is idempotent — operations whose proposed state is already persisted are
+ *    reported as skipped/no-op;
+ *  - never writes ResourceType/NamedResource candidate columns, never touches
+ *    `CapacityProfile.legacy` on updates, never deletes snapshots and never
+ *    weakens the permanent readiness command.
+ *
+ * Exit contract (shared with the CLI):
+ *   0 — every plan operation applied or already applied, and post-apply
+ *       readiness + planner checks are clean;
+ *   1 — operational, structural or drift failure (nothing was written in
+ *       pre-write failures; a committed run that fails post-apply reports
+ *       loudly);
+ *   2 — plan valid but explicit decisions remain unresolved (refused).
+ */
+
+import type { Prisma, PrismaClient } from '@prisma/client'
+
+import {
+  canonicalJson,
+  evidenceHash,
+  classifyPlanExit,
+  resolvePlanWithManifest,
+  parsePlanJson,
+  buildRtEvidence,
+  buildNrEvidence,
+  buildProfileEvidence,
+  buildSnapshotEntryEvidence,
+  loadRemediationState,
+  buildRemediationPlan,
+  type RemediationOperation,
+  type RemediationPlan,
+  type RemediationManifest,
+  type ProposedProfile,
+  type ProposedSnapshotRewrite,
+  type FindingClassification,
+  type RemediationProfile,
+} from './productionRemediationPlan.js'
+import { runProductionMigrationReadiness } from './productionMigrationReadiness.js'
+import {
+  isSnapshotV2,
+  parseSnapshotData,
+  type SnapshotV2,
+} from './projectSnapshotTypes.js'
+import { translateV2SnapshotProfiles } from './projectSnapshotCapacity.js'
+import { validateProfileStructure } from './capacityProfileStructureValidation.js'
+
+// ─── Errors ─────────────────────────────────────────────────────────────────
+
+export class RemediationApplyError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'RemediationApplyError'
+  }
+}
+
+export class RemediationDriftError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'RemediationDriftError'
+  }
+}
+
+// ─── Outcome ────────────────────────────────────────────────────────────────
+
+export interface PostApplyCheck {
+  planFindings: Record<FindingClassification, number>
+  readinessPassed: boolean
+  readinessBlockers: string[]
+}
+
+export interface ApplyOutcome {
+  exitCode: 0 | 1 | 2
+  applied: number
+  skipped: number
+  errors: string[]
+  postApply: PostApplyCheck | null
+  report: string
+}
+
+// ─── Test seam (mirrors squadPlannerProfileWriter conventions) ──────────────
+
+let applyFailureSeam: (() => void | Promise<void>) | null = null
+
+/** Test-only: inject a failure between pre-flight verification and the first write. */
+export function __setRemediationApplyFailureSeam(fn: (() => void | Promise<void>) | null): void {
+  applyFailureSeam = fn
+}
+
+// ─── Current-state re-read (drift protection) ───────────────────────────────
+
+interface OperationCurrentState {
+  rt: Awaited<ReturnType<typeof loadResourceType>> | null
+  nr: Awaited<ReturnType<typeof loadNamedResource>> | null
+  profile: RemediationProfile | null
+  snapshotRaw: { snapshot: unknown; projectId: string } | null
+  activePlanPeriods: Awaited<ReturnType<typeof loadActivePlanPeriods>>
+  /** Persisted profiles currently owned by the operation's owner (create ops). */
+  existingProfiles: RemediationProfile[]
+}
+
+async function loadResourceType(client: PrismaClient | Prisma.TransactionClient, id: string) {
+  return client.resourceType.findUnique({
+    where: { id },
+    select: {
+      id: true,
+      name: true,
+      count: true,
+      allocationMode: true,
+      allocationPercent: true,
+      allocationStartWeek: true,
+      allocationEndWeek: true,
+      projectId: true,
+      namedResources: {
+        orderBy: { id: 'asc' },
+        select: {
+          id: true,
+          name: true,
+          allocationMode: true,
+          allocationPercent: true,
+          allocationPct: true,
+          allocationStartWeek: true,
+          allocationEndWeek: true,
+          startWeek: true,
+          endWeek: true,
+        },
+      },
+    },
+  })
+}
+
+async function loadNamedResource(client: PrismaClient | Prisma.TransactionClient, id: string) {
+  return client.namedResource.findUnique({
+    where: { id },
+    select: {
+      id: true,
+      name: true,
+      resourceTypeId: true,
+      resourceType: { select: { projectId: true } },
+      allocationMode: true,
+      allocationPercent: true,
+      allocationPct: true,
+      allocationStartWeek: true,
+      allocationEndWeek: true,
+      startWeek: true,
+      endWeek: true,
+    },
+  })
+}
+
+async function loadActivePlanPeriods(client: PrismaClient | Prisma.TransactionClient, projectId: string) {
+  const activePlan = await client.capacityPlan.findFirst({
+    where: { projectId, isActive: true },
+    select: {
+      periods: {
+        orderBy: { periodIndex: 'asc' },
+        select: {
+          periodIndex: true,
+          startWeek: true,
+          endWeek: true,
+          entries: {
+            orderBy: { resourceTypeId: 'asc' },
+            select: { resourceTypeId: true, headcount: true },
+          },
+        },
+      },
+    },
+  })
+  return (activePlan?.periods ?? []).map(period => ({
+    periodIndex: period.periodIndex,
+    startWeek: period.startWeek,
+    endWeek: period.endWeek,
+    entries: period.entries.map(entry => ({
+      resourceTypeId: entry.resourceTypeId,
+      headcount: entry.headcount,
+    })),
+  }))
+}
+
+async function loadCurrentState(
+  client: PrismaClient | Prisma.TransactionClient,
+  op: RemediationOperation,
+): Promise<OperationCurrentState> {
+  const [rt, nr, profile, snapshotRaw, activePlanPeriods, existingProfiles] = await Promise.all([
+    op.kind === 'create-role-profile' ? loadResourceType(client, op.ownerId) : Promise.resolve(null),
+    op.kind === 'create-named-profile' ? loadNamedResource(client, op.ownerId) : Promise.resolve(null),
+    op.kind === 'update-profile' && typeof op.proposed === 'object' && 'profileId' in op.proposed
+      ? loadPersistedProfile(client, (op.proposed as ProposedProfile).profileId)
+      : Promise.resolve(null),
+    op.kind === 'rewrite-snapshot-entry'
+      ? client.backlogSnapshot.findUnique({ where: { id: (op.proposed as ProposedSnapshotRewrite).snapshotId }, select: { snapshot: true, projectId: true } })
+      : Promise.resolve(null),
+    op.kind === 'create-role-profile'
+      ? loadActivePlanPeriods(client, op.projectId)
+      : Promise.resolve([]),
+    op.kind === 'create-role-profile' || op.kind === 'create-named-profile'
+      ? client.capacityProfile.findMany({
+          where: op.kind === 'create-role-profile'
+            ? { projectId: op.projectId, resourceTypeId: op.ownerId, ownerKind: 'ROLE' }
+            : { projectId: op.projectId, namedResourceId: op.ownerId },
+          include: { segments: { orderBy: [{ startWeek: 'asc' }, { id: 'asc' }] } },
+        })
+      : Promise.resolve([]),
+  ])
+  return {
+    rt,
+    nr,
+    profile,
+    snapshotRaw,
+    activePlanPeriods,
+    existingProfiles: existingProfiles.map(row => ({
+      id: row.id,
+      projectId: row.projectId,
+      resourceTypeId: row.resourceTypeId,
+      namedResourceId: row.namedResourceId,
+      ownerKind: row.ownerKind,
+      planningBasis: row.planningBasis,
+      source: row.source,
+      defaultPercent: row.defaultPercent,
+      startWeek: row.startWeek,
+      endWeek: row.endWeek,
+      legacy: row.legacy,
+      segments: row.segments.map(segment => ({
+        id: segment.id,
+        startWeek: segment.startWeek,
+        endWeek: segment.endWeek,
+        capacityPercent: segment.capacityPercent,
+        source: segment.source,
+      })),
+    })),
+  }
+}
+
+async function loadPersistedProfile(
+  client: PrismaClient | Prisma.TransactionClient,
+  profileId: string,
+): Promise<RemediationProfile | null> {
+  const row = await client.capacityProfile.findUnique({
+    where: { id: profileId },
+    include: {
+      segments: { orderBy: [{ startWeek: 'asc' }, { id: 'asc' }] },
+    },
+  })
+  if (!row) return null
+  return {
+    id: row.id,
+    projectId: row.projectId,
+    resourceTypeId: row.resourceTypeId,
+    namedResourceId: row.namedResourceId,
+    ownerKind: row.ownerKind,
+    planningBasis: row.planningBasis,
+    source: row.source,
+    defaultPercent: row.defaultPercent,
+    startWeek: row.startWeek,
+    endWeek: row.endWeek,
+    legacy: row.legacy,
+    segments: row.segments.map(segment => ({
+      id: segment.id,
+      startWeek: segment.startWeek,
+      endWeek: segment.endWeek,
+      capacityPercent: segment.capacityPercent,
+      source: segment.source,
+    })),
+  }
+}
+
+/** Recompute the operation's evidence from current state (mirrors the planner). */
+function recomputeOperationEvidence(
+  op: RemediationOperation,
+  current: OperationCurrentState,
+): { evidence: Record<string, unknown>; ownerMissing: boolean } | null {
+  if (op.kind === 'create-role-profile') {
+    if (!current.rt) return null
+    return {
+      evidence: buildRtEvidence({
+        id: current.rt.id,
+        name: current.rt.name,
+        count: current.rt.count,
+        allocationMode: current.rt.allocationMode,
+        allocationPercent: current.rt.allocationPercent,
+        allocationStartWeek: current.rt.allocationStartWeek,
+        allocationEndWeek: current.rt.allocationEndWeek,
+        namedResources: current.rt.namedResources.map(nr => ({
+          id: nr.id,
+          name: nr.name,
+          allocationMode: nr.allocationMode,
+          allocationPercent: nr.allocationPercent,
+          allocationPct: nr.allocationPct,
+          allocationStartWeek: nr.allocationStartWeek,
+          allocationEndWeek: nr.allocationEndWeek,
+          startWeek: nr.startWeek,
+          endWeek: nr.endWeek,
+        })),
+      }, current.activePlanPeriods),
+      ownerMissing: false,
+    }
+  }
+  if (op.kind === 'create-named-profile') {
+    if (!current.nr) return null
+    return {
+      evidence: buildNrEvidence({
+        id: current.nr.id,
+        name: current.nr.name,
+        allocationMode: current.nr.allocationMode,
+        allocationPercent: current.nr.allocationPercent,
+        allocationPct: current.nr.allocationPct,
+        allocationStartWeek: current.nr.allocationStartWeek,
+        allocationEndWeek: current.nr.allocationEndWeek,
+        startWeek: current.nr.startWeek,
+        endWeek: current.nr.endWeek,
+      }),
+      ownerMissing: false,
+    }
+  }
+  if (op.kind === 'update-profile') {
+    if (!current.profile) return null
+    return { evidence: buildProfileEvidence(current.profile), ownerMissing: false }
+  }
+  if (op.kind === 'rewrite-snapshot-entry') {
+    if (!current.snapshotRaw) return null
+    const rewrite = op.proposed as ProposedSnapshotRewrite
+    const captured = extractCapturedSnapshotEntry(current.snapshotRaw.snapshot, rewrite)
+    if (!captured) return null
+    return {
+      evidence: buildSnapshotEntryEvidence(rewrite.snapshotId, rewrite.entryType, rewrite.entryId, captured),
+      ownerMissing: false,
+    }
+  }
+  return null
+}
+
+/** Extract the captured capacity fields of one v2 entry (mirrors the planner). */
+function extractCapturedSnapshotEntry(
+  snapshot: unknown,
+  rewrite: ProposedSnapshotRewrite,
+): Record<string, unknown> | null {
+  let parsed: unknown
+  try {
+    parsed = parseSnapshotData(snapshot)
+  } catch {
+    return null
+  }
+  if (!isSnapshotV2(parsed)) return null
+  const v2 = parsed as SnapshotV2
+  if (rewrite.entryType === 'resourceType') {
+    const entry = v2.resourceTypes.find(rt => rt.id === rewrite.entryId)
+    if (!entry) return null
+    return {
+      allocationMode: entry.allocationMode ?? null,
+      allocationPercent: entry.allocationPercent ?? null,
+      allocationStartWeek: entry.allocationStartWeek ?? null,
+      allocationEndWeek: entry.allocationEndWeek ?? null,
+    }
+  }
+  const entry = v2.namedResources.find(nr => nr.id === rewrite.entryId)
+  if (!entry) return null
+  return {
+    allocationMode: entry.allocationMode ?? null,
+    allocationPercent: entry.allocationPercent ?? null,
+    allocationPct: entry.allocationPct ?? null,
+    allocationStartWeek: entry.allocationStartWeek ?? null,
+    allocationEndWeek: entry.allocationEndWeek ?? null,
+    startWeek: entry.startWeek ?? null,
+    endWeek: entry.endWeek ?? null,
+  }
+}
+
+// ─── Proposed-state comparison (idempotency + post-write verification) ──────
+
+function proposedProfileCore(proposed: ProposedProfile): Record<string, unknown> {
+  return {
+    profileId: proposed.profileId,
+    ownerKind: proposed.ownerKind,
+    planningBasis: proposed.planningBasis,
+    source: proposed.source,
+    defaultPercent: proposed.defaultPercent,
+    startWeek: proposed.startWeek,
+    endWeek: proposed.endWeek,
+    segments: proposed.segments.map(segment => ({
+      id: segment.id,
+      startWeek: segment.startWeek,
+      endWeek: segment.endWeek,
+      capacityPercent: segment.capacityPercent,
+      source: segment.source,
+    })),
+  }
+}
+
+function persistedProfileMatchesProposed(profile: RemediationProfile, proposed: ProposedProfile): boolean {
+  const persisted: Record<string, unknown> = {
+    profileId: profile.id,
+    ownerKind: profile.ownerKind,
+    planningBasis: profile.planningBasis,
+    source: profile.source,
+    defaultPercent: profile.defaultPercent,
+    startWeek: profile.startWeek,
+    endWeek: profile.endWeek,
+    segments: profile.segments.map(segment => ({
+      id: segment.id,
+      startWeek: segment.startWeek,
+      endWeek: segment.endWeek,
+      capacityPercent: segment.capacityPercent,
+      source: segment.source,
+    })),
+  }
+  const coreMatch = canonicalJson(persisted) === canonicalJson(proposedProfileCore(proposed))
+  if (!coreMatch) return false
+  if (proposed.legacy == null) return true
+  return canonicalJson(profile.legacy ?? null) === canonicalJson(proposed.legacy)
+}
+
+function snapshotAlreadyRewritten(snapshot: unknown, rewrite: ProposedSnapshotRewrite): boolean {
+  const captured = extractCapturedSnapshotEntry(snapshot, rewrite)
+  if (!captured) return false
+  return captured.allocationStartWeek === rewrite.startWeek && captured.allocationEndWeek === rewrite.endWeek
+}
+
+// ─── Operation verification (drift + idempotency) ───────────────────────────
+
+type VerificationResult =
+  | { verdict: 'write' }
+  | { verdict: 'skip' }
+  | { verdict: 'refuse'; reason: string }
+
+function verifyOperation(
+  op: RemediationOperation,
+  current: OperationCurrentState,
+): VerificationResult {
+  const recomputed = recomputeOperationEvidence(op, current)
+  if (!recomputed) {
+    return { verdict: 'refuse', reason: `owner/snapshot row vanished since dry-run (${op.ownerId})` }
+  }
+  const matchesEvidence = evidenceHash(recomputed.evidence) === op.evidenceHash
+
+  if (op.kind === 'create-role-profile' || op.kind === 'create-named-profile') {
+    const proposed = op.proposed as ProposedProfile
+    if (op.kind === 'create-role-profile' && current.rt && current.rt.projectId !== op.projectId) {
+      return { verdict: 'refuse', reason: `resource type ${op.ownerId} moved to another project since dry-run` }
+    }
+    if (op.kind === 'create-named-profile' && current.nr && current.nr.resourceType?.projectId !== op.projectId) {
+      return { verdict: 'refuse', reason: `named resource ${op.ownerId} moved to another project since dry-run` }
+    }
+    if (current.existingProfiles.length === 0) {
+      if (matchesEvidence) return { verdict: 'write' }
+      return { verdict: 'refuse', reason: `current state of ${op.ownerId} differs from the reviewed plan evidence` }
+    }
+    if (
+      current.existingProfiles.length === 1 &&
+      persistedProfileMatchesProposed(current.existingProfiles[0]!, proposed)
+    ) {
+      return { verdict: 'skip' }
+    }
+    return { verdict: 'refuse', reason: `owner ${op.ownerId} now has a different persisted profile than the reviewed plan expects` }
+  }
+
+  if (op.kind === 'update-profile') {
+    const proposed = op.proposed as ProposedProfile
+    if (matchesEvidence) return { verdict: 'write' }
+    if (current.profile && persistedProfileMatchesProposed(current.profile, proposed)) {
+      return { verdict: 'skip' }
+    }
+    return { verdict: 'refuse', reason: `profile ${proposed.profileId} state differs from the reviewed plan evidence` }
+  }
+
+  if (op.kind === 'rewrite-snapshot-entry') {
+    const rewrite = op.proposed as ProposedSnapshotRewrite
+    if (matchesEvidence) return { verdict: 'write' }
+    if (current.snapshotRaw && snapshotAlreadyRewritten(current.snapshotRaw.snapshot, rewrite)) {
+      return { verdict: 'skip' }
+    }
+    return { verdict: 'refuse', reason: `snapshot ${rewrite.snapshotId} entry ${rewrite.entryId} differs from the reviewed plan evidence` }
+  }
+
+  return { verdict: 'refuse', reason: `unknown operation kind ${op.kind}` }
+}
+
+// ─── Writes (inside the transaction) ────────────────────────────────────────
+
+async function writeOperation(
+  tx: Prisma.TransactionClient,
+  op: RemediationOperation,
+): Promise<void> {
+  if (op.kind === 'create-role-profile' || op.kind === 'create-named-profile') {
+    const proposed = op.proposed as ProposedProfile
+    await tx.capacityProfile.create({
+      data: {
+        id: proposed.profileId,
+        projectId: op.projectId,
+        ownerKind: proposed.ownerKind,
+        resourceTypeId: op.kind === 'create-role-profile' ? op.ownerId : null,
+        namedResourceId: op.kind === 'create-named-profile' ? op.ownerId : null,
+        planningBasis: proposed.planningBasis,
+        source: proposed.source,
+        defaultPercent: proposed.defaultPercent,
+        startWeek: proposed.startWeek,
+        endWeek: proposed.endWeek,
+        legacy: proposed.legacy as Prisma.InputJsonValue | undefined,
+        segments: {
+          create: proposed.segments.map(segment => ({
+            id: segment.id,
+            startWeek: segment.startWeek,
+            endWeek: segment.endWeek,
+            capacityPercent: segment.capacityPercent,
+            source: segment.source as never,
+          })),
+        },
+      },
+    })
+    return
+  }
+
+  if (op.kind === 'update-profile') {
+    const proposed = op.proposed as ProposedProfile
+    await tx.capacityProfile.update({
+      where: { id: proposed.profileId },
+      data: {
+        ownerKind: proposed.ownerKind,
+        planningBasis: proposed.planningBasis,
+        source: proposed.source,
+        defaultPercent: proposed.defaultPercent,
+        startWeek: proposed.startWeek,
+        endWeek: proposed.endWeek,
+      },
+    })
+    await tx.capacitySegment.deleteMany({ where: { capacityProfileId: proposed.profileId } })
+    for (const segment of proposed.segments) {
+      await tx.capacitySegment.create({
+        data: {
+          id: segment.id,
+          capacityProfileId: proposed.profileId,
+          startWeek: segment.startWeek,
+          endWeek: segment.endWeek,
+          capacityPercent: segment.capacityPercent,
+          source: segment.source as never,
+        },
+      })
+    }
+    return
+  }
+
+  if (op.kind === 'rewrite-snapshot-entry') {
+    const rewrite = op.proposed as ProposedSnapshotRewrite
+    const row = await tx.backlogSnapshot.findUnique({
+      where: { id: rewrite.snapshotId },
+      select: { snapshot: true, projectId: true },
+    })
+    if (!row) {
+      throw new RemediationDriftError(`snapshot ${rewrite.snapshotId} vanished before write`)
+    }
+    if (row.projectId !== op.projectId) {
+      throw new RemediationDriftError(`snapshot ${rewrite.snapshotId} moved to another project since dry-run`)
+    }
+    let parsed: unknown
+    try {
+      parsed = parseSnapshotData(row.snapshot)
+    } catch (error) {
+      throw new RemediationApplyError(
+        `snapshot ${rewrite.snapshotId} is no longer parseable: ${error instanceof Error ? error.message : String(error)}`,
+      )
+    }
+    if (!isSnapshotV2(parsed)) {
+      throw new RemediationApplyError(`snapshot ${rewrite.snapshotId} is no longer a v2 snapshot`)
+    }
+    const rewritten = structuredClone(row.snapshot) as Record<string, unknown>
+    const resourceTypes = Array.isArray(rewritten.resourceTypes) ? rewritten.resourceTypes : []
+    const namedResources = Array.isArray(rewritten.namedResources) ? rewritten.namedResources : []
+    const target = rewrite.entryType === 'resourceType'
+      ? resourceTypes.find((entry: Record<string, unknown>) => entry.id === rewrite.entryId)
+      : namedResources.find((entry: Record<string, unknown>) => entry.id === rewrite.entryId)
+    if (!target) {
+      throw new RemediationDriftError(`snapshot ${rewrite.snapshotId} no longer contains entry ${rewrite.entryId}`)
+    }
+    // Minimal capacity-field update: only the two primary window aliases are
+    // written; any negative fallback alias (startWeek/endWeek) is cleared to
+    // null so the single -1 sentinel edge cannot break translation after the
+    // approved interpretation is recorded.
+    target.allocationStartWeek = rewrite.startWeek
+    target.allocationEndWeek = rewrite.endWeek
+    if (typeof target.startWeek === 'number' && target.startWeek < 0) target.startWeek = null
+    if (typeof target.endWeek === 'number' && target.endWeek < 0) target.endWeek = null
+
+    // Validate the complete resulting snapshot before writing.
+    let validated: unknown
+    try {
+      validated = parseSnapshotData(rewritten)
+    } catch (error) {
+      throw new RemediationApplyError(
+        `rewritten snapshot ${rewrite.snapshotId} is malformed: ${error instanceof Error ? error.message : String(error)}`,
+      )
+    }
+    if (!isSnapshotV2(validated)) {
+      throw new RemediationApplyError(`rewritten snapshot ${rewrite.snapshotId} is no longer a v2 snapshot`)
+    }
+    const translation = translateV2SnapshotProfiles(validated, row.projectId)
+    if (translation.errors.length > 0) {
+      throw new RemediationApplyError(
+        `rewritten snapshot ${rewrite.snapshotId} is not translatable: ${translation.errors.join('; ')}`,
+      )
+    }
+    await tx.backlogSnapshot.update({
+      where: { id: rewrite.snapshotId },
+      data: { snapshot: rewritten as Prisma.InputJsonValue },
+    })
+    return
+  }
+
+  throw new RemediationApplyError(`unknown operation kind ${op.kind}`)
+}
+
+// ─── Main apply ─────────────────────────────────────────────────────────────
+
+export interface ApplyOptions {
+  plan: RemediationPlan
+  manifest?: RemediationManifest | null
+}
+
+/**
+ * Apply the reviewed remediation plan inside one transaction.
+ *
+ * @param prisma Connected PrismaClient (never disconnected here).
+ * @param options Plan (already parsed and fingerprint-validated) and optional manifest.
+ * @returns Outcome with exit code, applied/skipped counts and post-apply checks.
+ */
+export async function applyRemediationPlan(
+  prisma: PrismaClient,
+  options: ApplyOptions,
+): Promise<ApplyOutcome> {
+  const errors: string[] = []
+
+  let plan = options.plan
+  if (options.manifest) {
+    const resolved = resolvePlanWithManifest(plan, options.manifest)
+    if (resolved.errors.length > 0) {
+      errors.push(...resolved.errors.map(error => `manifest: ${error}`))
+      return {
+        exitCode: 1,
+        applied: 0,
+        skipped: 0,
+        errors,
+        postApply: null,
+        report: formatApplyReport(errors, 0, 0, null),
+      }
+    }
+    plan = resolved.plan
+  }
+
+  const exit = classifyPlanExit(plan)
+  if (exit !== 0) {
+    const message = exit === 2
+      ? 'plan has unresolved explicit decisions — apply is refused until every decision is resolved by an approved manifest'
+      : 'plan contains unsupported or structurally invalid findings — apply is refused'
+    errors.push(message)
+    return {
+      exitCode: exit as 1 | 2,
+      applied: 0,
+      skipped: 0,
+      errors,
+      postApply: null,
+      report: formatApplyReport(errors, 0, 0, null),
+    }
+  }
+
+  if (plan.operations.length === 0) {
+    return {
+      exitCode: 0,
+      applied: 0,
+      skipped: 0,
+      errors: [],
+      postApply: null,
+      report: formatApplyReport([], 0, 0, null) + '\nNo operations in plan — nothing to apply.',
+    }
+  }
+
+  let applied = 0
+  let skipped = 0
+  const refused: string[] = []
+
+  try {
+    await prisma.$transaction(async tx => {
+      // ── Pre-flight: re-read every affected row and verify evidence ──────
+      const verdicts: VerificationResult[] = []
+      for (const op of plan.operations) {
+        const current = await loadCurrentState(tx, op)
+        const verdict = verifyOperation(op, current)
+        verdicts.push(verdict)
+        if (verdict.verdict === 'refuse') {
+          refused.push(`${op.id} (${op.ownerId}): ${verdict.reason}`)
+        }
+      }
+      if (refused.length > 0) {
+        throw new RemediationDriftError(
+          `state changed since dry-run — ${refused.length} operation(s) refused: ${refused.join('; ')}`,
+        )
+      }
+
+      // ── Structural validation of every proposed profile against current owner sets ──
+      for (const op of plan.operations) {
+        if (op.kind === 'rewrite-snapshot-entry') continue
+        const proposed = op.proposed as ProposedProfile
+        const current = await loadCurrentState(tx, op)
+        // Owner FKs come from the current owner row (create ops) or the
+        // existing profile row (update ops) — never from the plan alone.
+        const ownerResourceTypeId = op.kind === 'create-role-profile'
+          ? op.ownerId
+          : op.kind === 'update-profile'
+            ? (current.profile?.resourceTypeId ?? null)
+            : null
+        const ownerNamedResourceId = op.kind === 'create-named-profile'
+          ? op.ownerId
+          : op.kind === 'update-profile'
+            ? (current.profile?.namedResourceId ?? null)
+            : null
+        const rtIds = new Set<string>()
+        const nrIds = new Set<string>()
+        if (op.kind === 'create-role-profile' && current.rt) {
+          rtIds.add(current.rt.id)
+          for (const nr of current.rt.namedResources) nrIds.add(nr.id)
+        }
+        if (op.kind === 'create-named-profile' && current.nr) {
+          nrIds.add(current.nr.id)
+        }
+        if (ownerResourceTypeId) rtIds.add(ownerResourceTypeId)
+        if (ownerNamedResourceId) nrIds.add(ownerNamedResourceId)
+        const structureErrors = validateProfileStructure(
+          {
+            id: proposed.profileId,
+            projectId: op.projectId,
+            resourceTypeId: ownerResourceTypeId,
+            namedResourceId: ownerNamedResourceId,
+            ownerKind: proposed.ownerKind,
+            planningBasis: proposed.planningBasis,
+            source: proposed.source,
+            defaultPercent: proposed.defaultPercent,
+            startWeek: proposed.startWeek,
+            endWeek: proposed.endWeek,
+            segments: proposed.segments.map(segment => ({
+              id: segment.id,
+              startWeek: segment.startWeek,
+              endWeek: segment.endWeek,
+              capacityPercent: segment.capacityPercent,
+              source: segment.source,
+            })),
+          },
+          { projectId: op.projectId, resourceTypeIds: rtIds, namedResourceIds: nrIds },
+        )
+        if (structureErrors.length > 0) {
+          throw new RemediationApplyError(
+            `proposed profile ${proposed.profileId} is structurally invalid: ${structureErrors.join('; ')}`,
+          )
+        }
+      }
+
+      // ── Test seam: injected failure before the first write ─────────────
+      if (applyFailureSeam) {
+        await applyFailureSeam()
+      }
+
+      // ── Write every operation ──────────────────────────────────────────
+      for (let i = 0; i < plan.operations.length; i++) {
+        const op = plan.operations[i]
+        const verdict = verdicts[i]
+        if (verdict.verdict === 'skip') {
+          skipped++
+          continue
+        }
+        await writeOperation(tx, op)
+        applied++
+      }
+
+      // ── Post-write verification per operation ──────────────────────────
+      for (const op of plan.operations) {
+        const current = await loadCurrentState(tx, op)
+        if (op.kind === 'rewrite-snapshot-entry') {
+          const rewrite = op.proposed as ProposedSnapshotRewrite
+          if (!current.snapshotRaw || !snapshotAlreadyRewritten(current.snapshotRaw.snapshot, rewrite)) {
+            throw new RemediationApplyError(`post-write verification failed for ${op.id} (snapshot rewrite)`)
+          }
+          continue
+        }
+        const proposed = op.proposed as ProposedProfile
+        if (op.kind === 'create-role-profile' || op.kind === 'create-named-profile') {
+          if (!current.rt && !current.nr) {
+            throw new RemediationApplyError(`post-write verification failed for ${op.id} (owner vanished)`)
+          }
+        }
+        if (op.kind === 'update-profile' || op.kind === 'create-role-profile' || op.kind === 'create-named-profile') {
+          const persisted = await loadPersistedProfile(tx, proposed.profileId)
+          if (!persisted || !persistedProfileMatchesProposed(persisted, proposed)) {
+            throw new RemediationApplyError(`post-write verification failed for ${op.id} (profile mismatch)`)
+          }
+        }
+      }
+    })
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    errors.push(message)
+    return {
+      exitCode: 1,
+      applied: 0,
+      skipped: 0,
+      errors,
+      postApply: null,
+      report: formatApplyReport(errors, 0, 0, null),
+    }
+  }
+
+  // ── Post-apply: re-run planner + permanent readiness (outside tx) ──────
+  let postApply: PostApplyCheck
+  try {
+    const state = await loadRemediationState(prisma)
+    const freshPlan = buildRemediationPlan(state, plan.applicationCommit)
+    const readiness = await runProductionMigrationReadiness(prisma)
+    postApply = {
+      planFindings: freshPlan.summary.findings,
+      readinessPassed: readiness.passed,
+      readinessBlockers: readiness.sections.flatMap(section => section.blockers),
+    }
+    const unexpectedFindings =
+      freshPlan.summary.findings.decisionRequired +
+      freshPlan.summary.findings.unsupported +
+      freshPlan.summary.operations
+    if (unexpectedFindings > 0) {
+      errors.push(
+        `post-apply planner found ${unexpectedFindings} unresolved finding(s)/operation(s) that should have been remediated — review the report`,
+      )
+    }
+    if (!readiness.passed) {
+      errors.push(
+        `post-apply readiness FAILED with ${postApply.readinessBlockers.length} blocker(s) — review the report`,
+      )
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    errors.push(`post-apply verification error: ${message}`)
+    postApply = {
+      planFindings: { deterministic: 0, decisionRequired: 0, unsupported: 0, alreadyValid: 0 },
+      readinessPassed: false,
+      readinessBlockers: [message],
+    }
+  }
+
+  const exitCode = errors.length > 0 ? 1 : 0
+  return {
+    exitCode: exitCode as 0 | 1,
+    applied,
+    skipped,
+    errors,
+    postApply,
+    report: formatApplyReport(errors, applied, skipped, postApply),
+  }
+}
+
+function formatApplyReport(
+  errors: string[],
+  applied: number,
+  skipped: number,
+  postApply: PostApplyCheck | null,
+): string {
+  const lines: string[] = []
+  lines.push('═══ Capacity-Profile Readiness Remediation Apply ═══')
+  lines.push('')
+  lines.push(`Operations applied: ${applied}`)
+  lines.push(`Operations skipped (already applied): ${skipped}`)
+  if (errors.length > 0) {
+    lines.push('')
+    lines.push('❌ Errors:')
+    for (const error of errors) lines.push(`   - ${error}`)
+  }
+  if (postApply) {
+    lines.push('')
+    lines.push('Post-apply verification:')
+    lines.push(`  planner findings remaining: ${JSON.stringify(postApply.planFindings)}`)
+    lines.push(`  permanent readiness: ${postApply.readinessPassed ? 'PASS' : 'FAIL'}`)
+    for (const blocker of postApply.readinessBlockers.slice(0, 20)) {
+      lines.push(`     - ${blocker}`)
+    }
+    if (postApply.readinessBlockers.length > 20) {
+      lines.push(`     … and ${postApply.readinessBlockers.length - 20} more`)
+    }
+  }
+  if (errors.length === 0) {
+    lines.push('')
+    lines.push('✅ APPLY COMPLETED — every planned operation applied or already applied; readiness clean.')
+  }
+  return lines.join('\n')
+}
+
+// Re-export for the CLI
+export { parsePlanJson }

--- a/server/src/lib/productionRemediationPlan.ts
+++ b/server/src/lib/productionRemediationPlan.ts
@@ -1,0 +1,1867 @@
+/**
+ * productionRemediationPlan.ts — Issue #421: pure read-only remediation
+ * planning for production capacity-profile readiness blockers.
+ *
+ * This module builds the reviewed remediation plan that #404 executes BEFORE
+ * the destructive legacy-column migration (#418 PR 2). It is deliberately
+ * pure where possible (no Prisma calls inside the planner itself) so the
+ * full classification matrix, fingerprint contract and manifest merge are
+ * unit-testable without a database.
+ *
+ * Guarantees:
+ *  - NEVER runs during application startup or from an HTTP request.
+ *  - Planning performs NO writes; the CLI wraps it in dry-run mode.
+ *  - Every operation carries an `evidenceHash` over the exact current-state
+ *    evidence used to derive it; apply refuses when re-read state differs.
+ *  - Ambiguous owners are never guessed: they become decision entries that
+ *    require an explicit reviewed manifest resolution before apply.
+ *  - Candidate ResourceType/NamedResource columns are only READ here, never
+ *    written, and the permanent readiness command is never weakened.
+ *
+ * Exit contract (shared by the CLI):
+ *   0 — plan is valid and has no unresolved decisions;
+ *   1 — operational, structural or drift failure;
+ *   2 — plan is valid but explicit decisions remain unresolved.
+ */
+
+import { createHash } from 'node:crypto'
+import type { PrismaClient } from '@prisma/client'
+
+import {
+  mapResourceTypeToCapacityProfile,
+  mapNamedResourceToCapacityProfile,
+  type CapacityProfileResourceTypeLike,
+  type CapacityProfileNamedResourceLike,
+  type CapacityProfileDTO,
+} from './capacityProfileMapping.js'
+import { buildRoleProfileData } from './squadPlannerProfileWriter.js'
+import { isNeverActiveWindow } from './projectSnapshotCapacity.js'
+import {
+  validateProfileStructure,
+  type ProfileStructureInput,
+  type ProfileStructureSegment,
+} from './capacityProfileStructureValidation.js'
+import {
+  isLegacyV1Snapshot,
+  isSnapshotV2,
+  isSnapshotV3,
+  isSnapshotV4,
+  parseSnapshotData,
+  type SnapshotV2,
+} from './projectSnapshotTypes.js'
+import { validateSnapshotV3 } from './projectSnapshotValidation.js'
+
+function round2(value: number): number {
+  return Math.round(value * 100) / 100
+}
+
+// ─── Format versions ─────────────────────────────────────────────────────────
+
+export const REMEDIATION_PLAN_FORMAT_VERSION = 1
+export const REMEDIATION_MANIFEST_FORMAT_VERSION = 1
+
+// ─── Classifications ─────────────────────────────────────────────────────────
+
+export type FindingClassification =
+  | 'deterministic'
+  | 'decisionRequired'
+  | 'unsupported'
+  | 'alreadyValid'
+
+export type OperationKind =
+  | 'create-role-profile'
+  | 'create-named-profile'
+  | 'update-profile'
+  | 'rewrite-snapshot-entry'
+
+// ─── Current-state evidence types ────────────────────────────────────────────
+
+export interface RemediationNamedResource {
+  id: string
+  name: string
+  allocationMode: string | null
+  allocationPercent: number | null
+  allocationPct: number | null
+  allocationStartWeek: number | null
+  allocationEndWeek: number | null
+  startWeek: number | null
+  endWeek: number | null
+}
+
+export interface RemediationResourceType {
+  id: string
+  name: string
+  count: number
+  allocationMode: string | null
+  allocationPercent: number | null
+  allocationStartWeek: number | null
+  allocationEndWeek: number | null
+  namedResources: RemediationNamedResource[]
+}
+
+export interface RemediationSegment {
+  id: string
+  startWeek: number
+  endWeek: number
+  capacityPercent: number
+  source: string
+}
+
+export interface RemediationProfile {
+  id: string
+  projectId: string
+  resourceTypeId: string | null
+  namedResourceId: string | null
+  ownerKind: string
+  planningBasis: string
+  source: string
+  defaultPercent: number | null
+  startWeek: number | null
+  endWeek: number | null
+  legacy: unknown
+  segments: RemediationSegment[]
+}
+
+export interface RemediationPlanPeriod {
+  periodIndex: number
+  startWeek: number
+  endWeek: number
+  entries: Array<{ resourceTypeId: string; headcount: number }>
+}
+
+export interface RemediationProject {
+  id: string
+  name: string
+  resourceTypes: RemediationResourceType[]
+  capacityProfiles: RemediationProfile[]
+  /** Periods of the active CapacityPlan (ordered by periodIndex); [] when none. */
+  activePlanPeriods: RemediationPlanPeriod[]
+}
+
+export interface RemediationSnapshot {
+  id: string
+  projectId: string
+  snapshot: unknown
+}
+
+export interface RemediationDatabaseState {
+  projects: RemediationProject[]
+  snapshots: RemediationSnapshot[]
+}
+
+// ─── Proposed writes ─────────────────────────────────────────────────────────
+
+export interface ProposedSegment {
+  id: string
+  startWeek: number
+  endWeek: number
+  capacityPercent: number
+  source: string
+}
+
+export interface ProposedProfile {
+  /** Existing profile id for updates, deterministic new id for creates. */
+  profileId: string
+  ownerKind: 'ROLE' | 'NAMED_PERSON' | 'PLANNED_RESOURCE'
+  planningBasis: 'DEMAND_FOLLOWING' | 'AVAILABILITY_WINDOW' | 'WHOLE_PROJECT_ALLOCATION' | 'CAPACITY_PROFILE'
+  source: 'FIXED' | 'AVAILABILITY_WINDOW' | 'LEGACY' | 'SQUAD_PLANNER'
+  defaultPercent: number | null
+  startWeek: number | null
+  endWeek: number | null
+  /**
+   * Mapper-shaped legacy JSON written on create; `null`/undefined for update
+   * operations, whose existing legacy payload is preserved untouched.
+   */
+  legacy?: Record<string, unknown> | null
+  segments: ProposedSegment[]
+}
+
+export interface ProposedSnapshotRewrite {
+  snapshotId: string
+  entryType: 'resourceType' | 'namedResource'
+  entryId: string
+  /** Approved captured window written to allocationStartWeek/allocationEndWeek. */
+  startWeek: number
+  endWeek: number
+}
+
+export interface RemediationOperation {
+  /** Stable id within the plan: `op-0001`. */
+  id: string
+  kind: OperationKind
+  classification: 'deterministic' | 'decisionResolved'
+  projectId: string
+  ownerId: string
+  ownerName: string
+  /** Exact current-state evidence hash (canonical JSON, SHA-256). */
+  evidenceHash: string
+  proposed: ProposedProfile | ProposedSnapshotRewrite
+  /** Set when the operation comes from an explicit manifest decision. */
+  decisionId?: string
+}
+
+export interface RemediationFinding {
+  id: string
+  category: 'live-owner' | 'persisted-profile' | 'snapshot-entry' | 'snapshot'
+  projectId: string
+  ownerId: string | null
+  ownerName: string | null
+  profileId: string | null
+  snapshotId: string | null
+  entryId: string | null
+  classification: FindingClassification
+  message: string
+  evidenceHash: string
+  operationId: string | null
+  decisionId: string | null
+}
+
+export interface PlanDecisionEntry {
+  id: string
+  projectId: string
+  ownerId: string
+  ownerKind: 'role' | 'namedPerson'
+  profileId: string | null
+  snapshotId: string | null
+  entryId: string | null
+  /** Mapper-shaped legacy base used to build the resolved profile. */
+  legacyBase: Record<string, unknown> | null
+  evidenceHash: string
+  allowedResolutions: string[]
+  message: string
+}
+
+export interface RemediationPlanSummary {
+  findings: Record<FindingClassification, number>
+  operations: number
+  decisionsRequired: number
+}
+
+export interface RemediationPlan {
+  formatVersion: typeof REMEDIATION_PLAN_FORMAT_VERSION
+  generatedAt: string
+  /** Informational: the git commit the plan was generated on (never enforced). */
+  applicationCommit: string
+  /** SHA-256 over the canonical actionable content (stable across reruns). */
+  fingerprint: string
+  summary: RemediationPlanSummary
+  findings: RemediationFinding[]
+  operations: RemediationOperation[]
+  decisions: PlanDecisionEntry[]
+}
+
+// ─── Manifest (explicit reviewed decisions) ─────────────────────────────────
+
+export type ManifestCapacityResolution =
+  | {
+      shape: 'scalar-profile'
+      planningBasis: 'DEMAND_FOLLOWING' | 'WHOLE_PROJECT_ALLOCATION'
+      defaultPercent: number | null
+    }
+  | {
+      shape: 'availability-window'
+      defaultPercent: number | null
+      startWeek: number | null
+      endWeek: number | null
+    }
+  | {
+      shape: 'segmented-capacity-profile'
+      defaultPercent: number | null
+      segments: Array<{ startWeek: number; endWeek: number; capacityPercent: number }>
+    }
+
+export type ManifestResolution =
+  | ManifestCapacityResolution
+  | {
+      shape: 'owner-kind-decision'
+      ownerKind: 'NAMED_PERSON' | 'PLANNED_RESOURCE'
+      capacity: ManifestCapacityResolution
+    }
+  | {
+      shape: 'snapshot-window-interpretation'
+      startWeek: number
+      endWeek: number
+    }
+
+export interface ManifestDecision {
+  decisionId: string
+  projectId: string
+  ownerId: string
+  snapshotId: string | null
+  resolution: ManifestResolution
+  rationale?: string
+}
+
+export interface RemediationManifest {
+  formatVersion: typeof REMEDIATION_MANIFEST_FORMAT_VERSION
+  applicationCommit: string
+  /** Must equal the referenced plan's fingerprint. */
+  planFingerprint: string
+  decisions: ManifestDecision[]
+}
+
+// ─── Canonical serialisation + fingerprint ──────────────────────────────────
+
+/**
+ * Deterministic JSON serialisation: object keys sorted recursively, arrays in
+ * order. Used for evidence hashes and the plan fingerprint so identical state
+ * always yields identical hashes.
+ */
+export function canonicalJson(value: unknown): string {
+  if (value === null) return 'null'
+  if (Array.isArray(value)) {
+    return `[${value.map(v => canonicalJson(v)).join(',')}]`
+  }
+  if (typeof value === 'object') {
+    const obj = value as Record<string, unknown>
+    const keys = Object.keys(obj).sort()
+    const body = keys.map(key => `${JSON.stringify(key)}:${canonicalJson(obj[key])}`).join(',')
+    return `{${body}}`
+  }
+  return JSON.stringify(value)
+}
+
+export function sha256Hex(text: string): string {
+  return createHash('sha256').update(text).digest('hex')
+}
+
+export function evidenceHash(evidence: Record<string, unknown>): string {
+  return sha256Hex(canonicalJson(evidence))
+}
+
+/** Stable per-plan fingerprint over the actionable content (never timestamps). */
+export function computePlanFingerprint(plan: {
+  formatVersion: number
+  summary: RemediationPlanSummary
+  findings: RemediationFinding[]
+  operations: RemediationOperation[]
+  decisions: PlanDecisionEntry[]
+}): string {
+  return sha256Hex(canonicalJson({
+    formatVersion: plan.formatVersion,
+    summary: plan.summary,
+    findings: plan.findings,
+    operations: plan.operations,
+    decisions: plan.decisions,
+  }))
+}
+
+// ─── Small domain helpers ───────────────────────────────────────────────────
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value)
+}
+
+function isNonNegativeInteger(value: unknown): value is number {
+  return isFiniteNumber(value) && Number.isInteger(value) && value >= 0
+}
+
+function enumToUpper(value: string): string {
+  return value.replace(/[a-z][A-Z]/g, m => `${m[0]}_${m[1]}`).toUpperCase()
+}
+
+/** Deterministic new profile id for created profiles (traceable, collision-safe). */
+export function remediationProfileId(ownerKind: 'role' | 'namedPerson', ownerId: string): string {
+  return `remediation-${ownerKind === 'role' ? 'role' : 'named'}-${ownerId}`
+}
+
+function remediationSegmentId(profileId: string, index: number): string {
+  return `${profileId}-seg-${String(index + 1).padStart(3, '0')}`
+}
+
+// ─── Live-state derivation (deterministic matrix) ───────────────────────────
+
+export interface DerivedOwnerState {
+  classification: FindingClassification
+  proposed?: ProposedProfile
+  message: string
+}
+
+function mapperDtoToProposed(
+  dto: CapacityProfileDTO,
+  ownerKind: 'ROLE' | 'NAMED_PERSON',
+  profileId: string,
+  overrides?: Partial<ProposedProfile>,
+): ProposedProfile {
+  return {
+    profileId,
+    ownerKind,
+    planningBasis: enumToUpper(dto.planningBasis) as ProposedProfile['planningBasis'],
+    source: enumToUpper(dto.source) as ProposedProfile['source'],
+    defaultPercent: dto.defaultPercent ?? null,
+    startWeek: dto.startWeek ?? null,
+    endWeek: dto.endWeek ?? null,
+    legacy: dto.legacy as unknown as Record<string, unknown>,
+    segments: [],
+    ...overrides,
+  }
+}
+
+/**
+ * Deterministic ROLE profile derivation for a resource type that has no
+ * persisted profiles and no named resources (or is planner-owned).
+ *
+ * Mapping (reuses the approved mapper semantics, issue #421):
+ *   TIMELINE    → AVAILABILITY_WINDOW / AVAILABILITY_WINDOW, window preserved
+ *   EFFORT/null → DEMAND_FOLLOWING / FIXED
+ *   FULL_PROJECT→ WHOLE_PROJECT_ALLOCATION / FIXED
+ *   CAPACITY_PLAN with valid persisted active-plan entries
+ *               → CAPACITY_PROFILE / SQUAD_PLANNER via buildRoleProfileData
+ *                 (the current Squad Planner ROLE writer — aggregate weekly
+ *                 headcount segments, provenance preserved)
+ *   CAPACITY_PLAN without plan evidence → decisionRequired (never guessed)
+ */
+export function deriveRoleProfileFromLegacy(
+  rt: RemediationResourceType,
+  activePlanPeriods: RemediationPlanPeriod[],
+): DerivedOwnerState {
+  const mode = rt.allocationMode ?? null
+
+  if (mode === 'CAPACITY_PLAN') {
+    const rtPeriods = activePlanPeriods.map(period => ({
+      periodIndex: period.periodIndex,
+      startWeek: period.startWeek,
+      endWeek: period.endWeek,
+      entries: period.entries.filter(entry => entry.resourceTypeId === rt.id),
+    })).filter(period => period.entries.length > 0)
+    const hasPlanEntries = rtPeriods.some(period => period.entries.some(entry => entry.headcount > 0))
+
+    if (hasPlanEntries) {
+      const roleData = buildRoleProfileData(rt.id, rtPeriods)
+      const profileId = remediationProfileId('role', rt.id)
+      const segments: ProposedSegment[] = roleData.segments.map((segment, index) => ({
+        id: remediationSegmentId(profileId, index),
+        startWeek: segment.startWeek,
+        endWeek: segment.endWeek,
+        capacityPercent: segment.capacityPercent,
+        source: 'SQUAD_PLANNER',
+      }))
+      return {
+        classification: 'deterministic',
+        message: 'planner-owned role: ROLE profile reconstructed from valid persisted CapacityPlan entries',
+        proposed: {
+          profileId,
+          ownerKind: 'ROLE',
+          planningBasis: 'CAPACITY_PROFILE',
+          source: 'SQUAD_PLANNER',
+          defaultPercent: roleData.defaultPercent,
+          startWeek: roleData.startWeek,
+          endWeek: roleData.endWeek,
+          legacy: {
+            allocationMode: 'CAPACITY_PLAN',
+            allocationPercent: rt.allocationPercent,
+            allocationStartWeek: rt.allocationStartWeek,
+            allocationEndWeek: rt.allocationEndWeek,
+          },
+          segments,
+        },
+      }
+    }
+
+    return {
+      classification: 'decisionRequired',
+      message: 'CAPACITY_PLAN without usable window or plan evidence — owner intent required',
+    }
+  }
+
+  const dto = mapResourceTypeToCapacityProfile({
+    projectId: 'placeholder',
+    resourceType: rt as unknown as CapacityProfileResourceTypeLike,
+  })
+  // EFFORT / FULL_PROJECT / null never used window aliases (same stale-alias
+  // policy as the v2 snapshot translation) — discard them so the proposed
+  // DEMAND_FOLLOWING / WHOLE_PROJECT_ALLOCATION profile is structurally valid.
+  const modeDiscardsWindows = mode === 'EFFORT' || mode == null || mode === 'FULL_PROJECT'
+  const profileId = remediationProfileId('role', rt.id)
+  const overrides: Partial<ProposedProfile> = {
+    startWeek: modeDiscardsWindows ? null : (dto.startWeek ?? null),
+    endWeek: modeDiscardsWindows ? null : (dto.endWeek ?? null),
+  }
+  if (mode == null) {
+    // The v2 snapshot policy maps a missing mode to DEMAND_FOLLOWING/FIXED
+    // (same as EFFORT); the mapper alone labels it LEGACY.
+    overrides.source = 'FIXED'
+  }
+  return {
+    classification: 'deterministic',
+    message: `missing ROLE profile derived from unambiguous legacy mode ${JSON.stringify(mode)}`,
+    proposed: mapperDtoToProposed(dto, 'ROLE', profileId, overrides),
+  }
+}
+
+/**
+ * Deterministic NAMED_PERSON profile derivation for a named resource with no
+ * persisted profile. Mode is the named resource's OWN allocationMode (the
+ * legacy scheduler never inherited the parent role's mode).
+ *
+ *   TIMELINE     → AVAILABILITY_WINDOW / AVAILABILITY_WINDOW, window preserved
+ *   FULL_PROJECT → WHOLE_PROJECT_ALLOCATION / FIXED
+ *   EFFORT/null  → DEMAND_FOLLOWING / FIXED (windows discarded — the same
+ *                  stale-alias policy the v2 snapshot translation applies)
+ *   CAPACITY_PLAN with captured window
+ *                → AVAILABILITY_WINDOW / LEGACY (same policy as v2 translation)
+ *   CAPACITY_PLAN without captured window → decisionRequired
+ *   never-active (-1,-1 or inverted) window → zero-capacity profile (policy)
+ */
+export function deriveNamedProfileFromLegacy(
+  nr: RemediationNamedResource,
+): DerivedOwnerState {
+  const mode = nr.allocationMode ?? null
+  const effectiveStart = nr.allocationStartWeek ?? nr.startWeek
+  const effectiveEnd = nr.allocationEndWeek ?? nr.endWeek
+  const modeUsesWindows = mode === 'TIMELINE' || mode === 'CAPACITY_PLAN'
+  const neverActive = modeUsesWindows && isNeverActiveWindow(effectiveStart, effectiveEnd)
+
+  if (mode === 'CAPACITY_PLAN' && !neverActive) {
+    if (effectiveStart == null || effectiveEnd == null) {
+      return {
+        classification: 'decisionRequired',
+        message: 'CAPACITY_PLAN without a usable window — owner intent required',
+      }
+    }
+    if (!isNonNegativeInteger(effectiveStart) || !isNonNegativeInteger(effectiveEnd)) {
+      return {
+        classification: 'decisionRequired',
+        message: 'single -1 or negative window edge without established meaning — owner intent required',
+      }
+    }
+    const profileId = remediationProfileId('namedPerson', nr.id)
+    return {
+      classification: 'deterministic',
+      message: 'CAPACITY_PLAN with captured window maps to AVAILABILITY_WINDOW/LEGACY (v2 policy)',
+      proposed: {
+        profileId,
+        ownerKind: 'NAMED_PERSON',
+        planningBasis: 'AVAILABILITY_WINDOW',
+        source: 'LEGACY',
+        defaultPercent: nr.allocationPercent ?? nr.allocationPct ?? 100,
+        startWeek: effectiveStart,
+        endWeek: effectiveEnd,
+        legacy: {
+          allocationMode: mode,
+          allocationPercent: nr.allocationPercent,
+          allocationPct: nr.allocationPct,
+          allocationStartWeek: nr.allocationStartWeek,
+          allocationEndWeek: nr.allocationEndWeek,
+          startWeek: nr.startWeek,
+          endWeek: nr.endWeek,
+        },
+        segments: [],
+      },
+    }
+  }
+
+  if (neverActive) {
+    // Issue #421 never-active policy: the captured window never contributed
+    // capacity; the faithful profile is zero-capacity with a null window.
+    const profileId = remediationProfileId('namedPerson', nr.id)
+    return {
+      classification: 'deterministic',
+      message: 'never-active window (never contributed capacity) → zero-capacity profile',
+      proposed: {
+        profileId,
+        ownerKind: 'NAMED_PERSON',
+        planningBasis: 'AVAILABILITY_WINDOW',
+        source: mode === 'CAPACITY_PLAN' ? 'LEGACY' : 'AVAILABILITY_WINDOW',
+        defaultPercent: 0,
+        startWeek: null,
+        endWeek: null,
+        legacy: {
+          allocationMode: mode,
+          allocationPercent: nr.allocationPercent,
+          allocationPct: nr.allocationPct,
+          allocationStartWeek: nr.allocationStartWeek,
+          allocationEndWeek: nr.allocationEndWeek,
+          startWeek: nr.startWeek,
+          endWeek: nr.endWeek,
+        },
+        segments: [],
+      },
+    }
+  }
+
+  const dto = mapNamedResourceToCapacityProfile({
+    projectId: 'placeholder',
+    resourceType: { id: '', name: '', count: 1 } as unknown as CapacityProfileResourceTypeLike,
+    namedResource: nr as unknown as CapacityProfileNamedResourceLike,
+  })
+  const profileId = remediationProfileId('namedPerson', nr.id)
+  const modeDiscardsWindows = mode === 'EFFORT' || mode == null || mode === 'FULL_PROJECT'
+  return {
+    classification: 'deterministic',
+    message: `missing NAMED_PERSON profile derived from unambiguous legacy mode ${JSON.stringify(mode)}`,
+    proposed: mapperDtoToProposed(dto, 'NAMED_PERSON', profileId, {
+      defaultPercent: nr.allocationPercent ?? nr.allocationPct ?? 100,
+      startWeek: modeDiscardsWindows ? null : (effectiveStart ?? null),
+      endWeek: modeDiscardsWindows ? null : (effectiveEnd ?? null),
+    }),
+  }
+}
+
+// ─── Overlap decomposition (deterministic correction) ───────────────────────
+
+/**
+ * Decompose overlapping segments into the exact non-overlapping representation
+ * that preserves the per-week effective capacity (the sum of every segment
+ * covering that week). Only captured capacity values are used — nothing is
+ * invented. Existing segment IDs are preserved where the interval count
+ * allows; surplus intervals receive deterministic new IDs.
+ */
+export function decomposeOverlappingSegments(
+  profileId: string,
+  segments: ReadonlyArray<ProfileStructureSegment>,
+): ProposedSegment[] | null {
+  if (segments.length === 0) return []
+
+  const boundaries = new Set<number>()
+  for (const segment of segments) {
+    boundaries.add(segment.startWeek)
+    boundaries.add(segment.endWeek + 1)
+  }
+  const sortedBoundaries = [...boundaries].sort((a, b) => a - b)
+
+  const intervals: Array<{ startWeek: number; endWeek: number; capacityPercent: number; source: string }> = []
+  for (let i = 0; i < sortedBoundaries.length - 1; i++) {
+    const startWeek = sortedBoundaries[i]
+    const endWeek = sortedBoundaries[i + 1] - 1
+    if (endWeek < startWeek) continue
+    let total = 0
+    let covered = false
+    let coveringSource = 'LEGACY'
+    for (const segment of segments) {
+      if (segment.startWeek <= startWeek && segment.endWeek >= endWeek) {
+        covered = true
+        total += segment.capacityPercent
+        coveringSource = segment.source
+      }
+    }
+    if (!covered) continue
+    intervals.push({ startWeek, endWeek, capacityPercent: round2(total), source: coveringSource })
+  }
+  if (intervals.length === 0) return null
+
+  const orderedOriginals = [...segments].sort(
+    (a, b) => a.startWeek - b.startWeek || a.endWeek - b.endWeek || a.id.localeCompare(b.id),
+  )
+  return intervals.map((interval, index) => ({
+    id: orderedOriginals[index]?.id ?? remediationSegmentId(profileId, index),
+    startWeek: interval.startWeek,
+    endWeek: interval.endWeek,
+    capacityPercent: interval.capacityPercent,
+    // Mapped originals keep their own provenance; surplus intervals inherit
+    // the provenance of the first segment covering them.
+    source: orderedOriginals[index]?.source ?? interval.source,
+  }))
+}
+
+function segmentsOverlap(segments: ReadonlyArray<ProfileStructureSegment>): boolean {
+  const sorted = [...segments].sort((a, b) => a.startWeek - b.startWeek || a.endWeek - b.endWeek)
+  let priorEnd = -1
+  for (const segment of sorted) {
+    if (segment.startWeek <= priorEnd) return true
+    priorEnd = Math.max(priorEnd, segment.endWeek)
+  }
+  return false
+}
+
+// ─── Persisted-profile defect classification ────────────────────────────────
+
+export type ProfileDefectKind =
+  | 'window-clear'
+  | 'overlap-fix'
+  | 'segmentless-decision'
+  | 'window-decision'
+  | 'unsupported'
+
+export interface ProfileDefect {
+  kind: ProfileDefectKind
+  classification: FindingClassification
+  proposed?: ProposedProfile
+  message: string
+  allowedResolutions?: string[]
+}
+
+/**
+ * Classify a structurally invalid persisted profile. Deterministic
+ * corrections only where the intended state is proven (window fields that the
+ * basis forbids; overlapping segments whose exact non-overlapping sum
+ * representation is provable). Ambiguous shapes require explicit decisions.
+ */
+export function classifyPersistedProfileDefect(
+  profile: RemediationProfile,
+  context: {
+    projectId: string
+    resourceTypeIds: ReadonlySet<string>
+    namedResourceIds: ReadonlySet<string>
+  },
+): ProfileDefect | null {
+  const input: ProfileStructureInput = {
+    id: profile.id,
+    projectId: profile.projectId,
+    resourceTypeId: profile.resourceTypeId,
+    namedResourceId: profile.namedResourceId,
+    ownerKind: profile.ownerKind,
+    planningBasis: profile.planningBasis,
+    source: profile.source,
+    defaultPercent: profile.defaultPercent,
+    startWeek: profile.startWeek,
+    endWeek: profile.endWeek,
+    segments: profile.segments.map(segment => ({
+      id: segment.id,
+      startWeek: segment.startWeek,
+      endWeek: segment.endWeek,
+      capacityPercent: segment.capacityPercent,
+      source: segment.source,
+    })),
+  }
+  const errors = validateProfileStructure(input, context)
+  if (errors.length === 0) return null
+
+  const base: Omit<ProposedProfile, 'planningBasis' | 'source' | 'defaultPercent' | 'startWeek' | 'endWeek' | 'segments'> = {
+    profileId: profile.id,
+    ownerKind: profile.ownerKind as ProposedProfile['ownerKind'],
+    legacy: null,
+  }
+
+  // Window fields present on a basis that forbids them → deterministic clear.
+  const windowClearOnly = errors.every(error =>
+    error.includes('must not have startWeek') || error.includes('must not have endWeek'),
+  )
+  if (windowClearOnly) {
+    return {
+      kind: 'window-clear',
+      classification: 'deterministic',
+      proposed: {
+        ...base,
+        planningBasis: profile.planningBasis as ProposedProfile['planningBasis'],
+        source: profile.source as ProposedProfile['source'],
+        defaultPercent: profile.defaultPercent,
+        startWeek: null,
+        endWeek: null,
+        segments: profile.segments.map(segment => ({
+          id: segment.id,
+          startWeek: segment.startWeek,
+          endWeek: segment.endWeek,
+          capacityPercent: segment.capacityPercent,
+          source: segment.source,
+        })),
+      },
+      message: 'window fields are meaningless for this planning basis — deterministic clear',
+    }
+  }
+
+  // Overlapping segments on a segmented profile → deterministic decomposition.
+  if (
+    profile.planningBasis === 'CAPACITY_PROFILE' &&
+    profile.segments.length > 0 &&
+    errors.some(error =>
+      error.includes('overlaps with previous segment') ||
+      error.includes('duplicate segment with week range'),
+    ) &&
+    segmentsOverlap(profile.segments as unknown as ProfileStructureSegment[])
+  ) {
+    const decomposed = decomposeOverlappingSegments(profile.id, profile.segments as unknown as ProfileStructureSegment[])
+    if (!decomposed) {
+      return {
+        kind: 'unsupported',
+        classification: 'unsupported',
+        message: 'overlapping segments cannot be decomposed deterministically',
+      }
+    }
+    return {
+      kind: 'overlap-fix',
+      classification: 'deterministic',
+      proposed: {
+        ...base,
+        planningBasis: 'CAPACITY_PROFILE',
+        source: profile.source as ProposedProfile['source'],
+        defaultPercent: profile.defaultPercent,
+        startWeek: profile.startWeek,
+        endWeek: profile.endWeek,
+        segments: decomposed,
+      },
+      message: 'contained/partial overlap decomposed to the exact sum-preserving non-overlapping representation',
+    }
+  }
+
+  // Segmentless non-canonical CAPACITY_PROFILE → owner intent required.
+  if (
+    profile.planningBasis === 'CAPACITY_PROFILE' &&
+    profile.segments.length === 0 &&
+    errors.some(error => error.includes('CAPACITY_PROFILE with no segments is only valid'))
+  ) {
+    return {
+      kind: 'segmentless-decision',
+      classification: 'decisionRequired',
+      message: 'segmentless ROLE/NAMED_PERSON CAPACITY_PROFILE — authoritative capacity not provable',
+      allowedResolutions: ['segmented-capacity-profile', 'availability-window', 'scalar-profile'],
+    }
+  }
+
+  // AVAILABILITY_WINDOW with invalid or inverted weeks → owner intent required.
+  if (profile.planningBasis === 'AVAILABILITY_WINDOW') {
+    const windowErrors = errors.some(error =>
+      error.includes('must be a non-negative finite integer') ||
+      error.includes('must not exceed endWeek'),
+    )
+    if (windowErrors) {
+      return {
+        kind: 'window-decision',
+        classification: 'decisionRequired',
+        message: 'AVAILABILITY_WINDOW with invalid/inverted week fields — owner intent required',
+        allowedResolutions: ['availability-window', 'scalar-profile'],
+      }
+    }
+  }
+
+  return {
+    kind: 'unsupported',
+    classification: 'unsupported',
+    message: `structurally invalid profile with no deterministic remediation: ${errors[0] ?? 'unknown error'}`,
+  }
+}
+
+// ─── Snapshot entry classification ──────────────────────────────────────────
+
+export interface SnapshotEntryFinding {
+  classification: FindingClassification
+  message: string
+}
+
+export function classifySnapshotEntry(
+  entry: { allocationMode: string | null; allocationPercent: number | null; allocationPct?: number | null; allocationStartWeek: number | null; allocationEndWeek: number | null; startWeek?: number | null; endWeek?: number | null },
+): SnapshotEntryFinding {
+  const mode = entry.allocationMode ?? null
+  if (mode != null && mode !== 'EFFORT' && mode !== 'TIMELINE' && mode !== 'FULL_PROJECT' && mode !== 'CAPACITY_PLAN') {
+    return { classification: 'unsupported', message: `unknown allocationMode ${JSON.stringify(mode)}` }
+  }
+  const effectiveStart = entry.allocationStartWeek ?? entry.startWeek ?? null
+  const effectiveEnd = entry.allocationEndWeek ?? entry.endWeek ?? null
+  const modeUsesWindows = mode === 'TIMELINE' || mode === 'CAPACITY_PLAN'
+  const neverActive = modeUsesWindows && isNeverActiveWindow(effectiveStart, effectiveEnd)
+
+  if (neverActive) {
+    return {
+      classification: 'deterministic',
+      message: 'never-active window normalized by policy to a zero-capacity profile (no write required)',
+    }
+  }
+  if (modeUsesWindows) {
+    if (effectiveStart == null || effectiveEnd == null) {
+      if (mode === 'CAPACITY_PLAN') {
+        return {
+          classification: 'decisionRequired',
+          message: 'CAPACITY_PLAN without captured window — explicit window interpretation required',
+        }
+      }
+      // TIMELINE without captured window is valid (null = unbounded).
+      return { classification: 'alreadyValid', message: 'valid: windowless TIMELINE translates as unbounded' }
+    }
+    const singleNegative = effectiveStart < 0 || effectiveEnd < 0
+    if (singleNegative) {
+      return {
+        classification: 'decisionRequired',
+        message: 'single -1/negative window edge without established meaning — explicit window interpretation required',
+      }
+    }
+    if (effectiveStart > effectiveEnd) {
+      // Inverted window is handled by the never-active branch above; unreachable.
+      return { classification: 'unsupported', message: 'inverted window' }
+    }
+    return { classification: 'alreadyValid', message: 'valid: captured window translates directly' }
+  }
+  // EFFORT / FULL_PROJECT / null — windows are stale aliases, discarded.
+  return { classification: 'alreadyValid', message: 'valid: windows discarded for this mode' }
+}
+
+// ─── Plan builder ───────────────────────────────────────────────────────────
+
+const EMPTY_CLASS_COUNTS = (): Record<FindingClassification, number> => ({
+  deterministic: 0,
+  decisionRequired: 0,
+  unsupported: 0,
+  alreadyValid: 0,
+})
+
+function projectContext(project: RemediationProject): {
+  projectId: string
+  resourceTypeIds: ReadonlySet<string>
+  namedResourceIds: ReadonlySet<string>
+} {
+  const resourceTypeIds = new Set(project.resourceTypes.map(rt => rt.id))
+  const namedResourceIds = new Set(project.resourceTypes.flatMap(rt => rt.namedResources.map(nr => nr.id)))
+  return { projectId: project.id, resourceTypeIds, namedResourceIds }
+}
+
+/**
+ * Build the complete remediation plan from current database state.
+ *
+ * @param state                Loaded current state (see loadRemediationState).
+ * @param applicationCommit    Informational git commit for traceability.
+ * @returns                    The reviewed plan (never written by this function).
+ */
+export function buildRemediationPlan(
+  state: RemediationDatabaseState,
+  applicationCommit: string,
+): RemediationPlan {
+  const findings: RemediationFinding[] = []
+  const operations: RemediationOperation[] = []
+  const decisions: PlanDecisionEntry[] = []
+  const classCounts = EMPTY_CLASS_COUNTS()
+
+  const addFinding = (
+    finding: Omit<RemediationFinding, 'id' | 'evidenceHash' | 'operationId' | 'decisionId'>,
+    evidence: Record<string, unknown>,
+  ): RemediationFinding => {
+    const id = `finding-${String(findings.length + 1).padStart(4, '0')}`
+    const full: RemediationFinding = {
+      ...finding,
+      id,
+      evidenceHash: evidenceHash(evidence),
+      operationId: null,
+      decisionId: null,
+    }
+    classCounts[finding.classification]++
+    findings.push(full)
+    return full
+  }
+
+  const addOperation = (
+    finding: RemediationFinding,
+    op: Omit<RemediationOperation, 'id' | 'evidenceHash'>,
+  ): void => {
+    const id = `op-${String(operations.length + 1).padStart(4, '0')}`
+    const full: RemediationOperation = { ...op, id, evidenceHash: finding.evidenceHash }
+    operations.push(full)
+    finding.operationId = id
+  }
+
+  const addDecision = (
+    finding: RemediationFinding,
+    decision: Omit<PlanDecisionEntry, 'id' | 'evidenceHash'>,
+  ): void => {
+    const id = `decision-${String(decisions.length + 1).padStart(4, '0')}`
+    const full: PlanDecisionEntry = { ...decision, id, evidenceHash: finding.evidenceHash }
+    decisions.push(full)
+    finding.decisionId = id
+  }
+
+  // ── Live owners and persisted profiles ──────────────────────────────────
+  for (const project of state.projects) {
+    const context = projectContext(project)
+    const profilesByOwner = new Map<string, RemediationProfile[]>()
+    for (const profile of project.capacityProfiles) {
+      const ownerKey = profile.resourceTypeId
+        ? `rt::${profile.resourceTypeId}`
+        : profile.namedResourceId
+          ? `nr::${profile.namedResourceId}`
+          : `none::${profile.id}`
+      const list = profilesByOwner.get(ownerKey) ?? []
+      list.push(profile)
+      profilesByOwner.set(ownerKey, list)
+    }
+
+    for (const rt of project.resourceTypes) {
+      const roleProfiles = profilesByOwner.get(`rt::${rt.id}`)?.filter(p => p.ownerKind === 'ROLE') ?? []
+      const nrProfiles = new Map<string, RemediationProfile[]>()
+      for (const nr of rt.namedResources) {
+        const profiles = profilesByOwner.get(`nr::${nr.id}`) ?? []
+        if (profiles.length > 0) nrProfiles.set(nr.id, profiles)
+      }
+      const hasPlannerOwnership = roleProfiles.some(p => p.source === 'SQUAD_PLANNER') ||
+        [...nrProfiles.values()].flat().some(p => p.ownerKind === 'PLANNED_RESOURCE' || p.source === 'SQUAD_PLANNER')
+
+      for (const nr of rt.namedResources) {
+        const profiles = nrProfiles.get(nr.id) ?? []
+        if (profiles.length > 1) {
+          addFinding({
+            category: 'live-owner',
+            projectId: project.id,
+            ownerId: nr.id,
+            ownerName: nr.name,
+            profileId: null,
+            snapshotId: null,
+            entryId: null,
+            classification: 'unsupported',
+            message: `named resource has ${profiles.length} persisted profiles — duplicate owner`,
+          }, buildNrEvidence(nr))
+          continue
+        }
+        if (profiles.length === 1) continue
+
+        const derived = deriveNamedProfileFromLegacy(nr)
+        const evidence = buildNrEvidence(nr)
+        const finding = addFinding({
+          category: 'live-owner',
+          projectId: project.id,
+          ownerId: nr.id,
+          ownerName: nr.name,
+          profileId: null,
+          snapshotId: null,
+          entryId: null,
+          classification: derived.classification,
+          message: derived.message,
+        }, evidence)
+        if (derived.classification === 'deterministic' && derived.proposed) {
+          addOperation(finding, {
+            kind: 'create-named-profile',
+            classification: 'deterministic',
+            projectId: project.id,
+            ownerId: nr.id,
+            ownerName: nr.name,
+            proposed: derived.proposed,
+          })
+        } else if (derived.classification === 'decisionRequired') {
+          addDecision(finding, {
+            projectId: project.id,
+            ownerId: nr.id,
+            ownerKind: 'namedPerson',
+            profileId: null,
+            snapshotId: null,
+            entryId: null,
+            legacyBase: mapperLegacyForNamedResource(nr),
+            allowedResolutions: ['scalar-profile', 'availability-window', 'segmented-capacity-profile'],
+            message: derived.message,
+          })
+        }
+      }
+
+      // Role completeness: planner-owned roles require exactly one ROLE
+      // profile; NR-less roles require exactly one ROLE profile.
+      const roleMissing = hasPlannerOwnership
+        ? roleProfiles.length !== 1
+        : rt.namedResources.length === 0 && roleProfiles.length !== 1
+      if (roleMissing && roleProfiles.length > 1) {
+        addFinding({
+          category: 'live-owner',
+          projectId: project.id,
+          ownerId: rt.id,
+          ownerName: rt.name,
+          profileId: null,
+          snapshotId: null,
+          entryId: null,
+          classification: 'unsupported',
+          message: `resource type has ${roleProfiles.length} ROLE profiles — duplicate owner`,
+        }, buildRtEvidence(rt, stateProjectsActivePlan(state, project.id)))
+        continue
+      }
+      if (roleMissing) {
+        const derived = deriveRoleProfileFromLegacy(rt, stateProjectsActivePlan(state, project.id))
+        const evidence = buildRtEvidence(rt, stateProjectsActivePlan(state, project.id))
+        const finding = addFinding({
+          category: 'live-owner',
+          projectId: project.id,
+          ownerId: rt.id,
+          ownerName: rt.name,
+          profileId: null,
+          snapshotId: null,
+          entryId: null,
+          classification: derived.classification,
+          message: derived.message,
+        }, evidence)
+        if (derived.classification === 'deterministic' && derived.proposed) {
+          addOperation(finding, {
+            kind: 'create-role-profile',
+            classification: 'deterministic',
+            projectId: project.id,
+            ownerId: rt.id,
+            ownerName: rt.name,
+            proposed: derived.proposed,
+          })
+        } else if (derived.classification === 'decisionRequired') {
+          addDecision(finding, {
+            projectId: project.id,
+            ownerId: rt.id,
+            ownerKind: 'role',
+            profileId: null,
+            snapshotId: null,
+            entryId: null,
+            legacyBase: mapperLegacyForResourceType(rt),
+            allowedResolutions: ['scalar-profile', 'availability-window', 'segmented-capacity-profile'],
+            message: derived.message,
+          })
+        }
+      }
+    }
+
+    // ── Persisted profile defects ────────────────────────────────────────
+    for (const profile of project.capacityProfiles) {
+      const defect = classifyPersistedProfileDefect(profile, context)
+      if (!defect) continue
+      const ownerId = profile.resourceTypeId ?? profile.namedResourceId ?? profile.id
+      const evidence = buildProfileEvidence(profile)
+      const finding = addFinding({
+        category: 'persisted-profile',
+        projectId: project.id,
+        ownerId,
+        ownerName: null,
+        profileId: profile.id,
+        snapshotId: null,
+        entryId: null,
+        classification: defect.classification,
+        message: defect.message,
+      }, evidence)
+      if (defect.kind === 'window-clear' || defect.kind === 'overlap-fix') {
+        addOperation(finding, {
+          kind: 'update-profile',
+          classification: 'deterministic',
+          projectId: project.id,
+          ownerId,
+          ownerName: '',
+          proposed: defect.proposed!,
+        })
+      } else if (defect.kind === 'segmentless-decision' || defect.kind === 'window-decision') {
+        addDecision(finding, {
+          projectId: project.id,
+          ownerId,
+          ownerKind: profile.ownerKind === 'ROLE' ? 'role' : 'namedPerson',
+          profileId: profile.id,
+          snapshotId: null,
+          entryId: null,
+          legacyBase: null,
+          allowedResolutions: defect.allowedResolutions ?? [],
+          message: defect.message,
+        })
+      }
+    }
+  }
+
+  // ── Historical snapshots ────────────────────────────────────────────────
+  for (const snapshot of state.snapshots) {
+    let parsed: unknown
+    try {
+      parsed = parseSnapshotData(snapshot.snapshot)
+    } catch (error) {
+      addFinding({
+        category: 'snapshot',
+        projectId: snapshot.projectId,
+        ownerId: null,
+        ownerName: null,
+        profileId: null,
+        snapshotId: snapshot.id,
+        entryId: null,
+        classification: 'unsupported',
+        message: `malformed snapshot: ${error instanceof Error ? error.message : String(error)}`,
+      }, { snapshotId: snapshot.id, malformed: true })
+      continue
+    }
+
+    if (isLegacyV1Snapshot(parsed)) continue
+    if (isSnapshotV3(parsed) || isSnapshotV4(parsed)) {
+      try {
+        validateSnapshotV3(parsed as Parameters<typeof validateSnapshotV3>[0])
+      } catch (error) {
+        addFinding({
+          category: 'snapshot',
+          projectId: snapshot.projectId,
+          ownerId: null,
+          ownerName: null,
+          profileId: null,
+          snapshotId: snapshot.id,
+          entryId: null,
+          classification: 'unsupported',
+          message: `invalid v${String((parsed as { schemaVersion?: unknown }).schemaVersion)} payload: ${error instanceof Error ? error.message : String(error)}`,
+        }, { snapshotId: snapshot.id, schemaVersion: (parsed as { schemaVersion?: unknown }).schemaVersion })
+      }
+      continue
+    }
+    if (!isSnapshotV2(parsed)) continue
+
+    const v2 = parsed as SnapshotV2
+    const rtById = new Map(v2.resourceTypes.map(rt => [rt.id, true]))
+
+    for (let i = 0; i < v2.resourceTypes.length; i++) {
+      const rt = v2.resourceTypes[i]
+      const classified = classifySnapshotEntry({
+        allocationMode: rt.allocationMode ?? null,
+        allocationPercent: rt.allocationPercent ?? null,
+        allocationStartWeek: rt.allocationStartWeek ?? null,
+        allocationEndWeek: rt.allocationEndWeek ?? null,
+      })
+      const evidence = buildSnapshotEntryEvidence(snapshot.id, 'resourceType', rt.id, {
+        allocationMode: rt.allocationMode ?? null,
+        allocationPercent: rt.allocationPercent ?? null,
+        allocationStartWeek: rt.allocationStartWeek ?? null,
+        allocationEndWeek: rt.allocationEndWeek ?? null,
+      })
+      const finding = addFinding({
+        category: 'snapshot-entry',
+        projectId: snapshot.projectId,
+        ownerId: rt.id,
+        ownerName: rt.name,
+        profileId: null,
+        snapshotId: snapshot.id,
+        entryId: rt.id,
+        classification: classified.classification,
+        message: classified.message,
+      }, evidence)
+      if (classified.classification === 'decisionRequired') {
+        addDecision(finding, {
+          projectId: snapshot.projectId,
+          ownerId: rt.id,
+          ownerKind: 'role',
+          profileId: null,
+          snapshotId: snapshot.id,
+          entryId: rt.id,
+          legacyBase: null,
+          allowedResolutions: ['snapshot-window-interpretation'],
+          message: classified.message,
+        })
+      }
+    }
+
+    for (let i = 0; i < v2.namedResources.length; i++) {
+      const nr = v2.namedResources[i]
+      // Orphan-owner rejection (same rule as the v2 translation): a named
+      // resource whose parent resource type is absent from the snapshot
+      // cannot be translated into authoritative ownership.
+      if (!nr.resourceTypeId || !rtById.has(nr.resourceTypeId)) {
+        addFinding({
+          category: 'snapshot-entry',
+          projectId: snapshot.projectId,
+          ownerId: nr.id,
+          ownerName: nr.name,
+          profileId: null,
+          snapshotId: snapshot.id,
+          entryId: nr.id,
+          classification: 'unsupported',
+          message: 'named resource references a resource type absent from this snapshot — orphan ownership cannot be translated',
+        }, buildSnapshotEntryEvidence(snapshot.id, 'namedResource', nr.id, {
+          allocationMode: nr.allocationMode ?? null,
+          allocationPercent: nr.allocationPercent ?? null,
+          allocationPct: nr.allocationPct ?? null,
+          allocationStartWeek: nr.allocationStartWeek ?? null,
+          allocationEndWeek: nr.allocationEndWeek ?? null,
+          startWeek: nr.startWeek ?? null,
+          endWeek: nr.endWeek ?? null,
+        }))
+        continue
+      }
+      const classified = classifySnapshotEntry({
+        allocationMode: nr.allocationMode ?? null,
+        allocationPercent: nr.allocationPercent ?? null,
+        allocationPct: nr.allocationPct ?? null,
+        allocationStartWeek: nr.allocationStartWeek ?? null,
+        allocationEndWeek: nr.allocationEndWeek ?? null,
+        startWeek: nr.startWeek ?? null,
+        endWeek: nr.endWeek ?? null,
+      })
+      const evidence = buildSnapshotEntryEvidence(snapshot.id, 'namedResource', nr.id, {
+        allocationMode: nr.allocationMode ?? null,
+        allocationPercent: nr.allocationPercent ?? null,
+        allocationPct: nr.allocationPct ?? null,
+        allocationStartWeek: nr.allocationStartWeek ?? null,
+        allocationEndWeek: nr.allocationEndWeek ?? null,
+        startWeek: nr.startWeek ?? null,
+        endWeek: nr.endWeek ?? null,
+      })
+      const finding = addFinding({
+        category: 'snapshot-entry',
+        projectId: snapshot.projectId,
+        ownerId: nr.id,
+        ownerName: nr.name,
+        profileId: null,
+        snapshotId: snapshot.id,
+        entryId: nr.id,
+        classification: classified.classification,
+        message: classified.message,
+      }, evidence)
+      if (classified.classification === 'decisionRequired') {
+        addDecision(finding, {
+          projectId: snapshot.projectId,
+          ownerId: nr.id,
+          ownerKind: 'namedPerson',
+          profileId: null,
+          snapshotId: snapshot.id,
+          entryId: nr.id,
+          legacyBase: null,
+          allowedResolutions: ['snapshot-window-interpretation'],
+          message: classified.message,
+        })
+      }
+    }
+  }
+
+  const summary: RemediationPlanSummary = {
+    findings: classCounts,
+    operations: operations.length,
+    decisionsRequired: decisions.length,
+  }
+  const plan: RemediationPlan = {
+    formatVersion: REMEDIATION_PLAN_FORMAT_VERSION,
+    generatedAt: new Date().toISOString(),
+    applicationCommit,
+    fingerprint: '',
+    summary,
+    findings,
+    operations,
+    decisions,
+  }
+  plan.fingerprint = computePlanFingerprint(plan)
+  return plan
+}
+
+// ─── Evidence builders ──────────────────────────────────────────────────────
+
+function stateProjectsActivePlan(state: RemediationDatabaseState, projectId: string): RemediationPlanPeriod[] {
+  const project = state.projects.find(project => project.id === projectId)
+  return project?.activePlanPeriods ?? []
+}
+
+export function buildRtEvidence(rt: RemediationResourceType, activePlanPeriods: RemediationPlanPeriod[]): Record<string, unknown> {
+  const rtPeriods = activePlanPeriods
+    .map(period => ({
+      periodIndex: period.periodIndex,
+      startWeek: period.startWeek,
+      endWeek: period.endWeek,
+      entries: period.entries
+        .filter(entry => entry.resourceTypeId === rt.id)
+        .map(entry => ({ resourceTypeId: entry.resourceTypeId, headcount: entry.headcount })),
+    }))
+    .filter(period => period.entries.length > 0)
+  return {
+    ownerType: 'resourceType',
+    allocationMode: rt.allocationMode,
+    allocationPercent: rt.allocationPercent,
+    allocationStartWeek: rt.allocationStartWeek,
+    allocationEndWeek: rt.allocationEndWeek,
+    count: rt.count,
+    namedResourcesCount: rt.namedResources.length,
+    activePlanEntries: rtPeriods.length > 0 ? rtPeriods : null,
+  }
+}
+
+export function buildNrEvidence(nr: RemediationNamedResource): Record<string, unknown> {
+  return {
+    ownerType: 'namedResource',
+    allocationMode: nr.allocationMode,
+    allocationPercent: nr.allocationPercent,
+    allocationPct: nr.allocationPct,
+    allocationStartWeek: nr.allocationStartWeek,
+    allocationEndWeek: nr.allocationEndWeek,
+    startWeek: nr.startWeek,
+    endWeek: nr.endWeek,
+  }
+}
+
+export function buildProfileEvidence(profile: RemediationProfile): Record<string, unknown> {
+  return {
+    profileId: profile.id,
+    ownerKind: profile.ownerKind,
+    planningBasis: profile.planningBasis,
+    source: profile.source,
+    defaultPercent: profile.defaultPercent,
+    startWeek: profile.startWeek,
+    endWeek: profile.endWeek,
+    segments: profile.segments.map(segment => ({
+      id: segment.id,
+      startWeek: segment.startWeek,
+      endWeek: segment.endWeek,
+      capacityPercent: segment.capacityPercent,
+      source: segment.source,
+    })),
+    legacy: profile.legacy == null ? null : canonicalJson(profile.legacy),
+  }
+}
+
+export function buildSnapshotEntryEvidence(
+  snapshotId: string,
+  entryType: 'resourceType' | 'namedResource',
+  entryId: string,
+  captured: Record<string, unknown>,
+): Record<string, unknown> {
+  return { snapshotId, entryType, entryId, captured }
+}
+
+function mapperLegacyForResourceType(rt: RemediationResourceType): Record<string, unknown> {
+  return {
+    allocationMode: rt.allocationMode,
+    allocationPercent: rt.allocationPercent,
+    allocationStartWeek: rt.allocationStartWeek,
+    allocationEndWeek: rt.allocationEndWeek,
+  }
+}
+
+function mapperLegacyForNamedResource(nr: RemediationNamedResource): Record<string, unknown> {
+  return {
+    allocationMode: nr.allocationMode,
+    allocationPercent: nr.allocationPercent,
+    allocationPct: nr.allocationPct,
+    allocationStartWeek: nr.allocationStartWeek,
+    allocationEndWeek: nr.allocationEndWeek,
+    startWeek: nr.startWeek,
+    endWeek: nr.endWeek,
+  }
+}
+
+// ─── Database state loader ──────────────────────────────────────────────────
+
+/**
+ * Load the exact current profile/snapshot state the planner inspects. This is
+ * the only Prisma-touching part of the planner; everything above is pure.
+ */
+export async function loadRemediationState(prisma: PrismaClient): Promise<RemediationDatabaseState> {
+  const projects = await prisma.project.findMany({
+    select: { id: true, name: true },
+    orderBy: { id: 'asc' },
+  })
+
+  const loadedProjects: RemediationProject[] = []
+  for (const project of projects) {
+    const [resourceTypes, capacityProfiles, activePlan] = await Promise.all([
+      prisma.resourceType.findMany({
+        where: { projectId: project.id },
+        orderBy: { id: 'asc' },
+        select: {
+          id: true,
+          name: true,
+          count: true,
+          allocationMode: true,
+          allocationPercent: true,
+          allocationStartWeek: true,
+          allocationEndWeek: true,
+          namedResources: {
+            orderBy: { id: 'asc' },
+            select: {
+              id: true,
+              name: true,
+              allocationMode: true,
+              allocationPercent: true,
+              allocationPct: true,
+              allocationStartWeek: true,
+              allocationEndWeek: true,
+              startWeek: true,
+              endWeek: true,
+            },
+          },
+        },
+      }),
+      prisma.capacityProfile.findMany({
+        where: { projectId: project.id },
+        orderBy: { id: 'asc' },
+        include: {
+          segments: {
+            orderBy: [{ startWeek: 'asc' }, { id: 'asc' }],
+          },
+        },
+      }),
+      prisma.capacityPlan.findFirst({
+        where: { projectId: project.id, isActive: true },
+        select: {
+          periods: {
+            orderBy: { periodIndex: 'asc' },
+            select: {
+              periodIndex: true,
+              startWeek: true,
+              endWeek: true,
+              entries: {
+                orderBy: { resourceTypeId: 'asc' },
+                select: { resourceTypeId: true, headcount: true },
+              },
+            },
+          },
+        },
+      }),
+    ])
+
+    loadedProjects.push({
+      id: project.id,
+      name: project.name,
+      resourceTypes: resourceTypes.map(rt => ({
+        id: rt.id,
+        name: rt.name,
+        count: rt.count,
+        allocationMode: rt.allocationMode,
+        allocationPercent: rt.allocationPercent,
+        allocationStartWeek: rt.allocationStartWeek,
+        allocationEndWeek: rt.allocationEndWeek,
+        namedResources: rt.namedResources.map(nr => ({
+          id: nr.id,
+          name: nr.name,
+          allocationMode: nr.allocationMode,
+          allocationPercent: nr.allocationPercent,
+          allocationPct: nr.allocationPct,
+          allocationStartWeek: nr.allocationStartWeek,
+          allocationEndWeek: nr.allocationEndWeek,
+          startWeek: nr.startWeek,
+          endWeek: nr.endWeek,
+        })),
+      })),
+      capacityProfiles: capacityProfiles.map(profile => ({
+        id: profile.id,
+        projectId: profile.projectId,
+        resourceTypeId: profile.resourceTypeId,
+        namedResourceId: profile.namedResourceId,
+        ownerKind: profile.ownerKind,
+        planningBasis: profile.planningBasis,
+        source: profile.source,
+        defaultPercent: profile.defaultPercent,
+        startWeek: profile.startWeek,
+        endWeek: profile.endWeek,
+        legacy: profile.legacy,
+        segments: profile.segments.map(segment => ({
+          id: segment.id,
+          startWeek: segment.startWeek,
+          endWeek: segment.endWeek,
+          capacityPercent: segment.capacityPercent,
+          source: segment.source,
+        })),
+      })),
+      activePlanPeriods: (activePlan?.periods ?? []).map(period => ({
+        periodIndex: period.periodIndex,
+        startWeek: period.startWeek,
+        endWeek: period.endWeek,
+        entries: period.entries.map(entry => ({
+          resourceTypeId: entry.resourceTypeId,
+          headcount: entry.headcount,
+        })),
+      })),
+    })
+  }
+
+  const snapshots = await prisma.backlogSnapshot.findMany({
+    select: { id: true, projectId: true, snapshot: true },
+    orderBy: { id: 'asc' },
+  })
+
+  return { projects: loadedProjects, snapshots }
+}
+
+// ─── Manifest merge ─────────────────────────────────────────────────────────
+
+export interface ResolvedPlanResult {
+  plan: RemediationPlan
+  errors: string[]
+}
+
+function capacityResolutionToProposed(
+  resolution: ManifestCapacityResolution,
+  base: {
+    profileId: string
+    ownerKind: 'ROLE' | 'NAMED_PERSON' | 'PLANNED_RESOURCE'
+    legacy: Record<string, unknown> | null
+  },
+): ProposedProfile {
+  switch (resolution.shape) {
+    case 'scalar-profile':
+      return {
+        profileId: base.profileId,
+        ownerKind: base.ownerKind,
+        planningBasis: resolution.planningBasis,
+        source: 'FIXED',
+        defaultPercent: resolution.defaultPercent ?? null,
+        startWeek: null,
+        endWeek: null,
+        legacy: base.legacy,
+        segments: [],
+      }
+    case 'availability-window':
+      return {
+        profileId: base.profileId,
+        ownerKind: base.ownerKind,
+        planningBasis: 'AVAILABILITY_WINDOW',
+        source: 'AVAILABILITY_WINDOW',
+        defaultPercent: resolution.defaultPercent ?? null,
+        startWeek: resolution.startWeek ?? null,
+        endWeek: resolution.endWeek ?? null,
+        legacy: base.legacy,
+        segments: [],
+      }
+    case 'segmented-capacity-profile':
+      return {
+        profileId: base.profileId,
+        ownerKind: base.ownerKind,
+        planningBasis: 'CAPACITY_PROFILE',
+        source: 'LEGACY',
+        defaultPercent: resolution.defaultPercent ?? null,
+        startWeek: null,
+        endWeek: null,
+        legacy: base.legacy,
+        segments: resolution.segments.map((segment, index) => ({
+          id: remediationSegmentId(base.profileId, index),
+          startWeek: segment.startWeek,
+          endWeek: segment.endWeek,
+          capacityPercent: segment.capacityPercent,
+          source: 'LEGACY',
+        })),
+      }
+  }
+}
+
+/**
+ * Merge an approved decision manifest into a plan, converting every resolved
+ * decision into a concrete operation. Validation errors are returned; the
+ * caller must refuse apply when `errors` is non-empty or any decision remains
+ * unresolved.
+ */
+export function resolvePlanWithManifest(
+  plan: RemediationPlan,
+  manifest: RemediationManifest,
+): ResolvedPlanResult {
+  const errors: string[] = []
+  if (manifest.formatVersion !== REMEDIATION_MANIFEST_FORMAT_VERSION) {
+    errors.push(`unsupported manifest formatVersion ${manifest.formatVersion}`)
+  }
+  if (manifest.planFingerprint !== plan.fingerprint) {
+    errors.push('manifest planFingerprint does not match the plan fingerprint — manifest references different plan content')
+  }
+  if (errors.length > 0) return { plan, errors }
+
+  const resolvedByDecisionId = new Map<string, ManifestDecision>()
+  for (const decision of manifest.decisions) {
+    if (resolvedByDecisionId.has(decision.decisionId)) {
+      errors.push(`duplicate manifest decision ${decision.decisionId}`)
+      continue
+    }
+    resolvedByDecisionId.set(decision.decisionId, decision)
+  }
+
+  const operations: RemediationOperation[] = [...plan.operations]
+  const decisions: PlanDecisionEntry[] = []
+  const findings: RemediationFinding[] = plan.findings.map(finding => ({ ...finding }))
+  const findingByDecisionId = new Map<string, RemediationFinding>()
+  for (const finding of findings) {
+    if (finding.decisionId) findingByDecisionId.set(finding.decisionId, finding)
+  }
+
+  for (const entry of plan.decisions) {
+    const manifestDecision = resolvedByDecisionId.get(entry.id)
+    if (!manifestDecision) {
+      decisions.push(entry)
+      continue
+    }
+    if (manifestDecision.projectId !== entry.projectId || manifestDecision.ownerId !== entry.ownerId) {
+      errors.push(`manifest decision ${entry.id} references ${manifestDecision.projectId}/${manifestDecision.ownerId} but the plan entry is ${entry.projectId}/${entry.ownerId}`)
+      continue
+    }
+    if (entry.snapshotId != null && manifestDecision.snapshotId !== entry.snapshotId) {
+      errors.push(`manifest decision ${entry.id} snapshot mismatch`)
+      continue
+    }
+    if (!entry.allowedResolutions.includes(manifestDecision.resolution.shape)) {
+      errors.push(`manifest decision ${entry.id} uses resolution shape "${manifestDecision.resolution.shape}" which is not allowed for this entry (allowed: ${entry.allowedResolutions.join(', ')})`)
+      continue
+    }
+
+    const resolution = manifestDecision.resolution
+    if (resolution.shape === 'snapshot-window-interpretation') {
+      if (!isNonNegativeInteger(resolution.startWeek) || !isNonNegativeInteger(resolution.endWeek) || resolution.startWeek > resolution.endWeek) {
+        errors.push(`manifest decision ${entry.id}: snapshot window interpretation must be non-negative with start <= end`)
+        continue
+      }
+      const finding = findingByDecisionId.get(entry.id)
+      if (finding) {
+        finding.classification = 'deterministic'
+        finding.operationId = `op-${String(operations.length + 1).padStart(4, '0')}`
+      }
+      operations.push({
+        id: `op-${String(operations.length + 1).padStart(4, '0')}`,
+        kind: 'rewrite-snapshot-entry',
+        classification: 'decisionResolved',
+        projectId: entry.projectId,
+        ownerId: entry.ownerId,
+        ownerName: '',
+        evidenceHash: entry.evidenceHash,
+        decisionId: entry.id,
+        proposed: {
+          snapshotId: entry.snapshotId!,
+          entryType: entry.ownerKind === 'role' ? 'resourceType' : 'namedResource',
+          entryId: entry.entryId!,
+          startWeek: resolution.startWeek,
+          endWeek: resolution.endWeek,
+        },
+      })
+      continue
+    }
+
+    // Profile-producing resolution (live owner or persisted profile).
+    let ownerKind: 'ROLE' | 'NAMED_PERSON' | 'PLANNED_RESOURCE'
+    let capacity: ManifestCapacityResolution
+    if (resolution.shape === 'owner-kind-decision') {
+      ownerKind = resolution.ownerKind
+      capacity = resolution.capacity
+    } else {
+      ownerKind = entry.ownerKind === 'role' ? 'ROLE' : 'NAMED_PERSON'
+      capacity = resolution
+    }
+
+    const profileId = entry.profileId ?? remediationProfileId(entry.ownerKind, entry.ownerId)
+    const proposed = capacityResolutionToProposed(capacity, {
+      profileId,
+      ownerKind,
+      legacy: entry.legacyBase ?? null,
+    })
+
+    const finding = findingByDecisionId.get(entry.id)
+    if (finding) {
+      finding.classification = 'deterministic'
+      finding.operationId = `op-${String(operations.length + 1).padStart(4, '0')}`
+    }
+    operations.push({
+      id: `op-${String(operations.length + 1).padStart(4, '0')}`,
+      kind: entry.profileId ? 'update-profile' : entry.ownerKind === 'role' ? 'create-role-profile' : 'create-named-profile',
+      classification: 'decisionResolved',
+      projectId: entry.projectId,
+      ownerId: entry.ownerId,
+      ownerName: '',
+      evidenceHash: entry.evidenceHash,
+      decisionId: entry.id,
+      proposed,
+    })
+  }
+
+  const merged: RemediationPlan = {
+    ...plan,
+    findings,
+    operations,
+    decisions,
+    summary: {
+      findings: {
+        deterministic: findings.filter(f => f.classification === 'deterministic').length,
+        decisionRequired: findings.filter(f => f.classification === 'decisionRequired').length,
+        unsupported: findings.filter(f => f.classification === 'unsupported').length,
+        alreadyValid: findings.filter(f => f.classification === 'alreadyValid').length,
+      },
+      operations: operations.length,
+      decisionsRequired: decisions.length,
+    },
+    fingerprint: computePlanFingerprint({
+      formatVersion: plan.formatVersion,
+      summary: {
+        findings: {
+          deterministic: findings.filter(f => f.classification === 'deterministic').length,
+          decisionRequired: findings.filter(f => f.classification === 'decisionRequired').length,
+          unsupported: findings.filter(f => f.classification === 'unsupported').length,
+          alreadyValid: findings.filter(f => f.classification === 'alreadyValid').length,
+        },
+        operations: operations.length,
+        decisionsRequired: decisions.length,
+      },
+      findings,
+      operations,
+      decisions,
+    }),
+  }
+  return { plan: merged, errors }
+}
+
+// ─── Plan serialisation / parsing ───────────────────────────────────────────
+
+export function planToJson(plan: RemediationPlan): string {
+  return JSON.stringify(plan, null, 2)
+}
+
+export interface ParsePlanResult {
+  plan: RemediationPlan | null
+  errors: string[]
+}
+
+export function parsePlanJson(raw: string): ParsePlanResult {
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch (error) {
+    return { plan: null, errors: [`plan is not valid JSON: ${error instanceof Error ? error.message : String(error)}`] }
+  }
+  if (typeof parsed !== 'object' || parsed === null) {
+    return { plan: null, errors: ['plan must be a JSON object'] }
+  }
+  const obj = parsed as Record<string, unknown>
+  if (obj.formatVersion !== REMEDIATION_PLAN_FORMAT_VERSION) {
+    return { plan: null, errors: [`unsupported plan formatVersion ${String(obj.formatVersion)} (expected ${REMEDIATION_PLAN_FORMAT_VERSION})`] }
+  }
+  if (!Array.isArray(obj.findings) || !Array.isArray(obj.operations) || !Array.isArray(obj.decisions)) {
+    return { plan: null, errors: ['plan must contain findings, operations and decisions arrays'] }
+  }
+  const candidate = obj as unknown as RemediationPlan
+  const recomputed = computePlanFingerprint({
+    formatVersion: candidate.formatVersion,
+    summary: candidate.summary,
+    findings: candidate.findings,
+    operations: candidate.operations,
+    decisions: candidate.decisions,
+  })
+  if (recomputed !== candidate.fingerprint) {
+    return { plan: null, errors: ['plan fingerprint mismatch — plan content was altered after review'] }
+  }
+  return { plan: candidate, errors: [] }
+}
+
+export function parseManifestJson(raw: string): { manifest: RemediationManifest | null; errors: string[] } {
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch (error) {
+    return { manifest: null, errors: [`manifest is not valid JSON: ${error instanceof Error ? error.message : String(error)}`] }
+  }
+  if (typeof parsed !== 'object' || parsed === null) {
+    return { manifest: null, errors: ['manifest must be a JSON object'] }
+  }
+  const obj = parsed as Record<string, unknown>
+  if (obj.formatVersion !== REMEDIATION_MANIFEST_FORMAT_VERSION) {
+    return { manifest: null, errors: [`unsupported manifest formatVersion ${String(obj.formatVersion)} (expected ${REMEDIATION_MANIFEST_FORMAT_VERSION})`] }
+  }
+  if (typeof obj.planFingerprint !== 'string' || !Array.isArray(obj.decisions)) {
+    return { manifest: null, errors: ['manifest must contain planFingerprint and decisions'] }
+  }
+  return { manifest: obj as unknown as RemediationManifest, errors: [] }
+}
+
+/** Exit classification for a plan (0 = clean, 1 = structural, 2 = decisions). */
+export function classifyPlanExit(plan: RemediationPlan): 0 | 1 | 2 {
+  if (plan.summary.findings.unsupported > 0) return 1
+  if (plan.summary.decisionsRequired > 0) return 2
+  return 0
+}
+
+// ─── Human-readable report ──────────────────────────────────────────────────
+
+export function formatRemediationPlanReport(plan: RemediationPlan): string {
+  const lines: string[] = []
+  lines.push('═══ Capacity-Profile Readiness Remediation Plan ═══')
+  lines.push('')
+  lines.push(`Application commit (informational): ${plan.applicationCommit}`)
+  lines.push(`Plan fingerprint: ${plan.fingerprint}`)
+  lines.push(`Format version: ${plan.formatVersion}`)
+  lines.push('')
+  lines.push('Summary:')
+  lines.push(`  deterministic changes:     ${plan.summary.findings.deterministic}`)
+  lines.push(`  explicit decisions needed: ${plan.summary.findings.decisionRequired}`)
+  lines.push(`  unsupported / invalid:     ${plan.summary.findings.unsupported}`)
+  lines.push(`  already valid / no action: ${plan.summary.findings.alreadyValid}`)
+  lines.push(`  operations (writes):       ${plan.summary.operations}`)
+  lines.push(`  unresolved decisions:      ${plan.summary.decisionsRequired}`)
+  lines.push('')
+  if (plan.summary.findings.unsupported > 0) {
+    lines.push('❌ Unsupported or structurally invalid findings present:')
+    for (const finding of plan.findings.filter(f => f.classification === 'unsupported')) {
+      lines.push(`   - ${finding.id}: ${finding.message} (${finding.projectId}${finding.ownerId ? ` / ${finding.ownerId}` : ''}${finding.snapshotId ? ` / snapshot ${finding.snapshotId}` : ''})`)
+    }
+    lines.push('')
+  }
+  if (plan.summary.findings.decisionRequired > 0) {
+    lines.push('⚠ Explicit reviewed decisions required:')
+    for (const decision of plan.decisions) {
+      lines.push(`   - ${decision.id}: ${decision.message} (${decision.projectId} / ${decision.ownerId}${decision.snapshotId ? ` / snapshot ${decision.snapshotId}` : ''})`)
+      lines.push(`     allowed resolutions: ${decision.allowedResolutions.join(', ')}`)
+    }
+    lines.push('')
+  }
+  if (plan.summary.operations > 0) {
+    lines.push('Planned operations (no writes in dry-run):')
+    for (const operation of plan.operations) {
+      lines.push(`   - ${operation.id}: ${operation.kind} ${operation.projectId} / ${operation.ownerId}${operation.decisionId ? ` (decision ${operation.decisionId})` : ''}`)
+    }
+    lines.push('')
+  }
+  const exit = classifyPlanExit(plan)
+  lines.push(exit === 0
+    ? '✅ PLAN VALID — no unresolved decisions.'
+    : exit === 2
+      ? '⚠ PLAN VALID BUT DECISIONS REMAIN — apply is refused until every decision is resolved.'
+      : '❌ PLAN INVALID — unsupported/structural findings must be reviewed before any apply.')
+  return lines.join('\n')
+}
+
+// re-export for apply's structural validation
+export type { ProfileStructureInput, ProfileStructureSegment }

--- a/server/src/lib/productionRemediationPlan.ts
+++ b/server/src/lib/productionRemediationPlan.ts
@@ -230,13 +230,17 @@ export interface PlanDecisionEntry {
   allowedResolutions: string[]
   message: string
   /**
-   * Owner-kind-required NamedResource decisions only: when the parent
-   * ResourceType's ROLE profile can be derived deterministically, this
-   * carries the derived profile so an explicit PLANNED_RESOURCE selection can
-   * also create the planner-owned ROLE profile (readiness completeness
-   * requires it). Null/absent when the ROLE cannot be proven — the
-   * PLANNED_RESOURCE selection is then rejected rather than guessed.
+   * Owner-kind-required NamedResource decisions only. Parent ROLE state for a
+   * PLANNED_RESOURCE selection:
+   *   - 'existing': exactly one structurally valid ROLE profile exists — it
+   *     is retained; no parent operation is emitted;
+   *   - 'derived': no valid ROLE profile exists and the deterministic
+   *     derivation was captured (roleOwnerId/roleProposed/roleEvidenceHash);
+   *     the merge coordinates at most one creation per parent ResourceType;
+   *   - 'unproven': no valid ROLE profile and no deterministic derivation —
+   *     PLANNED_RESOURCE is rejected rather than guessed.
    */
+  roleState?: 'existing' | 'derived' | 'unproven'
   roleOwnerId?: string | null
   roleProposed?: ProposedProfile | null
   roleEvidenceHash?: string | null
@@ -1042,15 +1046,34 @@ export function buildRemediationPlan(
             proposed: derived.proposed,
           })
         } else if (derived.classification === 'decisionRequired') {
-          // The parent role's ROLE profile may be required if the reviewed
-          // decision selects PLANNED_RESOURCE (planner-owned completeness).
-          const roleDerivation = deriveRoleProfileFromLegacy(rt, stateProjectsActivePlan(state, project.id))
-          const roleProposed = roleDerivation.classification === 'deterministic'
-            ? roleDerivation.proposed ?? null
-            : null
-          const roleEvidenceHash = roleProposed
-            ? evidenceHash(buildRtEvidence(rt, stateProjectsActivePlan(state, project.id)))
-            : null
+          // Parent ROLE state for a PLANNED_RESOURCE selection (issue #421
+          // review round 3): exactly one structurally valid ROLE profile is
+          // retained as-is; otherwise a deterministic derivation is captured
+          // for coordination; anything else stays fail-closed ('unproven').
+          const parentRoleProfiles = (profilesByOwner.get(`rt::${rt.id}`) ?? [])
+            .filter(p => p.ownerKind === 'ROLE')
+          const validParentRole = parentRoleProfiles.length === 1 &&
+            validateProfileStructure(parentRoleProfiles[0]!, context).length === 0
+          let roleState: 'existing' | 'derived' | 'unproven'
+          let roleProposed: ProposedProfile | null = null
+          let roleEvidenceHash: string | null = null
+          if (validParentRole) {
+            roleState = 'existing'
+          } else if (parentRoleProfiles.length > 0) {
+            // A parent ROLE profile exists but is not a valid single owner
+            // state — never replace or duplicate it without a separate
+            // explicit reviewed decision.
+            roleState = 'unproven'
+          } else {
+            const roleDerivation = deriveRoleProfileFromLegacy(rt, stateProjectsActivePlan(state, project.id))
+            if (roleDerivation.classification === 'deterministic' && roleDerivation.proposed) {
+              roleState = 'derived'
+              roleProposed = roleDerivation.proposed
+              roleEvidenceHash = evidenceHash(buildRtEvidence(rt, stateProjectsActivePlan(state, project.id)))
+            } else {
+              roleState = 'unproven'
+            }
+          }
           addDecision(finding, {
             projectId: project.id,
             ownerId: nr.id,
@@ -1067,7 +1090,8 @@ export function buildRemediationPlan(
             // NAMED_PERSON.
             allowedResolutions: ['owner-kind-decision'],
             message: `${derived.message} — owner kind and capacity require explicit review`,
-            roleOwnerId: roleProposed ? rt.id : null,
+            roleState,
+            roleOwnerId: roleState === 'derived' ? rt.id : null,
             roleProposed,
             roleEvidenceHash,
           })
@@ -1679,6 +1703,32 @@ export function resolvePlanWithManifest(
     if (finding.decisionId) findingByDecisionId.set(finding.decisionId, finding)
   }
 
+  // ── Parent ROLE coordination (issue #421 review round 3) ─────────────────
+  // Baseline ROLE-profile operations (create or update) indexed by parent
+  // ResourceType id, so PLANNED_RESOURCE decisions can reuse a compatible
+  // existing operation instead of emitting a duplicate.
+  const baselineRoleOpsByParent = new Map<string, RemediationOperation[]>()
+  for (const op of plan.operations) {
+    const proposed = op.proposed as ProposedProfile
+    const isRoleOp = op.kind === 'create-role-profile' ||
+      (op.kind === 'update-profile' && proposed?.ownerKind === 'ROLE')
+    if (isRoleOp) {
+      const list = baselineRoleOpsByParent.get(op.ownerId) ?? []
+      list.push(op)
+      baselineRoleOpsByParent.set(op.ownerId, list)
+    }
+  }
+  // Parent ROLE requirements introduced by resolved PLANNED_RESOURCE
+  // decisions, grouped deterministically by parent ResourceType id. Multiple
+  // child decisions for the same parent collapse into one requirement;
+  // incompatible proposals are rejected instead of silently selecting one.
+  const roleRequirements = new Map<string, {
+    projectId: string
+    roleProposed: ProposedProfile
+    roleEvidenceHash: string
+    decisionIds: string[]
+  }>()
+
   for (const entry of plan.decisions) {
     const manifestDecision = resolvedByDecisionId.get(entry.id)
     if (!manifestDecision) {
@@ -1746,14 +1796,42 @@ export function resolvePlanWithManifest(
       }
       // A PLANNED_RESOURCE selection makes the parent role planner-owned,
       // which requires exactly one ROLE profile (readiness completeness).
-      // The ROLE profile must come from the reviewed deterministic
-      // derivation captured at dry-run — never invented here.
-      if (resolution.ownerKind === 'PLANNED_RESOURCE' && !(entry.roleProposed && entry.roleEvidenceHash && entry.roleOwnerId)) {
-        errors.push(
-          `manifest decision ${entry.id}: PLANNED_RESOURCE requires a deterministically derivable parent ROLE profile, ` +
-          'which is not available for this owner — choose NAMED_PERSON or resolve the parent role separately',
-        )
-        continue
+      // The ROLE profile comes from the reviewed deterministic derivation
+      // captured at dry-run — never invented here. A valid existing ROLE
+      // profile is retained as-is (roleState 'existing'); a derived
+      // proposal is coordinated once per parent (roleState 'derived');
+      // anything else stays fail-closed (roleState 'unproven').
+      if (resolution.ownerKind === 'PLANNED_RESOURCE') {
+        if (entry.roleState === 'existing') {
+          // Valid parent ROLE profile already exists — retained, no parent op.
+        } else if (entry.roleState === 'derived' && entry.roleOwnerId && entry.roleProposed && entry.roleEvidenceHash) {
+          const requirement = roleRequirements.get(entry.roleOwnerId)
+          if (requirement) {
+            if (
+              requirement.roleEvidenceHash !== entry.roleEvidenceHash ||
+              canonicalJson(requirement.roleProposed) !== canonicalJson(entry.roleProposed)
+            ) {
+              errors.push(
+                `manifest decisions ${requirement.decisionIds.join(', ')} and ${entry.id} imply conflicting parent ROLE proposals for ResourceType ${entry.roleOwnerId}`,
+              )
+              continue
+            }
+            requirement.decisionIds.push(entry.id)
+          } else {
+            roleRequirements.set(entry.roleOwnerId, {
+              projectId: entry.projectId,
+              roleProposed: entry.roleProposed,
+              roleEvidenceHash: entry.roleEvidenceHash,
+              decisionIds: [entry.id],
+            })
+          }
+        } else {
+          errors.push(
+            `manifest decision ${entry.id}: PLANNED_RESOURCE requires a valid existing or deterministically derivable parent ROLE profile, ` +
+            'which is not available for this owner — choose NAMED_PERSON or resolve the parent role separately',
+          )
+          continue
+        }
       }
       ownerKind = resolution.ownerKind
       capacity = resolution.capacity
@@ -1785,23 +1863,37 @@ export function resolvePlanWithManifest(
       decisionId: entry.id,
       proposed,
     })
+  }
 
-    // PLANNED_RESOURCE selection: also create the planner-owned ROLE profile
-    // for the parent ResourceType (exact deterministic derivation captured at
-    // dry-run; readiness completeness requires it).
-    if (resolution.shape === 'owner-kind-decision' && ownerKind === 'PLANNED_RESOURCE' && entry.roleOwnerId && entry.roleProposed && entry.roleEvidenceHash) {
-      operations.push({
-        id: `op-${String(operations.length + 1).padStart(4, '0')}`,
-        kind: 'create-role-profile',
-        classification: 'decisionResolved',
-        projectId: entry.projectId,
-        ownerId: entry.roleOwnerId,
-        ownerName: '',
-        evidenceHash: entry.roleEvidenceHash,
-        decisionId: entry.id,
-        proposed: entry.roleProposed,
-      })
+  // ── Emit coordinated parent ROLE operations (at most one per parent) ─────
+  // Deterministic order: requirements sorted by parent ResourceType id. A
+  // compatible baseline ROLE operation for the parent is reused; otherwise
+  // exactly one create operation is emitted for all PLANNED_RESOURCE child
+  // decisions sharing the parent.
+  for (const [parentId, requirement] of [...roleRequirements.entries()].sort((a, b) => a[0].localeCompare(b[0]))) {
+    const baselineOps = baselineRoleOpsByParent.get(parentId) ?? []
+    if (baselineOps.length > 0) {
+      const compatible = baselineOps.some(op => canonicalJson(op.proposed) === canonicalJson(requirement.roleProposed))
+      if (!compatible) {
+        errors.push(
+          `parent ROLE requirement for ResourceType ${parentId} (decisions ${requirement.decisionIds.join(', ')}) conflicts with ` +
+          `baseline operation(s) ${baselineOps.map(op => op.id).join(', ')} — resolve the parent role with a separate reviewed decision`,
+        )
+      }
+      // Compatible baseline operations are reused; no duplicate is emitted.
+      continue
     }
+    operations.push({
+      id: `op-${String(operations.length + 1).padStart(4, '0')}`,
+      kind: 'create-role-profile',
+      classification: 'decisionResolved',
+      projectId: requirement.projectId,
+      ownerId: parentId,
+      ownerName: '',
+      evidenceHash: requirement.roleEvidenceHash,
+      decisionId: requirement.decisionIds[0]!,
+      proposed: requirement.roleProposed,
+    })
   }
 
   const merged: RemediationPlan = {

--- a/server/src/lib/productionRemediationPlan.ts
+++ b/server/src/lib/productionRemediationPlan.ts
@@ -25,7 +25,7 @@
  */
 
 import { createHash } from 'node:crypto'
-import type { PrismaClient } from '@prisma/client'
+import type { Prisma, PrismaClient } from '@prisma/client'
 
 import {
   mapResourceTypeToCapacityProfile,
@@ -229,6 +229,17 @@ export interface PlanDecisionEntry {
   evidenceHash: string
   allowedResolutions: string[]
   message: string
+  /**
+   * Owner-kind-required NamedResource decisions only: when the parent
+   * ResourceType's ROLE profile can be derived deterministically, this
+   * carries the derived profile so an explicit PLANNED_RESOURCE selection can
+   * also create the planner-owned ROLE profile (readiness completeness
+   * requires it). Null/absent when the ROLE cannot be proven — the
+   * PLANNED_RESOURCE selection is then rejected rather than guessed.
+   */
+  roleOwnerId?: string | null
+  roleProposed?: ProposedProfile | null
+  roleEvidenceHash?: string | null
 }
 
 export interface RemediationPlanSummary {
@@ -242,6 +253,14 @@ export interface RemediationPlan {
   generatedAt: string
   /** Informational: the git commit the plan was generated on (never enforced). */
   applicationCommit: string
+  /**
+   * SHA-256 over the canonical complete remediation state (projects,
+   * resource types, named resources, profiles, segments, active plan periods
+   * and backlog snapshots) the plan was generated from. Apply re-loads the
+   * same scope inside the transaction and refuses before any write when the
+   * current state does not match this hash (issue #421 review round 2).
+   */
+  baselineStateHash: string
   /** SHA-256 over the canonical actionable content (stable across reruns). */
   fingerprint: string
   summary: RemediationPlanSummary
@@ -336,6 +355,7 @@ export function computePlanFingerprint(plan: {
   findings: RemediationFinding[]
   operations: RemediationOperation[]
   decisions: PlanDecisionEntry[]
+  baselineStateHash: string
 }): string {
   return sha256Hex(canonicalJson({
     formatVersion: plan.formatVersion,
@@ -343,7 +363,17 @@ export function computePlanFingerprint(plan: {
     findings: plan.findings,
     operations: plan.operations,
     decisions: plan.decisions,
+    baselineStateHash: plan.baselineStateHash,
   }))
+}
+
+/**
+ * SHA-256 over the canonical complete remediation state — the exact scope
+ * the dry-run planner inspects. Apply recomputes this from a fresh load
+ * inside the transaction and refuses before the first write on any mismatch.
+ */
+export function computeStateHash(state: RemediationDatabaseState): string {
+  return sha256Hex(canonicalJson(state))
 }
 
 // ─── Small domain helpers ───────────────────────────────────────────────────
@@ -1012,6 +1042,15 @@ export function buildRemediationPlan(
             proposed: derived.proposed,
           })
         } else if (derived.classification === 'decisionRequired') {
+          // The parent role's ROLE profile may be required if the reviewed
+          // decision selects PLANNED_RESOURCE (planner-owned completeness).
+          const roleDerivation = deriveRoleProfileFromLegacy(rt, stateProjectsActivePlan(state, project.id))
+          const roleProposed = roleDerivation.classification === 'deterministic'
+            ? roleDerivation.proposed ?? null
+            : null
+          const roleEvidenceHash = roleProposed
+            ? evidenceHash(buildRtEvidence(rt, stateProjectsActivePlan(state, project.id)))
+            : null
           addDecision(finding, {
             projectId: project.id,
             ownerId: nr.id,
@@ -1020,8 +1059,17 @@ export function buildRemediationPlan(
             snapshotId: null,
             entryId: null,
             legacyBase: mapperLegacyForNamedResource(nr),
-            allowedResolutions: ['scalar-profile', 'availability-window', 'segmented-capacity-profile'],
-            message: derived.message,
+            // The owner kind of a missing NamedResource with unproven
+            // capacity is itself unproven (issue #421: never guess owner kind
+            // or planner intent). Only an explicit owner-kind decision with a
+            // nested capacity resolution is accepted; a direct capacity
+            // resolution must never silently default the owner to
+            // NAMED_PERSON.
+            allowedResolutions: ['owner-kind-decision'],
+            message: `${derived.message} — owner kind and capacity require explicit review`,
+            roleOwnerId: roleProposed ? rt.id : null,
+            roleProposed,
+            roleEvidenceHash,
           })
         }
       }
@@ -1291,6 +1339,7 @@ export function buildRemediationPlan(
     formatVersion: REMEDIATION_PLAN_FORMAT_VERSION,
     generatedAt: new Date().toISOString(),
     applicationCommit,
+    baselineStateHash: computeStateHash(state),
     fingerprint: '',
     summary,
     findings,
@@ -1399,8 +1448,10 @@ function mapperLegacyForNamedResource(nr: RemediationNamedResource): Record<stri
 /**
  * Load the exact current profile/snapshot state the planner inspects. This is
  * the only Prisma-touching part of the planner; everything above is pure.
+ * Accepts a transaction client so the apply can perform its full-scope drift
+ * check inside the same transaction as the writes.
  */
-export async function loadRemediationState(prisma: PrismaClient): Promise<RemediationDatabaseState> {
+export async function loadRemediationState(prisma: PrismaClient | Prisma.TransactionClient): Promise<RemediationDatabaseState> {
   const projects = await prisma.project.findMany({
     select: { id: true, name: true },
     orderBy: { id: 'asc' },
@@ -1577,13 +1628,17 @@ function capacityResolutionToProposed(
         startWeek: null,
         endWeek: null,
         legacy: base.legacy,
-        segments: resolution.segments.map((segment, index) => ({
-          id: remediationSegmentId(base.profileId, index),
-          startWeek: segment.startWeek,
-          endWeek: segment.endWeek,
-          capacityPercent: segment.capacityPercent,
-          source: 'LEGACY',
-        })),
+        // Persisted segments are ordered by (startWeek, id); proposed segments
+        // must use the same ordering so read-back verification is exact.
+        segments: resolution.segments
+          .map((segment, index) => ({
+            id: remediationSegmentId(base.profileId, index),
+            startWeek: segment.startWeek,
+            endWeek: segment.endWeek,
+            capacityPercent: segment.capacityPercent,
+            source: 'LEGACY',
+          }))
+          .sort((a, b) => a.startWeek - b.startWeek || a.id.localeCompare(b.id)),
       }
   }
 }
@@ -1678,6 +1733,28 @@ export function resolvePlanWithManifest(
     let ownerKind: 'ROLE' | 'NAMED_PERSON' | 'PLANNED_RESOURCE'
     let capacity: ManifestCapacityResolution
     if (resolution.shape === 'owner-kind-decision') {
+      // Defensive runtime validation of hand-edited manifests: the nested
+      // capacity shape must be one of the three supported shapes.
+      const nestedShape = resolution.capacity?.shape
+      if (
+        nestedShape !== 'scalar-profile' &&
+        nestedShape !== 'availability-window' &&
+        nestedShape !== 'segmented-capacity-profile'
+      ) {
+        errors.push(`manifest decision ${entry.id}: unknown nested capacity shape ${JSON.stringify(nestedShape)}`)
+        continue
+      }
+      // A PLANNED_RESOURCE selection makes the parent role planner-owned,
+      // which requires exactly one ROLE profile (readiness completeness).
+      // The ROLE profile must come from the reviewed deterministic
+      // derivation captured at dry-run — never invented here.
+      if (resolution.ownerKind === 'PLANNED_RESOURCE' && !(entry.roleProposed && entry.roleEvidenceHash && entry.roleOwnerId)) {
+        errors.push(
+          `manifest decision ${entry.id}: PLANNED_RESOURCE requires a deterministically derivable parent ROLE profile, ` +
+          'which is not available for this owner — choose NAMED_PERSON or resolve the parent role separately',
+        )
+        continue
+      }
       ownerKind = resolution.ownerKind
       capacity = resolution.capacity
     } else {
@@ -1708,6 +1785,23 @@ export function resolvePlanWithManifest(
       decisionId: entry.id,
       proposed,
     })
+
+    // PLANNED_RESOURCE selection: also create the planner-owned ROLE profile
+    // for the parent ResourceType (exact deterministic derivation captured at
+    // dry-run; readiness completeness requires it).
+    if (resolution.shape === 'owner-kind-decision' && ownerKind === 'PLANNED_RESOURCE' && entry.roleOwnerId && entry.roleProposed && entry.roleEvidenceHash) {
+      operations.push({
+        id: `op-${String(operations.length + 1).padStart(4, '0')}`,
+        kind: 'create-role-profile',
+        classification: 'decisionResolved',
+        projectId: entry.projectId,
+        ownerId: entry.roleOwnerId,
+        ownerName: '',
+        evidenceHash: entry.roleEvidenceHash,
+        decisionId: entry.id,
+        proposed: entry.roleProposed,
+      })
+    }
   }
 
   const merged: RemediationPlan = {
@@ -1740,6 +1834,7 @@ export function resolvePlanWithManifest(
       findings,
       operations,
       decisions,
+      baselineStateHash: plan.baselineStateHash,
     }),
   }
   return { plan: merged, errors }
@@ -1773,6 +1868,9 @@ export function parsePlanJson(raw: string): ParsePlanResult {
   if (!Array.isArray(obj.findings) || !Array.isArray(obj.operations) || !Array.isArray(obj.decisions)) {
     return { plan: null, errors: ['plan must contain findings, operations and decisions arrays'] }
   }
+  if (typeof obj.baselineStateHash !== 'string') {
+    return { plan: null, errors: ['plan must contain baselineStateHash'] }
+  }
   const candidate = obj as unknown as RemediationPlan
   const recomputed = computePlanFingerprint({
     formatVersion: candidate.formatVersion,
@@ -1780,6 +1878,7 @@ export function parsePlanJson(raw: string): ParsePlanResult {
     findings: candidate.findings,
     operations: candidate.operations,
     decisions: candidate.decisions,
+    baselineStateHash: candidate.baselineStateHash,
   })
   if (recomputed !== candidate.fingerprint) {
     return { plan: null, errors: ['plan fingerprint mismatch — plan content was altered after review'] }
@@ -1822,6 +1921,7 @@ export function formatRemediationPlanReport(plan: RemediationPlan): string {
   lines.push('')
   lines.push(`Application commit (informational): ${plan.applicationCommit}`)
   lines.push(`Plan fingerprint: ${plan.fingerprint}`)
+  lines.push(`Baseline state hash: ${plan.baselineStateHash}`)
   lines.push(`Format version: ${plan.formatVersion}`)
   lines.push('')
   lines.push('Summary:')

--- a/server/src/lib/projectSnapshotCapacity.ts
+++ b/server/src/lib/projectSnapshotCapacity.ts
@@ -240,6 +240,50 @@ function isNonNegativeInteger(value: unknown): value is number {
 }
 
 /**
+ * Issue #421 never-active window policy.
+ *
+ * A captured window is "never active" when no non-negative week can ever
+ * match it under the legacy scheduler gate (`week >= start && week <= end`):
+ *
+ *  - both edges are the `-1` sentinel that the legacy Squad Planner apply
+ *    path wrote for named resources without an assigned slot window
+ *    (`routes/squadPlan.ts`, pre-#359: `slotWindows[idx] ?? { startWeek: -1,
+ *    endWeek: -1, allocationPercent: 100 }`); or
+ *  - the window is inverted (`start > end`), which the legacy scheduler
+ *    tolerated without clamping — no week satisfies the gate, so the entry
+ *    contributed zero capacity.
+ *
+ * Evidence: `server/src/test/scheduler.test.ts` ("slot never active →
+ * endWeek=-1 → does not contribute capacity") and the pre-cutover
+ * `scheduler.getWeeklyCapacity` window gate (`start = nr.startWeek ?? 0`,
+ * `end = nr.endWeek ?? Infinity`, match only when `week >= start &&
+ * week <= end`). `null`/`Infinity` meant unbounded; `-1` never meant
+ * "unset" or "unbounded" — it meant "never active".
+ *
+ * The translated state is a zero-capacity profile (defaultPercent 0, null
+ * window): the exact historical effective capacity, never a guess. A single
+ * `-1` edge (or any other negative value) has no established meaning and is
+ * NOT normalised here — callers treat it as requiring an explicit decision.
+ */
+export function isNeverActiveWindow(
+  start: number | null | undefined,
+  end: number | null | undefined,
+): boolean {
+  if (start === -1 && end === -1) return true
+  // Inverted window with non-negative edges: the legacy scheduler tolerated it
+  // without clamping and no week can ever match the gate.
+  return (
+    start != null &&
+    end != null &&
+    Number.isFinite(start) &&
+    Number.isFinite(end) &&
+    start >= 0 &&
+    end >= 0 &&
+    start > end
+  )
+}
+
+/**
  * Deterministic translation of a historical v2 snapshot into authoritative
  * CapacityProfile rows, using ONLY the values captured in the v2 payload
  * (never the active CapacityPlan, never sync/reconciliation tooling).
@@ -258,6 +302,12 @@ function isNonNegativeInteger(value: unknown): value is number {
  *                              CAPACITY_PLAN without a captured start/end
  *                              window cannot be translated without guessing
  *                              and is rejected).
+ *   - never-active windows    → (-1, -1) pairs (the legacy Squad Planner
+ *                              "no slot window" sentinel) and inverted windows
+ *                              (start > end, tolerated unclamped by the legacy
+ *                              scheduler) translate to a zero-capacity
+ *                              AVAILABILITY_WINDOW profile with a null window
+ *                              (issue #421 policy, `isNeverActiveWindow`).
  *
  * Every NamedResource must reference a ResourceType included in the same
  * snapshot (orphan rows are rejected with a clear error before any write).
@@ -302,23 +352,31 @@ export function translateV2SnapshotProfiles(
       errors.push(`${prefix}: allocationPercent must be finite`)
     }
     const rtModeUsesWindows = rt.allocationMode === 'TIMELINE' || rt.allocationMode === 'CAPACITY_PLAN'
-    for (const [key, value] of [
-      ['allocationStartWeek', rt.allocationStartWeek],
-      ['allocationEndWeek', rt.allocationEndWeek],
-    ] as const) {
-      if (value != null && !isNonNegativeInteger(value)) {
-        errors.push(`${prefix}: ${key} must be a non-negative integer or null`)
-      }
-    }
-    // Window aliases are only meaningful for the modes that used them;
-    // EFFORT/FULL_PROJECT stale aliases are discarded, never validated.
-    if (
+    // Issue #421 never-active policy: a captured (-1, -1) pair or an inverted
+    // window (start > end) never contributed capacity; it translates to a
+    // zero-capacity profile with a null window instead of failing.
+    const rtNeverActive =
       rtModeUsesWindows &&
-      rt.allocationStartWeek != null &&
-      rt.allocationEndWeek != null &&
-      rt.allocationStartWeek > rt.allocationEndWeek
-    ) {
-      errors.push(`${prefix}: allocationStartWeek must not exceed allocationEndWeek`)
+      isNeverActiveWindow(rt.allocationStartWeek, rt.allocationEndWeek)
+    if (!rtNeverActive) {
+      for (const [key, value] of [
+        ['allocationStartWeek', rt.allocationStartWeek],
+        ['allocationEndWeek', rt.allocationEndWeek],
+      ] as const) {
+        if (value != null && !isNonNegativeInteger(value)) {
+          errors.push(`${prefix}: ${key} must be a non-negative integer or null`)
+        }
+      }
+      // Window aliases are only meaningful for the modes that used them;
+      // EFFORT/FULL_PROJECT stale aliases are discarded, never validated.
+      if (
+        rtModeUsesWindows &&
+        rt.allocationStartWeek != null &&
+        rt.allocationEndWeek != null &&
+        rt.allocationStartWeek > rt.allocationEndWeek
+      ) {
+        errors.push(`${prefix}: allocationStartWeek must not exceed allocationEndWeek`)
+      }
     }
     if (rt.allocationMode === 'CAPACITY_PLAN' && (rt.allocationStartWeek == null || rt.allocationEndWeek == null)) {
       errors.push(
@@ -331,8 +389,8 @@ export function translateV2SnapshotProfiles(
     // translation discards them so the resulting DEMAND_FOLLOWING /
     // WHOLE_PROJECT_ALLOCATION profile is structurally valid.
     const modeDiscardsWindows = rt.allocationMode === 'EFFORT' || rt.allocationMode === 'FULL_PROJECT' || rt.allocationMode == null
-    const roleStartWeek = modeDiscardsWindows ? null : rt.allocationStartWeek
-    const roleEndWeek = modeDiscardsWindows ? null : rt.allocationEndWeek
+    const roleStartWeek = modeDiscardsWindows || rtNeverActive ? null : rt.allocationStartWeek
+    const roleEndWeek = modeDiscardsWindows || rtNeverActive ? null : rt.allocationEndWeek
     profiles.push({
       id: `snapshot-v2-role-${rt.id}`,
       projectId,
@@ -341,7 +399,7 @@ export function translateV2SnapshotProfiles(
       ownerKind: 'ROLE',
       planningBasis: basis,
       source,
-      defaultPercent: rt.allocationPercent,
+      defaultPercent: rtNeverActive ? 0 : rt.allocationPercent,
       startWeek: roleStartWeek,
       endWeek: roleEndWeek,
       legacy: {
@@ -384,21 +442,28 @@ export function translateV2SnapshotProfiles(
     if (nr.allocationPct != null && !Number.isFinite(nr.allocationPct)) {
       errors.push(`${prefix}: allocationPct must be finite`)
     }
-    for (const [key, value] of [
-      ['allocationStartWeek', nr.allocationStartWeek],
-      ['allocationEndWeek', nr.allocationEndWeek],
-      ['startWeek', nr.startWeek],
-      ['endWeek', nr.endWeek],
-    ] as const) {
-      if (value != null && !isNonNegativeInteger(value)) {
-        errors.push(`${prefix}: ${key} must be a non-negative integer or null`)
-      }
-    }
     const effectiveStart = nr.allocationStartWeek ?? nr.startWeek
     const effectiveEnd = nr.allocationEndWeek ?? nr.endWeek
     const nrModeUsesWindows = mode === 'TIMELINE' || mode === 'CAPACITY_PLAN'
-    if (nrModeUsesWindows && effectiveStart != null && effectiveEnd != null && effectiveStart > effectiveEnd) {
-      errors.push(`${prefix}: allocation window start must not exceed end`)
+    // Issue #421 never-active policy (same as the resource-type branch): a
+    // captured (-1, -1) pair or inverted window never contributed capacity;
+    // its window aliases are normalised instead of rejected.
+    const nrNeverActive =
+      nrModeUsesWindows && isNeverActiveWindow(effectiveStart, effectiveEnd)
+    if (!nrNeverActive) {
+      for (const [key, value] of [
+        ['allocationStartWeek', nr.allocationStartWeek],
+        ['allocationEndWeek', nr.allocationEndWeek],
+        ['startWeek', nr.startWeek],
+        ['endWeek', nr.endWeek],
+      ] as const) {
+        if (value != null && !isNonNegativeInteger(value)) {
+          errors.push(`${prefix}: ${key} must be a non-negative integer or null`)
+        }
+      }
+      if (nrModeUsesWindows && effectiveStart != null && effectiveEnd != null && effectiveStart > effectiveEnd) {
+        errors.push(`${prefix}: allocation window start must not exceed end`)
+      }
     }
     if (mode === 'CAPACITY_PLAN' && (effectiveStart == null || effectiveEnd == null)) {
       errors.push(
@@ -412,8 +477,8 @@ export function translateV2SnapshotProfiles(
     // resulting DEMAND_FOLLOWING / WHOLE_PROJECT_ALLOCATION profile is
     // structurally valid.
     const modeDiscardsWindows = mode === 'EFFORT' || mode === 'FULL_PROJECT' || mode == null
-    const namedStartWeek = modeDiscardsWindows ? null : effectiveStart
-    const namedEndWeek = modeDiscardsWindows ? null : effectiveEnd
+    const namedStartWeek = modeDiscardsWindows || nrNeverActive ? null : effectiveStart
+    const namedEndWeek = modeDiscardsWindows || nrNeverActive ? null : effectiveEnd
     profiles.push({
       id: `snapshot-v2-named-${nr.id}`,
       projectId,
@@ -422,7 +487,7 @@ export function translateV2SnapshotProfiles(
       ownerKind: 'NAMED_PERSON',
       planningBasis: basis,
       source,
-      defaultPercent: effectivePercent,
+      defaultPercent: nrNeverActive ? 0 : effectivePercent,
       startWeek: namedStartWeek,
       endWeek: namedEndWeek,
       legacy: {

--- a/server/src/scripts/remediateProductionReadiness.ts
+++ b/server/src/scripts/remediateProductionReadiness.ts
@@ -1,0 +1,245 @@
+/**
+ * remediateProductionReadiness.ts — Issue #421: standalone explicitly-invoked
+ * remediation command for production capacity-profile readiness blockers.
+ *
+ * NEVER runs during application startup or from an HTTP request; exposes no
+ * API or UI. Requires explicit CLI invocation.
+ *
+ * Usage:
+ *   npx tsx src/scripts/remediateProductionReadiness.ts                     # dry-run (default)
+ *   npx tsx src/scripts/remediateProductionReadiness.ts --json plan.json    # dry-run + machine plan
+ *   npx tsx src/scripts/remediateProductionReadiness.ts --json plan.json --manifest decisions.json
+ *   npx tsx src/scripts/remediateProductionReadiness.ts --apply --plan plan.json [--manifest decisions.json]
+ *
+ * Or via npm scripts (repository root):
+ *   npm run capacity-profiles:remediate-readiness -- --dry-run
+ *   npm run capacity-profiles:remediate-readiness -- --apply --plan <reviewed-plan.json>
+ *
+ * Exit contract:
+ *   0 — plan is valid and has no unresolved decisions (apply mode: every
+ *       operation applied or already applied, and post-apply readiness is clean);
+ *   1 — operational, structural or drift failure (apply mode: nothing was
+ *       written when the failure occurred before the transaction committed);
+ *   2 — plan is valid but explicit decisions remain unresolved (apply refused).
+ *
+ * Dry-run performs ZERO writes. Apply performs only the reviewed plan
+ * operations inside one transaction. Credentials and complete database URLs
+ * are never printed.
+ */
+
+import { execSync } from 'node:child_process'
+import { readFileSync, writeFileSync } from 'node:fs'
+import { PrismaPg } from '@prisma/adapter-pg'
+import { PrismaClient } from '@prisma/client'
+import 'dotenv/config'
+
+import {
+  buildRemediationPlan,
+  classifyPlanExit,
+  loadRemediationState,
+  parseManifestJson,
+  parsePlanJson,
+  formatRemediationPlanReport,
+  planToJson,
+  resolvePlanWithManifest,
+  type RemediationManifest,
+  type RemediationPlan,
+} from '../lib/productionRemediationPlan.js'
+import { applyRemediationPlan } from '../lib/productionRemediationApply.js'
+import {
+  runProductionMigrationReadiness,
+  formatReadinessReport,
+} from '../lib/productionMigrationReadiness.js'
+
+// ─── CLI argument parsing ──────────────────────────────────────────────────
+
+interface CliOptions {
+  dryRun: boolean
+  apply: boolean
+  planPath: string | null
+  manifestPath: string | null
+  jsonPath: string | null
+}
+
+function parseArgs(args: string[]): CliOptions | { error: string } {
+  const options: CliOptions = {
+    dryRun: true,
+    apply: false,
+    planPath: null,
+    manifestPath: null,
+    jsonPath: null,
+  }
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i]
+    switch (arg) {
+      case '--dry-run':
+        options.dryRun = true
+        break
+      case '--apply':
+        options.apply = true
+        options.dryRun = false
+        break
+      case '--plan':
+        options.planPath = args[++i] ?? null
+        if (!options.planPath) return { error: '--plan requires a file path' }
+        break
+      case '--manifest':
+        options.manifestPath = args[++i] ?? null
+        if (!options.manifestPath) return { error: '--manifest requires a file path' }
+        break
+      case '--json':
+        options.jsonPath = args[++i] ?? null
+        if (!options.jsonPath) return { error: '--json requires a file path' }
+        break
+      default:
+        return { error: `unknown argument "${arg}"` }
+    }
+  }
+  if (options.apply && !options.planPath) {
+    return { error: '--apply requires --plan <reviewed-plan.json>' }
+  }
+  if (options.dryRun && options.planPath) {
+    return { error: '--plan is only valid with --apply' }
+  }
+  return options
+}
+
+function currentCommit(): string {
+  try {
+    return execSync('git rev-parse HEAD', { stdio: ['ignore', 'pipe', 'ignore'], encoding: 'utf-8' }).trim()
+  } catch {
+    return 'unknown'
+  }
+}
+
+function usage(): string {
+  return [
+    'Usage:',
+    '  remediateProductionReadiness.ts [--dry-run] [--json <plan.json>] [--manifest <decisions.json>]',
+    '  remediateProductionReadiness.ts --apply --plan <reviewed-plan.json> [--manifest <decisions.json>]',
+    '',
+    'Exit codes: 0 = plan valid & no unresolved decisions; 1 = operational/structural/drift failure; 2 = decisions remain unresolved.',
+  ].join('\n')
+}
+
+// ─── Main ──────────────────────────────────────────────────────────────────
+
+async function main(): Promise<number> {
+  const parsed = parseArgs(process.argv.slice(2))
+  if ('error' in parsed) {
+    console.error(`❌ ${parsed.error}`)
+    console.error(usage())
+    return 1
+  }
+  const options = parsed
+
+  console.log('🔧 Capacity-Profile Readiness Remediation')
+  console.log('=========================================')
+  console.log(options.apply ? 'Mode: APPLY (writes only the reviewed plan)' : 'Mode: DRY-RUN (zero writes)')
+  console.log('')
+
+  const adapter = new PrismaPg({ connectionString: process.env.DATABASE_URL })
+  const prisma = new PrismaClient({ adapter })
+
+  try {
+    if (!options.apply) {
+      const state = await loadRemediationState(prisma)
+      const plan = buildRemediationPlan(state, currentCommit())
+
+      let manifest: RemediationManifest | null = null
+      if (options.manifestPath) {
+        let raw: string
+        try {
+          raw = readFileSync(options.manifestPath, 'utf-8')
+        } catch (error) {
+          console.error(`❌ Cannot read manifest: ${error instanceof Error ? error.message : String(error)}`)
+          return 1
+        }
+        const parsedManifest = parseManifestJson(raw)
+        if (!parsedManifest.manifest) {
+          console.error(`❌ ${parsedManifest.errors.join('; ')}`)
+          return 1
+        }
+        manifest = parsedManifest.manifest
+        const resolved = resolvePlanWithManifest(plan, manifest)
+        if (resolved.errors.length > 0) {
+          console.error('❌ Manifest validation failed:')
+          for (const error of resolved.errors) console.error(`   - ${error}`)
+          return 1
+        }
+        console.log(`Manifest: ${manifest.decisions.length} decision(s) merged for reporting.`)
+        console.log('')
+        console.log(formatRemediationPlanReport(resolved.plan))
+        if (options.jsonPath) {
+          writeFileSync(options.jsonPath, planToJson(resolved.plan))
+          console.log(`\nPlan written to ${options.jsonPath}`)
+        }
+        const exit = classifyPlanExit(resolved.plan)
+        return exit
+      }
+
+      // Baseline dry-run: also run the permanent readiness check for context.
+      const readiness = await runProductionMigrationReadiness(prisma)
+      console.log(formatReadinessReport(readiness))
+      console.log('')
+      console.log(formatRemediationPlanReport(plan))
+      if (options.jsonPath) {
+        writeFileSync(options.jsonPath, planToJson(plan))
+        console.log(`\nPlan written to ${options.jsonPath}`)
+      }
+      return classifyPlanExit(plan)
+    }
+
+    // ── Apply mode ───────────────────────────────────────────────────────
+    if (!options.planPath) {
+      console.error('❌ --apply requires --plan <reviewed-plan.json>')
+      return 1
+    }
+    let planRaw: string
+    try {
+      planRaw = readFileSync(options.planPath, 'utf-8')
+    } catch (error) {
+      console.error(`❌ Cannot read plan: ${error instanceof Error ? error.message : String(error)}`)
+      return 1
+    }
+    const parsedPlan = parsePlanJson(planRaw)
+    if (!parsedPlan.plan) {
+      console.error(`❌ ${parsedPlan.errors.join('; ')}`)
+      return 1
+    }
+    const plan: RemediationPlan = parsedPlan.plan
+
+    let manifest: RemediationManifest | null = null
+    if (options.manifestPath) {
+      let raw: string
+      try {
+        raw = readFileSync(options.manifestPath, 'utf-8')
+      } catch (error) {
+        console.error(`❌ Cannot read manifest: ${error instanceof Error ? error.message : String(error)}`)
+        return 1
+      }
+      const parsedManifest = parseManifestJson(raw)
+      if (!parsedManifest.manifest) {
+        console.error(`❌ ${parsedManifest.errors.join('; ')}`)
+        return 1
+      }
+      manifest = parsedManifest.manifest
+    }
+
+    console.log(`Plan: ${options.planPath} (fingerprint ${plan.fingerprint})`)
+    console.log(`Plan application commit: ${plan.applicationCommit}`)
+    console.log('')
+    const outcome = await applyRemediationPlan(prisma, { plan, manifest })
+    console.log(outcome.report)
+    return outcome.exitCode
+  } catch (error) {
+    console.error('')
+    console.error('❌ Remediation command failed:', error instanceof Error ? error.message : String(error))
+    return 1
+  } finally {
+    await prisma.$disconnect()
+  }
+}
+
+const exitCode = await main()
+process.exit(exitCode)

--- a/server/src/test/legacyCapacityFieldSourceGuard.ts
+++ b/server/src/test/legacyCapacityFieldSourceGuard.ts
@@ -58,6 +58,8 @@ export const GUARD_ALLOWLIST = [
   'src/lib/capacityProfileMapping.ts',
   'src/lib/syncCapacityProfiles.ts',
   'src/lib/reconcileCapacityProfiles.ts',
+  'src/lib/productionRemediationPlan.ts',
+  'src/lib/productionRemediationApply.ts',
 ] as const
 
 export interface GuardFinding {

--- a/server/src/test/productionRemediation.integration.test.ts
+++ b/server/src/test/productionRemediation.integration.test.ts
@@ -1,0 +1,1188 @@
+/**
+ * productionRemediation.integration.test.ts — Real PostgreSQL 15 integration
+ * tests for the Issue #421 capacity-profile readiness remediation command.
+ *
+ * Proves against a disposable database:
+ *   - dry-run performs zero writes, classifies every production blocker class
+ *     and produces stable fingerprints/counts;
+ *   - deterministic apply creates/corrects profiles while preserving exact
+ *     effective capacity, profile/segment identity and candidate columns;
+ *   - manifest decisions resolve ambiguous owners exactly and block apply
+ *     when unresolved, malformed or fingerprint-mismatched;
+ *   - the apply transaction rolls back on any failure (no partial success);
+ *   - historical v2 snapshot policy (never-active normalisation, windowless
+ *     CAPACITY_PLAN decisions, minimal rewrites) is shared by readiness and
+ *     rollback;
+ *   - end-to-end: readiness fails → dry-run → approved plan applies → audit
+ *     passes → readiness passes → runtime resolver loads → representative
+ *     snapshot restoration succeeds → candidate columns remain.
+ *
+ * Requires INTEGRATION_TEST=true and a disposable PostgreSQL 15 Docker
+ * container (see scripts/run-integration-local.mjs).
+ */
+import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest'
+import { PrismaPg } from '@prisma/adapter-pg'
+import { PrismaClient, Prisma } from '@prisma/client'
+import type { $Enums } from '@prisma/client'
+
+import {
+  buildRemediationPlan,
+  classifyPlanExit,
+  loadRemediationState,
+  parsePlanJson,
+  planToJson,
+  resolvePlanWithManifest,
+  type RemediationManifest,
+  type RemediationPlan,
+} from '../lib/productionRemediationPlan.js'
+import {
+  applyRemediationPlan,
+  __setRemediationApplyFailureSeam,
+} from '../lib/productionRemediationApply.js'
+import {
+  runProductionMigrationReadiness,
+  formatReadinessReport,
+} from '../lib/productionMigrationReadiness.js'
+import { runOwnershipAudit } from '../lib/capacityProfileOwnershipAudit.js'
+import { resolveSchedulerCapacity } from '../lib/schedulerCapacityResolver.js'
+import { rollbackProjectSnapshot } from '../lib/projectSnapshotService.js'
+import { translateV2SnapshotProfiles } from '../lib/projectSnapshotCapacity.js'
+import { parseSnapshotData, isSnapshotV2 } from '../lib/projectSnapshotTypes.js'
+
+// ─── Guard ──────────────────────────────────────────────────────────────────
+
+const runIntegration = process.env.INTEGRATION_TEST === 'true'
+const describeIf = runIntegration ? describe : describe.skip
+
+// ─── Shared state ───────────────────────────────────────────────────────────
+
+let prisma: PrismaClient
+let ownerId: string
+
+const createdProjectIds: string[] = []
+
+beforeAll(async () => {
+  if (!runIntegration) return
+  prisma = new PrismaClient({
+    adapter: new PrismaPg({ connectionString: process.env.DATABASE_URL }),
+  })
+  await prisma.$connect()
+  await prisma.backlogSnapshot.deleteMany({})
+  await prisma.featureTemplate.deleteMany({})
+  await prisma.project.deleteMany({})
+  await prisma.customer.deleteMany({})
+  await prisma.documentTemplate.deleteMany({})
+  await prisma.user.deleteMany({})
+  const user = await prisma.user.create({
+    data: {
+      email: `remediation-${Date.now()}@example.com`,
+      name: 'Remediation Test',
+      password: '$2b$10$placeholder',
+    },
+  })
+  ownerId = user.id
+})
+
+afterEach(async () => {
+  if (!runIntegration) return
+  __setRemediationApplyFailureSeam(null)
+  await prisma.backlogSnapshot.deleteMany({})
+  await prisma.capacitySegment.deleteMany({})
+  await prisma.capacityProfile.deleteMany({})
+  await prisma.capacityPlanEntry.deleteMany({})
+  await prisma.capacityPlanPeriod.deleteMany({})
+  await prisma.capacityPlan.deleteMany({})
+  await prisma.namedResource.deleteMany({})
+  await prisma.resourceType.deleteMany({})
+  await prisma.featureTemplate.deleteMany({})
+  await prisma.project.deleteMany({})
+  await prisma.customer.deleteMany({})
+  await prisma.documentTemplate.deleteMany({})
+  await prisma.user.deleteMany({})
+  createdProjectIds.length = 0
+  // Recreate the owner user wiped above so the next test can create projects.
+  const user = await prisma.user.create({
+    data: {
+      email: `remediation-${Date.now()}@example.com`,
+      name: 'Remediation Test',
+      password: '$2b$10$placeholder',
+    },
+  })
+  ownerId = user.id
+})
+
+afterAll(async () => {
+  if (!runIntegration) return
+  await prisma.backlogSnapshot.deleteMany({})
+  await prisma.capacitySegment.deleteMany({})
+  await prisma.capacityProfile.deleteMany({})
+  await prisma.capacityPlanEntry.deleteMany({})
+  await prisma.capacityPlanPeriod.deleteMany({})
+  await prisma.capacityPlan.deleteMany({})
+  await prisma.namedResource.deleteMany({})
+  await prisma.resourceType.deleteMany({})
+  await prisma.project.deleteMany({})
+  await prisma.customer.deleteMany({})
+  await prisma.documentTemplate.deleteMany({})
+  await prisma.user.deleteMany({})
+  await prisma.$disconnect()
+})
+
+// ─── Fixture helpers ────────────────────────────────────────────────────────
+
+let fixtureCounter = 0
+
+async function createProject(name = 'Remediation Project'): Promise<string> {
+  const project = await prisma.project.create({
+    data: { name: `${name} ${Date.now()}-${fixtureCounter++}`, ownerId },
+  })
+  createdProjectIds.push(project.id)
+  return project.id
+}
+
+async function createRole(
+  projectId: string,
+  overrides: Partial<{
+    name: string
+    allocationMode: $Enums.AllocationMode | null
+    allocationPercent: number | null
+    allocationStartWeek: number | null
+    allocationEndWeek: number | null
+    count: number
+  }> = {},
+): Promise<string> {
+  const rt = await prisma.resourceType.create({
+    data: {
+      name: overrides.name ?? `Role ${fixtureCounter++}`,
+      category: 'ENGINEERING',
+      count: overrides.count ?? 1,
+      projectId,
+      allocationMode: overrides.allocationMode ?? 'TIMELINE',
+      allocationPercent: overrides.allocationPercent ?? 100,
+      allocationStartWeek: overrides.allocationStartWeek ?? null,
+      allocationEndWeek: overrides.allocationEndWeek ?? null,
+    },
+  })
+  return rt.id
+}
+
+async function createNamedPerson(
+  projectId: string,
+  rtId: string,
+  overrides: Partial<{
+    name: string
+    allocationMode: $Enums.AllocationMode | null
+    allocationPercent: number | null
+    allocationPct: number | null
+    allocationStartWeek: number | null
+    allocationEndWeek: number | null
+    startWeek: number | null
+    endWeek: number | null
+  }> = {},
+): Promise<string> {
+  void projectId
+  const nr = await prisma.namedResource.create({
+    data: {
+      name: overrides.name ?? `Person ${fixtureCounter++}`,
+      resourceTypeId: rtId,
+      allocationMode: overrides.allocationMode ?? 'EFFORT',
+      allocationPercent: overrides.allocationPercent ?? 100,
+      allocationPct: overrides.allocationPct ?? 100,
+      allocationStartWeek: overrides.allocationStartWeek ?? null,
+      allocationEndWeek: overrides.allocationEndWeek ?? null,
+      startWeek: overrides.startWeek ?? null,
+      endWeek: overrides.endWeek ?? null,
+    },
+  })
+  return nr.id
+}
+
+async function createProfile(
+  projectId: string,
+  data: {
+    resourceTypeId?: string | null
+    namedResourceId?: string | null
+    ownerKind: $Enums.CapacityProfileOwnerKind
+    planningBasis: $Enums.CapacityProfilePlanningBasis
+    source: $Enums.CapacityProfileSource
+    defaultPercent?: number | null
+    startWeek?: number | null
+    endWeek?: number | null
+    legacy?: unknown
+    segments?: Array<{ id?: string; startWeek: number; endWeek: number; capacityPercent: number; source: $Enums.CapacityProfileSource }>
+    id?: string
+  },
+): Promise<string> {
+  const profile = await prisma.capacityProfile.create({
+    data: {
+      ...(data.id ? { id: data.id } : {}),
+      projectId,
+      resourceTypeId: data.resourceTypeId ?? null,
+      namedResourceId: data.namedResourceId ?? null,
+      ownerKind: data.ownerKind,
+      planningBasis: data.planningBasis,
+      source: data.source,
+      defaultPercent: data.defaultPercent ?? null,
+      startWeek: data.startWeek ?? null,
+      endWeek: data.endWeek ?? null,
+      legacy: data.legacy as never,
+      segments: data.segments
+        ? { create: data.segments.map(segment => ({
+            ...(segment.id ? { id: segment.id } : {}),
+            startWeek: segment.startWeek,
+            endWeek: segment.endWeek,
+            capacityPercent: segment.capacityPercent,
+            source: segment.source,
+          })) }
+        : undefined,
+    },
+  })
+  return profile.id
+}
+
+async function createActivePlan(
+  projectId: string,
+  periods: Array<{ periodIndex: number; startWeek: number; endWeek: number; entries: Array<{ resourceTypeId: string; headcount: number }> }>,
+): Promise<void> {
+  await prisma.capacityPlan.create({
+    data: {
+      projectId,
+      name: `Plan ${fixtureCounter++}`,
+      targetWeeks: 52,
+      periodWeeks: 4,
+      isActive: true,
+      periods: {
+        create: periods.map(period => ({
+          periodIndex: period.periodIndex,
+          startWeek: period.startWeek,
+          endWeek: period.endWeek,
+          entries: {
+            create: period.entries.map(entry => ({
+              resourceTypeId: entry.resourceTypeId,
+              headcount: entry.headcount,
+              demandFTE: entry.headcount,
+              utilisationPct: 100,
+            })),
+          },
+        })),
+      },
+    },
+  })
+}
+
+async function createBacklogSnapshot(projectId: string, payload: unknown): Promise<string> {
+  const snapshot = await prisma.backlogSnapshot.create({
+    data: {
+      projectId,
+      label: `remediation fixture ${fixtureCounter++}`,
+      trigger: 'manual',
+      snapshot: payload as object,
+      createdById: ownerId,
+    },
+  })
+  return snapshot.id
+}
+
+function v2Snapshot(payload: {
+  resourceTypes?: Array<Record<string, unknown>>
+  namedResources?: Array<Record<string, unknown>>
+  sentinel?: Record<string, unknown>
+}): Record<string, unknown> {
+  return {
+    schemaVersion: 2,
+    epics: [],
+    project: null,
+    resourceTypes: payload.resourceTypes ?? [],
+    namedResources: payload.namedResources ?? [],
+    timelineEntries: [],
+    storyTimelineEntries: [],
+    epicDependencies: [],
+    featureDependencies: [],
+    overheadItems: [],
+    ...payload.sentinel,
+  }
+}
+
+function v2Role(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: 'rt-snap-1',
+    name: 'Snapshot Role',
+    category: 'ENGINEERING',
+    count: 1,
+    hoursPerDay: null,
+    dayRate: null,
+    allocationMode: 'EFFORT',
+    globalTypeId: null,
+    allocationPercent: 100,
+    allocationStartWeek: null,
+    allocationEndWeek: null,
+    ...overrides,
+  }
+}
+
+function v2Person(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: 'nr-snap-1',
+    resourceTypeId: 'rt-snap-1',
+    name: 'Snapshot Person',
+    startWeek: null,
+    endWeek: null,
+    allocationPct: 100,
+    allocationMode: 'EFFORT',
+    allocationPercent: 100,
+    allocationStartWeek: null,
+    allocationEndWeek: null,
+    pricingModel: 'ACTUAL_DAYS',
+    ...overrides,
+  }
+}
+
+async function runDryRun(): Promise<{ plan: RemediationPlan; exit: number }> {
+  const state = await loadRemediationState(prisma)
+  const plan = buildRemediationPlan(state, 'test-commit')
+  return { plan, exit: classifyPlanExit(plan) }
+}
+
+async function buildManifest(plan: RemediationPlan, resolutions: Array<{ decisionId: string; resolution: RemediationManifest['decisions'][number]['resolution'] }>): Promise<RemediationManifest> {
+  return {
+    formatVersion: 1,
+    applicationCommit: 'test-commit',
+    planFingerprint: plan.fingerprint,
+    decisions: resolutions.map(({ decisionId, resolution }) => {
+      const entry = plan.decisions.find(d => d.id === decisionId)!
+      return {
+        decisionId,
+        projectId: entry.projectId,
+        ownerId: entry.ownerId,
+        snapshotId: entry.snapshotId,
+        resolution,
+        rationale: 'integration test',
+      }
+    }),
+  }
+}
+
+async function candidateColumnsPresent(): Promise<boolean> {
+  const rows = await prisma.$queryRaw<Array<{ column_name: string }>>(
+    Prisma.sql`SELECT column_name FROM information_schema.columns
+      WHERE table_name IN ('ResourceType', 'NamedResource')
+        AND column_name IN ('allocationMode','allocationPercent','allocationPct','allocationStartWeek','allocationEndWeek','startWeek','endWeek')`,
+  )
+  return rows.length === 11
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// 1. Planning and dry-run
+// ════════════════════════════════════════════════════════════════════════════
+
+describeIf('remediation dry-run', () => {
+  it('performs zero writes and classifies deterministic + decision-required owners', async () => {
+    const projectId = await createProject()
+    await createRole(projectId, { allocationMode: 'TIMELINE' })
+    await createRole(projectId, { allocationMode: 'EFFORT' })
+    await createRole(projectId, { allocationMode: 'FULL_PROJECT' })
+    await createRole(projectId, { allocationMode: 'CAPACITY_PLAN' })
+
+    const profilesBefore = await prisma.capacityProfile.count()
+    const segmentsBefore = await prisma.capacitySegment.count()
+
+    const { plan, exit } = await runDryRun()
+    expect(exit).toBe(2) // decisions remain
+    expect(profilesBefore).toBe(await prisma.capacityProfile.count())
+    expect(segmentsBefore).toBe(await prisma.capacitySegment.count())
+    expect(plan.summary.findings.deterministic).toBe(3)
+    expect(plan.summary.findings.decisionRequired).toBe(1)
+    expect(plan.operations).toHaveLength(3)
+    expect(plan.operations.every(op => op.classification === 'deterministic')).toBe(true)
+    expect(plan.decisions).toHaveLength(1)
+  })
+
+  it('produces stable fingerprints across repeated dry-runs', async () => {
+    const projectId = await createProject()
+    await createRole(projectId, { allocationMode: 'TIMELINE', allocationPercent: 80 })
+    await createNamedPerson(projectId, await createRole(projectId, { allocationMode: 'TIMELINE' }), {
+      allocationMode: 'TIMELINE',
+      startWeek: 0,
+      endWeek: 8,
+    })
+
+    const first = await runDryRun()
+    const second = await runDryRun()
+    expect(first.plan.fingerprint).toBe(second.plan.fingerprint)
+    // generatedAt is intentionally volatile; the fingerprint is the stability
+    // contract, and the rest of the JSON content must be identical.
+    const stripGeneratedAt = (plan: typeof first.plan) => {
+      const { generatedAt, ...rest } = plan
+      void generatedAt
+      return JSON.stringify(rest)
+    }
+    expect(stripGeneratedAt(first.plan)).toBe(stripGeneratedAt(second.plan))
+    // Round-trip through the file contract keeps the fingerprint valid.
+    const parsed = parsePlanJson(planToJson(first.plan))
+    expect(parsed.errors).toEqual([])
+    expect(parsed.plan!.fingerprint).toBe(first.plan.fingerprint)
+  })
+
+  it('never prints credentials or database URLs in plan output', async () => {
+    const projectId = await createProject()
+    await createRole(projectId, { allocationMode: 'TIMELINE' })
+    const { plan } = await runDryRun()
+    const json = planToJson(plan)
+    expect(json).not.toContain('postgres://')
+    expect(json).not.toContain('postgresql://')
+    expect(json).not.toContain('DATABASE_URL')
+    expect(json).not.toContain('password')
+    expect(formatReadinessReport(await runProductionMigrationReadiness(prisma)))
+      .not.toContain('postgres://')
+  })
+
+  it('handles production-scale fixture counts without speculative infrastructure', async () => {
+    const projectId = await createProject('Scale Project')
+    for (let i = 0; i < 2000; i++) {
+      await createRole(projectId, {
+        allocationMode: i % 10 === 0 ? 'EFFORT' : 'TIMELINE',
+        allocationPercent: null,
+      })
+    }
+    const { plan } = await runDryRun()
+    expect(plan.summary.findings.deterministic).toBe(2000)
+    expect(plan.operations).toHaveLength(2000)
+  })
+})
+
+// ════════════════════════════════════════════════════════════════════════════
+// 2. Deterministic apply
+// ════════════════════════════════════════════════════════════════════════════
+
+describeIf('remediation deterministic apply', () => {
+  it('creates missing deterministic ROLE profiles (TIMELINE/EFFORT/FULL_PROJECT) and preserves capacity', async () => {
+    const projectId = await createProject()
+    const timelineRt = await createRole(projectId, { allocationMode: 'TIMELINE', allocationPercent: 75, allocationStartWeek: 2, allocationEndWeek: 10 })
+    const effortRt = await createRole(projectId, { allocationMode: 'EFFORT' })
+    const fullProjectRt = await createRole(projectId, { allocationMode: 'FULL_PROJECT', allocationPercent: 40 })
+
+    const { plan } = await runDryRun()
+    expect(classifyPlanExit(plan)).toBe(0)
+    const outcome = await applyRemediationPlan(prisma, { plan })
+    expect(outcome.exitCode).toBe(0)
+    expect(outcome.applied).toBe(3)
+    expect(outcome.errors).toEqual([])
+    expect(outcome.postApply!.readinessPassed).toBe(true)
+
+    const timelineProfile = await prisma.capacityProfile.findFirstOrThrow({ where: { resourceTypeId: timelineRt } })
+    expect(timelineProfile).toMatchObject({
+      ownerKind: 'ROLE',
+      planningBasis: 'AVAILABILITY_WINDOW',
+      source: 'AVAILABILITY_WINDOW',
+      defaultPercent: 75,
+      startWeek: 2,
+      endWeek: 10,
+    })
+    const effortProfile = await prisma.capacityProfile.findFirstOrThrow({ where: { resourceTypeId: effortRt } })
+    expect(effortProfile).toMatchObject({ planningBasis: 'DEMAND_FOLLOWING', source: 'FIXED', startWeek: null, endWeek: null })
+    const fullProfile = await prisma.capacityProfile.findFirstOrThrow({ where: { resourceTypeId: fullProjectRt } })
+    expect(fullProfile).toMatchObject({ planningBasis: 'WHOLE_PROJECT_ALLOCATION', source: 'FIXED', defaultPercent: 40 })
+
+    // Legacy provenance captured in the mapper shape.
+    const legacy = timelineProfile.legacy as Record<string, unknown>
+    expect(legacy.allocationMode).toBe('TIMELINE')
+    expect(legacy.allocationPercent).toBe(75)
+  })
+
+  it('creates missing NAMED_PERSON profiles (TIMELINE/FULL_PROJECT/EFFORT/CAPACITY_PLAN-with-window)', async () => {
+    const projectId = await createProject()
+    const parent = await createRole(projectId, { allocationMode: 'EFFORT' })
+    await createNamedPerson(projectId, parent, {
+      allocationMode: 'TIMELINE', allocationPercent: 50, startWeek: 0, endWeek: 8,
+    })
+    await createNamedPerson(projectId, parent, { allocationMode: 'FULL_PROJECT', allocationPercent: 80 })
+    await createNamedPerson(projectId, parent, { allocationMode: 'EFFORT' })
+    await createNamedPerson(projectId, parent, { allocationMode: 'CAPACITY_PLAN', allocationPercent: 100, startWeek: 1, endWeek: 6 })
+
+    const { plan } = await runDryRun()
+    expect(classifyPlanExit(plan)).toBe(0)
+    const outcome = await applyRemediationPlan(prisma, { plan })
+    expect(outcome.exitCode).toBe(0)
+    expect(outcome.applied).toBe(4)
+
+    const profiles = await prisma.capacityProfile.findMany({
+      where: { projectId, ownerKind: 'NAMED_PERSON' },
+      orderBy: { namedResourceId: 'asc' },
+    })
+    expect(profiles).toHaveLength(4)
+    // TIMELINE person: AVAILABILITY_WINDOW/AVAILABILITY_WINDOW at 50% 0-8.
+    const timelinePerson = profiles.find(p => p.source === 'AVAILABILITY_WINDOW')
+    expect(timelinePerson).toMatchObject({ planningBasis: 'AVAILABILITY_WINDOW', defaultPercent: 50, startWeek: 0, endWeek: 8 })
+    // FULL_PROJECT person.
+    const fullPerson = profiles.find(p => p.planningBasis === 'WHOLE_PROJECT_ALLOCATION')
+    expect(fullPerson).toMatchObject({ source: 'FIXED', defaultPercent: 80, startWeek: null, endWeek: null })
+    // EFFORT person.
+    const effortPerson = profiles.find(p => p.planningBasis === 'DEMAND_FOLLOWING')
+    expect(effortPerson).toMatchObject({ source: 'FIXED', defaultPercent: 100, startWeek: null, endWeek: null })
+    // CAPACITY_PLAN with captured window follows the v2 policy.
+    const windowPerson = profiles.find(p => p.source === 'LEGACY')
+    expect(windowPerson).toMatchObject({ planningBasis: 'AVAILABILITY_WINDOW', defaultPercent: 100, startWeek: 1, endWeek: 6 })
+  })
+
+  it('reconstructs planner-owned ROLE profiles only from exact captured plan evidence', async () => {
+    const projectId = await createProject()
+    const plannerRt = await createRole(projectId, { allocationMode: 'CAPACITY_PLAN', count: 2 })
+    await createActivePlan(projectId, [
+      { periodIndex: 0, startWeek: 0, endWeek: 8, entries: [{ resourceTypeId: plannerRt, headcount: 2 }] },
+      { periodIndex: 1, startWeek: 8, endWeek: 16, entries: [{ resourceTypeId: plannerRt, headcount: 1 }] },
+    ])
+
+    const { plan } = await runDryRun()
+    const roleOps = plan.operations.filter(op => op.ownerId === plannerRt)
+    expect(roleOps).toHaveLength(1)
+    expect(roleOps[0]!.kind).toBe('create-role-profile')
+    const outcome = await applyRemediationPlan(prisma, { plan })
+    expect(outcome.exitCode).toBe(0)
+
+    const profile = await prisma.capacityProfile.findFirstOrThrow({ where: { resourceTypeId: plannerRt } })
+    expect(profile).toMatchObject({ planningBasis: 'CAPACITY_PROFILE', source: 'SQUAD_PLANNER' })
+    const segments = await prisma.capacitySegment.findMany({ where: { capacityProfileId: profile.id }, orderBy: { startWeek: 'asc' } })
+    expect(segments.length).toBeGreaterThan(0)
+    expect(segments[0]).toMatchObject({ startWeek: 0, endWeek: 7, capacityPercent: 200, source: 'SQUAD_PLANNER' })
+  })
+
+  it('normalises stale DEMAND_FOLLOWING windows and fixes the contained overlap preserving IDs', async () => {
+    const projectId = await createProject()
+    const personRt = await createRole(projectId, { allocationMode: 'TIMELINE' })
+    const nrId = await createNamedPerson(projectId, personRt, { allocationMode: 'EFFORT' })
+
+    // Stale DEMAND_FOLLOWING window profile (production blocker D).
+    const staleProfileId = await createProfile(projectId, {
+      namedResourceId: nrId,
+      ownerKind: 'NAMED_PERSON',
+      planningBasis: 'DEMAND_FOLLOWING',
+      source: 'FIXED',
+      defaultPercent: 100,
+      startWeek: 0,
+      endWeek: 29,
+      legacy: { allocationMode: 'EFFORT', allocationPercent: 100, allocationStartWeek: 0, allocationEndWeek: 29 },
+    })
+
+    // Overlapping segments profile (production blocker D).
+    const overlapRt = await createRole(projectId, { allocationMode: 'CAPACITY_PLAN', count: 1 })
+    const overlapProfileId = await createProfile(projectId, {
+      resourceTypeId: overlapRt,
+      ownerKind: 'ROLE',
+      planningBasis: 'CAPACITY_PROFILE',
+      source: 'SQUAD_PLANNER',
+      defaultPercent: 25,
+      startWeek: 39,
+      endWeek: 64,
+      segments: [
+        { id: 'seg-overlap-a', startWeek: 39, endWeek: 64, capacityPercent: 25, source: 'SQUAD_PLANNER' },
+        { id: 'seg-overlap-b', startWeek: 52, endWeek: 64, capacityPercent: 25, source: 'SQUAD_PLANNER' },
+      ],
+    })
+
+    const { plan } = await runDryRun()
+    const staleOp = plan.operations.find(op => op.proposed !== null && 'profileId' in op.proposed && (op.proposed as { profileId: string }).profileId === staleProfileId)
+    expect(staleOp?.kind).toBe('update-profile')
+    const overlapOp = plan.operations.find(op => 'proposed' in op && op.proposed !== null && 'profileId' in op.proposed && (op.proposed as { profileId: string }).profileId === overlapProfileId)
+    expect(overlapOp?.kind).toBe('update-profile')
+
+    const outcome = await applyRemediationPlan(prisma, { plan })
+    expect(outcome.exitCode).toBe(0)
+    expect(outcome.postApply!.readinessPassed).toBe(true)
+
+    const staleProfile = await prisma.capacityProfile.findUniqueOrThrow({ where: { id: staleProfileId } })
+    expect(staleProfile.startWeek).toBeNull()
+    expect(staleProfile.endWeek).toBeNull()
+    expect(staleProfile.defaultPercent).toBe(100)
+    // Legacy provenance untouched.
+    expect((staleProfile.legacy as Record<string, unknown>).allocationMode).toBe('EFFORT')
+
+    const overlapSegments = await prisma.capacitySegment.findMany({
+      where: { capacityProfileId: overlapProfileId },
+      orderBy: { startWeek: 'asc' },
+    })
+    expect(overlapSegments).toHaveLength(2)
+    expect(overlapSegments[0]).toMatchObject({ id: 'seg-overlap-a', startWeek: 39, endWeek: 51, capacityPercent: 25 })
+    expect(overlapSegments[1]).toMatchObject({ id: 'seg-overlap-b', startWeek: 52, endWeek: 64, capacityPercent: 50 })
+  })
+
+  it('preserves candidate columns and leaves normal runtime profile-first', async () => {
+    const projectId = await createProject()
+    const rtId = await createRole(projectId, { allocationMode: 'TIMELINE', allocationPercent: 90 })
+    const nrId = await createNamedPerson(projectId, rtId, { allocationMode: 'TIMELINE', startWeek: 0, endWeek: 4 })
+
+    const beforeRt = await prisma.resourceType.findUniqueOrThrow({ where: { id: rtId } })
+    const beforeNr = await prisma.namedResource.findUniqueOrThrow({ where: { id: nrId } })
+
+    const { plan } = await runDryRun()
+    const outcome = await applyRemediationPlan(prisma, { plan })
+    expect(outcome.exitCode).toBe(0)
+
+    const afterRt = await prisma.resourceType.findUniqueOrThrow({ where: { id: rtId } })
+    const afterNr = await prisma.namedResource.findUniqueOrThrow({ where: { id: nrId } })
+    expect(afterRt.allocationMode).toBe(beforeRt.allocationMode)
+    expect(afterRt.allocationPercent).toBe(beforeRt.allocationPercent)
+    expect(afterRt.allocationStartWeek).toBe(beforeRt.allocationStartWeek)
+    expect(afterRt.allocationEndWeek).toBe(beforeRt.allocationEndWeek)
+    expect(afterNr.startWeek).toBe(beforeNr.startWeek)
+    expect(afterNr.endWeek).toBe(beforeNr.endWeek)
+    expect(afterNr.allocationPercent).toBe(beforeNr.allocationPercent)
+    expect(await candidateColumnsPresent()).toBe(true)
+
+    // Normal runtime: scheduler capacity resolves exclusively from profiles.
+    const resolved = await resolveSchedulerCapacity(prisma, projectId)
+    expect(resolved.resourceTypes).toHaveLength(1)
+    const rt = resolved.resourceTypes[0]!
+    expect(rt.namedResources).toHaveLength(1)
+    const week0 = (rt.namedResources[0]!.capacitySegments ?? []).length
+    expect(week0).toBeGreaterThan(0)
+    expect(resolved.meta.profileBackedCount).toBe(1)
+    expect(resolved.meta.legacyCount).toBe(0)
+  })
+})
+
+// ════════════════════════════════════════════════════════════════════════════
+// 3. Manifest decisions
+// ════════════════════════════════════════════════════════════════════════════
+
+describeIf('remediation manifest decisions', () => {
+  it('blocks apply while decisions remain unresolved (no writes, exit 2)', async () => {
+    const projectId = await createProject()
+    await createRole(projectId, { allocationMode: 'CAPACITY_PLAN' })
+    const { plan } = await runDryRun()
+    expect(classifyPlanExit(plan)).toBe(2)
+
+    const profilesBefore = await prisma.capacityProfile.count()
+    const outcome = await applyRemediationPlan(prisma, { plan })
+    expect(outcome.exitCode).toBe(2)
+    expect(outcome.errors.join(' ')).toContain('unresolved')
+    expect(await prisma.capacityProfile.count()).toBe(profilesBefore)
+  })
+
+  it('applies an explicit valid resolution exactly and touches no unrelated owner', async () => {
+    const projectId = await createProject()
+    const ambiguous = await createRole(projectId, { allocationMode: 'CAPACITY_PLAN' })
+    const unrelated = await createRole(projectId, { allocationMode: 'TIMELINE', allocationPercent: 60 })
+
+    const { plan } = await runDryRun()
+    const manifest = await buildManifest(plan, [{
+      decisionId: plan.decisions.find(d => d.ownerId === ambiguous)!.id,
+      resolution: { shape: 'availability-window', defaultPercent: 100, startWeek: 0, endWeek: 20 },
+    }])
+    const merged = resolvePlanWithManifest(plan, manifest)
+    expect(merged.errors).toEqual([])
+
+    const outcome = await applyRemediationPlan(prisma, { plan, manifest })
+    expect(outcome.exitCode).toBe(0)
+    expect(outcome.applied).toBe(2) // ambiguous + unrelated deterministic
+
+    const ambiguousProfile = await prisma.capacityProfile.findFirstOrThrow({ where: { resourceTypeId: ambiguous } })
+    expect(ambiguousProfile).toMatchObject({
+      planningBasis: 'AVAILABILITY_WINDOW',
+      source: 'AVAILABILITY_WINDOW',
+      defaultPercent: 100,
+      startWeek: 0,
+      endWeek: 20,
+    })
+    const unrelatedProfile = await prisma.capacityProfile.findFirstOrThrow({ where: { resourceTypeId: unrelated } })
+    expect(unrelatedProfile).toMatchObject({ defaultPercent: 60 })
+    expect(await prisma.capacityProfile.count()).toBe(2)
+  })
+
+  it('rejects a malformed resolution shape (allowed-shape violation)', async () => {
+    const projectId = await createProject()
+    await createRole(projectId, { allocationMode: 'CAPACITY_PLAN' })
+    const { plan } = await runDryRun()
+    const manifest = await buildManifest(plan, [{
+      decisionId: plan.decisions[0]!.id,
+      resolution: { shape: 'snapshot-window-interpretation', startWeek: 0, endWeek: 5 },
+    }])
+    const profilesBefore = await prisma.capacityProfile.count()
+    const outcome = await applyRemediationPlan(prisma, { plan, manifest })
+    expect(outcome.exitCode).toBe(1)
+    expect(outcome.errors.join(' ')).toContain('not allowed')
+    expect(await prisma.capacityProfile.count()).toBe(profilesBefore)
+  })
+
+  it('refuses apply when the manifest fingerprint does not match the plan', async () => {
+    const projectId = await createProject()
+    await createRole(projectId, { allocationMode: 'CAPACITY_PLAN' })
+    const { plan } = await runDryRun()
+    const manifest: RemediationManifest = {
+      formatVersion: 1,
+      applicationCommit: 'test-commit',
+      planFingerprint: 'deadbeef',
+      decisions: [],
+    }
+    const outcome = await applyRemediationPlan(prisma, { plan, manifest })
+    expect(outcome.exitCode).toBe(1)
+    expect(outcome.errors.join(' ')).toContain('planFingerprint')
+  })
+
+  it('refuses when data changed between dry-run and apply', async () => {
+    const projectId = await createProject()
+    const rtId = await createRole(projectId, { allocationMode: 'TIMELINE', allocationPercent: 90 })
+    const { plan } = await runDryRun()
+    expect(classifyPlanExit(plan)).toBe(0)
+
+    // Drift: legacy state changes after the dry-run.
+    await prisma.resourceType.update({ where: { id: rtId }, data: { allocationPercent: 50 } })
+
+    const profilesBefore = await prisma.capacityProfile.count()
+    const outcome = await applyRemediationPlan(prisma, { plan })
+    expect(outcome.exitCode).toBe(1)
+    expect(outcome.errors.join(' ')).toContain('changed since dry-run')
+    expect(await prisma.capacityProfile.count()).toBe(profilesBefore)
+  })
+
+  it('is a no-op on rerun (apply followed by apply is safe)', async () => {
+    const projectId = await createProject()
+    await createRole(projectId, { allocationMode: 'TIMELINE' })
+    await createRole(projectId, { allocationMode: 'CAPACITY_PLAN' })
+    const { plan } = await runDryRun()
+    const manifest = await buildManifest(plan, [{
+      decisionId: plan.decisions[0]!.id,
+      resolution: { shape: 'scalar-profile', planningBasis: 'DEMAND_FOLLOWING', defaultPercent: 100 },
+    }])
+
+    const first = await applyRemediationPlan(prisma, { plan, manifest })
+    expect(first.exitCode).toBe(0)
+    expect(first.applied).toBe(2)
+
+    const second = await applyRemediationPlan(prisma, { plan, manifest })
+    expect(second.exitCode).toBe(0)
+    expect(second.applied).toBe(0)
+    expect(second.skipped).toBe(2)
+    expect(await prisma.capacityProfile.count()).toBe(2)
+  })
+
+  it('rejects a tampered plan file (fingerprint invalid)', async () => {
+    const projectId = await createProject()
+    await createRole(projectId, { allocationMode: 'TIMELINE', allocationPercent: 90 })
+    const { plan } = await runDryRun()
+    const json = JSON.parse(planToJson(plan)) as unknown as Record<string, unknown>
+    const operations = json.operations as Array<Record<string, unknown>>
+    operations[0]!.proposed = {
+      ...(operations[0]!.proposed as Record<string, unknown>),
+      defaultPercent: 5,
+    }
+    const parsed = parsePlanJson(JSON.stringify(json))
+    expect(parsed.plan).toBeNull()
+    expect(parsed.errors.join(' ')).toContain('fingerprint mismatch')
+  })
+
+  it('resolves a segmentless ROLE CAPACITY_PROFILE via explicit segments', async () => {
+    const projectId = await createProject()
+    const rtId = await createRole(projectId, { allocationMode: 'CAPACITY_PLAN' })
+    const profileId = await createProfile(projectId, {
+      resourceTypeId: rtId,
+      ownerKind: 'ROLE',
+      planningBasis: 'CAPACITY_PROFILE',
+      source: 'LEGACY',
+      defaultPercent: 100,
+      legacy: { allocationMode: 'CAPACITY_PLAN', allocationPercent: null, allocationStartWeek: null, allocationEndWeek: null },
+    })
+
+    const { plan } = await runDryRun()
+    const decision = plan.decisions.find(d => d.profileId === profileId)
+    expect(decision).toBeDefined()
+    const manifest = await buildManifest(plan, [{
+      decisionId: decision!.id,
+      resolution: {
+        shape: 'segmented-capacity-profile',
+        defaultPercent: 50,
+        segments: [
+          { startWeek: 0, endWeek: 10, capacityPercent: 50 },
+          { startWeek: 11, endWeek: 20, capacityPercent: 25 },
+        ],
+      },
+    }])
+    const outcome = await applyRemediationPlan(prisma, { plan, manifest })
+    expect(outcome.exitCode).toBe(0)
+
+    const profile = await prisma.capacityProfile.findUniqueOrThrow({ where: { id: profileId } })
+    expect(profile.planningBasis).toBe('CAPACITY_PROFILE')
+    expect(profile.defaultPercent).toBe(50)
+    // Legacy provenance preserved on updates.
+    expect((profile.legacy as Record<string, unknown>).allocationMode).toBe('CAPACITY_PLAN')
+    const segments = await prisma.capacitySegment.findMany({ where: { capacityProfileId: profileId }, orderBy: { startWeek: 'asc' } })
+    expect(segments).toHaveLength(2)
+    expect(segments[0]).toMatchObject({ startWeek: 0, endWeek: 10, capacityPercent: 50 })
+  })
+})
+
+// ════════════════════════════════════════════════════════════════════════════
+// 4. Transaction safety
+// ════════════════════════════════════════════════════════════════════════════
+
+describeIf('remediation transaction safety', () => {
+  it('rolls back everything when a failure occurs mid-transaction', async () => {
+    const projectId = await createProject()
+    await createRole(projectId, { allocationMode: 'TIMELINE' })
+    await createRole(projectId, { allocationMode: 'EFFORT' })
+    await createRole(projectId, { allocationMode: 'FULL_PROJECT' })
+
+    const { plan } = await runDryRun()
+    expect(plan.operations).toHaveLength(3)
+
+    __setRemediationApplyFailureSeam(() => {
+      throw new Error('injected mid-transaction failure')
+    })
+    const outcome = await applyRemediationPlan(prisma, { plan })
+    expect(outcome.exitCode).toBe(1)
+    expect(outcome.errors.join(' ')).toContain('injected mid-transaction failure')
+
+    // Nothing partially applied.
+    expect(await prisma.capacityProfile.count()).toBe(0)
+    expect(await prisma.capacitySegment.count()).toBe(0)
+  })
+
+  it('refuses before the first write when any operation drifted', async () => {
+    const projectId = await createProject()
+    const rtA = await createRole(projectId, { allocationMode: 'TIMELINE' })
+    await createRole(projectId, { allocationMode: 'EFFORT' })
+    const { plan } = await runDryRun()
+    expect(plan.operations).toHaveLength(2)
+
+    await prisma.resourceType.update({ where: { id: rtA }, data: { allocationMode: 'FULL_PROJECT' } })
+    const outcome = await applyRemediationPlan(prisma, { plan })
+    expect(outcome.exitCode).toBe(1)
+    expect(await prisma.capacityProfile.count()).toBe(0)
+  })
+
+  it('reports complete applied counts and no partial success', async () => {
+    const projectId = await createProject()
+    await createRole(projectId, { allocationMode: 'TIMELINE' })
+    await createRole(projectId, { allocationMode: 'CAPACITY_PLAN' })
+    const { plan } = await runDryRun()
+
+    // Unresolved: nothing applied, nothing reported as success.
+    const outcome = await applyRemediationPlan(prisma, { plan })
+    expect(outcome.exitCode).toBe(2)
+    expect(outcome.applied).toBe(0)
+    expect(outcome.skipped).toBe(0)
+    expect(await prisma.capacityProfile.count()).toBe(0)
+  })
+})
+
+// ════════════════════════════════════════════════════════════════════════════
+// 5. Historical snapshots
+// ════════════════════════════════════════════════════════════════════════════
+
+describeIf('remediation historical v2 snapshot policy', () => {
+  it('translates v2 EFFORT / FULL_PROJECT / TIMELINE / windowed CAPACITY_PLAN entries', async () => {
+    const projectId = await createProject()
+    const snapshotId = await createBacklogSnapshot(projectId, v2Snapshot({
+      resourceTypes: [
+        v2Role({ id: 'rt-1', allocationMode: 'EFFORT', allocationStartWeek: 2, allocationEndWeek: 9 }),
+        v2Role({ id: 'rt-2', allocationMode: 'FULL_PROJECT', allocationPercent: 60 }),
+        v2Role({ id: 'rt-3', allocationMode: 'TIMELINE', allocationStartWeek: 0, allocationEndWeek: 10 }),
+        v2Role({ id: 'rt-4', allocationMode: 'CAPACITY_PLAN', allocationStartWeek: 3, allocationEndWeek: 12 }),
+      ],
+      namedResources: [
+        v2Person({ id: 'nr-1', resourceTypeId: 'rt-1', allocationMode: 'EFFORT' }),
+        v2Person({ id: 'nr-2', resourceTypeId: 'rt-4', allocationMode: 'CAPACITY_PLAN', allocationStartWeek: 3, allocationEndWeek: 12 }),
+      ],
+    }))
+
+    const readiness = await runProductionMigrationReadiness(prisma)
+    expect(readiness.passed).toBe(true)
+
+    const { plan } = await runDryRun()
+    expect(plan.summary.findings.deterministic).toBe(0)
+    expect(plan.summary.findings.decisionRequired).toBe(0)
+    expect(classifyPlanExit(plan)).toBe(0)
+    void snapshotId
+  })
+
+  it('applies the never-active policy to (-1,-1) pairs and inverted windows', async () => {
+    const projectId = await createProject()
+    await createBacklogSnapshot(projectId, v2Snapshot({
+      resourceTypes: [v2Role({ id: 'rt-snap-1', allocationMode: 'EFFORT' })],
+      namedResources: [
+        v2Person({ id: 'nr-neg', allocationMode: 'CAPACITY_PLAN', allocationPercent: 100, startWeek: -1, endWeek: -1 }),
+        v2Person({ id: 'nr-inv', allocationMode: 'CAPACITY_PLAN', allocationPercent: 100, startWeek: 4, endWeek: 3 }),
+      ],
+    }))
+
+    const readiness = await runProductionMigrationReadiness(prisma)
+    expect(readiness.passed).toBe(true)
+
+    const { plan } = await runDryRun()
+    expect(plan.summary.findings.deterministic).toBe(2)
+    expect(plan.summary.findings.decisionRequired).toBe(0)
+    expect(classifyPlanExit(plan)).toBe(0)
+
+    // Rollback agrees with readiness: the same translation produces
+    // zero-capacity profiles with null windows.
+    const row = await prisma.backlogSnapshot.findFirstOrThrow()
+    const parsed = parseSnapshotData(row.snapshot)
+    expect(isSnapshotV2(parsed)).toBe(true)
+    const translation = translateV2SnapshotProfiles(parsed as never, projectId)
+    expect(translation.errors).toEqual([])
+    const zeroProfiles = translation.profiles.filter(p => p.defaultPercent === 0)
+    expect(zeroProfiles).toHaveLength(2)
+    for (const profile of zeroProfiles) {
+      expect(profile.startWeek).toBeNull()
+      expect(profile.endWeek).toBeNull()
+    }
+  })
+
+  it('classifies windowless CAPACITY_PLAN entries as decisions and rewrites only the minimum fields', async () => {
+    const projectId = await createProject()
+    const snapshotId = await createBacklogSnapshot(projectId, v2Snapshot({
+      resourceTypes: [v2Role({ id: 'rt-snap-1', allocationMode: 'EFFORT' })],
+      namedResources: [
+        v2Person({
+          id: 'nr-windowless',
+          allocationMode: 'CAPACITY_PLAN',
+          allocationPercent: 100,
+          startWeek: null,
+          endWeek: null,
+          allocationStartWeek: null,
+          allocationEndWeek: null,
+        }),
+      ],
+      sentinel: { marker: 'preserve-me', nested: { a: [1, 2, 3], b: 'x' } },
+    }))
+
+    const readiness = await runProductionMigrationReadiness(prisma)
+    expect(readiness.passed).toBe(false)
+    expect(formatReadinessReport(readiness)).toContain('cannot be translated without guessing')
+
+    const { plan } = await runDryRun()
+    expect(classifyPlanExit(plan)).toBe(2)
+    expect(plan.summary.findings.decisionRequired).toBe(1)
+
+    const manifest = await buildManifest(plan, [{
+      decisionId: plan.decisions[0]!.id,
+      resolution: { shape: 'snapshot-window-interpretation', startWeek: 0, endWeek: 10 },
+    }])
+    const outcome = await applyRemediationPlan(prisma, { plan, manifest })
+    expect(outcome.exitCode).toBe(0)
+    expect(outcome.applied).toBe(1)
+
+    // Minimum fields changed; unrelated content preserved.
+    const row = await prisma.backlogSnapshot.findUniqueOrThrow({ where: { id: snapshotId } })
+    const snap = row.snapshot as Record<string, unknown>
+    expect((snap as { marker?: string }).marker).toBe('preserve-me')
+    expect((snap as { nested?: unknown }).nested).toEqual({ a: [1, 2, 3], b: 'x' })
+    const nrs = snap.namedResources as Array<Record<string, unknown>>
+    const entry = nrs.find(e => e.id === 'nr-windowless')!
+    expect(entry.allocationStartWeek).toBe(0)
+    expect(entry.allocationEndWeek).toBe(10)
+    expect(entry.startWeek).toBeNull()
+    expect(entry.endWeek).toBeNull()
+    expect(entry.allocationMode).toBe('CAPACITY_PLAN')
+
+    // Readiness passes after the rewrite.
+    const after = await runProductionMigrationReadiness(prisma)
+    expect(after.passed).toBe(true)
+
+    // Rollback of the rewritten snapshot succeeds (readiness/rollback agree).
+    await rollbackProjectSnapshot({ projectId, snapshotId, userId: ownerId, db: prisma })
+    const profiles = await prisma.capacityProfile.findMany({ where: { projectId } })
+    const windowed = profiles.find(p => p.namedResourceId === 'nr-windowless')
+    expect(windowed).toMatchObject({ planningBasis: 'AVAILABILITY_WINDOW', source: 'LEGACY', startWeek: 0, endWeek: 10 })
+  })
+
+  it('classifies a single -1 edge as decision-required', async () => {
+    const projectId = await createProject()
+    await createBacklogSnapshot(projectId, v2Snapshot({
+      resourceTypes: [v2Role({ id: 'rt-snap-1', allocationMode: 'EFFORT' })],
+      namedResources: [
+        v2Person({ id: 'nr-single-neg', allocationMode: 'CAPACITY_PLAN', allocationPercent: 100, startWeek: 0, endWeek: -1 }),
+      ],
+    }))
+    const { plan } = await runDryRun()
+    expect(plan.summary.findings.decisionRequired).toBe(1)
+    expect(classifyPlanExit(plan)).toBe(2)
+    expect(plan.decisions[0]!.allowedResolutions).toEqual(['snapshot-window-interpretation'])
+  })
+
+  it('refuses malformed snapshots as unsupported (never deleted)', async () => {
+    const projectId = await createProject()
+    const snapshotId = await createBacklogSnapshot(projectId, { schemaVersion: 2, epics: 'not-an-array' })
+    const { plan } = await runDryRun()
+    expect(plan.summary.findings.unsupported).toBeGreaterThan(0)
+    expect(classifyPlanExit(plan)).toBe(1)
+
+    // A malformed snapshot is never deleted to pass readiness.
+    const row = await prisma.backlogSnapshot.findUnique({ where: { id: snapshotId } })
+    expect(row).not.toBeNull()
+    const outcome = await applyRemediationPlan(prisma, { plan })
+    expect(outcome.exitCode).toBe(1)
+    expect(await prisma.backlogSnapshot.count()).toBe(1)
+  })
+})
+
+// ════════════════════════════════════════════════════════════════════════════
+// 6. End-to-end readiness on a database with every production blocker class
+// ════════════════════════════════════════════════════════════════════════════
+
+describeIf('remediation end-to-end', () => {
+  it('fails readiness → dry-runs → applies approved plan → audit + readiness pass → runtime + rollback work', async () => {
+    const projectId = await createProject('Blocker Zoo')
+
+    // A. Missing ROLE profiles (deterministic + decision).
+    const timelineRt = await createRole(projectId, { allocationMode: 'TIMELINE', allocationPercent: 75 })
+    const effortRt = await createRole(projectId, { allocationMode: 'EFFORT' })
+    const fullRt = await createRole(projectId, { allocationMode: 'FULL_PROJECT' })
+    const capPlanRt = await createRole(projectId, { allocationMode: 'CAPACITY_PLAN' })
+
+    // B. Missing NAMED_PERSON profiles (deterministic + decision).
+    const personRt = await createRole(projectId, { allocationMode: 'TIMELINE' })
+    const timelineNr = await createNamedPerson(projectId, personRt, { allocationMode: 'TIMELINE', startWeek: 0, endWeek: 6 })
+    const capNr = await createNamedPerson(projectId, personRt, { allocationMode: 'CAPACITY_PLAN' })
+
+    // C. Planner-owned RT without ROLE profile (deterministic reconstruction).
+    const plannerRt = await createRole(projectId, { allocationMode: 'CAPACITY_PLAN', count: 1 })
+    await createActivePlan(projectId, [
+      { periodIndex: 0, startWeek: 0, endWeek: 8, entries: [{ resourceTypeId: plannerRt, headcount: 1 }] },
+    ])
+
+    // D. Invalid persisted profiles.
+    await createProfile(projectId, {
+      namedResourceId: timelineNr,
+      ownerKind: 'NAMED_PERSON',
+      planningBasis: 'DEMAND_FOLLOWING',
+      source: 'FIXED',
+      defaultPercent: 100,
+      startWeek: 0,
+      endWeek: 29,
+      legacy: { allocationMode: 'EFFORT' },
+    })
+    await createProfile(projectId, {
+      resourceTypeId: effortRt,
+      ownerKind: 'ROLE',
+      planningBasis: 'CAPACITY_PROFILE',
+      source: 'LEGACY',
+      defaultPercent: 100,
+      legacy: { allocationMode: 'CAPACITY_PLAN', allocationStartWeek: null, allocationEndWeek: null },
+    })
+
+    // E. Historical v2 snapshots: valid + never-active + windowless + single -1.
+    const neverActiveSnapshotId = await createBacklogSnapshot(projectId, v2Snapshot({
+      resourceTypes: [v2Role({ id: 'rt-e2e-snap', allocationMode: 'EFFORT' })],
+      namedResources: [
+        v2Person({ id: 'nr-e2e-neg', resourceTypeId: 'rt-e2e-snap', allocationMode: 'CAPACITY_PLAN', allocationPercent: 100, startWeek: -1, endWeek: -1 }),
+      ],
+    }))
+    const windowlessSnapshotId = await createBacklogSnapshot(projectId, v2Snapshot({
+      resourceTypes: [v2Role({ id: 'rt-e2e-snap2', allocationMode: 'EFFORT' })],
+      namedResources: [
+        v2Person({ id: 'nr-e2e-windowless', resourceTypeId: 'rt-e2e-snap2', allocationMode: 'CAPACITY_PLAN', allocationPercent: 100, startWeek: null, endWeek: null }),
+      ],
+    }))
+    await createBacklogSnapshot(projectId, v2Snapshot({
+      resourceTypes: [v2Role({ id: 'rt-e2e-snap3', allocationMode: 'EFFORT' })],
+      namedResources: [
+        v2Person({ id: 'nr-e2e-single', resourceTypeId: 'rt-e2e-snap3', allocationMode: 'CAPACITY_PLAN', allocationPercent: 100, startWeek: 0, endWeek: -1 }),
+      ],
+    }))
+
+    // 1. Readiness fails before remediation.
+    const before = await runProductionMigrationReadiness(prisma)
+    expect(before.passed).toBe(false)
+
+    // 2. Dry-run reports the expected classes.
+    const { plan } = await runDryRun()
+    expect(plan.summary.findings.deterministic).toBeGreaterThanOrEqual(5)
+    expect(plan.summary.findings.decisionRequired).toBeGreaterThanOrEqual(4)
+    expect(classifyPlanExit(plan)).toBe(2)
+
+    // 3. Approved plan applies (all decisions supplied).
+    const decisions = plan.decisions.filter(d => d.snapshotId === windowlessSnapshotId)
+    const manifest = await buildManifest(plan, [
+      ...decisions.map(d => ({
+        decisionId: d.id,
+        resolution: { shape: 'snapshot-window-interpretation' as const, startWeek: 0, endWeek: 10 },
+      })),
+      {
+        decisionId: plan.decisions.find(d => d.ownerId === capPlanRt)!.id,
+        resolution: { shape: 'scalar-profile' as const, planningBasis: 'DEMAND_FOLLOWING' as const, defaultPercent: 100 },
+      },
+      {
+        decisionId: plan.decisions.find(d => d.ownerId === capNr)!.id,
+        resolution: { shape: 'availability-window' as const, defaultPercent: 100, startWeek: 0, endWeek: 12 },
+      },
+      {
+        decisionId: plan.decisions.find(d => d.profileId !== null && d.ownerId === effortRt)!.id,
+        resolution: { shape: 'segmented-capacity-profile' as const, defaultPercent: 100, segments: [{ startWeek: 0, endWeek: 20, capacityPercent: 100 }] },
+      },
+    ])
+
+    // The single -1 snapshot entry remains unresolved → apply refused.
+    const unresolvedOutcome = await applyRemediationPlan(prisma, { plan, manifest })
+    expect(unresolvedOutcome.exitCode).toBe(2)
+    expect(await prisma.capacityProfile.count()).toBe(2) // only the two seeded profiles
+
+    // Resolve the single -1 entry as well.
+    const singleNegDecisions = plan.decisions.filter(d => d.snapshotId !== null && d.snapshotId !== windowlessSnapshotId)
+    const fullManifest = await buildManifest(plan, [
+      ...manifest.decisions.map(d => ({ decisionId: d.decisionId, resolution: d.resolution })),
+      ...singleNegDecisions.map(d => ({
+        decisionId: d.id,
+        resolution: { shape: 'snapshot-window-interpretation' as const, startWeek: 0, endWeek: 5 },
+      })),
+    ])
+    const outcome = await applyRemediationPlan(prisma, { plan, manifest: fullManifest })
+    expect(outcome.errors).toEqual([])
+    expect(outcome.exitCode).toBe(0)
+    expect(outcome.postApply!.readinessPassed).toBe(true)
+    // Deterministic findings may remain only for policy-normalised snapshot
+    // entries (never-active windows) that require no write.
+    expect(outcome.postApply!.planFindings.deterministic).toBeGreaterThanOrEqual(1)
+    expect(outcome.postApply!.planFindings.decisionRequired).toBe(0)
+    expect(outcome.postApply!.planFindings.unsupported).toBe(0)
+
+    // 4. Permanent audit passes.
+    const audit = await runOwnershipAudit(prisma)
+    expect(audit.isClean).toBe(true)
+
+    // 5. Readiness passes.
+    const after = await runProductionMigrationReadiness(prisma)
+    expect(after.passed).toBe(true)
+
+    // 6. Resource Profile / Timeline / scheduler load successfully (profile-first).
+    const resolved = await resolveSchedulerCapacity(prisma, projectId)
+    expect(resolved.resourceTypes.length).toBeGreaterThanOrEqual(4)
+    expect(resolved.meta.legacyCount).toBe(0)
+    const timelineProfile = await prisma.capacityProfile.findFirstOrThrow({ where: { resourceTypeId: timelineRt } })
+    expect(timelineProfile.planningBasis).toBe('AVAILABILITY_WINDOW')
+
+    // 7. Representative snapshot restoration succeeds (v2 rollback) — proven
+    // in a dedicated self-contained project below.
+    void neverActiveSnapshotId
+    void fullRt
+
+    // 8. No legacy candidate column removed.
+    expect(await candidateColumnsPresent()).toBe(true)
+  })
+
+  it('restores a representative v2 snapshot after remediation (readiness/rollback agreement)', async () => {
+    const projectId = await createProject('Rollback Project')
+    const rt = await createRole(projectId, { allocationMode: 'TIMELINE', allocationStartWeek: 0, allocationEndWeek: 10 })
+    const nr = await createNamedPerson(projectId, rt, { allocationMode: 'CAPACITY_PLAN', startWeek: 0, endWeek: 10 })
+    const snapshotId = await createBacklogSnapshot(projectId, v2Snapshot({
+      resourceTypes: [v2Role({ id: rt, allocationMode: 'TIMELINE', allocationStartWeek: 0, allocationEndWeek: 10 })],
+      namedResources: [
+        v2Person({ id: nr, resourceTypeId: rt, allocationMode: 'CAPACITY_PLAN', allocationStartWeek: 0, allocationEndWeek: 10 }),
+      ],
+    }))
+
+    const { plan } = await runDryRun()
+    const outcome = await applyRemediationPlan(prisma, { plan })
+    expect(outcome.exitCode).toBe(0)
+
+    await rollbackProjectSnapshot({ projectId, snapshotId, userId: ownerId, db: prisma })
+    const profiles = await prisma.capacityProfile.findMany({ where: { projectId } })
+    expect(profiles).toHaveLength(2)
+    const roleProfile = profiles.find(p => p.ownerKind === 'ROLE')
+    expect(roleProfile).toMatchObject({ planningBasis: 'AVAILABILITY_WINDOW', startWeek: 0, endWeek: 10 })
+    const namedProfile = profiles.find(p => p.ownerKind === 'NAMED_PERSON')
+    expect(namedProfile).toMatchObject({ planningBasis: 'AVAILABILITY_WINDOW', source: 'LEGACY', startWeek: 0, endWeek: 10 })
+
+    const readiness = await runProductionMigrationReadiness(prisma)
+    expect(readiness.passed).toBe(true)
+  })
+})

--- a/server/src/test/productionRemediation.integration.test.ts
+++ b/server/src/test/productionRemediation.integration.test.ts
@@ -1016,6 +1016,423 @@ describeIf('remediation historical v2 snapshot policy', () => {
 })
 
 // ════════════════════════════════════════════════════════════════════════════
+// 5b. Owner-kind decisions for ambiguous NamedResources (review round 2)
+// ════════════════════════════════════════════════════════════════════════════
+
+describeIf('remediation owner-kind decisions', () => {
+  async function seedAmbiguousNr(): Promise<{ projectId: string; parentRt: string; nrId: string }> {
+    const projectId = await createProject()
+    const parentRt = await createRole(projectId, { allocationMode: 'EFFORT' })
+    const nrId = await createNamedPerson(projectId, parentRt, { allocationMode: 'CAPACITY_PLAN' })
+    return { projectId, parentRt, nrId }
+  }
+
+  it('emits an owner-kind-required decision and rejects a direct capacity-only resolution', async () => {
+    const { projectId, nrId } = await seedAmbiguousNr()
+    const { plan } = await runDryRun()
+    const decision = plan.decisions.find(d => d.ownerId === nrId)!
+    expect(decision.allowedResolutions).toEqual(['owner-kind-decision'])
+
+    const directManifest = await buildManifest(plan, [{
+      decisionId: decision.id,
+      resolution: { shape: 'availability-window', defaultPercent: 100, startWeek: 0, endWeek: 10 },
+    }])
+    const profilesBefore = await prisma.capacityProfile.count()
+    const outcome = await applyRemediationPlan(prisma, { plan, manifest: directManifest })
+    expect(outcome.exitCode).toBe(1)
+    expect(outcome.errors.join(' ')).toContain('not allowed for this entry')
+    expect(await prisma.capacityProfile.count()).toBe(profilesBefore)
+    void projectId
+  })
+
+  it('creates the exact reviewed NAMED_PERSON profile from an explicit owner-kind decision', async () => {
+    const { projectId, nrId } = await seedAmbiguousNr()
+    const { plan } = await runDryRun()
+    const manifest = await buildManifest(plan, [{
+      decisionId: plan.decisions.find(d => d.ownerId === nrId)!.id,
+      resolution: {
+        shape: 'owner-kind-decision',
+        ownerKind: 'NAMED_PERSON',
+        capacity: { shape: 'availability-window', defaultPercent: 100, startWeek: 0, endWeek: 10 },
+      },
+    }])
+    const outcome = await applyRemediationPlan(prisma, { plan, manifest })
+    expect(outcome.exitCode).toBe(0)
+    const profile = await prisma.capacityProfile.findFirstOrThrow({ where: { namedResourceId: nrId } })
+    expect(profile).toMatchObject({
+      ownerKind: 'NAMED_PERSON',
+      planningBasis: 'AVAILABILITY_WINDOW',
+      source: 'AVAILABILITY_WINDOW',
+      defaultPercent: 100,
+      startWeek: 0,
+      endWeek: 10,
+    })
+    // The profile passes structural validation, ownership audit, readiness
+    // and the runtime resolver.
+    const audit = await runOwnershipAudit(prisma)
+    expect(audit.isClean).toBe(true)
+    const readiness = await runProductionMigrationReadiness(prisma)
+    expect(readiness.passed).toBe(true)
+    const resolved = await resolveSchedulerCapacity(prisma, projectId)
+    expect(resolved.meta.legacyCount).toBe(0)
+    expect(resolved.meta.profileBackedCount).toBe(1)
+  })
+
+  it('creates the exact reviewed PLANNED_RESOURCE profile from an explicit owner-kind decision', async () => {
+    const { projectId, nrId } = await seedAmbiguousNr()
+    const { plan } = await runDryRun()
+    const manifest = await buildManifest(plan, [{
+      decisionId: plan.decisions.find(d => d.ownerId === nrId)!.id,
+      resolution: {
+        shape: 'owner-kind-decision',
+        ownerKind: 'PLANNED_RESOURCE',
+        capacity: {
+          shape: 'segmented-capacity-profile',
+          defaultPercent: 50,
+          segments: [
+            { startWeek: 5, endWeek: 10, capacityPercent: 25 },
+            { startWeek: 0, endWeek: 4, capacityPercent: 50 },
+          ],
+        },
+      },
+    }])
+    const outcome = await applyRemediationPlan(prisma, { plan, manifest })
+    expect(outcome.exitCode).toBe(0)
+    const profile = await prisma.capacityProfile.findFirstOrThrow({ where: { namedResourceId: nrId } })
+    expect(profile).toMatchObject({
+      ownerKind: 'PLANNED_RESOURCE',
+      planningBasis: 'CAPACITY_PROFILE',
+      source: 'LEGACY',
+      defaultPercent: 50,
+    })
+    const segments = await prisma.capacitySegment.findMany({
+      where: { capacityProfileId: profile.id },
+      orderBy: { startWeek: 'asc' },
+    })
+    expect(segments).toEqual([
+      expect.objectContaining({ startWeek: 0, endWeek: 4, capacityPercent: 50 }),
+      expect.objectContaining({ startWeek: 5, endWeek: 10, capacityPercent: 25 }),
+    ])
+    const audit = await runOwnershipAudit(prisma)
+    expect(audit.isClean).toBe(true)
+    const readiness = await runProductionMigrationReadiness(prisma)
+    expect(readiness.passed).toBe(true)
+    const resolved = await resolveSchedulerCapacity(prisma, projectId)
+    expect(resolved.meta.legacyCount).toBe(0)
+    expect(resolved.meta.profileBackedCount).toBe(1)
+  })
+
+  it('rejects an unknown or structurally invalid nested capacity resolution before writes', async () => {
+    const { nrId } = await seedAmbiguousNr()
+    const { plan } = await runDryRun()
+
+    // Unknown nested shape.
+    const unknownManifest = await buildManifest(plan, [{
+      decisionId: plan.decisions.find(d => d.ownerId === nrId)!.id,
+      resolution: {
+        shape: 'owner-kind-decision',
+        ownerKind: 'NAMED_PERSON',
+        capacity: { shape: 'mystery-shape' } as never,
+      },
+    }])
+    const profilesBefore = await prisma.capacityProfile.count()
+    const unknownOutcome = await applyRemediationPlan(prisma, { plan, manifest: unknownManifest })
+    expect(unknownOutcome.exitCode).toBe(1)
+    expect(unknownOutcome.errors.join(' ')).toContain('unknown nested capacity shape')
+    expect(await prisma.capacityProfile.count()).toBe(profilesBefore)
+
+    // Structurally invalid nested window (inverted) is refused before writes.
+    const invalidManifest = await buildManifest(plan, [{
+      decisionId: plan.decisions.find(d => d.ownerId === nrId)!.id,
+      resolution: {
+        shape: 'owner-kind-decision',
+        ownerKind: 'NAMED_PERSON',
+        capacity: { shape: 'availability-window', defaultPercent: 100, startWeek: 9, endWeek: 3 },
+      },
+    }])
+    const invalidOutcome = await applyRemediationPlan(prisma, { plan, manifest: invalidManifest })
+    expect(invalidOutcome.exitCode).toBe(1)
+    expect(invalidOutcome.errors.join(' ')).toContain('structurally invalid')
+    expect(await prisma.capacityProfile.count()).toBe(profilesBefore)
+  })
+
+  it('keeps deterministic NamedResource mappings unchanged', async () => {
+    const projectId = await createProject()
+    const parentRt = await createRole(projectId, { allocationMode: 'EFFORT' })
+    const detNr = await createNamedPerson(projectId, parentRt, { allocationMode: 'TIMELINE', startWeek: 0, endWeek: 8 })
+    const { plan } = await runDryRun()
+    expect(plan.decisions).toHaveLength(0)
+    expect(plan.operations).toHaveLength(1)
+    expect(plan.operations[0]!.proposed).toMatchObject({ ownerKind: 'NAMED_PERSON' })
+    const outcome = await applyRemediationPlan(prisma, { plan })
+    expect(outcome.exitCode).toBe(0)
+    const profile = await prisma.capacityProfile.findFirstOrThrow({ where: { namedResourceId: detNr } })
+    expect(profile.ownerKind).toBe('NAMED_PERSON')
+  })
+})
+
+// ════════════════════════════════════════════════════════════════════════════
+// 5c. Full-scope drift refusal before writes (review round 2)
+// ════════════════════════════════════════════════════════════════════════════
+
+describeIf('remediation full-scope drift', () => {
+  async function assertZeroWrites(baseline: { profiles: number; segments: number; snapshots: number }): Promise<void> {
+    expect(await prisma.capacityProfile.count()).toBe(baseline.profiles)
+    expect(await prisma.capacitySegment.count()).toBe(baseline.segments)
+    expect(await prisma.backlogSnapshot.count()).toBe(baseline.snapshots)
+  }
+
+  async function snapshotCounts(): Promise<{ profiles: number; segments: number; snapshots: number }> {
+    return {
+      profiles: await prisma.capacityProfile.count(),
+      segments: await prisma.capacitySegment.count(),
+      snapshots: await prisma.backlogSnapshot.count(),
+    }
+  }
+
+  it('refuses before writes when a new unprofiled ResourceType is added after dry-run', async () => {
+    const projectId = await createProject()
+    await createRole(projectId, { allocationMode: 'TIMELINE' })
+    const { plan } = await runDryRun()
+    expect(plan.operations).toHaveLength(1)
+
+    await createRole(projectId, { allocationMode: 'EFFORT' })
+    const baseline = await snapshotCounts()
+    const outcome = await applyRemediationPlan(prisma, { plan })
+    expect(outcome.exitCode).toBe(1)
+    expect(outcome.errors.join(' ')).toContain('complete remediation state changed since dry-run')
+    await assertZeroWrites(baseline)
+  })
+
+  it('refuses before writes when a new unprofiled NamedResource is added after dry-run', async () => {
+    const projectId = await createProject()
+    const rtId = await createRole(projectId, { allocationMode: 'TIMELINE' })
+    const { plan } = await runDryRun()
+    expect(plan.operations).toHaveLength(1)
+
+    await createNamedPerson(projectId, rtId, { allocationMode: 'EFFORT' })
+    const baseline = await snapshotCounts()
+    const outcome = await applyRemediationPlan(prisma, { plan })
+    expect(outcome.exitCode).toBe(1)
+    await assertZeroWrites(baseline)
+  })
+
+  it('refuses before writes when a previously valid profile becomes malformed', async () => {
+    const projectId = await createProject()
+    const validRt = await createRole(projectId, { allocationMode: 'EFFORT' })
+    const validProfileId = await createProfile(projectId, {
+      resourceTypeId: validRt,
+      ownerKind: 'ROLE',
+      planningBasis: 'DEMAND_FOLLOWING',
+      source: 'FIXED',
+      defaultPercent: 100,
+    })
+    const unprofiledRt = await createRole(projectId, { allocationMode: 'TIMELINE' })
+    const { plan } = await runDryRun()
+    expect(plan.operations).toHaveLength(1) // only the unprofiled RT
+
+    // The previously valid profile becomes structurally invalid.
+    await prisma.capacityProfile.update({
+      where: { id: validProfileId },
+      data: { startWeek: 5, endWeek: 10 },
+    })
+    const baseline = await snapshotCounts()
+    const outcome = await applyRemediationPlan(prisma, { plan })
+    expect(outcome.exitCode).toBe(1)
+    expect(outcome.errors.join(' ')).toContain('complete remediation state changed since dry-run')
+    await assertZeroWrites(baseline)
+    void unprofiledRt
+  })
+
+  it('refuses before writes when a new untranslatable BacklogSnapshot is inserted', async () => {
+    const projectId = await createProject()
+    await createRole(projectId, { allocationMode: 'TIMELINE' })
+    const { plan } = await runDryRun()
+    expect(plan.operations).toHaveLength(1)
+
+    await createBacklogSnapshot(projectId, v2Snapshot({
+      resourceTypes: [v2Role({ id: 'rt-drift-snap', allocationMode: 'EFFORT' })],
+      namedResources: [
+        v2Person({ id: 'nr-drift', resourceTypeId: 'rt-drift-snap', allocationMode: 'CAPACITY_PLAN' }),
+      ],
+    }))
+    const baseline = await snapshotCounts()
+    const outcome = await applyRemediationPlan(prisma, { plan })
+    expect(outcome.exitCode).toBe(1)
+    await assertZeroWrites(baseline)
+  })
+
+  it('refuses before writes when an existing unplanned snapshot entry changes', async () => {
+    const projectId = await createProject()
+    await createRole(projectId, { allocationMode: 'TIMELINE' })
+    const snapshotId = await createBacklogSnapshot(projectId, v2Snapshot({
+      resourceTypes: [v2Role({ id: 'rt-snap-e', allocationMode: 'EFFORT' })],
+      namedResources: [
+        v2Person({ id: 'nr-snap-e', resourceTypeId: 'rt-snap-e', allocationMode: 'CAPACITY_PLAN', allocationStartWeek: 0, allocationEndWeek: 10 }),
+      ],
+    }))
+    const { plan } = await runDryRun()
+    expect(plan.operations).toHaveLength(1)
+
+    // Change the already-valid unplanned entry (stays translatable).
+    const row = await prisma.backlogSnapshot.findUniqueOrThrow({ where: { id: snapshotId } })
+    const snap = structuredClone(row.snapshot) as Record<string, unknown>
+    const nrs = snap.namedResources as Array<Record<string, unknown>>
+    nrs.find(e => e.id === 'nr-snap-e')!.allocationPercent = 90
+    await prisma.backlogSnapshot.update({ where: { id: snapshotId }, data: { snapshot: snap as never } })
+
+    const baseline = await snapshotCounts()
+    const outcome = await applyRemediationPlan(prisma, { plan })
+    expect(outcome.exitCode).toBe(1)
+    expect(outcome.errors.join(' ')).toContain('complete remediation state changed since dry-run')
+    await assertZeroWrites(baseline)
+  })
+
+  it('refuses before writes when an active CapacityPlan changes outside operation evidence', async () => {
+    const projectId = await createProject()
+    // A planner-owned RT with a valid ROLE profile (no operation for it).
+    const plannerRt = await createRole(projectId, { allocationMode: 'CAPACITY_PLAN', count: 1 })
+    await createActivePlan(projectId, [
+      { periodIndex: 0, startWeek: 0, endWeek: 8, entries: [{ resourceTypeId: plannerRt, headcount: 1 }] },
+    ])
+    const plannerProfileId = await createProfile(projectId, {
+      resourceTypeId: plannerRt,
+      ownerKind: 'ROLE',
+      planningBasis: 'CAPACITY_PROFILE',
+      source: 'SQUAD_PLANNER',
+      defaultPercent: 100,
+      segments: [{ id: 'seg-planner', startWeek: 0, endWeek: 7, capacityPercent: 100, source: 'SQUAD_PLANNER' }],
+    })
+    // An unprofiled RT produces the operation.
+    await createRole(projectId, { allocationMode: 'TIMELINE' })
+    const { plan } = await runDryRun()
+    expect(plan.operations).toHaveLength(1)
+
+    // Change the plan entry for the ALREADY VALID planner RT (outside the
+    // operation's local evidence).
+    await prisma.capacityPlanEntry.updateMany({
+      where: { resourceTypeId: plannerRt },
+      data: { headcount: 2 },
+    })
+    const baseline = await snapshotCounts()
+    const outcome = await applyRemediationPlan(prisma, { plan })
+    expect(outcome.exitCode).toBe(1)
+    expect(outcome.errors.join(' ')).toContain('complete remediation state changed since dry-run')
+    await assertZeroWrites(baseline)
+    void plannerProfileId
+  })
+
+  it('refuses before writes when a cross-project ownership defect appears', async () => {
+    const projectId = await createProject()
+    await createRole(projectId, { allocationMode: 'TIMELINE' })
+    const { plan } = await runDryRun()
+    expect(plan.operations).toHaveLength(1)
+
+    // A profile in this project referencing a ResourceType owned by another
+    // project (cross-project ownership — the partial unique indexes still
+    // allow the FK, so this row is insertable).
+    const otherProjectId = await createProject('Other Project')
+    const otherRt = await createRole(otherProjectId, { allocationMode: 'EFFORT' })
+    await prisma.capacityProfile.create({
+      data: {
+        projectId,
+        resourceTypeId: otherRt,
+        ownerKind: 'ROLE',
+        planningBasis: 'DEMAND_FOLLOWING',
+        source: 'FIXED',
+        defaultPercent: 100,
+      },
+    })
+    const baseline = await snapshotCounts()
+    const outcome = await applyRemediationPlan(prisma, { plan })
+    expect(outcome.exitCode).toBe(1)
+    await assertZeroWrites(baseline)
+  })
+
+  it('refuses before writes on mixed partial state (one op manually applied)', async () => {
+    const projectId = await createProject()
+    const rtA = await createRole(projectId, { allocationMode: 'TIMELINE' })
+    const rtB = await createRole(projectId, { allocationMode: 'EFFORT' })
+    const { plan } = await runDryRun()
+    expect(plan.operations).toHaveLength(2)
+
+    // Manually apply exactly one of the two proposed profiles.
+    const opA = plan.operations.find(op => op.ownerId === rtA)!
+    const proposed = opA.proposed as { profileId: string; planningBasis: string; source: string; defaultPercent: number | null; startWeek: number | null; endWeek: number | null; legacy?: unknown }
+    await prisma.capacityProfile.create({
+      data: {
+        id: proposed.profileId,
+        projectId,
+        resourceTypeId: rtA,
+        ownerKind: 'ROLE',
+        planningBasis: proposed.planningBasis as $Enums.CapacityProfilePlanningBasis,
+        source: proposed.source as $Enums.CapacityProfileSource,
+        defaultPercent: proposed.defaultPercent,
+        startWeek: proposed.startWeek,
+        endWeek: proposed.endWeek,
+        legacy: proposed.legacy as never,
+      },
+    })
+
+    const baseline = await snapshotCounts()
+    const outcome = await applyRemediationPlan(prisma, { plan })
+    expect(outcome.exitCode).toBe(1)
+    expect(outcome.errors.join(' ')).toContain('complete remediation state changed since dry-run')
+    await assertZeroWrites(baseline)
+    void rtB
+  })
+
+  it('exact post-apply rerun is a no-op for both invocation forms', async () => {
+    const projectId = await createProject()
+    await createRole(projectId, { allocationMode: 'TIMELINE' })
+    await createRole(projectId, { allocationMode: 'CAPACITY_PLAN' })
+    const { plan } = await runDryRun()
+    const manifest = await buildManifest(plan, [{
+      decisionId: plan.decisions.find(d => d.ownerKind === 'role')!.id,
+      resolution: { shape: 'scalar-profile', planningBasis: 'DEMAND_FOLLOWING', defaultPercent: 100 },
+    }])
+
+    // Resolved-plan form (as saved by dry-run with a manifest).
+    const resolved = resolvePlanWithManifest(plan, manifest)
+    expect(resolved.errors).toEqual([])
+    const first = await applyRemediationPlan(prisma, { plan: resolved.plan })
+    expect(first.exitCode).toBe(0)
+    expect(first.applied).toBe(2)
+    const rerun = await applyRemediationPlan(prisma, { plan: resolved.plan })
+    expect(rerun.exitCode).toBe(0)
+    expect(rerun.applied).toBe(0)
+    expect(rerun.skipped).toBe(2)
+
+    // Baseline-plan-plus-manifest form: first apply and rerun both work.
+    const secondFirst = await applyRemediationPlan(prisma, { plan, manifest })
+    expect(secondFirst.exitCode).toBe(0)
+    expect(secondFirst.skipped).toBe(2)
+    const secondRerun = await applyRemediationPlan(prisma, { plan, manifest })
+    expect(secondRerun.exitCode).toBe(0)
+    expect(secondRerun.applied).toBe(0)
+    expect(secondRerun.skipped).toBe(2)
+    expect(await prisma.capacityProfile.count()).toBe(2)
+  })
+
+  it('baseline-plan-plus-manifest and resolved-plan forms enforce the same full-scope drift contract', async () => {
+    const projectId = await createProject()
+    await createRole(projectId, { allocationMode: 'TIMELINE' })
+    const { plan } = await runDryRun()
+    const manifest = await buildManifest(plan, [])
+    const resolved = resolvePlanWithManifest(plan, manifest)
+    expect(resolved.errors).toEqual([])
+
+    await createRole(projectId, { allocationMode: 'EFFORT' })
+    const baseline = await snapshotCounts()
+    const baseOutcome = await applyRemediationPlan(prisma, { plan, manifest })
+    expect(baseOutcome.exitCode).toBe(1)
+    const resolvedOutcome = await applyRemediationPlan(prisma, { plan: resolved.plan })
+    expect(resolvedOutcome.exitCode).toBe(1)
+    await assertZeroWrites(baseline)
+  })
+})
+
+// ════════════════════════════════════════════════════════════════════════════
 // 6. End-to-end readiness on a database with every production blocker class
 // ════════════════════════════════════════════════════════════════════════════
 
@@ -1103,7 +1520,11 @@ describeIf('remediation end-to-end', () => {
       },
       {
         decisionId: plan.decisions.find(d => d.ownerId === capNr)!.id,
-        resolution: { shape: 'availability-window' as const, defaultPercent: 100, startWeek: 0, endWeek: 12 },
+        resolution: {
+          shape: 'owner-kind-decision' as const,
+          ownerKind: 'NAMED_PERSON' as const,
+          capacity: { shape: 'availability-window' as const, defaultPercent: 100, startWeek: 0, endWeek: 12 },
+        },
       },
       {
         decisionId: plan.decisions.find(d => d.profileId !== null && d.ownerId === effortRt)!.id,

--- a/server/src/test/productionRemediation.integration.test.ts
+++ b/server/src/test/productionRemediation.integration.test.ts
@@ -1172,6 +1172,223 @@ describeIf('remediation owner-kind decisions', () => {
 })
 
 // ════════════════════════════════════════════════════════════════════════════
+// 5d. Shared-parent ROLE coordination (review round 3)
+// ════════════════════════════════════════════════════════════════════════════
+
+describeIf('remediation shared-parent ROLE coordination', () => {
+  function plannedResourceResolution(): { shape: 'owner-kind-decision'; ownerKind: 'PLANNED_RESOURCE'; capacity: { shape: 'scalar-profile'; planningBasis: 'DEMAND_FOLLOWING'; defaultPercent: number } } {
+    return {
+      shape: 'owner-kind-decision' as const,
+      ownerKind: 'PLANNED_RESOURCE' as const,
+      capacity: { shape: 'scalar-profile' as const, planningBasis: 'DEMAND_FOLLOWING' as const, defaultPercent: 100 },
+    }
+  }
+
+  it('two PLANNED_RESOURCE children of one parent emit one parent ROLE op and apply exactly once', async () => {
+    const projectId = await createProject()
+    const parentRt = await createRole(projectId, { allocationMode: 'EFFORT' })
+    const nrA = await createNamedPerson(projectId, parentRt, { allocationMode: 'CAPACITY_PLAN' })
+    const nrB = await createNamedPerson(projectId, parentRt, { allocationMode: 'CAPACITY_PLAN' })
+    const { plan } = await runDryRun()
+    const decA = plan.decisions.find(d => d.ownerId === nrA)!
+    const decB = plan.decisions.find(d => d.ownerId === nrB)!
+    expect(decA.roleState).toBe('derived')
+    expect(decB.roleState).toBe('derived')
+    const manifest = await buildManifest(plan, [
+      { decisionId: decA.id, resolution: plannedResourceResolution() },
+      { decisionId: decB.id, resolution: plannedResourceResolution() },
+    ])
+    const merged = resolvePlanWithManifest(plan, manifest)
+    expect(merged.errors).toEqual([])
+    const parentOps = merged.plan.operations.filter(op => op.ownerId === parentRt && op.kind === 'create-role-profile')
+    expect(parentOps).toHaveLength(1)
+    expect(merged.plan.operations.filter(op => op.ownerId === nrA || op.ownerId === nrB)).toHaveLength(2)
+
+    const outcome = await applyRemediationPlan(prisma, { plan, manifest })
+    expect(outcome.exitCode).toBe(0)
+    const childProfiles = await prisma.capacityProfile.findMany({
+      where: { namedResourceId: { in: [nrA, nrB] } },
+    })
+    expect(childProfiles).toHaveLength(2)
+    expect(childProfiles.every(p => p.ownerKind === 'PLANNED_RESOURCE')).toBe(true)
+    const roleProfiles = await prisma.capacityProfile.findMany({
+      where: { resourceTypeId: parentRt, ownerKind: 'ROLE' },
+    })
+    expect(roleProfiles).toHaveLength(1)
+
+    const audit = await runOwnershipAudit(prisma)
+    expect(audit.isClean).toBe(true)
+    const readiness = await runProductionMigrationReadiness(prisma)
+    expect(readiness.passed).toBe(true)
+    const resolved = await resolveSchedulerCapacity(prisma, projectId)
+    expect(resolved.meta.legacyCount).toBe(0)
+
+    // Exact rerun is a no-op.
+    const rerun = await applyRemediationPlan(prisma, { plan, manifest })
+    expect(rerun.exitCode).toBe(0)
+    expect(rerun.applied).toBe(0)
+    expect(rerun.skipped).toBe(3)
+  })
+
+  it('mixed PLANNED_RESOURCE and NAMED_PERSON children persist exact kinds with one parent ROLE profile', async () => {
+    const projectId = await createProject()
+    const parentRt = await createRole(projectId, { allocationMode: 'EFFORT' })
+    const plannedNr = await createNamedPerson(projectId, parentRt, { allocationMode: 'CAPACITY_PLAN' })
+    const namedNr = await createNamedPerson(projectId, parentRt, { allocationMode: 'CAPACITY_PLAN' })
+    const { plan } = await runDryRun()
+    const manifest = await buildManifest(plan, [
+      {
+        decisionId: plan.decisions.find(d => d.ownerId === plannedNr)!.id,
+        resolution: plannedResourceResolution(),
+      },
+      {
+        decisionId: plan.decisions.find(d => d.ownerId === namedNr)!.id,
+        resolution: {
+          shape: 'owner-kind-decision' as const,
+          ownerKind: 'NAMED_PERSON' as const,
+          capacity: { shape: 'availability-window' as const, defaultPercent: 100, startWeek: 0, endWeek: 10 },
+        },
+      },
+    ])
+    const merged = resolvePlanWithManifest(plan, manifest)
+    expect(merged.errors).toEqual([])
+    const parentOps = merged.plan.operations.filter(op => op.ownerId === parentRt && op.kind === 'create-role-profile')
+    expect(parentOps).toHaveLength(1)
+
+    const outcome = await applyRemediationPlan(prisma, { plan, manifest })
+    expect(outcome.exitCode).toBe(0)
+    const plannedProfile = await prisma.capacityProfile.findFirstOrThrow({ where: { namedResourceId: plannedNr } })
+    const namedProfile = await prisma.capacityProfile.findFirstOrThrow({ where: { namedResourceId: namedNr } })
+    expect(plannedProfile.ownerKind).toBe('PLANNED_RESOURCE')
+    expect(namedProfile.ownerKind).toBe('NAMED_PERSON')
+    const roleCount = await prisma.capacityProfile.count({ where: { resourceTypeId: parentRt, ownerKind: 'ROLE' } })
+    expect(roleCount).toBe(1)
+    const readiness = await runProductionMigrationReadiness(prisma)
+    expect(readiness.passed).toBe(true)
+    const resolved = await resolveSchedulerCapacity(prisma, projectId)
+    expect(resolved.meta.legacyCount).toBe(0)
+  })
+
+  it('retains a valid existing parent ROLE profile unchanged (no replacement, no duplicate op)', async () => {
+    const projectId = await createProject()
+    const parentRt = await createRole(projectId, { allocationMode: 'EFFORT' })
+    const existingProfileId = await createProfile(projectId, {
+      resourceTypeId: parentRt,
+      ownerKind: 'ROLE',
+      planningBasis: 'DEMAND_FOLLOWING',
+      source: 'FIXED',
+      defaultPercent: 100,
+      legacy: { allocationMode: 'EFFORT', allocationPercent: 100 },
+    })
+    const nr = await createNamedPerson(projectId, parentRt, { allocationMode: 'CAPACITY_PLAN' })
+    const { plan } = await runDryRun()
+    const decision = plan.decisions.find(d => d.ownerId === nr)!
+    expect(decision.roleState).toBe('existing')
+    const manifest = await buildManifest(plan, [
+      { decisionId: decision.id, resolution: plannedResourceResolution() },
+    ])
+    const merged = resolvePlanWithManifest(plan, manifest)
+    expect(merged.errors).toEqual([])
+    expect(merged.plan.operations.filter(op => op.ownerId === parentRt && op.kind === 'create-role-profile')).toHaveLength(0)
+
+    const outcome = await applyRemediationPlan(prisma, { plan, manifest })
+    expect(outcome.exitCode).toBe(0)
+    const existing = await prisma.capacityProfile.findUniqueOrThrow({ where: { id: existingProfileId } })
+    expect(existing.planningBasis).toBe('DEMAND_FOLLOWING')
+    expect(existing.defaultPercent).toBe(100)
+    expect((existing.legacy as Record<string, unknown>).allocationMode).toBe('EFFORT')
+    const roleCount = await prisma.capacityProfile.count({ where: { resourceTypeId: parentRt, ownerKind: 'ROLE' } })
+    expect(roleCount).toBe(1)
+    const readiness = await runProductionMigrationReadiness(prisma)
+    expect(readiness.passed).toBe(true)
+  })
+
+  it('reuses a compatible baseline parent ROLE operation for a planner-owned parent', async () => {
+    const projectId = await createProject()
+    const plannerRt = await createRole(projectId, { allocationMode: 'CAPACITY_PLAN', count: 1 })
+    await createActivePlan(projectId, [
+      { periodIndex: 0, startWeek: 0, endWeek: 8, entries: [{ resourceTypeId: plannerRt, headcount: 1 }] },
+    ])
+    const plannedNr = await createNamedPerson(projectId, plannerRt, { allocationMode: 'CAPACITY_PLAN', startWeek: 0, endWeek: 7 })
+    await createProfile(projectId, {
+      namedResourceId: plannedNr,
+      ownerKind: 'PLANNED_RESOURCE',
+      planningBasis: 'CAPACITY_PROFILE',
+      source: 'SQUAD_PLANNER',
+      defaultPercent: 100,
+      segments: [{ startWeek: 0, endWeek: 7, capacityPercent: 100, source: 'SQUAD_PLANNER' }],
+    })
+    const ambiguousNr = await createNamedPerson(projectId, plannerRt, { allocationMode: 'CAPACITY_PLAN' })
+    const { plan } = await runDryRun()
+    const baselineRoleOps = plan.operations.filter(op => op.ownerId === plannerRt && op.kind === 'create-role-profile')
+    expect(baselineRoleOps).toHaveLength(1)
+    const decision = plan.decisions.find(d => d.ownerId === ambiguousNr)!
+    const manifest = await buildManifest(plan, [
+      { decisionId: decision.id, resolution: plannedResourceResolution() },
+    ])
+    const merged = resolvePlanWithManifest(plan, manifest)
+    expect(merged.errors).toEqual([])
+    expect(merged.plan.operations.filter(op => op.ownerId === plannerRt && op.kind === 'create-role-profile')).toHaveLength(1)
+
+    const outcome = await applyRemediationPlan(prisma, { plan, manifest })
+    expect(outcome.exitCode).toBe(0)
+    const roleCount = await prisma.capacityProfile.count({ where: { resourceTypeId: plannerRt, ownerKind: 'ROLE' } })
+    expect(roleCount).toBe(1)
+    const readiness = await runProductionMigrationReadiness(prisma)
+    expect(readiness.passed).toBe(true)
+  })
+
+  it('rejects conflicting parent ROLE evidence before writes, identifying parent and decisions', async () => {
+    const projectId = await createProject()
+    const parentRt = await createRole(projectId, { allocationMode: 'EFFORT' })
+    const nrA = await createNamedPerson(projectId, parentRt, { allocationMode: 'CAPACITY_PLAN' })
+    const nrB = await createNamedPerson(projectId, parentRt, { allocationMode: 'CAPACITY_PLAN' })
+    const { plan } = await runDryRun()
+    const mutated = JSON.parse(JSON.stringify(plan)) as unknown as Record<string, unknown>
+    const mutatedDecisions = mutated.decisions as Array<Record<string, unknown>>
+    const mutatedB = mutatedDecisions.find(d => d.ownerId === nrB)!
+    mutatedB.roleProposed = {
+      ...(mutatedB.roleProposed as Record<string, unknown>),
+      defaultPercent: 123,
+    }
+    const manifest = await buildManifest(plan, [
+      { decisionId: (mutatedDecisions.find(d => d.ownerId === nrA)!.id as string), resolution: plannedResourceResolution() },
+      { decisionId: (mutatedB.id as string), resolution: plannedResourceResolution() },
+    ])
+    const profilesBefore = await prisma.capacityProfile.count()
+    const outcome = await applyRemediationPlan(prisma, { plan: mutated as never, manifest })
+    expect(outcome.exitCode).toBe(1)
+    expect(outcome.errors.join(' ')).toContain('conflicting parent ROLE proposals')
+    expect(outcome.errors.join(' ')).toContain(parentRt)
+    expect(await prisma.capacityProfile.count()).toBe(profilesBefore)
+  })
+
+  it('keeps coordinated operations and fingerprint stable under reversed manifest order', async () => {
+    const projectId = await createProject()
+    const parentRt = await createRole(projectId, { allocationMode: 'EFFORT' })
+    const nrA = await createNamedPerson(projectId, parentRt, { allocationMode: 'CAPACITY_PLAN' })
+    const nrB = await createNamedPerson(projectId, parentRt, { allocationMode: 'CAPACITY_PLAN' })
+    const { plan } = await runDryRun()
+    const decA = plan.decisions.find(d => d.ownerId === nrA)!
+    const decB = plan.decisions.find(d => d.ownerId === nrB)!
+    const forward = await buildManifest(plan, [
+      { decisionId: decA.id, resolution: plannedResourceResolution() },
+      { decisionId: decB.id, resolution: plannedResourceResolution() },
+    ])
+    const reversed = await buildManifest(plan, [
+      { decisionId: decB.id, resolution: plannedResourceResolution() },
+      { decisionId: decA.id, resolution: plannedResourceResolution() },
+    ])
+    const forwardMerged = resolvePlanWithManifest(plan, forward)
+    const reversedMerged = resolvePlanWithManifest(plan, reversed)
+    expect(forwardMerged.errors).toEqual([])
+    expect(reversedMerged.errors).toEqual([])
+    expect(forwardMerged.plan.operations.map(op => op.id)).toEqual(reversedMerged.plan.operations.map(op => op.id))
+    expect(forwardMerged.plan.fingerprint).toBe(reversedMerged.plan.fingerprint)
+  })
+})
+
+// ════════════════════════════════════════════════════════════════════════════
 // 5c. Full-scope drift refusal before writes (review round 2)
 // ════════════════════════════════════════════════════════════════════════════
 

--- a/server/src/test/productionRemediationPlan.test.ts
+++ b/server/src/test/productionRemediationPlan.test.ts
@@ -1,0 +1,786 @@
+/**
+ * productionRemediationPlan.test.ts — Pure unit tests for the Issue #421
+ * remediation planner (no database).
+ *
+ * Coverage:
+ *   - deterministic live-state derivation matrix (ROLE + NAMED_PERSON);
+ *   - planner-owned ROLE reconstruction from valid CapacityPlan entries;
+ *   - never-active window policy (shared with readiness/rollback translation);
+ *   - persisted-profile defect classification (window-clear, overlap-fix,
+ *     segmentless-decision, unsupported);
+ *   - overlap decomposition preserves per-week effective capacity and IDs;
+ *   - snapshot entry classification matrix;
+ *   - canonical JSON + stable fingerprints (reruns identical, tampering detected);
+ *   - plan/manifest parse validation and merge (resolutions, refusals);
+ *   - exit classification (0/1/2).
+ */
+import { describe, expect, it } from 'vitest'
+
+import {
+  buildRemediationPlan,
+  canonicalJson,
+  classifyPlanExit,
+  computePlanFingerprint,
+  decomposeOverlappingSegments,
+  deriveNamedProfileFromLegacy,
+  deriveRoleProfileFromLegacy,
+  classifyPersistedProfileDefect,
+  classifySnapshotEntry,
+  parsePlanJson,
+  parseManifestJson,
+  resolvePlanWithManifest,
+  remediationProfileId,
+  sha256Hex,
+  type RemediationDatabaseState,
+  type RemediationManifest,
+  type RemediationNamedResource,
+  type RemediationProject,
+  type RemediationResourceType,
+} from '../lib/productionRemediationPlan.js'
+import { isNeverActiveWindow } from '../lib/projectSnapshotCapacity.js'
+
+// ─── Fixture helpers ────────────────────────────────────────────────────────
+
+function makeRt(overrides: Partial<RemediationResourceType> = {}): RemediationResourceType {
+  return {
+    id: 'rt-1',
+    name: 'Engineer',
+    count: 1,
+    allocationMode: 'EFFORT',
+    allocationPercent: 100,
+    allocationStartWeek: null,
+    allocationEndWeek: null,
+    namedResources: [],
+    ...overrides,
+  }
+}
+
+function makeNr(overrides: Partial<RemediationNamedResource> = {}): RemediationNamedResource {
+  return {
+    id: 'nr-1',
+    name: 'Alice',
+    allocationMode: 'EFFORT',
+    allocationPercent: 100,
+    allocationPct: null,
+    allocationStartWeek: null,
+    allocationEndWeek: null,
+    startWeek: null,
+    endWeek: null,
+    ...overrides,
+  }
+}
+
+function makeProject(overrides: Partial<RemediationProject> = {}): RemediationProject {
+  return {
+    id: 'proj-1',
+    name: 'Project One',
+    resourceTypes: [],
+    capacityProfiles: [],
+    activePlanPeriods: [],
+    ...overrides,
+  }
+}
+
+function makeState(project: RemediationProject): RemediationDatabaseState {
+  return { projects: [project], snapshots: [] }
+}
+
+// ─── never-active policy ────────────────────────────────────────────────────
+
+describe('isNeverActiveWindow (issue #421 policy)', () => {
+  it('treats the (-1, -1) Squad Planner sentinel as never active', () => {
+    expect(isNeverActiveWindow(-1, -1)).toBe(true)
+  })
+
+  it('treats inverted windows (start > end) as never active', () => {
+    expect(isNeverActiveWindow(4, 3)).toBe(true)
+  })
+
+  it('does not treat null/unbounded windows as never active', () => {
+    expect(isNeverActiveWindow(null, null)).toBe(false)
+    expect(isNeverActiveWindow(0, null)).toBe(false)
+    expect(isNeverActiveWindow(null, 10)).toBe(false)
+  })
+
+  it('does not normalise a single -1 edge (no established meaning)', () => {
+    expect(isNeverActiveWindow(-1, 5)).toBe(false)
+    expect(isNeverActiveWindow(0, -1)).toBe(false)
+  })
+
+  it('treats valid windows as active', () => {
+    expect(isNeverActiveWindow(0, 10)).toBe(false)
+  })
+})
+
+// ─── Deterministic ROLE derivation matrix ───────────────────────────────────
+
+describe('deriveRoleProfileFromLegacy', () => {
+  it('maps TIMELINE → AVAILABILITY_WINDOW preserving percent and window', () => {
+    const result = deriveRoleProfileFromLegacy(makeRt({
+      allocationMode: 'TIMELINE',
+      allocationPercent: 75,
+      allocationStartWeek: 2,
+      allocationEndWeek: 10,
+    }), [])
+    expect(result.classification).toBe('deterministic')
+    expect(result.proposed).toMatchObject({
+      profileId: remediationProfileId('role', 'rt-1'),
+      ownerKind: 'ROLE',
+      planningBasis: 'AVAILABILITY_WINDOW',
+      source: 'AVAILABILITY_WINDOW',
+      defaultPercent: 75,
+      startWeek: 2,
+      endWeek: 10,
+      segments: [],
+    })
+  })
+
+  it('maps EFFORT → DEMAND_FOLLOWING and discards stale windows', () => {
+    const result = deriveRoleProfileFromLegacy(makeRt({
+      allocationMode: 'EFFORT',
+      allocationPercent: null,
+      allocationStartWeek: 2,
+      allocationEndWeek: 10,
+    }), [])
+    expect(result.classification).toBe('deterministic')
+    expect(result.proposed).toMatchObject({
+      planningBasis: 'DEMAND_FOLLOWING',
+      source: 'FIXED',
+      defaultPercent: null,
+      startWeek: null,
+      endWeek: null,
+    })
+  })
+
+  it('maps null mode → DEMAND_FOLLOWING', () => {
+    const result = deriveRoleProfileFromLegacy(makeRt({ allocationMode: null }), [])
+    expect(result.classification).toBe('deterministic')
+    expect(result.proposed).toMatchObject({ planningBasis: 'DEMAND_FOLLOWING', source: 'FIXED' })
+  })
+
+  it('maps FULL_PROJECT → WHOLE_PROJECT_ALLOCATION', () => {
+    const result = deriveRoleProfileFromLegacy(makeRt({ allocationMode: 'FULL_PROJECT' }), [])
+    expect(result.classification).toBe('deterministic')
+    expect(result.proposed).toMatchObject({
+      planningBasis: 'WHOLE_PROJECT_ALLOCATION',
+      source: 'FIXED',
+      defaultPercent: 100,
+      startWeek: null,
+      endWeek: null,
+    })
+  })
+
+  it('reconstructs a planner-owned ROLE profile from valid active-plan entries', () => {
+    const periods = [
+      {
+        periodIndex: 0,
+        startWeek: 0,
+        endWeek: 8,
+        entries: [{ resourceTypeId: 'rt-1', headcount: 2 }],
+      },
+      {
+        periodIndex: 1,
+        startWeek: 8,
+        endWeek: 16,
+        entries: [{ resourceTypeId: 'rt-1', headcount: 2 }],
+      },
+    ]
+    const result = deriveRoleProfileFromLegacy(makeRt({ allocationMode: 'CAPACITY_PLAN' }), periods)
+    expect(result.classification).toBe('deterministic')
+    expect(result.proposed).toMatchObject({
+      ownerKind: 'ROLE',
+      planningBasis: 'CAPACITY_PROFILE',
+      source: 'SQUAD_PLANNER',
+      defaultPercent: 200,
+    })
+    expect(result.proposed!.segments).toEqual([{
+      id: `${result.proposed!.profileId}-seg-001`,
+      startWeek: 0,
+      endWeek: 15,
+      capacityPercent: 200,
+      source: 'SQUAD_PLANNER',
+    }])
+    expect(result.proposed!.legacy).toMatchObject({ allocationMode: 'CAPACITY_PLAN' })
+  })
+
+  it('requires a decision for CAPACITY_PLAN without plan evidence', () => {
+    const result = deriveRoleProfileFromLegacy(makeRt({ allocationMode: 'CAPACITY_PLAN' }), [])
+    expect(result.classification).toBe('decisionRequired')
+    expect(result.proposed).toBeUndefined()
+  })
+})
+
+// ─── Deterministic NAMED_PERSON derivation matrix ───────────────────────────
+
+describe('deriveNamedProfileFromLegacy', () => {
+  it('maps TIMELINE → AVAILABILITY_WINDOW with field precedence', () => {
+    const result = deriveNamedProfileFromLegacy(makeNr({
+      allocationMode: 'TIMELINE',
+      allocationPercent: 50,
+      allocationStartWeek: null,
+      allocationEndWeek: null,
+      startWeek: 3,
+      endWeek: 9,
+    }))
+    expect(result.classification).toBe('deterministic')
+    expect(result.proposed).toMatchObject({
+      ownerKind: 'NAMED_PERSON',
+      planningBasis: 'AVAILABILITY_WINDOW',
+      source: 'AVAILABILITY_WINDOW',
+      defaultPercent: 50,
+      startWeek: 3,
+      endWeek: 9,
+    })
+  })
+
+  it('maps FULL_PROJECT → WHOLE_PROJECT_ALLOCATION and discards windows', () => {
+    const result = deriveNamedProfileFromLegacy(makeNr({
+      allocationMode: 'FULL_PROJECT',
+      allocationPercent: 80,
+      startWeek: 1,
+      endWeek: 4,
+    }))
+    expect(result.classification).toBe('deterministic')
+    expect(result.proposed).toMatchObject({
+      planningBasis: 'WHOLE_PROJECT_ALLOCATION',
+      source: 'FIXED',
+      defaultPercent: 80,
+      startWeek: null,
+      endWeek: null,
+    })
+  })
+
+  it('maps EFFORT → DEMAND_FOLLOWING at captured percent (approved mapper semantics)', () => {
+    const result = deriveNamedProfileFromLegacy(makeNr({ allocationMode: 'EFFORT' }))
+    expect(result.classification).toBe('deterministic')
+    expect(result.proposed).toMatchObject({
+      planningBasis: 'DEMAND_FOLLOWING',
+      source: 'FIXED',
+      defaultPercent: 100,
+      startWeek: null,
+      endWeek: null,
+    })
+  })
+
+  it('maps CAPACITY_PLAN with captured window → AVAILABILITY_WINDOW/LEGACY (v2 policy)', () => {
+    const result = deriveNamedProfileFromLegacy(makeNr({
+      allocationMode: 'CAPACITY_PLAN',
+      allocationPercent: 100,
+      startWeek: 0,
+      endWeek: 29,
+    }))
+    expect(result.classification).toBe('deterministic')
+    expect(result.proposed).toMatchObject({
+      planningBasis: 'AVAILABILITY_WINDOW',
+      source: 'LEGACY',
+      defaultPercent: 100,
+      startWeek: 0,
+      endWeek: 29,
+    })
+  })
+
+  it('requires a decision for CAPACITY_PLAN without a captured window', () => {
+    const result = deriveNamedProfileFromLegacy(makeNr({ allocationMode: 'CAPACITY_PLAN' }))
+    expect(result.classification).toBe('decisionRequired')
+  })
+
+  it('normalises a never-active (-1, -1) window to zero capacity', () => {
+    const result = deriveNamedProfileFromLegacy(makeNr({
+      allocationMode: 'CAPACITY_PLAN',
+      allocationPercent: 100,
+      startWeek: -1,
+      endWeek: -1,
+    }))
+    expect(result.classification).toBe('deterministic')
+    expect(result.proposed).toMatchObject({
+      planningBasis: 'AVAILABILITY_WINDOW',
+      source: 'LEGACY',
+      defaultPercent: 0,
+      startWeek: null,
+      endWeek: null,
+    })
+  })
+
+  it('requires a decision for a single -1 edge', () => {
+    const result = deriveNamedProfileFromLegacy(makeNr({
+      allocationMode: 'CAPACITY_PLAN',
+      startWeek: 0,
+      endWeek: -1,
+    }))
+    expect(result.classification).toBe('decisionRequired')
+  })
+})
+
+// ─── Overlap decomposition ──────────────────────────────────────────────────
+
+describe('decomposeOverlappingSegments', () => {
+  it('splits a contained overlap preserving weekly sums and segment IDs', () => {
+    const result = decomposeOverlappingSegments('prof-1', [
+      { id: 'seg-a', startWeek: 39, endWeek: 64, capacityPercent: 25, source: 'SQUAD_PLANNER' },
+      { id: 'seg-b', startWeek: 52, endWeek: 64, capacityPercent: 25, source: 'SQUAD_PLANNER' },
+    ])
+    expect(result).toEqual([
+      { id: 'seg-a', startWeek: 39, endWeek: 51, capacityPercent: 25, source: 'SQUAD_PLANNER' },
+      { id: 'seg-b', startWeek: 52, endWeek: 64, capacityPercent: 50, source: 'SQUAD_PLANNER' },
+    ])
+  })
+
+  it('handles partial overlaps with differing percents', () => {
+    const result = decomposeOverlappingSegments('prof-1', [
+      { id: 'seg-a', startWeek: 0, endWeek: 8, capacityPercent: 100, source: 'SQUAD_PLANNER' },
+      { id: 'seg-b', startWeek: 4, endWeek: 12, capacityPercent: 50, source: 'SQUAD_PLANNER' },
+    ])
+    expect(result).toEqual([
+      { id: 'seg-a', startWeek: 0, endWeek: 3, capacityPercent: 100, source: 'SQUAD_PLANNER' },
+      { id: 'seg-b', startWeek: 4, endWeek: 8, capacityPercent: 150, source: 'SQUAD_PLANNER' },
+      { id: `${'prof-1'}-seg-003`, startWeek: 9, endWeek: 12, capacityPercent: 50, source: 'SQUAD_PLANNER' },
+    ])
+  })
+
+  it('returns empty for an empty segment list', () => {
+    expect(decomposeOverlappingSegments('prof-1', [])).toEqual([])
+  })
+
+  it('preserves non-overlapping segments unchanged', () => {
+    const segments = [
+      { id: 'seg-a', startWeek: 0, endWeek: 4, capacityPercent: 25, source: 'SQUAD_PLANNER' },
+      { id: 'seg-b', startWeek: 5, endWeek: 8, capacityPercent: 50, source: 'SQUAD_PLANNER' },
+    ]
+    expect(decomposeOverlappingSegments('prof-1', segments)).toEqual([
+      { id: 'seg-a', startWeek: 0, endWeek: 4, capacityPercent: 25, source: 'SQUAD_PLANNER' },
+      { id: 'seg-b', startWeek: 5, endWeek: 8, capacityPercent: 50, source: 'SQUAD_PLANNER' },
+    ])
+  })
+})
+
+// ─── Persisted-profile defect classification ────────────────────────────────
+
+describe('classifyPersistedProfileDefect', () => {
+  const ctx = {
+    projectId: 'proj-1',
+    resourceTypeIds: new Set(['rt-1']),
+    namedResourceIds: new Set(['nr-1']),
+  }
+
+  function profile(overrides: Record<string, unknown> = {}) {
+    return {
+      id: 'p-1',
+      projectId: 'proj-1',
+      resourceTypeId: 'rt-1',
+      namedResourceId: null,
+      ownerKind: 'ROLE',
+      planningBasis: 'DEMAND_FOLLOWING',
+      source: 'FIXED',
+      defaultPercent: 100,
+      startWeek: null,
+      endWeek: null,
+      legacy: null,
+      segments: [],
+      ...overrides,
+    }
+  }
+
+  it('returns null for a valid profile', () => {
+    expect(classifyPersistedProfileDefect(profile(), ctx)).toBeNull()
+  })
+
+  it('deterministically clears DEMAND_FOLLOWING window fields', () => {
+    const defect = classifyPersistedProfileDefect(profile({ startWeek: 0, endWeek: 29 }), ctx)
+    expect(defect).not.toBeNull()
+    expect(defect!.kind).toBe('window-clear')
+    expect(defect!.classification).toBe('deterministic')
+    expect(defect!.proposed).toMatchObject({ profileId: 'p-1', startWeek: null, endWeek: null })
+  })
+
+  it('deterministically fixes a contained overlap preserving IDs', () => {
+    const defect = classifyPersistedProfileDefect(profile({
+      planningBasis: 'CAPACITY_PROFILE',
+      source: 'SQUAD_PLANNER',
+      segments: [
+        { id: 'seg-a', startWeek: 39, endWeek: 64, capacityPercent: 25, source: 'SQUAD_PLANNER' },
+        { id: 'seg-b', startWeek: 52, endWeek: 64, capacityPercent: 25, source: 'SQUAD_PLANNER' },
+      ],
+    }), ctx)
+    expect(defect!.kind).toBe('overlap-fix')
+    expect(defect!.classification).toBe('deterministic')
+    expect(defect!.proposed!.segments).toEqual([
+      { id: 'seg-a', startWeek: 39, endWeek: 51, capacityPercent: 25, source: 'SQUAD_PLANNER' },
+      { id: 'seg-b', startWeek: 52, endWeek: 64, capacityPercent: 50, source: 'SQUAD_PLANNER' },
+    ])
+  })
+
+  it('requires a decision for segmentless non-canonical CAPACITY_PROFILE', () => {
+    const defect = classifyPersistedProfileDefect(profile({
+      planningBasis: 'CAPACITY_PROFILE',
+      source: 'LEGACY',
+      defaultPercent: 100,
+    }), ctx)
+    expect(defect!.classification).toBe('decisionRequired')
+    expect(defect!.kind).toBe('segmentless-decision')
+    expect(defect!.allowedResolutions).toContain('segmented-capacity-profile')
+  })
+
+  it('classifies unrelated structural errors as unsupported', () => {
+    const defect = classifyPersistedProfileDefect(profile({
+      resourceTypeId: null,
+      namedResourceId: null,
+    }), ctx)
+    expect(defect!.classification).toBe('unsupported')
+  })
+})
+
+// ─── Snapshot entry classification ──────────────────────────────────────────
+
+describe('classifySnapshotEntry', () => {
+  it('classifies valid windowed CAPACITY_PLAN entries as already valid', () => {
+    const result = classifySnapshotEntry({
+      allocationMode: 'CAPACITY_PLAN',
+      allocationPercent: 100,
+      allocationStartWeek: 0,
+      allocationEndWeek: 10,
+    })
+    expect(result.classification).toBe('alreadyValid')
+  })
+
+  it('classifies windowless CAPACITY_PLAN entries as decision required', () => {
+    const result = classifySnapshotEntry({
+      allocationMode: 'CAPACITY_PLAN',
+      allocationPercent: 100,
+      allocationStartWeek: null,
+      allocationEndWeek: null,
+    })
+    expect(result.classification).toBe('decisionRequired')
+  })
+
+  it('classifies windowless TIMELINE entries as already valid (unbounded)', () => {
+    const result = classifySnapshotEntry({
+      allocationMode: 'TIMELINE',
+      allocationPercent: 100,
+      allocationStartWeek: null,
+      allocationEndWeek: null,
+    })
+    expect(result.classification).toBe('alreadyValid')
+  })
+
+  it('classifies (-1, -1) entries as deterministic policy normalisation', () => {
+    const result = classifySnapshotEntry({
+      allocationMode: 'CAPACITY_PLAN',
+      allocationPercent: 100,
+      allocationStartWeek: -1,
+      allocationEndWeek: -1,
+    })
+    expect(result.classification).toBe('deterministic')
+  })
+
+  it('classifies inverted windows as deterministic policy normalisation', () => {
+    const result = classifySnapshotEntry({
+      allocationMode: 'CAPACITY_PLAN',
+      allocationPercent: 100,
+      allocationStartWeek: 4,
+      allocationEndWeek: 3,
+    })
+    expect(result.classification).toBe('deterministic')
+  })
+
+  it('classifies a single -1 edge as decision required', () => {
+    const result = classifySnapshotEntry({
+      allocationMode: 'CAPACITY_PLAN',
+      allocationPercent: 100,
+      allocationStartWeek: 0,
+      allocationEndWeek: -1,
+    })
+    expect(result.classification).toBe('decisionRequired')
+  })
+
+  it('classifies unknown modes as unsupported', () => {
+    const result = classifySnapshotEntry({
+      allocationMode: 'MYSTERY',
+      allocationPercent: 100,
+      allocationStartWeek: null,
+      allocationEndWeek: null,
+    })
+    expect(result.classification).toBe('unsupported')
+  })
+
+  it('classifies EFFORT/FULL_PROJECT entries as already valid (windows discarded)', () => {
+    expect(classifySnapshotEntry({
+      allocationMode: 'EFFORT', allocationPercent: 100,
+      allocationStartWeek: 2, allocationEndWeek: 9,
+    }).classification).toBe('alreadyValid')
+    expect(classifySnapshotEntry({
+      allocationMode: 'FULL_PROJECT', allocationPercent: 100,
+      allocationStartWeek: 2, allocationEndWeek: 9,
+    }).classification).toBe('alreadyValid')
+  })
+})
+
+// ─── Canonical JSON + fingerprints ──────────────────────────────────────────
+
+describe('canonicalJson / fingerprints', () => {
+  it('serialises objects with sorted keys', () => {
+    expect(canonicalJson({ b: 1, a: { d: 2, c: [3, 4] } }))
+      .toBe('{"a":{"c":[3,4],"d":2},"b":1}')
+  })
+
+  it('produces stable fingerprints for identical state across repeated runs', () => {
+    const plan1 = buildRemediationPlan(makeState(makeProject({
+      resourceTypes: [
+        makeRt({ id: 'rt-a', allocationMode: 'TIMELINE', allocationPercent: 80 }),
+        makeRt({ id: 'rt-b', allocationMode: 'CAPACITY_PLAN' }),
+      ],
+    })), 'commit-1')
+    const plan2 = buildRemediationPlan(makeState(makeProject({
+      resourceTypes: [
+        makeRt({ id: 'rt-a', allocationMode: 'TIMELINE', allocationPercent: 80 }),
+        makeRt({ id: 'rt-b', allocationMode: 'CAPACITY_PLAN' }),
+      ],
+    })), 'commit-2')
+    expect(plan1.fingerprint).toBe(plan2.fingerprint)
+    expect(computePlanFingerprint(plan1)).toBe(plan1.fingerprint)
+    expect(plan1.operations).toHaveLength(1)
+    expect(plan1.decisions).toHaveLength(1)
+  })
+
+  it('changes the fingerprint when plan content changes', () => {
+    const base = buildRemediationPlan(makeState(makeProject({
+      resourceTypes: [makeRt({ allocationMode: 'TIMELINE', allocationPercent: 80 })],
+    })), 'commit-1')
+    const changed = buildRemediationPlan(makeState(makeProject({
+      resourceTypes: [makeRt({ allocationMode: 'TIMELINE', allocationPercent: 90 })],
+    })), 'commit-1')
+    expect(changed.fingerprint).not.toBe(base.fingerprint)
+  })
+
+  it('detects tampered plan files via parsePlanJson', () => {
+    const plan = buildRemediationPlan(makeState(makeProject({
+      resourceTypes: [makeRt({ allocationMode: 'TIMELINE' })],
+    })), 'commit-1')
+    const json = JSON.parse(JSON.stringify(plan))
+    json.operations[0]!.proposed.defaultPercent = 55
+    const parsed = parsePlanJson(JSON.stringify(json))
+    expect(parsed.plan).toBeNull()
+    expect(parsed.errors.join(' ')).toContain('fingerprint mismatch')
+  })
+
+  it('accepts an unaltered plan file', () => {
+    const plan = buildRemediationPlan(makeState(makeProject({
+      resourceTypes: [makeRt({ allocationMode: 'TIMELINE' })],
+    })), 'commit-1')
+    const parsed = parsePlanJson(JSON.stringify(plan))
+    expect(parsed.plan).not.toBeNull()
+    expect(parsed.errors).toEqual([])
+  })
+})
+
+// ─── Manifest merge ─────────────────────────────────────────────────────────
+
+describe('resolvePlanWithManifest', () => {
+  it('resolves a windowless CAPACITY_PLAN owner with an availability window', () => {
+    const plan = buildRemediationPlan(makeState(makeProject({
+      resourceTypes: [makeRt({ id: 'rt-x', allocationMode: 'CAPACITY_PLAN' })],
+    })), 'commit-1')
+    const manifest = {
+      formatVersion: 1,
+      applicationCommit: 'commit-1',
+      planFingerprint: plan.fingerprint,
+      decisions: [{
+        decisionId: plan.decisions[0]!.id,
+        projectId: 'proj-1',
+        ownerId: 'rt-x',
+        snapshotId: null,
+        resolution: { shape: 'availability-window', defaultPercent: 100, startWeek: 0, endWeek: 20 },
+        rationale: 'reviewed owner intent',
+      }],
+    }
+    const parsed = parseManifestJson(JSON.stringify(manifest))
+    expect(parsed.errors).toEqual([])
+    const resolved = resolvePlanWithManifest(plan, parsed.manifest!)
+    expect(resolved.errors).toEqual([])
+    expect(resolved.plan.operations).toHaveLength(1)
+    expect(resolved.plan.decisions).toHaveLength(0)
+    expect(resolved.plan.operations[0]).toMatchObject({
+      kind: 'create-role-profile',
+      classification: 'decisionResolved',
+      decisionId: plan.decisions[0]!.id,
+    })
+    const proposed = resolved.plan.operations[0]!.proposed
+    expect(proposed).toMatchObject({
+      planningBasis: 'AVAILABILITY_WINDOW',
+      source: 'AVAILABILITY_WINDOW',
+      startWeek: 0,
+      endWeek: 20,
+    })
+  })
+
+  it('rejects a manifest with a mismatched plan fingerprint', () => {
+    const plan = buildRemediationPlan(makeState(makeProject({
+      resourceTypes: [makeRt({ allocationMode: 'CAPACITY_PLAN' })],
+    })), 'commit-1')
+    const manifest = {
+      formatVersion: 1 as const,
+      applicationCommit: 'commit-1',
+      planFingerprint: sha256Hex('wrong'),
+      decisions: [],
+    }
+    const resolved = resolvePlanWithManifest(plan, manifest as RemediationManifest)
+    expect(resolved.errors.join(' ')).toContain('planFingerprint')
+  })
+
+  it('rejects resolutions whose shape is not allowed for the entry', () => {
+    const plan = buildRemediationPlan(makeState(makeProject({
+      resourceTypes: [makeRt({ allocationMode: 'CAPACITY_PLAN' })],
+    })), 'commit-1')
+    const manifest = {
+      formatVersion: 1 as const,
+      applicationCommit: 'commit-1',
+      planFingerprint: plan.fingerprint,
+      decisions: [{
+        decisionId: plan.decisions[0]!.id,
+        projectId: 'proj-1',
+        ownerId: 'rt-1',
+        snapshotId: null,
+        resolution: { shape: 'snapshot-window-interpretation' as const, startWeek: 0, endWeek: 5 },
+      }],
+    }
+    const resolved = resolvePlanWithManifest(plan, manifest)
+    expect(resolved.errors.join(' ')).toContain('not allowed')
+  })
+
+  it('keeps unresolved decisions in the merged plan', () => {
+    const plan = buildRemediationPlan(makeState(makeProject({
+      resourceTypes: [makeRt({ id: 'rt-x', allocationMode: 'CAPACITY_PLAN' })],
+    })), 'commit-1')
+    const manifest = {
+      formatVersion: 1 as const,
+      applicationCommit: 'commit-1',
+      planFingerprint: plan.fingerprint,
+      decisions: [],
+    }
+    const resolved = resolvePlanWithManifest(plan, manifest as RemediationManifest)
+    expect(resolved.errors).toEqual([])
+    expect(resolved.plan.decisions).toHaveLength(1)
+    expect(resolved.plan.operations).toHaveLength(0)
+  })
+
+  it('rejects a malformed snapshot window interpretation', () => {
+    const plan = buildRemediationPlan(makeState(makeProject({
+      resourceTypes: [makeRt({ id: 'rt-x', allocationMode: 'CAPACITY_PLAN' })],
+    })), 'commit-1')
+    const manifest = {
+      formatVersion: 1 as const,
+      applicationCommit: 'commit-1',
+      planFingerprint: plan.fingerprint,
+      decisions: [{
+        decisionId: plan.decisions[0]!.id,
+        projectId: 'proj-1',
+        ownerId: 'rt-x',
+        snapshotId: null,
+        resolution: { shape: 'availability-window' as const, defaultPercent: 100, startWeek: 9, endWeek: 3 },
+      }],
+    }
+    // Inverted window on a live-owner resolution: structurally invalid → the
+    // resulting proposed profile fails the authoritative validator at apply,
+    // and the merged operation is still emitted; apply refuses. The merge
+    // itself validates shape membership only.
+    const resolved = resolvePlanWithManifest(plan, manifest)
+    expect(resolved.errors).toEqual([])
+    expect(resolved.plan.operations).toHaveLength(1)
+  })
+})
+
+// ─── Exit classification ────────────────────────────────────────────────────
+
+describe('classifyPlanExit', () => {
+  it('returns 2 when decisions remain', () => {
+    const plan = buildRemediationPlan(makeState(makeProject({
+      resourceTypes: [makeRt({ allocationMode: 'CAPACITY_PLAN' })],
+    })), 'commit-1')
+    expect(classifyPlanExit(plan)).toBe(2)
+  })
+
+  it('returns 0 for a fully resolved plan', () => {
+    const plan = buildRemediationPlan(makeState(makeProject({
+      resourceTypes: [makeRt({ allocationMode: 'TIMELINE' })],
+    })), 'commit-1')
+    expect(classifyPlanExit(plan)).toBe(0)
+  })
+
+  it('returns 1 for unsupported findings even without decisions', () => {
+    const plan = buildRemediationPlan({
+      projects: [],
+      snapshots: [{
+        id: 'snap-1',
+        projectId: 'proj-1',
+        snapshot: { schemaVersion: 99 },
+      }],
+    }, 'commit-1')
+    expect(classifyPlanExit(plan)).toBe(1)
+  })
+})
+
+// ─── Full plan shape ────────────────────────────────────────────────────────
+
+describe('buildRemediationPlan (integration of matrix)', () => {
+  it('classifies every live owner and emits operations/decisions/findings', () => {
+    const project = makeProject({
+      resourceTypes: [
+        makeRt({ id: 'rt-1', allocationMode: 'TIMELINE' }),
+        makeRt({ id: 'rt-2', allocationMode: 'CAPACITY_PLAN' }),
+        makeRt({
+          id: 'rt-3',
+          allocationMode: 'TIMELINE',
+          namedResources: [
+            makeNr({ id: 'nr-1', allocationMode: 'TIMELINE', startWeek: 0, endWeek: 8 }),
+            makeNr({ id: 'nr-2', allocationMode: 'CAPACITY_PLAN' }),
+          ],
+        }),
+      ],
+    })
+    const plan = buildRemediationPlan(makeState(project), 'commit-1')
+    expect(plan.operations).toHaveLength(2) // rt-1 role + nr-1 named
+    expect(plan.decisions).toHaveLength(2) // rt-2 role + nr-2 named
+    expect(plan.summary.findings.deterministic).toBe(2)
+    expect(plan.summary.findings.decisionRequired).toBe(2)
+    // Stable ordering: findings/operations sorted deterministically.
+    expect(plan.operations[0]!.ownerId).toBe('rt-1')
+    expect(plan.operations[1]!.ownerId).toBe('nr-1')
+  })
+
+  it('reports planner-owned RTs without ROLE profiles as deterministic when plan entries exist', () => {
+    const project = makeProject({
+      resourceTypes: [makeRt({ id: 'rt-p', allocationMode: 'CAPACITY_PLAN', count: 2 })],
+      activePlanPeriods: [{
+        periodIndex: 0,
+        startWeek: 0,
+        endWeek: 8,
+        entries: [{ resourceTypeId: 'rt-p', headcount: 1 }],
+      }],
+      capacityProfiles: [{
+        id: 'prof-nr-1',
+        projectId: 'proj-1',
+        resourceTypeId: null,
+        namedResourceId: 'nr-p-1',
+        ownerKind: 'PLANNED_RESOURCE',
+        planningBasis: 'CAPACITY_PROFILE',
+        source: 'SQUAD_PLANNER',
+        defaultPercent: null,
+        startWeek: 0,
+        endWeek: 7,
+        legacy: null,
+        segments: [{ id: 'seg-nr-1', startWeek: 0, endWeek: 7, capacityPercent: 100, source: 'SQUAD_PLANNER' }],
+      }],
+    })
+    const withNr = { ...project, resourceTypes: [{
+      ...project.resourceTypes[0]!,
+      namedResources: [
+        { ...makeNr({ id: 'nr-p-1', allocationMode: 'CAPACITY_PLAN' }), resourceTypeId: 'rt-p' },
+      ],
+    }] }
+    const plan = buildRemediationPlan(makeState(withNr), 'commit-1')
+    const roleOps = plan.operations.filter(op => op.ownerId === 'rt-p')
+    expect(roleOps).toHaveLength(1)
+    expect(roleOps[0]!.kind).toBe('create-role-profile')
+    const proposed = roleOps[0]!.proposed
+    expect(proposed).toMatchObject({ planningBasis: 'CAPACITY_PROFILE', source: 'SQUAD_PLANNER' })
+  })
+})

--- a/server/src/test/productionRemediationPlan.test.ts
+++ b/server/src/test/productionRemediationPlan.test.ts
@@ -784,3 +784,276 @@ describe('buildRemediationPlan (integration of matrix)', () => {
     expect(proposed).toMatchObject({ planningBasis: 'CAPACITY_PROFILE', source: 'SQUAD_PLANNER' })
   })
 })
+
+// ─── Owner-kind decisions (issue #421 review round 2) ───────────────────────
+
+describe('owner-kind decisions for ambiguous NamedResources', () => {
+  function ambiguousNrProject(): { project: RemediationProject; nr: RemediationNamedResource } {
+    const nr = makeNr({ id: 'nr-amb', allocationMode: 'CAPACITY_PLAN' })
+    return {
+      nr,
+      project: makeProject({
+        resourceTypes: [
+          makeRt({ id: 'rt-parent', allocationMode: 'EFFORT', namedResources: [nr] }),
+        ],
+      }),
+    }
+  }
+
+  it('emits an owner-kind-required decision for a missing ambiguous NamedResource', () => {
+    const { project } = ambiguousNrProject()
+    const plan = buildRemediationPlan(makeState(project), 'commit-1')
+    const decision = plan.decisions.find(d => d.ownerId === 'nr-amb')
+    expect(decision).toBeDefined()
+    expect(decision!.allowedResolutions).toEqual(['owner-kind-decision'])
+    expect(decision!.message).toContain('owner kind and capacity require explicit review')
+  })
+
+  it('emits an owner-kind-required decision for a single -1 missing NamedResource', () => {
+    const nr = makeNr({ id: 'nr-neg', allocationMode: 'CAPACITY_PLAN', startWeek: 0, endWeek: -1 })
+    const plan = buildRemediationPlan(makeState(makeProject({
+      resourceTypes: [makeRt({ id: 'rt-parent', allocationMode: 'EFFORT', namedResources: [nr] })],
+    })), 'commit-1')
+    const decision = plan.decisions.find(d => d.ownerId === 'nr-neg')
+    expect(decision!.allowedResolutions).toEqual(['owner-kind-decision'])
+  })
+
+  it('rejects a direct capacity-only resolution while owner kind is unresolved', () => {
+    const { project } = ambiguousNrProject()
+    const plan = buildRemediationPlan(makeState(project), 'commit-1')
+    const manifest = {
+      formatVersion: 1 as const,
+      applicationCommit: 'commit-1',
+      planFingerprint: plan.fingerprint,
+      decisions: [{
+        decisionId: plan.decisions[0]!.id,
+        projectId: 'proj-1',
+        ownerId: 'nr-amb',
+        snapshotId: null,
+        resolution: { shape: 'availability-window' as const, defaultPercent: 100, startWeek: 0, endWeek: 10 },
+      }],
+    }
+    const resolved = resolvePlanWithManifest(plan, manifest as RemediationManifest)
+    expect(resolved.errors.join(' ')).toContain('not allowed for this entry')
+  })
+
+  it('creates the exact NAMED_PERSON profile from an explicit owner-kind decision', () => {
+    const { project } = ambiguousNrProject()
+    const plan = buildRemediationPlan(makeState(project), 'commit-1')
+    const manifest = {
+      formatVersion: 1 as const,
+      applicationCommit: 'commit-1',
+      planFingerprint: plan.fingerprint,
+      decisions: [{
+        decisionId: plan.decisions[0]!.id,
+        projectId: 'proj-1',
+        ownerId: 'nr-amb',
+        snapshotId: null,
+        resolution: {
+          shape: 'owner-kind-decision' as const,
+          ownerKind: 'NAMED_PERSON' as const,
+          capacity: { shape: 'availability-window' as const, defaultPercent: 100, startWeek: 0, endWeek: 10 },
+        },
+      }],
+    }
+    const resolved = resolvePlanWithManifest(plan, manifest as RemediationManifest)
+    expect(resolved.errors).toEqual([])
+    expect(resolved.plan.operations).toHaveLength(1)
+    expect(resolved.plan.operations[0]!).toMatchObject({
+      kind: 'create-named-profile',
+      classification: 'decisionResolved',
+    })
+    expect(resolved.plan.operations[0]!.proposed).toMatchObject({
+      profileId: remediationProfileId('namedPerson', 'nr-amb'),
+      ownerKind: 'NAMED_PERSON',
+      planningBasis: 'AVAILABILITY_WINDOW',
+      source: 'AVAILABILITY_WINDOW',
+      defaultPercent: 100,
+      startWeek: 0,
+      endWeek: 10,
+    })
+  })
+
+  it('creates the exact PLANNED_RESOURCE profile from an explicit owner-kind decision', () => {
+    const { project } = ambiguousNrProject()
+    const plan = buildRemediationPlan(makeState(project), 'commit-1')
+    const manifest = {
+      formatVersion: 1 as const,
+      applicationCommit: 'commit-1',
+      planFingerprint: plan.fingerprint,
+      decisions: [{
+        decisionId: plan.decisions[0]!.id,
+        projectId: 'proj-1',
+        ownerId: 'nr-amb',
+        snapshotId: null,
+        resolution: {
+          shape: 'owner-kind-decision' as const,
+          ownerKind: 'PLANNED_RESOURCE' as const,
+          capacity: {
+            shape: 'segmented-capacity-profile' as const,
+            defaultPercent: 50,
+            segments: [
+              { startWeek: 5, endWeek: 10, capacityPercent: 25 },
+              { startWeek: 0, endWeek: 4, capacityPercent: 50 },
+            ],
+          },
+        },
+      }],
+    }
+    const resolved = resolvePlanWithManifest(plan, manifest as RemediationManifest)
+    expect(resolved.errors).toEqual([])
+    const proposed = resolved.plan.operations[0]!.proposed
+    expect(proposed).toMatchObject({
+      ownerKind: 'PLANNED_RESOURCE',
+      planningBasis: 'CAPACITY_PROFILE',
+      source: 'LEGACY',
+      defaultPercent: 50,
+    })
+    // Segments are ordered like the persisted read-back (startWeek, id).
+    expect(proposed).toMatchObject({
+      segments: [
+        { startWeek: 0, endWeek: 4, capacityPercent: 50 },
+        { startWeek: 5, endWeek: 10, capacityPercent: 25 },
+      ],
+    })
+  })
+
+  it('rejects an unknown nested capacity shape before writes', () => {
+    const { project } = ambiguousNrProject()
+    const plan = buildRemediationPlan(makeState(project), 'commit-1')
+    const manifest = {
+      formatVersion: 1 as const,
+      applicationCommit: 'commit-1',
+      planFingerprint: plan.fingerprint,
+      decisions: [{
+        decisionId: plan.decisions[0]!.id,
+        projectId: 'proj-1',
+        ownerId: 'nr-amb',
+        snapshotId: null,
+        resolution: {
+          shape: 'owner-kind-decision' as const,
+          ownerKind: 'NAMED_PERSON' as const,
+          capacity: { shape: 'mystery-shape' } as never,
+        },
+      }],
+    }
+    const resolved = resolvePlanWithManifest(plan, manifest as RemediationManifest)
+    expect(resolved.errors.join(' ')).toContain('unknown nested capacity shape')
+  })
+
+  it('rejects PLANNED_RESOURCE when the parent ROLE profile cannot be derived deterministically', () => {
+    // Parent role is CAPACITY_PLAN without plan evidence → its ROLE profile
+    // cannot be proven, so PLANNED_RESOURCE must not be selectable.
+    const nr = makeNr({ id: 'nr-amb2', allocationMode: 'CAPACITY_PLAN' })
+    const plan = buildRemediationPlan(makeState(makeProject({
+      resourceTypes: [
+        makeRt({ id: 'rt-parent2', allocationMode: 'CAPACITY_PLAN', namedResources: [nr] }),
+      ],
+    })), 'commit-1')
+    const decision = plan.decisions.find(d => d.ownerId === 'nr-amb2')!
+    expect(decision.roleProposed).toBeNull()
+    const manifest = {
+      formatVersion: 1 as const,
+      applicationCommit: 'commit-1',
+      planFingerprint: plan.fingerprint,
+      decisions: [{
+        decisionId: decision.id,
+        projectId: 'proj-1',
+        ownerId: 'nr-amb2',
+        snapshotId: null,
+        resolution: {
+          shape: 'owner-kind-decision' as const,
+          ownerKind: 'PLANNED_RESOURCE' as const,
+          capacity: { shape: 'scalar-profile' as const, planningBasis: 'DEMAND_FOLLOWING' as const, defaultPercent: 100 },
+        },
+      }],
+    }
+    const resolved = resolvePlanWithManifest(plan, manifest as RemediationManifest)
+    expect(resolved.errors.join(' ')).toContain('PLANNED_RESOURCE requires a deterministically derivable parent ROLE profile')
+  })
+
+  it('emits the deterministic parent ROLE op when PLANNED_RESOURCE is selected', () => {
+    const nr = makeNr({ id: 'nr-amb3', allocationMode: 'CAPACITY_PLAN' })
+    const plan = buildRemediationPlan(makeState(makeProject({
+      resourceTypes: [
+        makeRt({ id: 'rt-parent3', allocationMode: 'EFFORT', namedResources: [nr] }),
+      ],
+    })), 'commit-1')
+    const decision = plan.decisions.find(d => d.ownerId === 'nr-amb3')!
+    expect(decision.roleProposed).not.toBeNull()
+    expect(decision.roleOwnerId).toBe('rt-parent3')
+    const manifest = {
+      formatVersion: 1 as const,
+      applicationCommit: 'commit-1',
+      planFingerprint: plan.fingerprint,
+      decisions: [{
+        decisionId: decision.id,
+        projectId: 'proj-1',
+        ownerId: 'nr-amb3',
+        snapshotId: null,
+        resolution: {
+          shape: 'owner-kind-decision' as const,
+          ownerKind: 'PLANNED_RESOURCE' as const,
+          capacity: { shape: 'scalar-profile' as const, planningBasis: 'DEMAND_FOLLOWING' as const, defaultPercent: 100 },
+        },
+      }],
+    }
+    const resolved = resolvePlanWithManifest(plan, manifest as RemediationManifest)
+    expect(resolved.errors).toEqual([])
+    expect(resolved.plan.operations).toHaveLength(2)
+    expect(resolved.plan.operations[0]).toMatchObject({ kind: 'create-named-profile', ownerId: 'nr-amb3' })
+    expect(resolved.plan.operations[1]).toMatchObject({
+      kind: 'create-role-profile',
+      ownerId: 'rt-parent3',
+      decisionId: decision.id,
+    })
+    expect(resolved.plan.operations[1]!.proposed).toMatchObject({ ownerKind: 'ROLE', planningBasis: 'DEMAND_FOLLOWING' })
+  })
+
+  it('keeps deterministic NamedResource mappings unchanged (no owner-kind decision)', () => {
+    const nr = makeNr({ id: 'nr-det', allocationMode: 'TIMELINE', startWeek: 0, endWeek: 8 })
+    const plan = buildRemediationPlan(makeState(makeProject({
+      resourceTypes: [makeRt({ id: 'rt-parent', allocationMode: 'EFFORT', namedResources: [nr] })],
+    })), 'commit-1')
+    expect(plan.decisions).toHaveLength(0)
+    expect(plan.operations).toHaveLength(1)
+    expect(plan.operations[0]!.proposed).toMatchObject({ ownerKind: 'NAMED_PERSON' })
+  })
+})
+
+// ─── Baseline state hash (issue #421 review round 2) ────────────────────────
+
+describe('baselineStateHash', () => {
+  it('is present, stable for identical state and changes with state', () => {
+    const state = makeState(makeProject({
+      resourceTypes: [makeRt({ allocationMode: 'TIMELINE' })],
+    }))
+    const plan1 = buildRemediationPlan(state, 'commit-1')
+    const plan2 = buildRemediationPlan(state, 'commit-2')
+    expect(plan1.baselineStateHash).toBe(plan2.baselineStateHash)
+    const changed = buildRemediationPlan(makeState(makeProject({
+      resourceTypes: [makeRt({ allocationMode: 'TIMELINE', allocationPercent: 50 })],
+    })), 'commit-1')
+    expect(changed.baselineStateHash).not.toBe(plan1.baselineStateHash)
+  })
+
+  it('is covered by the plan fingerprint (tamper detection)', () => {
+    const plan = buildRemediationPlan(makeState(makeProject({
+      resourceTypes: [makeRt({ allocationMode: 'TIMELINE' })],
+    })), 'commit-1')
+    const json = JSON.parse(JSON.stringify(plan)) as Record<string, unknown>
+    json.baselineStateHash = 'deadbeef'
+    const parsed = parsePlanJson(JSON.stringify(json))
+    expect(parsed.plan).toBeNull()
+    expect(parsed.errors.join(' ')).toContain('fingerprint mismatch')
+  })
+
+  it('round-trips through the plan file contract', () => {
+    const plan = buildRemediationPlan(makeState(makeProject({
+      resourceTypes: [makeRt({ allocationMode: 'TIMELINE' })],
+    })), 'commit-1')
+    const parsed = parsePlanJson(JSON.stringify(plan))
+    expect(parsed.errors).toEqual([])
+    expect(parsed.plan!.baselineStateHash).toBe(plan.baselineStateHash)
+  })
+})

--- a/server/src/test/productionRemediationPlan.test.ts
+++ b/server/src/test/productionRemediationPlan.test.ts
@@ -33,7 +33,10 @@ import {
   sha256Hex,
   type RemediationDatabaseState,
   type RemediationManifest,
+  type ManifestDecision,
+  type ProposedProfile,
   type RemediationNamedResource,
+  type RemediationPlan,
   type RemediationProject,
   type RemediationResourceType,
 } from '../lib/productionRemediationPlan.js'
@@ -969,7 +972,7 @@ describe('owner-kind decisions for ambiguous NamedResources', () => {
       }],
     }
     const resolved = resolvePlanWithManifest(plan, manifest as RemediationManifest)
-    expect(resolved.errors.join(' ')).toContain('PLANNED_RESOURCE requires a deterministically derivable parent ROLE profile')
+    expect(resolved.errors.join(' ')).toContain('PLANNED_RESOURCE requires a valid existing or deterministically derivable parent ROLE profile')
   })
 
   it('emits the deterministic parent ROLE op when PLANNED_RESOURCE is selected', () => {
@@ -1008,6 +1011,309 @@ describe('owner-kind decisions for ambiguous NamedResources', () => {
       decisionId: decision.id,
     })
     expect(resolved.plan.operations[1]!.proposed).toMatchObject({ ownerKind: 'ROLE', planningBasis: 'DEMAND_FOLLOWING' })
+  })
+
+  // ── Shared-parent coordination (issue #421 review round 3) ───────────────
+
+  function sharedParentPlan(): {
+    plan: RemediationPlan
+    nrA: string
+    nrB: string
+    parentId: string
+  } {
+    const nrA = 'nr-shared-a'
+    const nrB = 'nr-shared-b'
+    const parentId = 'rt-shared'
+    const plan = buildRemediationPlan(makeState(makeProject({
+      resourceTypes: [
+        makeRt({
+          id: parentId,
+          allocationMode: 'EFFORT',
+          namedResources: [
+            makeNr({ id: nrA, allocationMode: 'CAPACITY_PLAN' }),
+            makeNr({ id: nrB, allocationMode: 'CAPACITY_PLAN' }),
+          ],
+        }),
+      ],
+    })), 'commit-1')
+    return { plan, nrA, nrB, parentId }
+  }
+
+  function plannedResourceResolution(ownerId: string, decisionId: string): ManifestDecision {
+    return {
+      decisionId,
+      projectId: 'proj-1',
+      ownerId,
+      snapshotId: null,
+      resolution: {
+        shape: 'owner-kind-decision',
+        ownerKind: 'PLANNED_RESOURCE',
+        capacity: { shape: 'scalar-profile', planningBasis: 'DEMAND_FOLLOWING', defaultPercent: 100 },
+      },
+    }
+  }
+
+  it('emits at most one parent ROLE op for two PLANNED_RESOURCE children of one parent', () => {
+    const { plan, nrA, nrB, parentId } = sharedParentPlan()
+    const decA = plan.decisions.find(d => d.ownerId === nrA)!
+    const decB = plan.decisions.find(d => d.ownerId === nrB)!
+    const manifest = {
+      formatVersion: 1 as const,
+      applicationCommit: 'commit-1',
+      planFingerprint: plan.fingerprint,
+      decisions: [
+        plannedResourceResolution(nrA, decA.id),
+        plannedResourceResolution(nrB, decB.id),
+      ],
+    }
+    const resolved = resolvePlanWithManifest(plan, manifest as RemediationManifest)
+    expect(resolved.errors).toEqual([])
+    const childOps = resolved.plan.operations.filter(op => op.ownerId === nrA || op.ownerId === nrB)
+    const parentOps = resolved.plan.operations.filter(op => op.ownerId === parentId && op.kind === 'create-role-profile')
+    expect(childOps).toHaveLength(2)
+    expect(parentOps).toHaveLength(1)
+    expect(resolved.plan.operations).toHaveLength(3)
+  })
+
+  it('produces identical coordinated operations and fingerprint regardless of manifest decision order', () => {
+    const { plan, nrA, nrB } = sharedParentPlan()
+    const decA = plan.decisions.find(d => d.ownerId === nrA)!
+    const decB = plan.decisions.find(d => d.ownerId === nrB)!
+    const forward = {
+      formatVersion: 1 as const,
+      applicationCommit: 'commit-1',
+      planFingerprint: plan.fingerprint,
+      decisions: [
+        plannedResourceResolution(nrA, decA.id),
+        plannedResourceResolution(nrB, decB.id),
+      ],
+    }
+    const reversed = {
+      formatVersion: 1 as const,
+      applicationCommit: 'commit-1',
+      planFingerprint: plan.fingerprint,
+      decisions: [
+        plannedResourceResolution(nrB, decB.id),
+        plannedResourceResolution(nrA, decA.id),
+      ],
+    }
+    const forwardResolved = resolvePlanWithManifest(plan, forward as RemediationManifest)
+    const reversedResolved = resolvePlanWithManifest(plan, reversed as RemediationManifest)
+    expect(forwardResolved.errors).toEqual([])
+    expect(reversedResolved.errors).toEqual([])
+    expect(forwardResolved.plan.operations.map(op => op.id)).toEqual(reversedResolved.plan.operations.map(op => op.id))
+    expect(forwardResolved.plan.fingerprint).toBe(reversedResolved.plan.fingerprint)
+  })
+
+  it('coordinates one parent ROLE op for mixed PLANNED_RESOURCE / NAMED_PERSON children', () => {
+    const { plan, nrA, nrB, parentId } = sharedParentPlan()
+    const decA = plan.decisions.find(d => d.ownerId === nrA)!
+    const decB = plan.decisions.find(d => d.ownerId === nrB)!
+    const manifest = {
+      formatVersion: 1 as const,
+      applicationCommit: 'commit-1',
+      planFingerprint: plan.fingerprint,
+      decisions: [
+        plannedResourceResolution(nrA, decA.id),
+        {
+          decisionId: decB.id,
+          projectId: 'proj-1',
+          ownerId: nrB,
+          snapshotId: null,
+          resolution: {
+            shape: 'owner-kind-decision' as const,
+            ownerKind: 'NAMED_PERSON' as const,
+            capacity: { shape: 'availability-window' as const, defaultPercent: 100, startWeek: 0, endWeek: 10 },
+          },
+        },
+      ],
+    }
+    const resolved = resolvePlanWithManifest(plan, manifest as RemediationManifest)
+    expect(resolved.errors).toEqual([])
+    const parentOps = resolved.plan.operations.filter(op => op.ownerId === parentId && op.kind === 'create-role-profile')
+    expect(parentOps).toHaveLength(1)
+    const childA = resolved.plan.operations.find(op => op.ownerId === nrA)!
+    const childB = resolved.plan.operations.find(op => op.ownerId === nrB)!
+    expect(childA.proposed).toMatchObject({ ownerKind: 'PLANNED_RESOURCE' })
+    expect(childB.proposed).toMatchObject({ ownerKind: 'NAMED_PERSON' })
+  })
+
+  it('retains a valid existing parent ROLE profile (roleState existing) and emits no parent op', () => {
+    const nr = makeNr({ id: 'nr-exist', allocationMode: 'CAPACITY_PLAN' })
+    const plan = buildRemediationPlan(makeState(makeProject({
+      resourceTypes: [
+        makeRt({
+          id: 'rt-exist',
+          allocationMode: 'EFFORT',
+          namedResources: [nr],
+        }),
+      ],
+      capacityProfiles: [{
+        id: 'prof-exist-role',
+        projectId: 'proj-1',
+        resourceTypeId: 'rt-exist',
+        namedResourceId: null,
+        ownerKind: 'ROLE',
+        planningBasis: 'DEMAND_FOLLOWING',
+        source: 'FIXED',
+        defaultPercent: 100,
+        startWeek: null,
+        endWeek: null,
+        legacy: null,
+        segments: [],
+      }],
+    })), 'commit-1')
+    const decision = plan.decisions.find(d => d.ownerId === 'nr-exist')!
+    expect(decision.roleState).toBe('existing')
+    expect(decision.roleProposed).toBeNull()
+    const manifest = {
+      formatVersion: 1 as const,
+      applicationCommit: 'commit-1',
+      planFingerprint: plan.fingerprint,
+      decisions: [plannedResourceResolution('nr-exist', decision.id)],
+    }
+    const resolved = resolvePlanWithManifest(plan, manifest as RemediationManifest)
+    expect(resolved.errors).toEqual([])
+    expect(resolved.plan.operations).toHaveLength(1) // child only
+    expect(resolved.plan.operations[0]!.ownerId).toBe('nr-exist')
+  })
+
+  it('reuses a compatible baseline parent ROLE operation (planner-owned parent)', () => {
+    // Planner-owned parent: baseline ROLE op derived from plan entries +
+    // one ambiguous NR decision; PLANNED_RESOURCE must reuse the baseline op.
+    const nr = makeNr({ id: 'nr-base', allocationMode: 'CAPACITY_PLAN' })
+    const plan = buildRemediationPlan(makeState(makeProject({
+      resourceTypes: [
+        makeRt({
+          id: 'rt-base',
+          allocationMode: 'CAPACITY_PLAN',
+          count: 1,
+          namedResources: [
+            makeNr({ id: 'nr-planned', allocationMode: 'CAPACITY_PLAN' }),
+            nr,
+          ],
+        }),
+      ],
+      activePlanPeriods: [{
+        periodIndex: 0,
+        startWeek: 0,
+        endWeek: 8,
+        entries: [{ resourceTypeId: 'rt-base', headcount: 1 }],
+      }],
+      capacityProfiles: [{
+        id: 'prof-nr-planned',
+        projectId: 'proj-1',
+        resourceTypeId: null,
+        namedResourceId: 'nr-planned',
+        ownerKind: 'PLANNED_RESOURCE',
+        planningBasis: 'CAPACITY_PROFILE',
+        source: 'SQUAD_PLANNER',
+        defaultPercent: null,
+        startWeek: 0,
+        endWeek: 7,
+        legacy: null,
+        segments: [{ id: 'seg-planned', startWeek: 0, endWeek: 7, capacityPercent: 100, source: 'SQUAD_PLANNER' }],
+      }],
+    })), 'commit-1')
+    const baselineRoleOps = plan.operations.filter(op => op.ownerId === 'rt-base' && op.kind === 'create-role-profile')
+    expect(baselineRoleOps).toHaveLength(1)
+    const decision = plan.decisions.find(d => d.ownerId === 'nr-base')!
+    expect(decision.roleState).toBe('derived')
+    const manifest = {
+      formatVersion: 1 as const,
+      applicationCommit: 'commit-1',
+      planFingerprint: plan.fingerprint,
+      decisions: [plannedResourceResolution('nr-base', decision.id)],
+    }
+    const resolved = resolvePlanWithManifest(plan, manifest as RemediationManifest)
+    expect(resolved.errors).toEqual([])
+    const parentRoleOps = resolved.plan.operations.filter(op => op.ownerId === 'rt-base' && op.kind === 'create-role-profile')
+    expect(parentRoleOps).toHaveLength(1) // baseline reused, no duplicate
+    expect(resolved.plan.operations).toHaveLength(2) // baseline role op + child
+  })
+
+  it('rejects conflicting parent ROLE requirements and identifies the parent and decisions', () => {
+    const { plan, nrA, nrB } = sharedParentPlan()
+    const decA = plan.decisions.find(d => d.ownerId === nrA)!
+    const decB = plan.decisions.find(d => d.ownerId === nrB)!
+    // Mutate one child's captured role proposal so the two decisions imply
+    // different parent ROLE profiles.
+    const mutatedPlan = JSON.parse(JSON.stringify(plan)) as RemediationPlan
+    const mutatedB = mutatedPlan.decisions.find(d => d.ownerId === nrB)!
+    mutatedB.roleProposed = {
+      ...JSON.parse(JSON.stringify(mutatedB.roleProposed)),
+      defaultPercent: 123,
+    } as unknown as ProposedProfile
+    const manifest = {
+      formatVersion: 1 as const,
+      applicationCommit: 'commit-1',
+      planFingerprint: plan.fingerprint,
+      decisions: [
+        plannedResourceResolution(nrA, decA.id),
+        plannedResourceResolution(nrB, decB.id),
+      ],
+    }
+    const resolved = resolvePlanWithManifest(mutatedPlan, manifest as RemediationManifest)
+    expect(resolved.errors.join(' ')).toContain('conflicting parent ROLE proposals')
+    expect(resolved.errors.join(' ')).toContain('rt-shared')
+    expect(resolved.errors.join(' ')).toContain(decA.id)
+    expect(resolved.errors.join(' ')).toContain(decB.id)
+  })
+
+  it('rejects a parent ROLE requirement conflicting with a baseline operation', () => {
+    const nr = makeNr({ id: 'nr-conflict', allocationMode: 'CAPACITY_PLAN' })
+    const plan = buildRemediationPlan(makeState(makeProject({
+      resourceTypes: [
+        makeRt({
+          id: 'rt-conflict',
+          allocationMode: 'CAPACITY_PLAN',
+          count: 1,
+          namedResources: [
+            makeNr({ id: 'nr-planned2', allocationMode: 'CAPACITY_PLAN' }),
+            nr,
+          ],
+        }),
+      ],
+      activePlanPeriods: [{
+        periodIndex: 0,
+        startWeek: 0,
+        endWeek: 8,
+        entries: [{ resourceTypeId: 'rt-conflict', headcount: 1 }],
+      }],
+      capacityProfiles: [{
+        id: 'prof-nr-planned2',
+        projectId: 'proj-1',
+        resourceTypeId: null,
+        namedResourceId: 'nr-planned2',
+        ownerKind: 'PLANNED_RESOURCE',
+        planningBasis: 'CAPACITY_PROFILE',
+        source: 'SQUAD_PLANNER',
+        defaultPercent: null,
+        startWeek: 0,
+        endWeek: 7,
+        legacy: null,
+        segments: [{ id: 'seg-planned2', startWeek: 0, endWeek: 7, capacityPercent: 100, source: 'SQUAD_PLANNER' }],
+      }],
+    })), 'commit-1')
+    const baselineRoleOps = plan.operations.filter(op => op.ownerId === 'rt-conflict' && op.kind === 'create-role-profile')
+    expect(baselineRoleOps).toHaveLength(1)
+    const decision = plan.decisions.find(d => d.ownerId === 'nr-conflict')!
+    const mutatedPlan = JSON.parse(JSON.stringify(plan)) as RemediationPlan
+    const mutatedDecision = mutatedPlan.decisions.find(d => d.ownerId === 'nr-conflict')!
+    mutatedDecision.roleProposed = {
+      ...JSON.parse(JSON.stringify(mutatedDecision.roleProposed)),
+      defaultPercent: 321,
+    } as unknown as ProposedProfile
+    const manifest = {
+      formatVersion: 1 as const,
+      applicationCommit: 'commit-1',
+      planFingerprint: plan.fingerprint,
+      decisions: [plannedResourceResolution('nr-conflict', decision.id)],
+    }
+    const resolved = resolvePlanWithManifest(mutatedPlan, manifest as RemediationManifest)
+    expect(resolved.errors.join(' ')).toContain('conflicts with baseline operation')
+    expect(resolved.errors.join(' ')).toContain('rt-conflict')
+    expect(resolved.errors.join(' ')).toContain(baselineRoleOps[0]!.id)
   })
 
   it('keeps deterministic NamedResource mappings unchanged (no owner-kind decision)', () => {


### PR DESCRIPTION
Part of #421

## Summary

Adds one explicitly invoked remediation command with dry-run and apply modes that lets #404 remediate the production capacity-profile readiness blockers recorded in https://github.com/NickMonrad/monrad-estimator/issues/404#issuecomment-5155476979, then rerun the permanent readiness gate. **This PR performs no production data changes** and does not authorize the destructive legacy-column migration (#418 PR 2 remains blocked).

- Starting SHA: `282f9bd6f566f8aecc1694649912038a964838e0` (current `origin/main`; worktree `monrad-estimator-wt-421`, branch `feature/421-production-readiness-remediation`).
- **No production database was accessed.** All testing used a disposable PostgreSQL on this development machine.

## Command and exit contract

```bash
npm run capacity-profiles:remediate-readiness -- --dry-run [--json <plan.json>] [--manifest <decisions.json>]
npm run capacity-profiles:remediate-readiness -- --apply --plan <reviewed-plan.json> [--manifest <decisions.json>]
```

| Code | Meaning |
|---|---|
| `0` | Plan valid, no unresolved decisions (apply: all operations applied/no-op, post-apply readiness + planner clean) |
| `1` | Operational / structural / drift failure (apply: nothing written pre-commit) |
| `2` | Plan valid but explicit decisions remain unresolved — apply refused |

Dry-run performs zero writes; apply runs inside one transaction; the permanent readiness command is untouched and remains fail-closed.

## Blocker classes covered (production inventory)

- Missing ROLE profiles (1,941 RTs) and missing NAMED_PERSON profiles (183 NRs) → deterministic matrix or decision entries.
- Planner-owned RTs without ROLE profiles (2, Supply Chain) → deterministic reconstruction from persisted active CapacityPlan entries via the current planner ROLE writer (`buildRoleProfileData`).
- 13 segmentless legacy ROLE `CAPACITY_PROFILE` rows + the DEMAND_FOLLOWING profile with stale windows → deterministic window clear / decision entries.
- One overlapping segment pair → deterministic sum-preserving decomposition preserving segment IDs.
- 67 untranslatable v2 snapshots → policy normalization or explicit decisions.

## Deterministic transformation matrix (reuses approved mappings)

| Source | Target |
|---|---|
| RT `TIMELINE` | `AVAILABILITY_WINDOW`/`AVAILABILITY_WINDOW`, percent + window preserved |
| RT `EFFORT`/absent | `DEMAND_FOLLOWING`/`FIXED`, stale windows discarded |
| RT `FULL_PROJECT` | `WHOLE_PROJECT_ALLOCATION`/`FIXED`, stale windows discarded |
| RT `CAPACITY_PLAN` + active-plan entries | `CAPACITY_PROFILE`/`SQUAD_PLANNER` via `buildRoleProfileData` |
| NR `TIMELINE` / `FULL_PROJECT` / `EFFORT` | same mode mapping as v2 policy; percent `allocationPercent ?? allocationPct ?? 100` |
| NR `CAPACITY_PLAN` + captured window | `AVAILABILITY_WINDOW`/`LEGACY` (exact v2 policy) |
| never-active window (`(-1,-1)` or inverted) | zero-capacity profile (`defaultPercent 0`, null window) |
| `DEMAND_FOLLOWING`/`WHOLE_PROJECT_ALLOCATION` with windows | deterministic clear |
| overlapping segments | exact non-overlapping decomposition, IDs preserved |
| `CAPACITY_PLAN` without usable window/plan evidence (104 RTs, 9 NRs), segmentless non-canonical `CAPACITY_PROFILE` (13), single-`-1` snapshot edges, 933 windowless snapshot entries | **decision required** — never guessed |

Effective weekly capacity is preserved exactly (mapper/planner-writer DTO equality asserted per operation); candidate ResourceType/NamedResource columns are read-only here; existing profile/segment IDs and `CapacityProfile.legacy` provenance are preserved on updates; created profiles use deterministic IDs and mapper-shaped legacy JSON.

### Owner-kind decisions for ambiguous NamedResources

A missing NamedResource whose capacity cannot be proven (windowless `CAPACITY_PLAN`, single `-1`) has an **unproven owner kind**. Such decisions accept only an explicit `owner-kind-decision` resolution selecting `NAMED_PERSON` or `PLANNED_RESOURCE` plus a nested capacity shape; a direct scalar/window/segmented resolution is rejected (it would silently default to `NAMED_PERSON`). Selecting `PLANNED_RESOURCE` also creates the parent role's ROLE profile from the reviewed deterministic derivation (planner-owned completeness); when the parent ROLE cannot be derived, `PLANNED_RESOURCE` is rejected rather than guessed. Deterministic NamedResource mappings are unchanged.

**Shared-parent ROLE coordination** — parent ROLE ownership is coordinated once per ResourceType across the complete resolved plan: a valid existing parent ROLE profile is retained as-is (no replacement, no duplicate op); a compatible baseline ROLE operation is reused; multiple `PLANNED_RESOURCE` children under the same parent collapse into exactly one deterministic parent ROLE operation (grouped by parent ResourceType id, independent of manifest decision ordering); conflicting parent ROLE proposals reject the resolved plan before any write, reporting the parent and the conflicting decision/operation IDs.

## Historical v2 snapshot policy and evidence

Readiness and rollback share `translateV2SnapshotProfiles`; the planner classifies every v2 entry with the same rules.

- **`-1` = "never active" (zero capacity), proven**: the legacy Squad Planner apply wrote `{ startWeek: -1, endWeek: -1, allocationPercent: 100 }` as the no-slot-window fallback (`routes/squadPlan.ts`, pre-#359); the legacy scheduler gate `week >= start && week <= end` never matches; `scheduler.test.ts` codifies "slot never active → endWeek=-1 → does not contribute capacity"; `null` (not `-1`) was unbounded (`endWeek ?? Infinity`).
- **Inverted windows (`start > end`)**: tolerated unclamped; never match the gate → zero capacity; same normalization.
- **Windowless `CAPACITY_PLAN`**: never translated to full-project/unbounded; requires an explicit `snapshot-window-interpretation` decision, applied as a minimal rewrite (only `allocationStartWeek`/`allocationEndWeek` written, negative fallback aliases cleared, all unrelated snapshot content preserved, full re-validation before write; reruns are no-ops).
- Single `-1` edges have no established meaning → decision required. Malformed snapshots are never deleted — they are unsupported and block apply.

## Plan fingerprint / drift contract

- `plan.fingerprint` = SHA-256 over canonical JSON (sorted keys) of the actionable content **plus `baselineStateHash`**; `generatedAt` excluded so reruns on unchanged state produce identical fingerprints.
- `plan.baselineStateHash` = SHA-256 over the canonical **complete remediation state** the dry-run inspected (all projects, ResourceTypes, NamedResources, CapacityProfiles, CapacitySegments, active CapacityPlan periods/entries, all BacklogSnapshots). It is covered by the reviewed fingerprint, so tampering invalidates the plan.
- `manifest.planFingerprint` must match; altered reviewed content invalidates the fingerprint and apply refuses.
- Every operation carries an `evidenceHash` over the exact current-state evidence used at plan time.

### Full-scope drift refusal (before any write)

Inside the same transaction and before the first write, apply re-loads the complete remediation state with the same loader as dry-run, recomputes `baselineStateHash` and compares it with the reviewed plan. Any unplanned change — a new unprofiled ResourceType or NamedResource, a previously valid profile becoming malformed, a duplicate/cross-project ownership defect, a new or changed BacklogSnapshot, an active CapacityPlan change, or any other state difference — refuses with exit `1` and **zero writes**, even when the existing operations' local evidence still matches. Per-operation evidence checks remain as a second layer.

### Idempotent rerun contract

A state that no longer equals the reviewed baseline is accepted as a no-op **only** when (1) every reviewed operation already matches its exact proposed state and (2) the planner rebuilt from the current state has no remaining operations, unresolved decisions or unsupported findings. It then returns success with all operations skipped (readiness re-runs as defence in depth). Any mixed, partially applied or otherwise different state refuses before writes. Identical for both invocation forms.

## Transaction strategy

One PostgreSQL transaction for the bounded production data size: verify all evidence → validate proposed profiles against the authoritative structural rules → write → re-verify every write → commit. Any failure rolls back completely; no partially repaired project is ever reported as successful. After commit, the planner and the permanent readiness gate re-run; non-policy findings fail the apply. No distributed/resumable infrastructure. Apply is idempotent (rerun = no-op).

## Ownership-invariant migration sequencing

`20260721000001_enforce_capacity_profile_ownership_invariants` (pending; production has 36 applied) is constraints/indexes only, with SQL preflights. Recommended: apply it as its **own controlled step** after #421 remediation + readiness pass + #404 Phase 2 backup/restore verification, keeping the PR 2 deploy a single-migration deploy. If left pending, Prisma applies it in order with the PR 2 migration — acceptable but couples the steps. This PR does not modify or apply it. Full details in the docs.

## Tests and CI

- `server/src/test/productionRemediationPlan.test.ts` — 50 pure unit tests (classification matrix, never-active policy, overlap decomposition, fingerprint stability/tamper detection, manifest merge/refusals, exit classification).
- `server/src/test/productionRemediation.integration.test.ts` — 27 Linux-PostgreSQL tests (dry-run zero writes, stable fingerprints, credentials absent, production-scale counts; deterministic apply with capacity/identity preservation and frozen candidate columns; manifest decisions incl. refusals and rerun no-op; transaction rollback; historical snapshot policy incl. readiness/rollback agreement and minimal rewrites; end-to-end blocker-class database: readiness fails → dry-run → approved apply → audit + readiness pass → runtime resolver loads → representative rollback → candidate columns remain).
- Existing readiness + snapshot rollback integration suites: 39 tests pass unchanged (policy change is additive).
- `npm run validate` — **passes (exit 0)**: lint, typecheck, build, 1470 server + 342 client tests.
- `npm run test:integration:local` — all 11 suites pass (258 integration tests) against a disposable PostgreSQL (external test-DB mode; Docker daemon unavailable on this machine).
- `npm run test:e2e:local` — passes (105 passed, 2 known-flaky UI timing tests retried green).
- `git diff --check` — clean.
- No CI run yet on this branch (PR is draft); required checks will be reported after push.

## Production handoff

`docs/domain/capacity-profile-readiness-remediation.md` gives #404 the exact 13-step procedure: install reviewed commit → verify clean checkout → fresh backup → dry-run (expect exit 2, compare counts/fingerprint) → save plan outside the repo → obtain reviewed decisions → rerun dry-run with manifest (expect exit 0) → apply the exact unchanged plan → rerun readiness + audit → fresh post-remediation backup + restore-test → apply the ownership-invariant migration as its own step → authorize PR 2 only after both gates pass. The production agent is never asked to invent data values.

## Confirmations

- **No production database was accessed** — all work used disposable PostgreSQL on the development machine; no credentials or production data were copied.
- **Candidate ResourceType/NamedResource columns remain physically present** — no Prisma schema change, no migration added, no candidate field is written by normal runtime or by the remediation.
- **#418 PR 2 remains blocked** — nothing in this PR authorizes the destructive migration; the permanent readiness gate is unchanged and fail-closed.
- Docs updated: `docs/domain/capacity-profile-readiness-remediation.md` (new), `docs/domain/legacy-capacity-column-runtime-cutover.md` (pointer + sequencing note).

**Do not merge — wait for review.**


