### PR TITLE
fix(#424): forward remediation CLI arguments

### DIFF
--- a/docs/domain/capacity-profile-readiness-remediation.md
+++ b/docs/domain/capacity-profile-readiness-remediation.md
@@ -33,7 +33,12 @@ npm run capacity-profiles:remediate-readiness -- --apply --plan reviewed-plan.js
 npm run capacity-profiles:remediate-readiness -- --apply --plan reviewed-plan.json --manifest approved-decisions.json
 ```
 
-Equivalent standalone invocation from `server/`:
+The root wrapper forwards every argument after `--` exactly once and in order
+to the server workspace command; the root form is the normal production
+interface.
+
+Equivalent direct invocation from `server/` (same command, not the normal
+production interface):
 
 ```bash
 npx tsx src/scripts/remediateProductionReadiness.ts [--dry-run] [--json <path>] [--manifest <path>]

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "test:integration:local": "node scripts/run-integration-local.mjs",
     "db:backup": "node scripts/db-backup.mjs",
     "test:backup": "node --test scripts/db-backup.test.mjs",
-    "test:local-db": "node --test scripts/local-postgres.test.mjs scripts/runner-lifecycle.test.mjs scripts/runner-monitoring.test.mjs scripts/aggregated-error.test.mjs scripts/db-setup.test.mjs",
+    "test:local-db": "node --test scripts/local-postgres.test.mjs scripts/runner-lifecycle.test.mjs scripts/runner-monitoring.test.mjs scripts/aggregated-error.test.mjs scripts/db-setup.test.mjs scripts/remediate-forwarding.test.mjs",
     "test:pdf-cleanup": "node --import tsx --test server/src/test/pdf-cleanup.test.mjs",
     "test:pdf-smoke": "node --import tsx --test server/src/test/pdf-smoke.test.mjs",
     "test:install-chrome": "node --test scripts/install-chrome-lifecycle.test.mjs",
@@ -32,7 +32,7 @@
     "capacity-profiles:audit:json": "npm run capacity-profiles:audit:json --workspace=server",
     "capacity-profiles:audit:repair": "npm run capacity-profiles:audit:repair --workspace=server",
     "capacity-profiles:readiness": "npm run capacity-profiles:readiness --workspace=server",
-    "capacity-profiles:remediate-readiness": "npm run capacity-profiles:remediate-readiness --workspace=server",
+    "capacity-profiles:remediate-readiness": "npm run capacity-profiles:remediate-readiness --workspace=server --",
     "capacity-profiles:backfill": "npm run capacity-profiles:backfill --workspace=server",
     "capacity-profiles:reconcile": "npm run capacity-profiles:reconcile --workspace=server"
   },

--- a/scripts/remediate-forwarding.test.mjs
+++ b/scripts/remediate-forwarding.test.mjs
@@ -1,0 +1,239 @@
+/**
+ * Regression test for Issue #424 — root `capacity-profiles:remediate-readiness`
+ * must forward every user-supplied argument exactly once and in order to the
+ * server workspace command.
+ *
+ * The production dry-run proved the double-nested wrapper consumed the flags:
+ * the inner `npm run … --workspace=server` layer parsed `--dry-run`/`--json`
+ * as its own configuration and dropped or reordered the remediation
+ * arguments. This test exercises the ACTUAL root package-script string through
+ * the real npm forwarding layers, intercepting only the innermost executable
+ * (the server leaf script) with a harmless fixture that records
+ * `process.argv`. It does not inspect forwarding behaviour from a string.
+ *
+ * Safety: the fixture replaces the real `tsx src/scripts/remediateProductionReadiness.ts`
+ * invocation, so the remediation planner never runs, nothing connects to
+ * PostgreSQL, and no plan, manifest or database write is possible. Only the
+ * recorded argv file (under the OS temp directory) is written.
+ */
+
+import assert from 'node:assert/strict'
+import { spawn } from 'node:child_process'
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync, rmSync } from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import test from 'node:test'
+
+const repositoryRoot = path.resolve(import.meta.dirname, '..')
+const rootPackageJson = JSON.parse(
+  readFileSync(path.join(repositoryRoot, 'package.json'), 'utf8'),
+)
+const serverPackageJson = JSON.parse(
+  readFileSync(path.join(repositoryRoot, 'server', 'package.json'), 'utf8'),
+)
+
+const rootRemediationScript =
+  rootPackageJson.scripts['capacity-profiles:remediate-readiness']
+const serverRemediationScript =
+  serverPackageJson.scripts['capacity-profiles:remediate-readiness']
+
+// The fixture may only stand in for the real server leaf command; if the
+// server command itself is renamed, the interception seam changes and this
+// test must be revisited rather than silently pass.
+const serverLeafIsTsx = () => {
+  assert.equal(
+    serverRemediationScript,
+    'tsx src/scripts/remediateProductionReadiness.ts',
+    'server leaf command changed; the forwarding fixture seam must be updated',
+  )
+}
+
+// Retained guard: the root script must declare the forwarding separator so
+// the inner npm layer does not consume the remediation flags as its own
+// configuration. The executable assertions below prove the actual behaviour.
+const rootScriptDeclaresSeparator = () => {
+  assert.match(
+    rootRemediationScript,
+    /--workspace=server\s+--\s*$/,
+    `root script must end with the npm forwarding separator: ${rootRemediationScript}`,
+  )
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────────
+
+function npmInvocation() {
+  // Under `npm run`/`npm test` the npm CLI path is provided in the
+  // environment; fall back to PATH resolution for direct `node --test` runs.
+  if (process.env.npm_execpath) {
+    return [process.execPath, process.env.npm_execpath]
+  }
+  return [process.platform === 'win32' ? 'npm.cmd' : 'npm']
+}
+
+function runNpm(args, { cwd, env }) {
+  const [command, ...prefix] = npmInvocation()
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, [...prefix, ...args], {
+      cwd,
+      env,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+    let stdout = ''
+    let stderr = ''
+    child.stdout.on('data', (chunk) => {
+      stdout += chunk
+    })
+    child.stderr.on('data', (chunk) => {
+      stderr += chunk
+    })
+    const timer = setTimeout(() => {
+      child.kill('SIGKILL')
+      reject(new Error(`npm timed out for: npm ${args.join(' ')}\n${stderr}`))
+    }, 60_000)
+    child.on('error', (error) => {
+      clearTimeout(timer)
+      reject(error)
+    })
+    child.on('close', (code, signal) => {
+      clearTimeout(timer)
+      resolve({ code, signal, stdout, stderr })
+    })
+  })
+}
+
+/**
+ * Mirror the repository root script string in a disposable workspace and
+ * invoke it through real npm, with the server leaf replaced by an argv
+ * recorder. Returns the recorded argument array.
+ */
+async function runRootScriptWithFixture(userArgs) {
+  const fixtureRoot = mkdtempSync(path.join(os.tmpdir(), 'monrad-fwd-'))
+  const recordPath = path.join(fixtureRoot, 'recorded-argv.json')
+  try {
+    writeFileSync(
+      path.join(fixtureRoot, 'package.json'),
+      JSON.stringify(
+        {
+          name: 'monrad-forwarding-fixture',
+          private: true,
+          workspaces: ['server'],
+          scripts: {
+            // The exact string from the repository root package.json — the
+            // artifact under test.
+            'capacity-profiles:remediate-readiness': rootRemediationScript,
+          },
+        },
+        null,
+        2,
+      ),
+    )
+    mkdirSync(path.join(fixtureRoot, 'server'))
+    writeFileSync(
+      path.join(fixtureRoot, 'server', 'package.json'),
+      JSON.stringify(
+        {
+          name: 'monrad-forwarding-fixture-server',
+          private: true,
+          scripts: {
+            // Harmless argv recorder in place of the real tsx invocation.
+            'capacity-profiles:remediate-readiness': 'node record-argv.mjs',
+          },
+        },
+        null,
+        2,
+      ),
+    )
+    writeFileSync(
+      path.join(fixtureRoot, 'server', 'record-argv.mjs'),
+      `import { writeFileSync } from 'node:fs'
+writeFileSync(process.env.RECORD_ARGV_OUT, JSON.stringify(process.argv.slice(2)))
+`,
+    )
+    writeFileSync(recordPath, '')
+
+    const result = await runNpm(
+      ['run', 'capacity-profiles:remediate-readiness', '--', ...userArgs],
+      {
+        cwd: fixtureRoot,
+        env: {
+          ...process.env,
+          RECORD_ARGV_OUT: recordPath,
+          npm_config_cache: path.join(fixtureRoot, 'npm-cache'),
+        },
+      },
+    )
+    assert.equal(
+      result.code,
+      0,
+      `root script exited ${result.code ?? `signal ${result.signal}`}\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
+    )
+    const recorded = readFileSync(recordPath, 'utf8')
+    assert.notEqual(
+      recorded,
+      '',
+      'argv recorder never ran — the inner npm layer consumed the arguments\n' +
+        `stderr:\n${result.stderr}`,
+    )
+    return JSON.parse(recorded)
+  } finally {
+    rmSync(fixtureRoot, { recursive: true, force: true })
+  }
+}
+
+// ── Static guards ───────────────────────────────────────────────────────
+
+test('root script declares the npm forwarding separator after --workspace=server', () => {
+  rootScriptDeclaresSeparator()
+})
+
+test('server leaf command is still the real tsx remediation invocation', () => {
+  serverLeafIsTsx()
+})
+
+// ── Forwarding vectors ──────────────────────────────────────────────────
+
+// Representative dry-run and apply invocations from the documented root
+// command, including values containing spaces. Deep equality proves the
+// arguments arrive exactly once, in the original order, unmodified.
+const vectors = [
+  {
+    name: 'dry-run with json output path',
+    args: ['--dry-run', '--json', '/tmp/plan.json'],
+  },
+  {
+    name: 'dry-run with spaces in the json path and a manifest',
+    args: [
+      '--dry-run',
+      '--json',
+      '/tmp/plan with spaces.json',
+      '--manifest',
+      '/tmp/decisions.json',
+    ],
+  },
+  {
+    name: 'apply with reviewed plan',
+    args: ['--apply', '--plan', '/tmp/plan.json'],
+  },
+  {
+    name: 'apply with reviewed plan and a manifest containing spaces',
+    args: [
+      '--apply',
+      '--plan',
+      '/tmp/plan.json',
+      '--manifest',
+      '/tmp/decisions with spaces.json',
+    ],
+  },
+]
+
+for (const { name, args } of vectors) {
+  test(`root command forwards arguments exactly once and in order — ${name}`, async () => {
+    const recorded = await runRootScriptWithFixture(args)
+    assert.deepEqual(recorded, args)
+  })
+}
+
+test('root command without arguments forwards none', async () => {
+  const recorded = await runRootScriptWithFixture([])
+  assert.deepEqual(recorded, [])
+})


### PR DESCRIPTION
## Summary

The documented root remediation command lost its CLI arguments through the nested npm workspace wrapper, so production had to bypass it and invoke `tsx` directly (evidence: issue #404 production dry-run). This PR adds the npm forwarding separator to the root script so every argument after `--` reaches the server remediation script exactly once and in order.

**Starting SHA:** `ede45b12041529c12c58993aa981b230d76d1622` (current `origin/main`)

**Exact root script change** (`package.json`):

```diff
- "capacity-profiles:remediate-readiness": "npm run capacity-profiles:remediate-readiness --workspace=server"
+ "capacity-profiles:remediate-readiness": "npm run capacity-profiles:remediate-readiness --workspace=server --"
```

**Why the original wrapper lost flags:** `npm run <script> -- <args>` appends `<args>` to the script's command line. The root script was `npm run capacity-profiles:remediate-readiness --workspace=server`, so the inner npm received e.g. `npm run … --workspace=server --dry-run --json /tmp/plan.json`. Without the `--` separator the inner npm parsed `--dry-run`/`--json` as its own configuration flags and `--manifest`/`--plan` as unknown config (warning/error), consuming or mangling the remediation arguments. The trailing `--` makes the inner npm pass everything after it through to the server script unchanged.

## Related issue

Part of #424 (non-closing — issue tracks its own acceptance criteria)

## Changes

- `package.json`: append `--` forwarding separator to `capacity-profiles:remediate-readiness` root script
- `scripts/remediate-forwarding.test.mjs` (new): regression test exercising the real root script string through real npm, with the inner executable replaced by an argv-recording fixture
- `package.json`: register the new test in the existing root lifecycle group `test:local-db`
- `docs/domain/capacity-profile-readiness-remediation.md`: confirm root argument forwarding; state that direct `tsx` invocation is equivalent but not the normal production interface

## Regression-test strategy

The test reads the actual `capacity-profiles:remediate-readiness` script string from the repository root `package.json`, mirrors it verbatim into a disposable temp workspace (`server` leaf replaced by a harmless `record-argv.mjs` that writes `process.argv.slice(2)` to a temp file), and invokes it through the real double-nested npm chain. Deep-equality assertions prove the arguments arrive exactly once, in the original order, unmodified — including values with spaces. It does not inspect a string in place of npm behaviour, does not connect to PostgreSQL, and cannot apply remediation (the real `tsx` script never runs; only a temp argv record is written).

Verified against the starting commit `ede45b1…` **before** the fix: 6 of 7 tests fail — the static separator guard, and all four forwarding vectors with mangled argv (e.g. `--dry-run --json /tmp/plan.json` arrived as `['/tmp/plan.json']`), proving the regression is real. After the fix: 7/7 pass.

## Design, data, or migration notes

- No schema, migration, remediation semantics, planner, fingerprint, drift, transaction or readiness code changed. Server CLI (`server/package.json`, `remediateProductionReadiness.ts`) untouched.
- The forwarding separator is a no-op when no arguments are passed (verified).

## Validation

**Repository validation:**

```text
npm run lint       → 0 errors (882 pre-existing warnings), exit 0
npm run typecheck  → pass (client + server)
npm run build      → pass (server tsc + client vite build)
npm test           → pass:
                     test:backup    31/31
                     test:local-db  189/189 (includes 7 new forwarding tests)
                     server         1489 passed, 309 skipped (59 files)
                     client         342 passed (22 files)
git diff --check   → clean
```

Focused wrapper regression (before fix → after fix): 6/7 fail → 7/7 pass.

Representative argument vectors proven through the real root script + npm layers (fixture interception, no database access):

```text
--dry-run --json /tmp/plan.json
--dry-run --json "/tmp/plan with spaces.json" --manifest /tmp/decisions.json
--apply --plan /tmp/plan.json
--apply --plan /tmp/plan.json --manifest "/tmp/decisions with spaces.json"
```

Each arrives exactly once, in order, with spaces intact. No real apply was executed.

- [x] Client and server lint passed
- [x] Client and server type-checking passed
- [x] Client and server builds passed
- [x] Client and server unit/integration tests passed
- [x] Backup regression tests passed (Linux and Windows CI — new test registered in `test:local-db`, which CI runs on the ubuntu/windows/macos lifecycle matrix)
- [x] No unexplained failures were classified as pre-existing

## Security

- [x] Backup credential handling was verified (PGPASSWORD used, no credential-bearing process arguments) — unchanged; no backup code touched

## E2E tests

**Tests added/modified:** none — package-script wrapper fix with a focused root-level lifecycle regression test.

**Result:**

```text
N/A — no user-visible behaviour, navigation, permissions, persistence or cross-domain workflow changed.
Focused coverage: scripts/remediate-forwarding.test.mjs (root lifecycle group `npm run test:local-db`).
```

- [x] Playwright coverage is explicitly not applicable (see above)
- [ ] `e2e/TESTS.md` updated — not applicable (no Playwright changes)

## Documentation and screenshots

- [x] `docs/domain/capacity-profile-readiness-remediation.md` updated (root forwarding confirmed; direct `tsx` noted as equivalent but not the normal production interface)
- [x] Screenshots not applicable (no UI change)

## Risks and follow-ups

- The production plan generated at merge `ede45b12041529c12c58993aa981b230d76d1622` must **not** be used for final apply: after this fix is merged and installed, #404 must create a fresh post-merge backup and generate a new production plan with the corrected root command. The existing plan fingerprint `834c39075c58edbb3a666b0692bf55ca50810da79b44b691ba…` is evidence only.
- #418 PR 2 remains blocked.
- Confirmation: **no production system or database was accessed**; no remediation behaviour, schema or migration changed; no real apply executed.

## Review control

- [x] This PR is ready for human review
- [x] Auto-merge is not enabled
- [x] Non-closing wording `Part of #424` used per issue instruction (tracked issue not closed by this PR)

**Do not merge — wait for review.**