### PR TITLE
chore(#432): add sanitized snapshot evidence command

### DIFF
--- a/docs/domain/capacity-profile-readiness-remediation.md
+++ b/docs/domain/capacity-profile-readiness-remediation.md
@@ -403,11 +403,15 @@ hard-coded as application constants. Shape:
   "liveDecisions": 130,
   "unsupported": 0,
   "rewriteOperations": 0,
+  "topology11Snapshots": 11,
+  "topology7Snapshots": 7,
   "topology11WindowlessDecisions": 226,
   "topology7WindowlessDecisions": 133,
   "topology7SingleMinusOneDecisions": 7
 }
 ```
+
+The reviewed subgroup **snapshot counts** (`topology11Snapshots`, `topology7Snapshots`) are gated explicitly: reconciliation fails unless the observed eleven-subgroup and seven-subgroup snapshot counts match, the expected subgroup sum equals `defectSnapshots`, and the observed subgroup counts sum to the observed defect-snapshot count. The reviewed subgroup decision totals (`topology11WindowlessDecisions` 226, `topology7WindowlessDecisions` 133, `topology7SingleMinusOneDecisions` 7) remain gated as before. A 10/8 subgroup split with otherwise matching decision totals is refused.
 
 Current reviewed production values (Issue #404 comment `5172781179`):
 fingerprint `eccf77edde816d59d2625b7988175f41dfa14f2ca792483bfcb2c271ba2130dc`,
@@ -431,9 +435,23 @@ Versioned JSON (`formatVersion: 1`) with `runMetadata`, `expectedBoundary`,
 `observedBoundary`, `integrityResult`, `topology`, `singleNegativeEntries`
 (S1… labels), `defectSnapshots` (M1… labels), `classAAggregates`,
 `unavailableEvidence`, `reconciliation` and `policyDecision:
-"not-assessed"`. Markdown is rendered from the same evidence object, so JSON
-and Markdown cannot diverge. Output ordering is deterministic apart from the
-explicit run timestamp.
+"not-assessed"`. Markdown is rendered from the same evidence object and
+carries **all** evidence categories required by the #430 review: S-record
+entry and structural error categories, exact sanitized mode categories,
+percentage categories and the independent-defect classification; M-record
+subgroup, per-snapshot decision counts (windowless, single-`-1`, and other
+decision-required reasons), alreadyValid/quarantined/unsupported counts,
+entry and structural error categories; and the complete Class A percentage
+evidence split by owner kind / mode source (`resourceType`, `explicit`,
+`inherited`, `other`, `unavailable` × `allocationPercent`/`allocationPct` ×
+every bucket). Output ordering is deterministic apart from the explicit run
+timestamp.
+
+Unknown or malformed historical mode strings are never copied into evidence
+output: the command normalizes every outward-facing mode value to the fixed
+vocabulary (`TIMELINE`, `CAPACITY_PLAN`, `EFFORT`, `FULL_PROJECT`, `null`,
+`other`), and unknown strings render only as `other`. This applies to JSON,
+Markdown and the content-derived labels.
 
 The command prevents output of project/snapshot/owner/finding/decision IDs,
 names, complete payloads, credentials and database details by construction
@@ -441,6 +459,17 @@ names, complete payloads, credentials and database details by construction
 serialized output for seeded sensitive fixture values and fail if any
 appear. Runtime errors are converted to controlled reason codes and concise
 safe messages.
+
+### Output publication (all-or-nothing)
+
+Both output files are published as a set: both complete strings are staged
+into exclusive temporary files (mode `0600`) in the corresponding output
+directories, and only after both are written and closed are the final paths
+published with same-directory renames. Any staging or publication failure
+removes every temporary file and any final file published by that run
+(leaving pre-existing files untouched), emits a controlled error and exits
+`1`. On success both finals exist with mode `0600` and no temporary files
+remain. Existing final files are never silently overwritten.
 
 ### Corrected 18-snapshot topology (evidence basis)
 

--- a/docs/domain/capacity-profile-readiness-remediation.md
+++ b/docs/domain/capacity-profile-readiness-remediation.md
@@ -456,13 +456,16 @@ timestamp.
 Class A aggregates also include **affected-snapshot counts** in addition to
 entry counts: `affectedSnapshotsByOwnerKind` (`resourceType` /
 `namedResource` / `unavailable`) and `affectedSnapshotsByNamedModeSource`
-(`explicit` / `inherited` / `other` / `unavailable`). A snapshot counts at
-most once per category; a mixed ResourceType/NamedResource snapshot may
-count in both owner-kind categories and a snapshot containing explicit and
-inherited NamedResource entries in both mode-source categories — the
-categories are not forced mutually exclusive. `snapshotsByOwnerKindMix`
-retains the mutually exclusive overall mix and the total Class A snapshot
-reconciliation stays at 49.
+(`explicit` / `inherited` / `other` / `unavailable`). The mode-source
+aggregate counts only snapshots containing Class A **NamedResource** entries
+in the applicable category — ResourceType entries carry no NamedResource
+mode-source category and ResourceType-only snapshots contribute zero to all
+four mode-source categories. Categories may overlap: a snapshot containing
+explicit and inherited NamedResource entries counts once in both; the
+aggregate is not expected to sum to the 49 Class A snapshots. A snapshot
+counts at most once per category.
+`snapshotsByOwnerKindMix` retains the mutually exclusive overall mix and the
+total Class A snapshot reconciliation stays at 49.
 
 Unknown or malformed historical mode strings are never copied into evidence
 output: the command normalizes every outward-facing mode value to the fixed

--- a/docs/domain/capacity-profile-readiness-remediation.md
+++ b/docs/domain/capacity-profile-readiness-remediation.md
@@ -385,6 +385,12 @@ and in order (regression-tested, same seam as the #424 forwarding fix).
 There is deliberately **no `--dry-run` option**: the command is inherently
 read-only.
 
+The JSON and Markdown output paths must resolve to **distinct** files: the
+command resolves and normalizes both paths and refuses (exit `1`) before
+reading the expectations file, inspecting the database or creating any
+temporary or final output when they are equal (including equivalent
+spellings such as `out.json` and `./out.json`).
+
 ### Expected-file schema (reviewed production-run input)
 
 The reviewed expectations are supplied explicitly per run; they are never
@@ -447,11 +453,38 @@ evidence split by owner kind / mode source (`resourceType`, `explicit`,
 every bucket). Output ordering is deterministic apart from the explicit run
 timestamp.
 
+Class A aggregates also include **affected-snapshot counts** in addition to
+entry counts: `affectedSnapshotsByOwnerKind` (`resourceType` /
+`namedResource` / `unavailable`) and `affectedSnapshotsByNamedModeSource`
+(`explicit` / `inherited` / `other` / `unavailable`). A snapshot counts at
+most once per category; a mixed ResourceType/NamedResource snapshot may
+count in both owner-kind categories and a snapshot containing explicit and
+inherited NamedResource entries in both mode-source categories — the
+categories are not forced mutually exclusive. `snapshotsByOwnerKindMix`
+retains the mutually exclusive overall mix and the total Class A snapshot
+reconciliation stays at 49.
+
 Unknown or malformed historical mode strings are never copied into evidence
 output: the command normalizes every outward-facing mode value to the fixed
 vocabulary (`TIMELINE`, `CAPACITY_PLAN`, `EFFORT`, `FULL_PROJECT`, `null`,
 `other`), and unknown strings render only as `other`. This applies to JSON,
 Markdown and the content-derived labels.
+
+Each S record reports the sanitized state of **all four raw window fields**
+(`allocationStartWeek`, `allocationEndWeek`, `startWeek`, `endWeek`) with
+exactly one value from the fixed vocabulary `minus-one` / `absent-null` /
+`populated` — populated numeric values are never emitted. `minusOneField`
+is reconciled one-to-one with the single `minus-one` field. Alias-conflict
+evidence is reported **per logical edge** (`aliasConflicts.startEdge` /
+`aliasConflicts.endEdge`) using the shared classifier alias semantics
+(window-using modes only), so a conflict on the start edge is distinguished
+from a conflict on the end edge. The aggregate `alternateAliasState` is
+derived from the same per-field states.
+
+S records are selected from the plan's single-negative decision class; the
+Markdown section is titled **"Single-negative decision entries"** (a clean
+`-1` + null shape may instead be classified through the windowless or Class
+B quarantine branch and is never implied by the heading).
 
 The command prevents output of project/snapshot/owner/finding/decision IDs,
 names, complete payloads, credentials and database details by construction
@@ -460,16 +493,25 @@ serialized output for seeded sensitive fixture values and fail if any
 appear. Runtime errors are converted to controlled reason codes and concise
 safe messages.
 
-### Output publication (all-or-nothing)
+### Output publication (all-or-nothing, no-clobber)
 
 Both output files are published as a set: both complete strings are staged
 into exclusive temporary files (mode `0600`) in the corresponding output
 directories, and only after both are written and closed are the final paths
-published with same-directory renames. Any staging or publication failure
-removes every temporary file and any final file published by that run
-(leaving pre-existing files untouched), emits a controlled error and exits
-`1`. On success both finals exist with mode `0600` and no temporary files
-remain. Existing final files are never silently overwritten.
+published. The final publication step itself refuses an existing
+destination: each final path is created as a hard link to the staged file
+(`link` fails with `EEXIST` when the destination exists), never a
+check-then-rename sequence — so a destination created by another process
+between the preflight and the final step can never be overwritten.
+
+Ownership is tracked explicitly: on any staging or publication failure the
+command removes every temporary file created by the run and only final
+files the run itself created (verified by inode); destinations that existed
+before or appeared independently are preserved. The command returns exit
+`1` with a controlled message. On success both finals exist as distinct
+files with mode `0600` (POSIX), contain the intended complete content, and
+no temporary files remain. Existing final files are never silently
+overwritten.
 
 ### Corrected 18-snapshot topology (evidence basis)
 

--- a/docs/domain/capacity-profile-readiness-remediation.md
+++ b/docs/domain/capacity-profile-readiness-remediation.md
@@ -355,6 +355,134 @@ PR 2 migration during the Phase 4 `prisma migrate deploy` — acceptable but
 couples the steps; the separate step is preferred. This PR does not modify,
 apply or fold in that migration.
 
+## Sanitized snapshot evidence command (Issue #432)
+
+A standalone, explicitly invoked, **read-only** command that extracts the
+sanitized aggregate historical snapshot evidence required by the Issue #430
+design investigation. It is evidence tooling only: it changes no
+classifier, readiness, rollback, retention or remediation behaviour, creates
+no manifest, selects no decisions and authorizes nothing. It never runs
+during application startup or HTTP requests.
+
+### Exact root command
+
+```bash
+npm run capacity-profiles:snapshot-evidence -- \
+  --json <output.json> \
+  --markdown <output.md> \
+  --expected <expected.json>
+```
+
+Equivalent standalone invocation from `server/`:
+
+```bash
+npx tsx src/scripts/generateSnapshotEvidence.ts \
+  --json <output.json> --markdown <output.md> --expected <expected.json>
+```
+
+All three arguments are required. Root arguments are forwarded exactly once
+and in order (regression-tested, same seam as the #424 forwarding fix).
+There is deliberately **no `--dry-run` option**: the command is inherently
+read-only.
+
+### Expected-file schema (reviewed production-run input)
+
+The reviewed expectations are supplied explicitly per run; they are never
+hard-coded as application constants. Shape:
+
+```json
+{
+  "fingerprint": "<64-hex remediation-plan fingerprint>",
+  "baselineStateHash": "<64-hex baseline-state hash>",
+  "quarantinedEntries": 574,
+  "quarantinedSnapshots": 49,
+  "defectSnapshots": 18,
+  "windowlessDecisions": 359,
+  "singleMinusOneDecisions": 7,
+  "snapshotDecisions": 366,
+  "liveDecisions": 130,
+  "unsupported": 0,
+  "rewriteOperations": 0,
+  "topology11WindowlessDecisions": 226,
+  "topology7WindowlessDecisions": 133,
+  "topology7SingleMinusOneDecisions": 7
+}
+```
+
+Current reviewed production values (Issue #404 comment `5172781179`):
+fingerprint `eccf77edde816d59d2625b7988175f41dfa14f2ca792483bfcb2c271ba2130dc`,
+baseline-state hash
+`09b504b5e27ee8362f7d983c2d00cda68711ed7e71c2f7737d90668ad50a02df`.
+
+### Exit contract
+
+- `0` — all gates passed (fingerprint, baseline, reviewed counts,
+  reconciliation) and both output files were written.
+- `1` — any refusal: bad arguments, malformed/unsafe expected values,
+  existing output file (never silently overwritten), snapshot parse failure,
+  unsupported schema version, fingerprint/baseline/count mismatch,
+  reconciliation failure, or output-write failure.
+
+No evidence is emitted until every gate passes.
+
+### Output schema and redaction guarantees
+
+Versioned JSON (`formatVersion: 1`) with `runMetadata`, `expectedBoundary`,
+`observedBoundary`, `integrityResult`, `topology`, `singleNegativeEntries`
+(S1… labels), `defectSnapshots` (M1… labels), `classAAggregates`,
+`unavailableEvidence`, `reconciliation` and `policyDecision:
+"not-assessed"`. Markdown is rendered from the same evidence object, so JSON
+and Markdown cannot diverge. Output ordering is deterministic apart from the
+explicit run timestamp.
+
+The command prevents output of project/snapshot/owner/finding/decision IDs,
+names, complete payloads, credentials and database details by construction
+(aggregates only, content-derived labels) and automated redaction tests scan
+serialized output for seeded sensitive fixture values and fail if any
+appear. Runtime errors are converted to controlled reason codes and concise
+safe messages.
+
+### Corrected 18-snapshot topology (evidence basis)
+
+The 359 windowless decisions span **all 18** defect-classified snapshots
+(Issue #404 comment `5174355909`): 226 windowless decisions in the
+11-snapshot windowless-only subgroup (21 each × 10, 16 × 1) and 133
+windowless + 7 single-`-1` decisions in the 7-snapshot subgroup (19
+windowless + 1 single-`-1` per snapshot, 140 total). The earlier topology
+attributing all 359 to the 11-snapshot subgroup is superseded.
+
+### Zero-write and read-only guarantee
+
+The command uses ordinary read queries through `loadRemediationState` and a
+separate read-only `createdAt` metadata query, then aggregates in pure code.
+It never invokes remediation apply, manifest resolution, migrations, schema
+mutation, snapshot rewrite/deletion or retention pruning. Focused
+integration tests capture canonical database state before and after a run
+and assert exact equality.
+
+### #404 run procedure (Issue #432 handoff)
+
+1. Install the reviewed merge commit without running migrations; confirm a
+   clean checkout at the exact expected commit and a healthy service.
+2. Create or retain the required #404 backup according to the documented
+   backup command — this evidence command is not migration authorization.
+3. Run the command once, writing outputs **outside the repository** (e.g.
+   `~/.monrad-estimator/ops/…/snapshot-evidence.json` and `.md`) with
+   restrictive permissions (directory 700, files 600).
+4. Verify fingerprint, baseline and reviewed counts against the handoff
+   values above (or the values recorded in the reviewed PR description).
+5. Post only the sanitized Markdown summary and the output file hashes to
+   Issue #404; never post or copy complete snapshot payloads or the useful
+   database.
+6. Return the evidence to Issue #430 for design review.
+7. Stop on any drift, mismatch, redaction failure or reconciliation failure.
+
+### Stop conditions and scope confirmation
+
+The command output is evidence only. It does **not** authorize remediation
+apply, migration deployment, manifest creation or decision selection.
+#404 and #418 remain blocked until the evidence is reviewed under #430.
+
 ## #404 Production handoff procedure
 
 The production machine must execute exactly these steps; stop on any failure

--- a/docs/domain/remaining-historical-snapshot-investigation.md
+++ b/docs/domain/remaining-historical-snapshot-investigation.md
@@ -372,18 +372,22 @@ The three questions are separated deliberately:
    investigation does not claim that 574 is the final authoritative policy
    boundary**; it is the current implementation outcome.
 
-## 4. Mixed-defect snapshot analysis (11 snapshots, 359 windowless entries)
+## 4. Mixed-defect snapshot analysis (18 snapshots, 359 windowless decisions)
 
 ### 4.1 Established facts
 
-- 11 of the 18 defect-classified snapshots contain 359 decision-required
-  entries whose message is the windowless `CAPACITY_PLAN` translation error
-  ("cannot be translated without guessing capacity"). The other 7 defect
-  snapshots are the single-`-1`+null class of Section 3 (7 entries; each of
-  those snapshots has no windowless entries — otherwise they would count in
-  the 359).
+- The **359 windowless decisions span all 18 defect-classified snapshots**
+  (production evidence comment `5174355909`):
+  - the **11-snapshot windowless-only subgroup** holds **226** windowless
+    decisions (per-snapshot: 21 each × 10, 16 × 1) and no recorded
+    single-`-1` signal;
+  - the **7-snapshot single-`-1` subgroup** holds **133** windowless plus
+    **7** single-`-1` decisions — **140 total decisions** (19 windowless +
+    1 single-`-1` per snapshot).
+  The earlier topology claiming all 359 windowless decisions occur only in
+  the 11-snapshot subgroup is superseded.
 - The plan reports **0 unsupported findings**, so the independent defects in
-  the 11 snapshots are **not** orphan NamedResources, unknown modes, or
+  the 18 snapshots are **not** orphan NamedResources, unknown modes, or
   malformed/unknown-version payloads.
 - The classifier's defect verdict for these snapshots is driven by per-entry
   errors and/or structural validation of the complete translated profile set
@@ -408,7 +412,7 @@ From `snapshotRestorability.ts` + `projectSnapshotCapacity.ts` +
 The 282f9bd-era readiness inventory (comment `5155476979`) recorded "211 NR
 entries with startWeek/endWeek = -1 (422 messages) + 415 synthetic-profile
 shape errors"; after the #421 never-active policy, the `(-1,-1)`-derived shape
-errors vanished, and the surviving structural errors in the 11 snapshots are
+errors vanished, and the surviving structural errors in the 18 snapshots are
 what remains. The exact surviving classes cannot be named from sanitized
 GitHub evidence (Section 5).
 
@@ -421,7 +425,7 @@ GitHub evidence (Section 5).
   - **window-exceed / never-active** are already handled deterministically
     (not present as defects);
   - **orphans / unknown modes** are provably absent (unsupported = 0).
-- The fail-closed principle is preserved: none of the 11 snapshots may
+- The fail-closed principle is preserved: none of the 18 defect snapshots may
   quarantine while their independent defect is unidentified, and no Class A
   entry inside them may quarantine (the approved snapshot-level rule).
 
@@ -437,7 +441,7 @@ cannot be derived from repository history:
    the sanitized percentage fields (decisive for assigning
    deterministic-zero vs deterministic-unbounded interval semantics and the
    historically used percentage).
-2. For the 11 defect-classified snapshots: the distinct independent-defect
+2. For the 18 defect-classified snapshots: the distinct independent-defect
    reasons with counts (decisive for the outcome of the 359 entries).
 3. Whether the 359 include partial-window entries (one-null/one-valid) or are
    purely both-null — the plan message cannot distinguish them.
@@ -471,7 +475,7 @@ identifiers required.
    the distinct non-"without captured window" messages (percent-range,
    alias-conflict, partial-window, below-`-1`, fractional, duplicate-owner,
    structural) and their counts.
-3. Per-snapshot classification counts for the 11 mixed snapshots:
+3. Per-snapshot classification counts for the 18 defect snapshots:
    `decisionRequired` by message (windowless vs partial vs single-negative),
    `alreadyValid`, `unsupported`, `quarantined` (expected 0/0/0/0).
 4. For the current Class A assessment: aggregate counts of the 574
@@ -490,7 +494,7 @@ customer/project names, decision IDs, credentials or database copies.
 | Class | Observed count | Proven historical semantics | Recommended outcome | Evidence |
 | ----- | -------------: | --------------------------- | ------------------- | -------- |
 | Class A windowless entries in fully-clean snapshots | 574 entries / 49 snapshots | no captured window; for NamedResource entries the legacy scheduler gate proves an unbounded active interval, with percentage per explicit/inherited mode (§3.5); RT semantics are not established by that gate | **Quarantine (current implementation outcome — unchanged); NamedResource subset under assessment (§3.5)** | #404 `5172781179`; classifier at `ffed1fa`; scheduler gate `f783b26`→`b194e6c` (percentage branch `74b98d3`) |
-| Windowless `CAPACITY_PLAN` entries inside 11 mixed-defect snapshots | 359 entries / 11 snapshots | same raw shape as Class A; snapshot carries ≥1 unidentified independent defect | **Decision-required (unchanged)** until defect classes are identified (Section 5.1 item 2) | #404 `5172781179`; fail-closed snapshot rule |
+| Windowless `CAPACITY_PLAN` entries inside all 18 defect-classified snapshots | 359 entries / 18 snapshots (226 in the 11-snapshot windowless-only subgroup, 133 in the 7-snapshot single-`-1` subgroup) | same raw shape as Class A; each containing snapshot carries ≥1 unidentified independent defect | **Decision-required (unchanged)** until defect classes are identified (Section 5.1 item 2) | #404 `5172781179`, `5174355909`; fail-closed snapshot rule |
 | `-1` + null (effective `CAPACITY_PLAN`) | 7 entries / 7 snapshots | orientation-dependent provable: `startWeek=null, endWeek=-1` → zero interval (≡ never-active); all other orientations → unbounded interval at the category-specific percentage (explicit `allocationPercent` or inherited `100` default) | **Decision-required (unchanged)** until orientation, alias and mode-source evidence exists (Section 5.1 item 1); zero orientation is deterministic zero; unbounded orientation is deterministic only when the historically used percentage is also established; explicit and inherited modes may require different deterministic target profiles — never quarantine | scheduler gate (`f783b26`→`b194e6c`; percentage branch `74b98d3`), planner writer trace (§3.2–3.3) |
 | `(-1,-1)` / non-negative inverted never-active | 205 normalized, not findings | zero capacity | Deterministic (unchanged) | #421 policy; `scheduler.test.ts` |
 | Single `-1` + non-negative other edge (Class B) | 0 | — | n/a (no production match) | #404 `5172781179` |
@@ -526,7 +530,7 @@ evidence and complete the deterministic interval-and-percentage assessment.**
   the #404 evidence review proposed zero resolutions (comment `5162109939`);
   the deterministic question here is about proven scheduler *outcomes*, not
   intent.
-- The 11 snapshots' independent defects must be identified before any
+- The 18 snapshots' independent defects must be identified before any
   per-class outcome (Section 4.3); quarantine must not be broadened to absorb
   them (fail-closed).
 - #404 and #418 remain blocked.

--- a/docs/domain/unrecoverable-historical-capacity-snapshots.md
+++ b/docs/domain/unrecoverable-historical-capacity-snapshots.md
@@ -752,9 +752,12 @@ At the merged release `ffed1fa` two stable read-only production dry-runs
 (identical fingerprints and baseline-state hash) observed: **574 quarantined
 snapshot-entry findings (all Class A), 49 policy-accepted quarantined
 snapshots, 18 defect-classified snapshots, 366 remaining snapshot decisions
-(359 windowless entries inside 11 mixed-defect snapshots + 7 single-`-1`
-with a null other edge), 130 live-state decisions, 0 unsupported, 0 snapshot
-rewrite operations** (Issue #404 comment `5172781179`).
+(359 windowless entries across all 18 defect-classified snapshots — 226 in
+the 11-snapshot windowless-only subgroup and 133 in the 7-snapshot
+single-`-1` subgroup — plus 7 single-`-1` with a null other edge, the
+seven-snapshot subgroup holding 140 total decisions), 130 live-state
+decisions, 0 unsupported, 0 snapshot rewrite operations** (Issue #404
+comments `5172781179`, `5174355909`).
 
 These figures supersede the earlier operational expectation that all 940
 pass-2 snapshot decisions (933 windowless + 7 single-`-1`) would immediately

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "test:integration:local": "node scripts/run-integration-local.mjs",
     "db:backup": "node scripts/db-backup.mjs",
     "test:backup": "node --test scripts/db-backup.test.mjs",
-    "test:local-db": "node --test scripts/local-postgres.test.mjs scripts/runner-lifecycle.test.mjs scripts/runner-monitoring.test.mjs scripts/aggregated-error.test.mjs scripts/db-setup.test.mjs scripts/remediate-forwarding.test.mjs",
+    "test:local-db": "node --test scripts/local-postgres.test.mjs scripts/runner-lifecycle.test.mjs scripts/runner-monitoring.test.mjs scripts/aggregated-error.test.mjs scripts/db-setup.test.mjs scripts/remediate-forwarding.test.mjs scripts/snapshot-evidence-forwarding.test.mjs",
     "test:pdf-cleanup": "node --import tsx --test server/src/test/pdf-cleanup.test.mjs",
     "test:pdf-smoke": "node --import tsx --test server/src/test/pdf-smoke.test.mjs",
     "test:install-chrome": "node --test scripts/install-chrome-lifecycle.test.mjs",
@@ -33,6 +33,7 @@
     "capacity-profiles:audit:repair": "npm run capacity-profiles:audit:repair --workspace=server",
     "capacity-profiles:readiness": "npm run capacity-profiles:readiness --workspace=server",
     "capacity-profiles:remediate-readiness": "npm run capacity-profiles:remediate-readiness --workspace=server --",
+    "capacity-profiles:snapshot-evidence": "npm run capacity-profiles:snapshot-evidence --workspace=server --",
     "capacity-profiles:backfill": "npm run capacity-profiles:backfill --workspace=server",
     "capacity-profiles:reconcile": "npm run capacity-profiles:reconcile --workspace=server"
   },

--- a/scripts/run-integration-local.mjs
+++ b/scripts/run-integration-local.mjs
@@ -20,6 +20,7 @@ try {
       'test:transfer-integration',
       'test:legacy-alias-removal-integration',
       'test:remediation-integration',
+      'test:snapshot-evidence-integration',
     ]) {
       if (guard.triggered) break
       await runCommand('npm', ['run', script, '--workspace=server'], { cwd: root, env: environment, signal: guard.abortSignal })

--- a/scripts/snapshot-evidence-forwarding.test.mjs
+++ b/scripts/snapshot-evidence-forwarding.test.mjs
@@ -1,0 +1,233 @@
+/**
+ * Regression test for Issue #432 — root `capacity-profiles:snapshot-evidence`
+ * must forward every user-supplied argument exactly once and in order to the
+ * server workspace command.
+ *
+ * Mirrors the Issue #424 forwarding regression test for the remediation
+ * command: exercises the ACTUAL root package-script string through the real
+ * npm forwarding layers, intercepting only the innermost executable (the
+ * server leaf script) with a harmless fixture that records `process.argv`.
+ * It does not inspect forwarding behaviour from a string.
+ *
+ * Safety: the fixture replaces the real `tsx src/scripts/generateSnapshotEvidence.ts`
+ * invocation, so the evidence command never runs, nothing connects to
+ * PostgreSQL, and no database or output-file write is possible. Only the
+ * recorded argv file (under the OS temp directory) is written.
+ */
+
+import assert from 'node:assert/strict'
+import { spawn } from 'node:child_process'
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync, rmSync } from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import test from 'node:test'
+
+const repositoryRoot = path.resolve(import.meta.dirname, '..')
+const rootPackageJson = JSON.parse(
+  readFileSync(path.join(repositoryRoot, 'package.json'), 'utf8'),
+)
+const serverPackageJson = JSON.parse(
+  readFileSync(path.join(repositoryRoot, 'server', 'package.json'), 'utf8'),
+)
+
+const rootEvidenceScript =
+  rootPackageJson.scripts['capacity-profiles:snapshot-evidence']
+const serverEvidenceScript =
+  serverPackageJson.scripts['capacity-profiles:snapshot-evidence']
+
+// The fixture may only stand in for the real server leaf command; if the
+// server command itself is renamed, the interception seam changes and this
+// test must be revisited rather than silently pass.
+const serverLeafIsTsx = () => {
+  assert.equal(
+    serverEvidenceScript,
+    'tsx src/scripts/generateSnapshotEvidence.ts',
+    'server leaf command changed; the forwarding fixture seam must be updated',
+  )
+}
+
+// Retained guard: the root script must declare the forwarding separator so
+// the inner npm layer does not consume the evidence flags as its own
+// configuration. The executable assertions below prove the actual behaviour.
+const rootScriptDeclaresSeparator = () => {
+  assert.match(
+    rootEvidenceScript,
+    /--workspace=server\s+--\s*$/,
+    `root script must end with the npm forwarding separator: ${rootEvidenceScript}`,
+  )
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────────
+
+function npmInvocation() {
+  if (process.env.npm_execpath) {
+    return [process.execPath, process.env.npm_execpath]
+  }
+  return [process.platform === 'win32' ? 'npm.cmd' : 'npm']
+}
+
+function runNpm(args, { cwd, env }) {
+  const [command, ...prefix] = npmInvocation()
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, [...prefix, ...args], {
+      cwd,
+      env,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+    let stdout = ''
+    let stderr = ''
+    child.stdout.on('data', (chunk) => {
+      stdout += chunk
+    })
+    child.stderr.on('data', (chunk) => {
+      stderr += chunk
+    })
+    const timer = setTimeout(() => {
+      child.kill('SIGKILL')
+      reject(new Error(`npm timed out for: npm ${args.join(' ')}\n${stderr}`))
+    }, 60_000)
+    child.on('error', (error) => {
+      clearTimeout(timer)
+      reject(error)
+    })
+    child.on('close', (code, signal) => {
+      clearTimeout(timer)
+      resolve({ code, signal, stdout, stderr })
+    })
+  })
+}
+
+/**
+ * Mirror the repository root script string in a disposable workspace and
+ * invoke it through real npm, with the server leaf replaced by an argv
+ * recorder. Returns the recorded argument array.
+ */
+async function runRootScriptWithFixture(userArgs) {
+  const fixtureRoot = mkdtempSync(path.join(os.tmpdir(), 'monrad-evidence-fwd-'))
+  const recordPath = path.join(fixtureRoot, 'recorded-argv.json')
+  try {
+    writeFileSync(
+      path.join(fixtureRoot, 'package.json'),
+      JSON.stringify(
+        {
+          name: 'monrad-evidence-forwarding-fixture',
+          private: true,
+          workspaces: ['server'],
+          scripts: {
+            // The exact string from the repository root package.json — the
+            // artifact under test.
+            'capacity-profiles:snapshot-evidence': rootEvidenceScript,
+          },
+        },
+        null,
+        2,
+      ),
+    )
+    mkdirSync(path.join(fixtureRoot, 'server'))
+    writeFileSync(
+      path.join(fixtureRoot, 'server', 'package.json'),
+      JSON.stringify(
+        {
+          name: 'monrad-evidence-forwarding-fixture-server',
+          private: true,
+          scripts: {
+            // Harmless argv recorder in place of the real tsx invocation.
+            'capacity-profiles:snapshot-evidence': 'node record-argv.mjs',
+          },
+        },
+        null,
+        2,
+      ),
+    )
+    writeFileSync(
+      path.join(fixtureRoot, 'server', 'record-argv.mjs'),
+      `import { writeFileSync } from 'node:fs'
+writeFileSync(process.env.RECORD_ARGV_OUT, JSON.stringify(process.argv.slice(2)))
+`,
+    )
+    writeFileSync(recordPath, '')
+
+    const result = await runNpm(
+      ['run', 'capacity-profiles:snapshot-evidence', '--', ...userArgs],
+      {
+        cwd: fixtureRoot,
+        env: {
+          ...process.env,
+          RECORD_ARGV_OUT: recordPath,
+          npm_config_cache: path.join(fixtureRoot, 'npm-cache'),
+        },
+      },
+    )
+    assert.equal(
+      result.code,
+      0,
+      `root script exited ${result.code ?? `signal ${result.signal}`}\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
+    )
+    const recorded = readFileSync(recordPath, 'utf8')
+    assert.notEqual(
+      recorded,
+      '',
+      'argv recorder never ran — the inner npm layer consumed the arguments\n' +
+        `stderr:\n${result.stderr}`,
+    )
+    return JSON.parse(recorded)
+  } finally {
+    rmSync(fixtureRoot, { recursive: true, force: true })
+  }
+}
+
+// ── Static guards ───────────────────────────────────────────────────────
+
+test('root script declares the npm forwarding separator after --workspace=server', () => {
+  rootScriptDeclaresSeparator()
+})
+
+test('server leaf command is still the real tsx evidence invocation', () => {
+  serverLeafIsTsx()
+})
+
+// ── Forwarding vectors ──────────────────────────────────────────────────
+
+// Representative invocations from the documented root command, including
+// values containing spaces. Deep equality proves the arguments arrive
+// exactly once, in the original order, unmodified.
+const vectors = [
+  {
+    name: 'json and markdown output paths',
+    args: ['--json', '/tmp/evidence.json', '--markdown', '/tmp/evidence.md'],
+  },
+  {
+    name: 'expected file with spaces in the output paths',
+    args: [
+      '--json',
+      '/tmp/evidence output.json',
+      '--markdown',
+      '/tmp/evidence output.md',
+      '--expected',
+      '/tmp/expected.json',
+    ],
+  },
+  {
+    name: 'argument order preserved with expected first',
+    args: [
+      '--expected',
+      '/tmp/expected.json',
+      '--json',
+      '/tmp/evidence.json',
+      '--markdown',
+      '/tmp/evidence.md',
+    ],
+  },
+]
+
+for (const { name, args } of vectors) {
+  test(`root command forwards arguments exactly once and in order — ${name}`, async () => {
+    const recorded = await runRootScriptWithFixture(args)
+    assert.deepEqual(recorded, args)
+  })
+}
+
+test('root command without arguments forwards none', async () => {
+  const recorded = await runRootScriptWithFixture([])
+  assert.deepEqual(recorded, [])
+})

--- a/server/package.json
+++ b/server/package.json
@@ -27,12 +27,14 @@
     "capacity-profiles:audit:repair:json": "tsx src/scripts/auditCapacityProfileOwnership.ts --repair-identical --json",
     "capacity-profiles:readiness": "tsx src/scripts/checkProductionMigrationReadiness.ts",
     "capacity-profiles:remediate-readiness": "tsx src/scripts/remediateProductionReadiness.ts",
+    "capacity-profiles:snapshot-evidence": "tsx src/scripts/generateSnapshotEvidence.ts",
     "test:ownership-invariants-integration": "vitest run --config vitest.integration.config.ts src/test/capacityProfileOwnershipInvariants.integration.test.ts",
     "test:runtime-cutover-integration": "vitest run --config vitest.integration.config.ts src/test/runtimeCutoverProfileFirst.integration.test.ts",
     "test:transfer-integration": "vitest run --config vitest.integration.config.ts src/test/capacityProfileTransfer.integration.test.ts",
     "postinstall": "prisma generate",
     "test:legacy-alias-removal-integration": "vitest run --config vitest.integration.config.ts src/test/legacyCapacityAliasRemoval.integration.test.ts",
-    "test:remediation-integration": "vitest run --config vitest.integration.config.ts src/test/productionRemediation.integration.test.ts"
+    "test:remediation-integration": "vitest run --config vitest.integration.config.ts src/test/productionRemediation.integration.test.ts",
+    "test:snapshot-evidence-integration": "vitest run --config vitest.integration.config.ts src/test/snapshotEvidence.integration.test.ts"
   },
   "prisma": {
     "seed": "tsx prisma/seed.ts"

--- a/server/src/lib/evidenceOutputPublication.ts
+++ b/server/src/lib/evidenceOutputPublication.ts
@@ -1,0 +1,118 @@
+/**
+ * evidenceOutputPublication.ts — Issue #432: all-or-nothing, no-clobber
+ * publication of the two evidence output files.
+ *
+ * Guarantees:
+ *   - both complete strings are staged into exclusive temporary files
+ *     (mode 0600) inside the corresponding output directories;
+ *   - the final publication step itself refuses an existing destination:
+ *     each final path is created as a hard link to the staged file
+ *     (fs.linkSync fails with EEXIST when the destination already exists —
+ *     never a check-then-rename sequence, so a destination created by
+ *     another process between preflight and publication cannot be
+ *     overwritten);
+ *   - temporary files are removed only after BOTH final paths have been
+ *     published;
+ *   - on any staging or publication failure every temporary file created by
+ *     this run and every final file created by this run (tracked by inode)
+ *     are removed; destinations that existed before or appeared
+ *     independently are never touched;
+ *   - on success both finals exist, are distinct files with mode 0600 on
+ *     POSIX, contain the intended complete content, and no temporary files
+ *     remain.
+ *
+ * The optional `hooks` parameter is a test-only failure injection seam (the
+ * production CLI never passes it).
+ */
+
+import { closeSync, linkSync, openSync, rmSync, statSync, unlinkSync, writeFileSync } from 'node:fs'
+import { randomBytes } from 'node:crypto'
+import path from 'node:path'
+
+/** Test-only failure injection phases; the production CLI never uses hooks. */
+export type EvidencePublishPhase =
+  | 'stage-json'
+  | 'stage-markdown'
+  | 'publish-json'
+  | 'publish-markdown'
+
+export interface EvidencePublishHooks {
+  failOn?: (phase: EvidencePublishPhase) => void
+}
+
+export interface PublishedEvidenceOutputs {
+  jsonPath: string
+  markdownPath: string
+}
+
+/**
+ * Publish the JSON and Markdown evidence outputs atomically as a set with
+ * no-clobber final steps. Throws on any failure after cleaning up every file
+ * created by this run (see module docs).
+ */
+export function publishEvidenceOutputs(
+  jsonPath: string,
+  markdownPath: string,
+  jsonContent: string,
+  markdownContent: string,
+  hooks?: EvidencePublishHooks,
+): PublishedEvidenceOutputs {
+  const tempPaths: string[] = []
+  /** Finals created by THIS run, tracked by (path, inode) for safe cleanup. */
+  const ownedFinals: Array<{ finalPath: string; ino: number }> = []
+  const fail = (phase: EvidencePublishPhase): void => {
+    if (hooks?.failOn) hooks.failOn(phase)
+  }
+  const cleanup = (): void => {
+    for (const temp of tempPaths) {
+      try { rmSync(temp, { force: true }) } catch { /* best-effort */ }
+    }
+    for (const owned of ownedFinals) {
+      try {
+        // Only remove the final when it is still the inode this run created;
+        // a destination that appeared independently is never deleted.
+        const current = statSync(owned.finalPath)
+        if (current.ino === owned.ino) unlinkSync(owned.finalPath)
+      } catch { /* already gone or unreadable — nothing owned to remove */ }
+    }
+  }
+  const tempPathFor = (finalPath: string): string => {
+    const dir = path.dirname(finalPath)
+    const base = path.basename(finalPath)
+    return path.join(dir, `.${base}.evidence-${randomBytes(8).toString('hex')}.tmp`)
+  }
+  const stage = (finalPath: string, content: string, phase: EvidencePublishPhase): string => {
+    const temp = tempPathFor(finalPath)
+    tempPaths.push(temp)
+    const fd = openSync(temp, 'wx', 0o600)
+    try {
+      writeFileSync(fd, content, 'utf8')
+    } finally {
+      closeSync(fd)
+    }
+    fail(phase)
+    return temp
+  }
+  /** No-clobber publish: hard link fails with EEXIST if the destination exists. */
+  const publish = (temp: string, finalPath: string, phase: EvidencePublishPhase): void => {
+    linkSync(temp, finalPath)
+    ownedFinals.push({ finalPath, ino: statSync(finalPath).ino })
+    fail(phase)
+  }
+
+  try {
+    const jsonTemp = stage(jsonPath, jsonContent, 'stage-json')
+    const markdownTemp = stage(markdownPath, markdownContent, 'stage-markdown')
+    publish(jsonTemp, jsonPath, 'publish-json')
+    publish(markdownTemp, markdownPath, 'publish-markdown')
+    // Both finals are published; only now remove the staged temporaries.
+    for (const temp of tempPaths) {
+      try { rmSync(temp, { force: true }) } catch { /* best-effort */ }
+    }
+    tempPaths.length = 0
+    return { jsonPath, markdownPath }
+  } catch (error) {
+    cleanup()
+    throw error
+  }
+}

--- a/server/src/lib/snapshotEvidence.ts
+++ b/server/src/lib/snapshotEvidence.ts
@@ -1,0 +1,1135 @@
+/**
+ * snapshotEvidence.ts — Issue #432: pure, read-only aggregation of sanitized
+ * historical snapshot evidence for the Issue #430 design investigation.
+ *
+ * One pure module with one responsibility: convert the existing read-only
+ * remediation-plan result and shared snapshot-classifier results into a
+ * versioned, sanitized aggregate evidence report. It reuses:
+ *   - buildRemediationPlan / computeStateHash / computePlanFingerprint /
+ *     classifyPlanExit (productionRemediationPlan.ts);
+ *   - classifySnapshotRestorability / classifyV2QuarantineShape /
+ *     v2NamedResourceAliasConflict (snapshotRestorability.ts);
+ *   - parseSnapshotData / isSnapshotV2 (projectSnapshotTypes.ts);
+ *   - v2EffectiveNamedMode / v2ResourceTypeEntryErrors /
+ *     v2NamedResourceEntryErrors / v2PercentIsValid /
+ *     translateV2SnapshotProfiles / validateV2TranslatedProfiles
+ *     (projectSnapshotCapacity.ts).
+ *
+ * It never decides whether an entry should be translated, quarantined,
+ * repaired or retained as decision-required: `policyDecision` is always
+ * `not-assessed`. It emits aggregate evidence only — no project/snapshot/
+ * owner/finding/decision identifiers, no names, no payloads.
+ *
+ * Pure function of its inputs (database state, snapshot created-at
+ * metadata, reviewed expectations); performs zero writes; contains no I/O.
+ */
+
+import { parseSnapshotData, isSnapshotV2, type SnapshotData, type SnapshotV2, type SnapshotResourceType, type SnapshotNamedResource } from './projectSnapshotTypes.js'
+import {
+  v2EffectiveNamedMode,
+  v2ResourceTypeEntryErrors,
+  v2NamedResourceEntryErrors,
+  v2PercentIsValid,
+  translateV2SnapshotProfiles,
+  validateV2TranslatedProfiles,
+} from './projectSnapshotCapacity.js'
+import {
+  classifySnapshotRestorability,
+  classifyV2QuarantineShape,
+  v2NamedResourceAliasConflict,
+  type SnapshotRestorability,
+} from './snapshotRestorability.js'
+import {
+  buildRemediationPlan,
+  canonicalJson,
+  classifyPlanExit,
+  classifySnapshotEntry,
+  computePlanFingerprint,
+  computeStateHash,
+  sha256Hex,
+  type RemediationDatabaseState,
+} from './productionRemediationPlan.js'
+
+// ─── Version and schema ─────────────────────────────────────────────────────
+
+export const SNAPSHOT_EVIDENCE_FORMAT_VERSION = 1 as const
+
+/** Stable evidence categories; never raw identifiers or payloads. */
+export type OwnerKindCategory = 'resourceType' | 'namedResource' | 'unavailable'
+export type NamedModeSourceCategory = 'explicit' | 'inherited' | 'other' | 'unavailable'
+export type PercentCategory =
+  | 'absent-null'
+  | 'zero'
+  | 'one-to-ninety-nine'
+  | 'hundred'
+  | 'above-hundred'
+  | 'invalid-non-finite'
+export type AlternateAliasState = 'all-absent-null' | 'populated' | 'conflicting'
+export type MinusOneField = 'allocationStartWeek' | 'allocationEndWeek' | 'startWeek' | 'endWeek'
+export type IndependentDefectCategory = 'entry-level' | 'structural' | 'both' | 'unavailable'
+export type DefectSubgroup = 'eleven-windowless-only' | 'seven-single-minus-one'
+export type SnapshotEraCategory =
+  | 'before-2026-05-05'
+  | '2026-05-05-to-2026-07-13'
+  | '2026-07-14-or-later'
+  | 'unavailable'
+
+/** Stable entry-level translator error categories (derived from the shared
+ * translator helpers, never a second policy implementation). */
+export type EntryErrorCategory =
+  | 'unknown-mode'
+  | 'orphan-ownership'
+  | 'non-finite-percent'
+  | 'windowless-capacity-plan'
+  | 'negative-one-window-value'
+  | 'below-minus-one-window-value'
+  | 'fractional-window-value'
+  | 'negative-window-value'
+  | 'inverted-window'
+  | 'alias-conflict'
+  | 'other'
+
+/** Stable snapshot-level structural validation error categories (from the
+ * shared validateV2TranslatedProfiles result). */
+export type StructuralErrorCategory =
+  | 'duplicate-owner'
+  | 'percent-range'
+  | 'profile-window'
+  | 'invalid-planning-basis'
+  | 'invalid-source'
+  | 'invalid-owner-kind'
+  | 'owner-fk'
+  | 'segmentless-capacity-profile'
+  | 'owner-not-found'
+  | 'planning-basis-shape'
+  | 'segment-shape'
+  | 'other'
+
+// ─── Reviewed expectations (production-run input, never hard-coded) ─────────
+
+export interface SnapshotEvidenceExpected {
+  /** Reviewed remediation-plan fingerprint (64 hex chars). */
+  fingerprint: string
+  /** Reviewed baseline-state hash over loadRemediationState scope. */
+  baselineStateHash: string
+  quarantinedEntries: number
+  quarantinedSnapshots: number
+  defectSnapshots: number
+  windowlessDecisions: number
+  singleMinusOneDecisions: number
+  snapshotDecisions: number
+  liveDecisions: number
+  unsupported: number
+  rewriteOperations: number
+  /** Corrected topology: 11-snapshot windowless-only subgroup. */
+  topology11WindowlessDecisions: number
+  /** Corrected topology: 7-snapshot subgroup windowless decisions. */
+  topology7WindowlessDecisions: number
+  /** Corrected topology: 7-snapshot subgroup single-`-1` decisions. */
+  topology7SingleMinusOneDecisions: number
+}
+
+// ─── Report schema (versioned, evidence-only) ───────────────────────────────
+
+export interface SnapshotEvidenceReport {
+  formatVersion: typeof SNAPSHOT_EVIDENCE_FORMAT_VERSION
+  runMetadata: {
+    generatedAt: string
+    applicationCommit: string
+  }
+  expectedBoundary: SnapshotEvidenceExpected
+  observedBoundary: {
+    fingerprint: string
+    baselineStateHash: string
+    planExit: 0 | 1 | 2
+    summary: {
+      findings: Record<string, number>
+      operations: number
+      decisionsRequired: number
+      quarantined: number
+      rewriteOperations: number
+    }
+    snapshotPopulation: {
+      totalSnapshots: number
+      restorable: number
+      quarantined: number
+      defect: number
+    }
+  }
+  integrityResult: {
+    fingerprintMatch: boolean
+    baselineMatch: boolean
+    countsMatch: boolean
+    reconciliationPassed: boolean
+  }
+  topology: {
+    quarantinedSnapshots: number
+    defectSnapshots: number
+    windowlessDecisions: number
+    singleMinusOneDecisions: number
+    snapshotDecisions: number
+    liveDecisions: number
+    elevenSnapshotSubgroup: { snapshots: number; windowlessDecisions: number }
+    sevenSnapshotSubgroup: {
+      snapshots: number
+      windowlessDecisions: number
+      singleMinusOneDecisions: number
+      totalDecisions: number
+    }
+    quarantinedFindingsWithDecisionOrOperationIds: number
+  }
+  singleNegativeEntries: Array<{
+    label: string
+    entryKind: OwnerKindCategory
+    minusOneField: MinusOneField
+    alternateAliasState: AlternateAliasState
+    rawMode: string | null
+    parentMode: string | null
+    effectiveMode: string | null
+    modeSource: NamedModeSourceCategory
+    allocationPercentCategory: PercentCategory
+    allocationPctCategory: PercentCategory
+    entryErrorCategories: EntryErrorCategory[]
+    structuralErrorCategories: StructuralErrorCategory[]
+    independentDefect: IndependentDefectCategory
+  }>
+  defectSnapshots: Array<{
+    label: string
+    subgroup: DefectSubgroup
+    windowlessDecisionCount: number
+    singleMinusOneDecisionCount: number
+    otherDecisionRequiredCounts: Record<string, number>
+    alreadyValidCount: number
+    quarantinedCount: number
+    unsupportedCount: number
+    entryErrorCategories: Record<EntryErrorCategory, number>
+    structuralErrorCategories: Record<StructuralErrorCategory, number>
+    independentDefect: IndependentDefectCategory
+  }>
+  classAAggregates: {
+    totalEntries: number
+    totalSnapshots: number
+    byOwnerKind: Record<OwnerKindCategory, number>
+    byNamedModeSource: Record<NamedModeSourceCategory, number>
+    percentageByCategory: Record<
+      'resourceType' | NamedModeSourceCategory,
+      { allocationPercent: Record<PercentCategory, number>; allocationPct: Record<PercentCategory, number> }
+    >
+    aliasShapes: {
+      primaryAbsentNull: number
+      fallbackAbsentNull: number
+      populatedAgreeing: number
+      conflicting: number
+      unavailable: number
+    }
+    snapshotsByOwnerKindMix: { resourceTypeOnly: number; namedResourceOnly: number; mixed: number }
+    entriesByEra: Record<SnapshotEraCategory, number>
+    snapshotsByEra: Record<SnapshotEraCategory, number>
+  }
+  unavailableEvidence: {
+    singleEntriesModeSourceUnavailable: number
+    defectSnapshotsIndependentDefectUnavailable: number
+    classAEntriesEraUnavailable: number
+    classASnapshotsEraUnavailable: number
+  }
+  reconciliation: {
+    passed: boolean
+    details: string[]
+  }
+  policyDecision: 'not-assessed'
+}
+
+// ─── Controlled error ───────────────────────────────────────────────────────
+
+export type EvidenceErrorCode = 'unsupported-snapshot' | 'snapshot-parse-failure'
+
+export class SnapshotEvidenceError extends Error {
+  readonly code: EvidenceErrorCode
+  constructor(code: EvidenceErrorCode, message: string) {
+    super(message)
+    this.name = 'SnapshotEvidenceError'
+    this.code = code
+  }
+}
+
+// ─── Small pure helpers ─────────────────────────────────────────────────────
+
+function isHex64(value: string): boolean {
+  return /^[0-9a-f]{64}$/.test(value)
+}
+
+export function isExpectedBoundaryShape(value: unknown): value is SnapshotEvidenceExpected {
+  if (typeof value !== 'object' || value === null) return false
+  const v = value as Record<string, unknown>
+  return (
+    typeof v.fingerprint === 'string' && isHex64(v.fingerprint) &&
+    typeof v.baselineStateHash === 'string' && isHex64(v.baselineStateHash) &&
+    typeof v.quarantinedEntries === 'number' && Number.isInteger(v.quarantinedEntries) &&
+    typeof v.quarantinedSnapshots === 'number' && Number.isInteger(v.quarantinedSnapshots) &&
+    typeof v.defectSnapshots === 'number' && Number.isInteger(v.defectSnapshots) &&
+    typeof v.windowlessDecisions === 'number' && Number.isInteger(v.windowlessDecisions) &&
+    typeof v.singleMinusOneDecisions === 'number' && Number.isInteger(v.singleMinusOneDecisions) &&
+    typeof v.snapshotDecisions === 'number' && Number.isInteger(v.snapshotDecisions) &&
+    typeof v.liveDecisions === 'number' && Number.isInteger(v.liveDecisions) &&
+    typeof v.unsupported === 'number' && Number.isInteger(v.unsupported) &&
+    typeof v.rewriteOperations === 'number' && Number.isInteger(v.rewriteOperations) &&
+    typeof v.topology11WindowlessDecisions === 'number' && Number.isInteger(v.topology11WindowlessDecisions) &&
+    typeof v.topology7WindowlessDecisions === 'number' && Number.isInteger(v.topology7WindowlessDecisions) &&
+    typeof v.topology7SingleMinusOneDecisions === 'number' && Number.isInteger(v.topology7SingleMinusOneDecisions)
+  )
+}
+
+/** Deterministic percentage bucket used for evidence only. */
+export function percentCategory(value: number | null | undefined): PercentCategory {
+  if (value == null) return 'absent-null'
+  if (!Number.isFinite(value)) return 'invalid-non-finite'
+  if (value === 0) return 'zero'
+  if (value >= 1 && value <= 99) return 'one-to-ninety-nine'
+  if (value === 100) return 'hundred'
+  return 'above-hundred'
+}
+
+const ERA_BEFORE: SnapshotEraCategory = 'before-2026-05-05'
+const ERA_MID: SnapshotEraCategory = '2026-05-05-to-2026-07-13'
+const ERA_AFTER: SnapshotEraCategory = '2026-07-14-or-later'
+const ERA_UNAVAILABLE: SnapshotEraCategory = 'unavailable'
+
+/** Snapshot writer-era grouping from the stored created-at timestamp. The
+ * timestamp is NOT proof of the exact historical writer; it is a directly
+ * available metadata grouping only. */
+export function snapshotEraCategory(createdAtIso: string | null | undefined): SnapshotEraCategory {
+  if (!createdAtIso) return ERA_UNAVAILABLE
+  const ms = Date.parse(createdAtIso)
+  if (!Number.isFinite(ms)) return ERA_UNAVAILABLE
+  const before = Date.parse('2026-05-05T00:00:00Z')
+  const after = Date.parse('2026-07-14T00:00:00Z')
+  if (ms < before) return ERA_BEFORE
+  if (ms < after) return ERA_MID
+  return ERA_AFTER
+}
+
+const WINDOW_FIELD_NAMES = ['allocationStartWeek', 'allocationEndWeek', 'startWeek', 'endWeek'] as const
+
+/** Map a shared-translator error message to a stable evidence category. The
+ * window-value message is refined from the raw field value the shared helper
+ * already rejected (evidence granularity, not a new predicate). */
+function entryErrorCategory(message: string, entry: SnapshotResourceType | SnapshotNamedResource): EntryErrorCategory {
+  if (message.includes('unknown allocationMode')) return 'unknown-mode'
+  if (message.includes('cannot be translated into authoritative ownership') || message.includes('orphan ownership cannot be translated')) return 'orphan-ownership'
+  if (message.includes('allocationPercent must be finite') || message.includes('allocationPct must be finite')) return 'non-finite-percent'
+  if (message.includes('cannot be translated without guessing capacity')) return 'windowless-capacity-plan'
+  if (message.includes('must not exceed')) return 'inverted-window'
+  for (const field of WINDOW_FIELD_NAMES) {
+    if (!message.includes(`${field} must be a non-negative integer or null`)) continue
+    const value = (entry as Record<string, unknown>)[field]
+    if (value === -1) return 'negative-one-window-value'
+    if (typeof value === 'number' && value < -1) return 'below-minus-one-window-value'
+    if (typeof value === 'number' && !Number.isInteger(value)) return 'fractional-window-value'
+    return 'negative-window-value'
+  }
+  return 'other'
+}
+
+/** Map a shared structural-validation message to a stable evidence category. */
+function structuralErrorCategory(message: string): StructuralErrorCategory {
+  if (message.includes('duplicate physical owner')) return 'duplicate-owner'
+  if (message.includes('defaultPercent')) return 'percent-range'
+  if (message.includes('invalid planningBasis')) return 'invalid-planning-basis'
+  if (message.includes('invalid source')) return 'invalid-source'
+  if (message.includes('invalid ownerKind')) return 'invalid-owner-kind'
+  if (message.includes('must have exactly one owner FK')) return 'owner-fk'
+  if (message.includes('CAPACITY_PROFILE with no segments')) return 'segmentless-capacity-profile'
+  if (message.includes('not found in project')) return 'owner-not-found'
+  if (message.includes('DEMAND_FOLLOWING must not') || message.includes('WHOLE_PROJECT_ALLOCATION must not')) return 'planning-basis-shape'
+  if (message.includes('Segment ')) return 'segment-shape'
+  if (message.includes('must be a non-negative finite integer') || message.includes('must not exceed')) return 'profile-window'
+  return 'other'
+}
+
+function emptyCounts<T extends string>(categories: readonly T[]): Record<T, number> {
+  const out = {} as Record<T, number>
+  for (const category of categories) out[category] = 0
+  return out
+}
+
+const ENTRY_ERROR_CATEGORIES: readonly EntryErrorCategory[] = [
+  'unknown-mode', 'orphan-ownership', 'non-finite-percent', 'windowless-capacity-plan',
+  'negative-one-window-value', 'below-minus-one-window-value', 'fractional-window-value',
+  'negative-window-value', 'inverted-window', 'alias-conflict', 'other',
+]
+
+const STRUCTURAL_ERROR_CATEGORIES: readonly StructuralErrorCategory[] = [
+  'duplicate-owner', 'percent-range', 'profile-window', 'invalid-planning-basis',
+  'invalid-source', 'invalid-owner-kind', 'owner-fk', 'segmentless-capacity-profile',
+  'owner-not-found', 'planning-basis-shape', 'segment-shape', 'other',
+]
+
+const PERCENT_CATEGORIES: readonly PercentCategory[] = [
+  'absent-null', 'zero', 'one-to-ninety-nine', 'hundred', 'above-hundred', 'invalid-non-finite',
+]
+
+// ─── Per-entry evidence extraction (shared helpers only) ────────────────────
+
+export interface V2EntryEvidence {
+  kind: 'resourceType' | 'namedResource'
+  effectiveMode: string | null
+  modeSource: NamedModeSourceCategory
+  parentMode: string | null
+  minusOneFields: MinusOneField[]
+  effectiveStart: number | null
+  effectiveEnd: number | null
+  entryErrorCategories: EntryErrorCategory[]
+  allocationPercentCategory: PercentCategory
+  allocationPctCategory: PercentCategory
+  /** Class A/B per the shared classifier predicate (evidence reuse). */
+  quarantineClass: 'A' | 'B' | null
+}
+
+function resourceTypeEntryEvidence(rt: SnapshotResourceType, index: number): V2EntryEvidence {
+  const errors = v2ResourceTypeEntryErrors(rt, `v2 snapshot resourceTypes[${index}]`)
+  const categories: EntryErrorCategory[] = []
+  for (const error of errors) {
+    const category = entryErrorCategory(error, rt)
+    if (!categories.includes(category)) categories.push(category)
+  }
+  const mode = rt.allocationMode ?? null
+  const minusOneFields: MinusOneField[] = []
+  if (rt.allocationStartWeek === -1) minusOneFields.push('allocationStartWeek')
+  if (rt.allocationEndWeek === -1) minusOneFields.push('allocationEndWeek')
+  const quarantineClass = mode === 'CAPACITY_PLAN' && v2PercentIsValid(rt.allocationPercent)
+    ? classifyV2QuarantineShape({
+        primaryStart: rt.allocationStartWeek ?? null,
+        aliasStart: null,
+        primaryEnd: rt.allocationEndWeek ?? null,
+        aliasEnd: null,
+      })
+    : null
+  return {
+    kind: 'resourceType',
+    effectiveMode: mode,
+    modeSource: 'unavailable',
+    parentMode: null,
+    minusOneFields,
+    effectiveStart: rt.allocationStartWeek ?? null,
+    effectiveEnd: rt.allocationEndWeek ?? null,
+    entryErrorCategories: categories,
+    allocationPercentCategory: percentCategory(rt.allocationPercent),
+    allocationPctCategory: 'absent-null',
+    quarantineClass,
+  }
+}
+
+function namedResourceEntryEvidence(
+  nr: SnapshotNamedResource,
+  parentRt: SnapshotResourceType | undefined,
+  index: number,
+): V2EntryEvidence {
+  const errors = v2NamedResourceEntryErrors(nr, parentRt, `v2 snapshot namedResources[${index}]`)
+  const categories: EntryErrorCategory[] = []
+  for (const error of errors) {
+    const category = entryErrorCategory(error, nr)
+    if (!categories.includes(category)) categories.push(category)
+  }
+  const parentMode = parentRt?.allocationMode ?? null
+  const rawMode = nr.allocationMode ?? null
+  const effectiveMode = v2EffectiveNamedMode(nr, parentRt)
+  // Classifier-only alias-conflict rule (shared export, verdict-neutral reuse).
+  if (v2NamedResourceAliasConflict(nr, effectiveMode) && !categories.includes('alias-conflict')) {
+    categories.push('alias-conflict')
+  }
+  const modeSource: NamedModeSourceCategory =
+    rawMode === 'CAPACITY_PLAN' ? 'explicit'
+      : rawMode != null ? 'other'
+        : parentMode === 'CAPACITY_PLAN' ? 'inherited'
+          : parentMode == null ? 'unavailable'
+            : 'other'
+  const minusOneFields: MinusOneField[] = []
+  if (nr.allocationStartWeek === -1) minusOneFields.push('allocationStartWeek')
+  if (nr.allocationEndWeek === -1) minusOneFields.push('allocationEndWeek')
+  if (nr.startWeek === -1) minusOneFields.push('startWeek')
+  if (nr.endWeek === -1) minusOneFields.push('endWeek')
+  const effectiveStart = nr.allocationStartWeek ?? nr.startWeek ?? null
+  const effectiveEnd = nr.allocationEndWeek ?? nr.endWeek ?? null
+  const quarantineClass =
+    effectiveMode === 'CAPACITY_PLAN' &&
+    v2PercentIsValid(nr.allocationPercent) &&
+    v2PercentIsValid(nr.allocationPct)
+      ? classifyV2QuarantineShape({
+          primaryStart: nr.allocationStartWeek ?? null,
+          aliasStart: nr.startWeek ?? null,
+          primaryEnd: nr.allocationEndWeek ?? null,
+          aliasEnd: nr.endWeek ?? null,
+        })
+      : null
+  return {
+    kind: 'namedResource',
+    effectiveMode,
+    modeSource,
+    parentMode,
+    minusOneFields,
+    effectiveStart,
+    effectiveEnd,
+    entryErrorCategories: categories,
+    allocationPercentCategory: percentCategory(nr.allocationPercent),
+    allocationPctCategory: percentCategory(nr.allocationPct),
+    quarantineClass,
+  }
+}
+
+// ─── Snapshot-level evidence ────────────────────────────────────────────────
+
+export interface SnapshotEvidence {
+  restorability: SnapshotRestorability
+  /** Entry evidence in payload order (resourceTypes then namedResources). */
+  entries: V2EntryEvidence[]
+  structuralErrorCategories: StructuralErrorCategory[]
+}
+
+/** Classify one stored snapshot through the shared classifier and shared
+ * translator helpers only. Throws SnapshotEvidenceError on parse failure or
+ * unsupported versions (fail closed). */
+export function classifySnapshotEvidence(raw: unknown, projectId: string): SnapshotEvidence {
+  let parsed: SnapshotData
+  try {
+    parsed = parseSnapshotData(raw)
+  } catch {
+    throw new SnapshotEvidenceError('snapshot-parse-failure', 'a stored snapshot payload could not be parsed')
+  }
+  const version = (parsed as { schemaVersion?: unknown }).schemaVersion
+  if (!isSnapshotV2(parsed)) {
+    // V1 is a bare epic array (no schemaVersion); V3/V4 carry schemaVersion 3/4.
+    if (!Array.isArray(parsed) && version !== 1 && version !== 3 && version !== 4) {
+      throw new SnapshotEvidenceError('unsupported-snapshot', 'a stored snapshot has an unsupported schema version')
+    }
+    return {
+      restorability: classifySnapshotRestorability(raw, projectId),
+      entries: [],
+      structuralErrorCategories: [],
+    }
+  }
+  const restorability = classifySnapshotRestorability(raw, projectId)
+  const rtById = new Map(parsed.resourceTypes.map(rt => [rt.id, rt]))
+  const entries: V2EntryEvidence[] = []
+  for (let i = 0; i < parsed.resourceTypes.length; i++) {
+    entries.push(resourceTypeEntryEvidence(parsed.resourceTypes[i]!, i))
+  }
+  for (let i = 0; i < parsed.namedResources.length; i++) {
+    const nr = parsed.namedResources[i]!
+    entries.push(namedResourceEntryEvidence(nr, rtById.get(nr.resourceTypeId ?? ''), i))
+  }
+  const translation = translateV2SnapshotProfiles(parsed, projectId)
+  const structuralErrorCategories = validateV2TranslatedProfiles(translation.profiles, projectId, parsed)
+    .map(message => structuralErrorCategory(message))
+  return { restorability, entries, structuralErrorCategories }
+}
+
+// ─── Evidence assembly ──────────────────────────────────────────────────────
+
+const WINDOWLESS_DECISION_MESSAGE = 'CAPACITY_PLAN without captured window'
+const SINGLE_NEGATIVE_DECISION_MESSAGE = 'single -1/negative window edge'
+
+function snapshotDecisionCategory(message: string): 'windowless' | 'single-negative' | 'other' {
+  if (message.includes(WINDOWLESS_DECISION_MESSAGE)) return 'windowless'
+  if (message.includes(SINGLE_NEGATIVE_DECISION_MESSAGE)) return 'single-negative'
+  return 'other'
+}
+
+/**
+ * Raw payload shape for the plan-level snapshot-entry classifier (the exact
+ * fields the remediation plan builder passes).
+ */
+function planEntryPayload(rt: SnapshotResourceType | SnapshotNamedResource, kind: 'resourceType' | 'namedResource'): {
+  allocationMode: string | null
+  allocationPercent: number | null
+  allocationPct?: number | null
+  allocationStartWeek: number | null
+  allocationEndWeek: number | null
+  startWeek?: number | null
+  endWeek?: number | null
+} {
+  return {
+    allocationMode: rt.allocationMode ?? null,
+    allocationPercent: rt.allocationPercent ?? null,
+    allocationStartWeek: rt.allocationStartWeek ?? null,
+    allocationEndWeek: rt.allocationEndWeek ?? null,
+    ...(kind === 'namedResource'
+      ? {
+          allocationPct: (rt as SnapshotNamedResource).allocationPct ?? null,
+          startWeek: (rt as SnapshotNamedResource).startWeek ?? null,
+          endWeek: (rt as SnapshotNamedResource).endWeek ?? null,
+        }
+      : {}),
+  }
+}
+
+export interface SnapshotEvidenceInputs {
+  state: RemediationDatabaseState
+  /** snapshot id → ISO created-at timestamp (separate read-only query;
+   * deliberately NOT part of the baseline-state hash scope). */
+  snapshotCreatedAtById: ReadonlyMap<string, string>
+  applicationCommit: string
+  generatedAt: string
+  expected: SnapshotEvidenceExpected
+}
+
+interface ClassifiedSnapshot {
+  evidence: SnapshotEvidence
+  v2: boolean
+  parsed: SnapshotData | null
+  /** Narrowed v2 payload when v2 (resourceTypes/namedResources access). */
+  parsedV2: SnapshotV2 | null
+}
+
+function classifyAllSnapshots(state: RemediationDatabaseState): ClassifiedSnapshot[] {
+  return state.snapshots.map(snapshot => {
+    const evidence = classifySnapshotEvidence(snapshot.snapshot, snapshot.projectId)
+    let parsed: SnapshotData | null = null
+    try {
+      parsed = parseSnapshotData(snapshot.snapshot)
+    } catch {
+      // classifySnapshotEvidence already failed closed above.
+    }
+    const parsedV2 = parsed != null && isSnapshotV2(parsed) ? parsed : null
+    return { evidence, v2: parsedV2 != null, parsed, parsedV2 }
+  })
+}
+
+/**
+ * Build the complete sanitized evidence report. Pure: no I/O, no writes, no
+ * policy decisions. Throws SnapshotEvidenceError on unsupported/malformed
+ * snapshots; the CLI refuses to emit any evidence in that case.
+ */
+export function buildSnapshotEvidenceReport(inputs: SnapshotEvidenceInputs): SnapshotEvidenceReport {
+  const { state, snapshotCreatedAtById, applicationCommit, generatedAt, expected } = inputs
+  const plan = buildRemediationPlan(state, applicationCommit)
+  const observedFingerprint = computePlanFingerprint(plan)
+  const observedBaseline = computeStateHash(state)
+  const planExit = classifyPlanExit(plan)
+
+  const classified = classifyAllSnapshots(state)
+  let restorableSnapshots = 0
+  let quarantinedSnapshots = 0
+  let defectSnapshots = 0
+  for (const item of classified) {
+    if (item.evidence.restorability.kind === 'restorable') restorableSnapshots++
+    else if (item.evidence.restorability.kind === 'quarantined') quarantinedSnapshots++
+    else defectSnapshots++
+  }
+
+  // ── Plan-level snapshot decisions grouped per snapshot ───────────────────
+  const decisionsBySnapshot = new Map<string, { windowless: number; singleNegative: number; other: Record<string, number> }>()
+  let windowlessDecisions = 0
+  let singleMinusOneDecisions = 0
+  let snapshotDecisions = 0
+  let liveDecisions = 0
+  for (const decision of plan.decisions) {
+    if (decision.snapshotId == null) {
+      liveDecisions++
+      continue
+    }
+    snapshotDecisions++
+    const category = snapshotDecisionCategory(decision.message)
+    const entry = decisionsBySnapshot.get(decision.snapshotId) ?? { windowless: 0, singleNegative: 0, other: {} as Record<string, number> }
+    if (category === 'windowless') {
+      entry.windowless++
+      windowlessDecisions++
+    } else if (category === 'single-negative') {
+      entry.singleNegative++
+      singleMinusOneDecisions++
+    } else {
+      entry.other[decision.message] = (entry.other[decision.message] ?? 0) + 1
+    }
+    decisionsBySnapshot.set(decision.snapshotId, entry)
+  }
+
+  // ── Plan findings per snapshot (alreadyValid/quarantined/unsupported) ────
+  const findingCountsBySnapshot = new Map<string, { alreadyValid: number; quarantined: number; unsupported: number }>()
+  for (const finding of plan.findings) {
+    if (finding.snapshotId == null || finding.category !== 'snapshot-entry') continue
+    const entry = findingCountsBySnapshot.get(finding.snapshotId) ?? { alreadyValid: 0, quarantined: 0, unsupported: 0 }
+    if (finding.classification === 'alreadyValid') entry.alreadyValid++
+    else if (finding.classification === 'quarantined') entry.quarantined++
+    else if (finding.classification === 'unsupported') entry.unsupported++
+    findingCountsBySnapshot.set(finding.snapshotId, entry)
+  }
+
+  // ── S entries: raw `-1` edge decisions — the exact entries the plan
+  // classifies as "single -1/negative window edge" (shared predicate via
+  // classifySnapshotEntry; the observed production shape is a single `-1`
+  // raw field; the other-edge state is reported as raw evidence, not
+  // assumed). Evidence, not policy.
+  interface SingleNegativeRecord {
+    key: string
+    entryKind: OwnerKindCategory
+    minusOneField: MinusOneField
+    alternateAliasState: AlternateAliasState
+    rawMode: string | null
+    parentMode: string | null
+    effectiveMode: string | null
+    modeSource: NamedModeSourceCategory
+    allocationPercentCategory: PercentCategory
+    allocationPctCategory: PercentCategory
+    entryErrorCategories: EntryErrorCategory[]
+    structuralErrorCategories: StructuralErrorCategory[]
+    independentDefect: IndependentDefectCategory
+  }
+  const singleNegativeRecords: SingleNegativeRecord[] = []
+
+  for (let snapshotIndex = 0; snapshotIndex < state.snapshots.length; snapshotIndex++) {
+    const item = classified[snapshotIndex]!
+    if (!item.v2 || !item.parsedV2) continue
+    const parsed = item.parsedV2
+    const rtById = new Map(parsed.resourceTypes.map(rt => [rt.id, rt]))
+    const evidence = item.evidence
+    // Entry evidence is in payload order: RTs then NRs.
+    for (let i = 0; i < evidence.entries.length; i++) {
+      const entry = evidence.entries[i]!
+      if (entry.minusOneFields.length !== 1) continue
+      let raw: SnapshotResourceType | SnapshotNamedResource
+      let kind: 'resourceType' | 'namedResource'
+      if (entry.kind === 'resourceType') {
+        raw = parsed.resourceTypes[i]!
+        kind = 'resourceType'
+      } else {
+        raw = parsed.namedResources[i - parsed.resourceTypes.length]!
+        kind = 'namedResource'
+      }
+      // Shared plan-level predicate: the entry must be exactly the
+      // "single -1/negative window edge" decision class.
+      const finding = classifySnapshotEntry(planEntryPayload(raw, kind))
+      if (finding.classification !== 'decisionRequired') continue
+      if (!finding.message.includes(SINGLE_NEGATIVE_DECISION_MESSAGE)) continue
+
+      let rawMode: string | null
+      let parentMode: string | null
+      let percent: number | null | undefined
+      let pct: number | null | undefined
+      let aliasState: AlternateAliasState
+      let sanitizedForKey: Record<string, unknown>
+      if (kind === 'resourceType') {
+        const rt = raw as SnapshotResourceType
+        rawMode = rt.allocationMode ?? null
+        parentMode = null
+        percent = rt.allocationPercent
+        aliasState = aliasStateFor(rt.allocationStartWeek, rt.allocationEndWeek, null, null, entry.minusOneFields[0])
+        sanitizedForKey = {
+          kind: entry.kind,
+          mode: rawMode,
+          percent: rt.allocationPercent ?? null,
+          asw: rt.allocationStartWeek ?? null,
+          aew: rt.allocationEndWeek ?? null,
+        }
+      } else {
+        const nr = raw as SnapshotNamedResource
+        rawMode = nr.allocationMode ?? null
+        parentMode = rtById.get(nr.resourceTypeId ?? '')?.allocationMode ?? null
+        percent = nr.allocationPercent
+        pct = nr.allocationPct
+        aliasState = aliasStateFor(
+          nr.allocationStartWeek, nr.allocationEndWeek, nr.startWeek, nr.endWeek,
+          entry.minusOneFields[0],
+        )
+        sanitizedForKey = {
+          kind: entry.kind,
+          mode: nr.allocationMode ?? null,
+          percent: nr.allocationPercent ?? null,
+          pct: nr.allocationPct ?? null,
+          asw: nr.allocationStartWeek ?? null,
+          aew: nr.allocationEndWeek ?? null,
+          sw: nr.startWeek ?? null,
+          ew: nr.endWeek ?? null,
+        }
+      }
+
+      singleNegativeRecords.push({
+        key: contentKey(sanitizedForKey),
+        entryKind: entry.kind,
+        minusOneField: entry.minusOneFields[0],
+        alternateAliasState: aliasState,
+        rawMode,
+        parentMode,
+        effectiveMode: entry.effectiveMode,
+        modeSource: entry.modeSource,
+        allocationPercentCategory: percentCategory(percent),
+        allocationPctCategory: percentCategory(pct),
+        entryErrorCategories: entry.entryErrorCategories,
+        structuralErrorCategories: evidence.structuralErrorCategories,
+        independentDefect: evidence.structuralErrorCategories.length > 0 ? 'both' : 'entry-level',
+      })
+    }
+  }
+
+  // ── M records: the defect-classified snapshots ───────────────────────────
+  interface DefectSnapshotRecord {
+    key: string
+    snapshotId: string
+    subgroup: DefectSubgroup
+    windowlessDecisionCount: number
+    singleMinusOneDecisionCount: number
+    otherDecisionRequiredCounts: Record<string, number>
+    alreadyValidCount: number
+    quarantinedCount: number
+    unsupportedCount: number
+    entryErrorCategories: Record<EntryErrorCategory, number>
+    structuralErrorCategories: Record<StructuralErrorCategory, number>
+    independentDefect: IndependentDefectCategory
+  }
+  const defectSnapshotRecords: DefectSnapshotRecord[] = []
+
+  for (let snapshotIndex = 0; snapshotIndex < state.snapshots.length; snapshotIndex++) {
+    const snapshot = state.snapshots[snapshotIndex]!
+    const item = classified[snapshotIndex]!
+    if (item.evidence.restorability.kind !== 'defect') continue
+    const decisions = decisionsBySnapshot.get(snapshot.id)
+    const windowlessCount = decisions?.windowless ?? 0
+    const singleNegativeCount = decisions?.singleNegative ?? 0
+    const subgroup: DefectSubgroup = singleNegativeCount > 0 ? 'seven-single-minus-one' : 'eleven-windowless-only'
+
+    const entryErrors = emptyCounts(ENTRY_ERROR_CATEGORIES)
+    const sanitizedEntries: unknown[] = []
+    for (const entry of item.evidence.entries) {
+      for (const category of entry.entryErrorCategories) entryErrors[category]++
+      sanitizedEntries.push({
+        kind: entry.kind,
+        mode: entry.effectiveMode,
+        source: entry.modeSource,
+        errors: entry.entryErrorCategories,
+      })
+    }
+    const structuralErrors = emptyCounts(STRUCTURAL_ERROR_CATEGORIES)
+    for (const category of item.evidence.structuralErrorCategories) structuralErrors[category]++
+    const findings = findingCountsBySnapshot.get(snapshot.id) ?? { alreadyValid: 0, quarantined: 0, unsupported: 0 }
+    const independentDefect: IndependentDefectCategory =
+      hasNonWindowlessEntryErrors(entryErrors)
+        ? (item.evidence.structuralErrorCategories.length > 0 ? 'both' : 'entry-level')
+        : item.evidence.structuralErrorCategories.length > 0
+          ? 'structural'
+          : 'unavailable'
+
+    defectSnapshotRecords.push({
+      key: contentKey(sanitizedEntries),
+      snapshotId: snapshot.id,
+      subgroup,
+      windowlessDecisionCount: windowlessCount,
+      singleMinusOneDecisionCount: singleNegativeCount,
+      otherDecisionRequiredCounts: decisions?.other ?? {},
+      alreadyValidCount: findings.alreadyValid,
+      quarantinedCount: findings.quarantined,
+      unsupportedCount: findings.unsupported,
+      entryErrorCategories: entryErrors,
+      structuralErrorCategories: structuralErrors,
+      independentDefect,
+    })
+  }
+
+  // ── Class A aggregates (574 expected; quarantined snapshots only) ────────
+  const byOwnerKind: Record<OwnerKindCategory, number> = { resourceType: 0, namedResource: 0, unavailable: 0 }
+  const byNamedModeSource: Record<NamedModeSourceCategory, number> = { explicit: 0, inherited: 0, other: 0, unavailable: 0 }
+  const percentageByCategory: Record<'resourceType' | NamedModeSourceCategory, { allocationPercent: Record<PercentCategory, number>; allocationPct: Record<PercentCategory, number> }> = {
+    resourceType: { allocationPercent: emptyCounts(PERCENT_CATEGORIES), allocationPct: emptyCounts(PERCENT_CATEGORIES) },
+    explicit: { allocationPercent: emptyCounts(PERCENT_CATEGORIES), allocationPct: emptyCounts(PERCENT_CATEGORIES) },
+    inherited: { allocationPercent: emptyCounts(PERCENT_CATEGORIES), allocationPct: emptyCounts(PERCENT_CATEGORIES) },
+    other: { allocationPercent: emptyCounts(PERCENT_CATEGORIES), allocationPct: emptyCounts(PERCENT_CATEGORIES) },
+    unavailable: { allocationPercent: emptyCounts(PERCENT_CATEGORIES), allocationPct: emptyCounts(PERCENT_CATEGORIES) },
+  }
+  const aliasShapes = { primaryAbsentNull: 0, fallbackAbsentNull: 0, populatedAgreeing: 0, conflicting: 0, unavailable: 0 }
+  const snapshotsByOwnerKindMix = { resourceTypeOnly: 0, namedResourceOnly: 0, mixed: 0 }
+  const entriesByEra = emptyCounts([ERA_BEFORE, ERA_MID, ERA_AFTER, ERA_UNAVAILABLE])
+  const snapshotsByEra = emptyCounts([ERA_BEFORE, ERA_MID, ERA_AFTER, ERA_UNAVAILABLE])
+  let classATotalEntries = 0
+  let classATotalSnapshots = 0
+
+  for (let snapshotIndex = 0; snapshotIndex < state.snapshots.length; snapshotIndex++) {
+    const snapshot = state.snapshots[snapshotIndex]!
+    const item = classified[snapshotIndex]!
+    if (item.evidence.restorability.kind !== 'quarantined') continue
+    const era = snapshotEraCategory(snapshotCreatedAtById.get(snapshot.id))
+    snapshotsByEra[era]++
+    let rtCount = 0
+    let nrCount = 0
+    for (const entry of item.evidence.entries) {
+      if (entry.quarantineClass !== 'A') continue
+      classATotalEntries++
+      entriesByEra[era]++
+      if (entry.kind === 'resourceType') {
+        byOwnerKind.resourceType++
+        rtCount++
+        percentageByCategory.resourceType.allocationPercent[entry.allocationPercentCategory]++
+        aliasShapes.primaryAbsentNull++
+      } else {
+        byOwnerKind.namedResource++
+        byNamedModeSource[entry.modeSource]++
+        nrCount++
+        percentageByCategory[entry.modeSource].allocationPercent[entry.allocationPercentCategory]++
+        percentageByCategory[entry.modeSource].allocationPct[entry.allocationPctCategory]++
+        // Every Class A entry has all four window fields absent by the shared
+        // shape predicate; reported for completeness/drift detection.
+        aliasShapes.primaryAbsentNull++
+        aliasShapes.fallbackAbsentNull++
+      }
+    }
+    if (rtCount > 0 && nrCount > 0) snapshotsByOwnerKindMix.mixed++
+    else if (nrCount > 0) snapshotsByOwnerKindMix.namedResourceOnly++
+    else if (rtCount > 0) snapshotsByOwnerKindMix.resourceTypeOnly++
+    if (rtCount + nrCount > 0) classATotalSnapshots++
+  }
+
+  // ── Reconciliation ────────────────────────────────────────────────────────
+  const details: string[] = []
+  const check = (label: string, observed: number, expectedValue: number): boolean => {
+    const ok = observed === expectedValue
+    details.push(`${label}: observed ${observed}, expected ${expectedValue} — ${ok ? 'OK' : 'MISMATCH'}`)
+    return ok
+  }
+  const rewriteOperations = plan.operations.filter(operation => operation.kind === 'rewrite-snapshot-entry').length
+  const quarantinedFindingsWithIds = plan.findings.filter(
+    finding => finding.classification === 'quarantined' && (finding.decisionId != null || finding.operationId != null),
+  ).length
+
+  const elevenRecords = defectSnapshotRecords.filter(record => record.subgroup === 'eleven-windowless-only')
+  const sevenRecords = defectSnapshotRecords.filter(record => record.subgroup === 'seven-single-minus-one')
+  const elevenWindowless = elevenRecords.reduce((sum, record) => sum + record.windowlessDecisionCount, 0)
+  const sevenWindowless = sevenRecords.reduce((sum, record) => sum + record.windowlessDecisionCount, 0)
+  const sevenSingle = sevenRecords.reduce((sum, record) => sum + record.singleMinusOneDecisionCount, 0)
+
+  const checks: boolean[] = [
+    check('quarantined entries', plan.summary.quarantined, expected.quarantinedEntries),
+    check('quarantined snapshots', quarantinedSnapshots, expected.quarantinedSnapshots),
+    check('defect snapshots', defectSnapshots, expected.defectSnapshots),
+    check('windowless decisions', windowlessDecisions, expected.windowlessDecisions),
+    check('single -1 decisions', singleMinusOneDecisions, expected.singleMinusOneDecisions),
+    check('snapshot decisions', snapshotDecisions, expected.snapshotDecisions),
+    check('live decisions', liveDecisions, expected.liveDecisions),
+    check('unsupported findings', plan.summary.findings.unsupported, expected.unsupported),
+    check('rewrite operations', rewriteOperations, expected.rewriteOperations),
+    check('topology 11 subgroup windowless', elevenWindowless, expected.topology11WindowlessDecisions),
+    check('topology 7 subgroup windowless', sevenWindowless, expected.topology7WindowlessDecisions),
+    check('topology 7 subgroup single -1', sevenSingle, expected.topology7SingleMinusOneDecisions),
+    check('windowless = topology 11 + topology 7', windowlessDecisions, elevenWindowless + sevenWindowless),
+    check('topology 7 total = windowless + single', sevenWindowless + sevenSingle, expected.topology7WindowlessDecisions + expected.topology7SingleMinusOneDecisions),
+    check('snapshot decisions = windowless + single', snapshotDecisions, windowlessDecisions + singleMinusOneDecisions),
+    check('quarantined findings carry no decision/op ids', quarantinedFindingsWithIds, 0),
+    check('single-negative records', singleNegativeRecords.length, expected.singleMinusOneDecisions),
+    check('class A entries reconcile', classATotalEntries, expected.quarantinedEntries),
+    check('class A snapshots reconcile', classATotalSnapshots, expected.quarantinedSnapshots),
+  ]
+  const countsMatch = checks.every(ok => ok)
+  const fingerprintMatch = observedFingerprint === expected.fingerprint
+  const baselineMatch = observedBaseline === expected.baselineStateHash
+  const reconciliationPassed = countsMatch && fingerprintMatch && baselineMatch
+
+  // ── Deterministic labels (content-derived, never raw IDs) ────────────────
+  const sortedS = [...singleNegativeRecords].sort((a, b) => a.key.localeCompare(b.key))
+  const sortedM = [...defectSnapshotRecords].sort((a, b) => a.key.localeCompare(b.key))
+
+  return {
+    formatVersion: SNAPSHOT_EVIDENCE_FORMAT_VERSION,
+    runMetadata: { generatedAt, applicationCommit },
+    expectedBoundary: expected,
+    observedBoundary: {
+      fingerprint: observedFingerprint,
+      baselineStateHash: observedBaseline,
+      planExit,
+      summary: {
+        findings: { ...plan.summary.findings },
+        operations: plan.summary.operations,
+        decisionsRequired: plan.summary.decisionsRequired,
+        quarantined: plan.summary.quarantined,
+        rewriteOperations,
+      },
+      snapshotPopulation: {
+        totalSnapshots: state.snapshots.length,
+        restorable: restorableSnapshots,
+        quarantined: quarantinedSnapshots,
+        defect: defectSnapshots,
+      },
+    },
+    integrityResult: {
+      fingerprintMatch,
+      baselineMatch,
+      countsMatch,
+      reconciliationPassed,
+    },
+    topology: {
+      quarantinedSnapshots,
+      defectSnapshots,
+      windowlessDecisions,
+      singleMinusOneDecisions,
+      snapshotDecisions,
+      liveDecisions,
+      elevenSnapshotSubgroup: {
+        snapshots: elevenRecords.length,
+        windowlessDecisions: elevenWindowless,
+      },
+      sevenSnapshotSubgroup: {
+        snapshots: sevenRecords.length,
+        windowlessDecisions: sevenWindowless,
+        singleMinusOneDecisions: sevenSingle,
+        totalDecisions: sevenWindowless + sevenSingle,
+      },
+      quarantinedFindingsWithDecisionOrOperationIds: quarantinedFindingsWithIds,
+    },
+    singleNegativeEntries: sortedS.map((record, index) => {
+      const { key: _key, ...rest } = record
+      return { ...rest, label: `S${index + 1}` }
+    }),
+    defectSnapshots: sortedM.map((record, index) => {
+      const { key: _key, snapshotId: _snapshotId, ...rest } = record
+      return { ...rest, label: `M${index + 1}` }
+    }),
+    classAAggregates: {
+      totalEntries: classATotalEntries,
+      totalSnapshots: classATotalSnapshots,
+      byOwnerKind,
+      byNamedModeSource,
+      percentageByCategory,
+      aliasShapes,
+      snapshotsByOwnerKindMix,
+      entriesByEra,
+      snapshotsByEra,
+    },
+    unavailableEvidence: {
+      singleEntriesModeSourceUnavailable: sortedS.filter(record => record.modeSource === 'unavailable').length,
+      defectSnapshotsIndependentDefectUnavailable: sortedM.filter(record => record.independentDefect === 'unavailable').length,
+      classAEntriesEraUnavailable: entriesByEra[ERA_UNAVAILABLE],
+      classASnapshotsEraUnavailable: snapshotsByEra[ERA_UNAVAILABLE],
+    },
+    reconciliation: { passed: reconciliationPassed, details },
+    policyDecision: 'not-assessed',
+  }
+}
+
+// ─── Small raw-field evidence helpers (no ids, no names) ────────────────────
+
+function aliasStateFor(
+  primaryStart: number | null,
+  primaryEnd: number | null,
+  fallbackStart: number | null | undefined,
+  fallbackEnd: number | null | undefined,
+  _minusOneField: MinusOneField,
+): AlternateAliasState {
+  const pairs: Array<[number | null | undefined, number | null | undefined]> = [
+    [primaryStart, fallbackStart],
+    [primaryEnd, fallbackEnd],
+  ]
+  for (const [primary, fallback] of pairs) {
+    if (primary != null && fallback != null && primary !== fallback) return 'conflicting'
+  }
+  const populated = [primaryStart, primaryEnd, fallbackStart, fallbackEnd].some(value => value != null)
+  return populated ? 'populated' : 'all-absent-null'
+}
+
+function hasNonWindowlessEntryErrors(entryErrors: Record<EntryErrorCategory, number>): boolean {
+  return ENTRY_ERROR_CATEGORIES.some(
+    category => category !== 'windowless-capacity-plan' && entryErrors[category] > 0,
+  )
+}
+
+function contentKey(payload: unknown): string {
+  return sha256Hex(canonicalJson(payload))
+}
+
+function summarizeCounts(counts: Record<string, number>): string {
+  const parts = Object.entries(counts)
+    .filter(([, count]) => count > 0)
+    .map(([category, count]) => `${category}:${count}`)
+  return parts.length > 0 ? parts.join(', ') : 'none'
+}
+
+// ─── Markdown rendering (from the same evidence object — JSON and Markdown
+// ─── cannot diverge) ────────────────────────────────────────────────────────
+
+/** Render the sanitized evidence report as human-readable Markdown. All data
+ * comes from the report object; no identifiers are introduced here. */
+export function renderSnapshotEvidenceMarkdown(report: SnapshotEvidenceReport): string {
+  const lines: string[] = []
+  lines.push('# Sanitized Historical Snapshot Evidence')
+  lines.push('')
+  lines.push(`- formatVersion: ${report.formatVersion}`)
+  lines.push(`- generatedAt: ${report.runMetadata.generatedAt}`)
+  lines.push(`- applicationCommit: ${report.runMetadata.applicationCommit}`)
+  lines.push(`- policyDecision: ${report.policyDecision} (this command assesses no policy)`)
+  lines.push('')
+  lines.push('## Integrity')
+  lines.push('')
+  lines.push(`- fingerprintMatch: ${report.integrityResult.fingerprintMatch}`)
+  lines.push(`- baselineMatch: ${report.integrityResult.baselineMatch}`)
+  lines.push(`- countsMatch: ${report.integrityResult.countsMatch}`)
+  lines.push(`- reconciliationPassed: ${report.integrityResult.reconciliationPassed}`)
+  lines.push('')
+  lines.push('## Observed boundary')
+  lines.push('')
+  lines.push(`- fingerprint: ${report.observedBoundary.fingerprint}`)
+  lines.push(`- baselineStateHash: ${report.observedBoundary.baselineStateHash}`)
+  lines.push(`- planExit: ${report.observedBoundary.planExit}`)
+  lines.push(`- findings: ${JSON.stringify(report.observedBoundary.summary.findings)}`)
+  lines.push(`- operations: ${report.observedBoundary.summary.operations} (rewrite: ${report.observedBoundary.summary.rewriteOperations})`)
+  lines.push(`- decisionsRequired: ${report.observedBoundary.summary.decisionsRequired}`)
+  lines.push(`- quarantined: ${report.observedBoundary.summary.quarantined}`)
+  lines.push(`- snapshotPopulation: total ${report.observedBoundary.snapshotPopulation.totalSnapshots}, restorable ${report.observedBoundary.snapshotPopulation.restorable}, quarantined ${report.observedBoundary.snapshotPopulation.quarantined}, defect ${report.observedBoundary.snapshotPopulation.defect}`)
+  lines.push('')
+  lines.push('## Topology')
+  lines.push('')
+  lines.push(`- quarantinedSnapshots: ${report.topology.quarantinedSnapshots}`)
+  lines.push(`- defectSnapshots: ${report.topology.defectSnapshots}`)
+  lines.push(`- windowlessDecisions: ${report.topology.windowlessDecisions}`)
+  lines.push(`- singleMinusOneDecisions: ${report.topology.singleMinusOneDecisions}`)
+  lines.push(`- snapshotDecisions: ${report.topology.snapshotDecisions}`)
+  lines.push(`- liveDecisions: ${report.topology.liveDecisions}`)
+  lines.push(`- 11-snapshot subgroup: ${report.topology.elevenSnapshotSubgroup.snapshots} snapshots, ${report.topology.elevenSnapshotSubgroup.windowlessDecisions} windowless decisions`)
+  lines.push(`- 7-snapshot subgroup: ${report.topology.sevenSnapshotSubgroup.snapshots} snapshots, ${report.topology.sevenSnapshotSubgroup.windowlessDecisions} windowless + ${report.topology.sevenSnapshotSubgroup.singleMinusOneDecisions} single-(-1) = ${report.topology.sevenSnapshotSubgroup.totalDecisions} total decisions`)
+  lines.push(`- quarantined findings with decision/op ids: ${report.topology.quarantinedFindingsWithDecisionOrOperationIds}`)
+  lines.push('')
+  if (report.singleNegativeEntries.length > 0) {
+    lines.push('## Single -1 + null entries')
+    lines.push('')
+    lines.push('| Label | Kind | -1 field | Alternate aliases | Raw mode | Parent mode | Effective mode | Mode source | allocationPercent | allocationPct | Entry errors | Independent defect |')
+    lines.push('|---|---|---|---|---|---|---|---|---|---|---|---|')
+    for (const entry of report.singleNegativeEntries) {
+      lines.push([
+        entry.label, entry.entryKind, entry.minusOneField, entry.alternateAliasState,
+        entry.rawMode ?? 'null', entry.parentMode ?? 'null', entry.effectiveMode ?? 'null', entry.modeSource,
+        entry.allocationPercentCategory, entry.allocationPctCategory,
+        entry.entryErrorCategories.join(','), entry.independentDefect,
+      ].join(' | '))
+    }
+    lines.push('')
+  }
+  if (report.defectSnapshots.length > 0) {
+    lines.push('## Defect-classified snapshots')
+    lines.push('')
+    lines.push('| Label | Subgroup | Windowless decisions | Single -1 decisions | Already valid | Quarantined | Unsupported | Entry error categories | Structural categories | Independent defect |')
+    lines.push('|---|---|---|---|---|---|---|---|---|---|')
+    for (const snapshot of report.defectSnapshots) {
+      lines.push([
+        snapshot.label, snapshot.subgroup, snapshot.windowlessDecisionCount, snapshot.singleMinusOneDecisionCount,
+        snapshot.alreadyValidCount, snapshot.quarantinedCount, snapshot.unsupportedCount,
+        summarizeCounts(snapshot.entryErrorCategories), summarizeCounts(snapshot.structuralErrorCategories),
+        snapshot.independentDefect,
+      ].join(' | '))
+    }
+    lines.push('')
+  }
+  lines.push('## Class A aggregates')
+  lines.push('')
+  lines.push(`- totalEntries: ${report.classAAggregates.totalEntries}`)
+  lines.push(`- totalSnapshots: ${report.classAAggregates.totalSnapshots}`)
+  lines.push(`- byOwnerKind: ${JSON.stringify(report.classAAggregates.byOwnerKind)}`)
+  lines.push(`- byNamedModeSource: ${JSON.stringify(report.classAAggregates.byNamedModeSource)}`)
+  lines.push(`- aliasShapes: ${JSON.stringify(report.classAAggregates.aliasShapes)}`)
+  lines.push(`- snapshotsByOwnerKindMix: ${JSON.stringify(report.classAAggregates.snapshotsByOwnerKindMix)}`)
+  lines.push(`- entriesByEra: ${JSON.stringify(report.classAAggregates.entriesByEra)} (timestamp is not proof of the exact historical writer)`)
+  lines.push(`- snapshotsByEra: ${JSON.stringify(report.classAAggregates.snapshotsByEra)}`)
+  lines.push('')
+  lines.push('## Reconciliation')
+  lines.push('')
+  lines.push(`- passed: ${report.reconciliation.passed}`)
+  for (const detail of report.reconciliation.details) lines.push(`- ${detail}`)
+  lines.push('')
+  lines.push('## Unavailable evidence')
+  lines.push('')
+  lines.push(`- ${JSON.stringify(report.unavailableEvidence)}`)
+  lines.push('')
+  lines.push('This report is evidence only. It does not authorize remediation, migration, manifest creation or decision selection.')
+  return `${lines.join('\n')}\n`
+}

--- a/server/src/lib/snapshotEvidence.ts
+++ b/server/src/lib/snapshotEvidence.ts
@@ -24,8 +24,9 @@
  * metadata, reviewed expectations); performs zero writes; contains no I/O.
  */
 
-import { parseSnapshotData, isSnapshotV2, type SnapshotData, type SnapshotV2, type SnapshotResourceType, type SnapshotNamedResource } from './projectSnapshotTypes.js'
+  import { parseSnapshotData, isSnapshotV2, type SnapshotData, type SnapshotV2, type SnapshotResourceType, type SnapshotNamedResource } from './projectSnapshotTypes.js'
 import {
+  isKnownV2Mode,
   v2EffectiveNamedMode,
   v2ResourceTypeEntryErrors,
   v2NamedResourceEntryErrors,
@@ -121,7 +122,11 @@ export interface SnapshotEvidenceExpected {
   liveDecisions: number
   unsupported: number
   rewriteOperations: number
-  /** Corrected topology: 11-snapshot windowless-only subgroup. */
+  /** Corrected topology: 11-snapshot windowless-only subgroup snapshot count. */
+  topology11Snapshots: number
+  /** Corrected topology: 7-snapshot single-`-1` subgroup snapshot count. */
+  topology7Snapshots: number
+  /** Corrected topology: 11-snapshot windowless-only subgroup decisions. */
   topology11WindowlessDecisions: number
   /** Corrected topology: 7-snapshot subgroup windowless decisions. */
   topology7WindowlessDecisions: number
@@ -183,9 +188,10 @@ export interface SnapshotEvidenceReport {
     entryKind: OwnerKindCategory
     minusOneField: MinusOneField
     alternateAliasState: AlternateAliasState
-    rawMode: string | null
-    parentMode: string | null
-    effectiveMode: string | null
+    /** Sanitized mode values only (fixed evidence vocabulary). */
+    rawMode: SanitizedMode
+    parentMode: SanitizedMode
+    effectiveMode: SanitizedMode
     modeSource: NamedModeSourceCategory
     allocationPercentCategory: PercentCategory
     allocationPctCategory: PercentCategory
@@ -264,19 +270,48 @@ export function isExpectedBoundaryShape(value: unknown): value is SnapshotEviden
   return (
     typeof v.fingerprint === 'string' && isHex64(v.fingerprint) &&
     typeof v.baselineStateHash === 'string' && isHex64(v.baselineStateHash) &&
-    typeof v.quarantinedEntries === 'number' && Number.isInteger(v.quarantinedEntries) &&
-    typeof v.quarantinedSnapshots === 'number' && Number.isInteger(v.quarantinedSnapshots) &&
-    typeof v.defectSnapshots === 'number' && Number.isInteger(v.defectSnapshots) &&
-    typeof v.windowlessDecisions === 'number' && Number.isInteger(v.windowlessDecisions) &&
-    typeof v.singleMinusOneDecisions === 'number' && Number.isInteger(v.singleMinusOneDecisions) &&
-    typeof v.snapshotDecisions === 'number' && Number.isInteger(v.snapshotDecisions) &&
-    typeof v.liveDecisions === 'number' && Number.isInteger(v.liveDecisions) &&
-    typeof v.unsupported === 'number' && Number.isInteger(v.unsupported) &&
-    typeof v.rewriteOperations === 'number' && Number.isInteger(v.rewriteOperations) &&
-    typeof v.topology11WindowlessDecisions === 'number' && Number.isInteger(v.topology11WindowlessDecisions) &&
-    typeof v.topology7WindowlessDecisions === 'number' && Number.isInteger(v.topology7WindowlessDecisions) &&
-    typeof v.topology7SingleMinusOneDecisions === 'number' && Number.isInteger(v.topology7SingleMinusOneDecisions)
+    typeof v.quarantinedEntries === 'number' && Number.isInteger(v.quarantinedEntries) && v.quarantinedEntries >= 0 &&
+    typeof v.quarantinedSnapshots === 'number' && Number.isInteger(v.quarantinedSnapshots) && v.quarantinedSnapshots >= 0 &&
+    typeof v.defectSnapshots === 'number' && Number.isInteger(v.defectSnapshots) && v.defectSnapshots >= 0 &&
+    typeof v.windowlessDecisions === 'number' && Number.isInteger(v.windowlessDecisions) && v.windowlessDecisions >= 0 &&
+    typeof v.singleMinusOneDecisions === 'number' && Number.isInteger(v.singleMinusOneDecisions) && v.singleMinusOneDecisions >= 0 &&
+    typeof v.snapshotDecisions === 'number' && Number.isInteger(v.snapshotDecisions) && v.snapshotDecisions >= 0 &&
+    typeof v.liveDecisions === 'number' && Number.isInteger(v.liveDecisions) && v.liveDecisions >= 0 &&
+    typeof v.unsupported === 'number' && Number.isInteger(v.unsupported) && v.unsupported >= 0 &&
+    typeof v.rewriteOperations === 'number' && Number.isInteger(v.rewriteOperations) && v.rewriteOperations >= 0 &&
+    typeof v.topology11Snapshots === 'number' && Number.isInteger(v.topology11Snapshots) && v.topology11Snapshots >= 0 &&
+    typeof v.topology7Snapshots === 'number' && Number.isInteger(v.topology7Snapshots) && v.topology7Snapshots >= 0 &&
+    typeof v.topology11WindowlessDecisions === 'number' && Number.isInteger(v.topology11WindowlessDecisions) && v.topology11WindowlessDecisions >= 0 &&
+    typeof v.topology7WindowlessDecisions === 'number' && Number.isInteger(v.topology7WindowlessDecisions) && v.topology7WindowlessDecisions >= 0 &&
+    typeof v.topology7SingleMinusOneDecisions === 'number' && Number.isInteger(v.topology7SingleMinusOneDecisions) && v.topology7SingleMinusOneDecisions >= 0
   )
+}
+
+/**
+ * Fixed evidence mode values. Arbitrary historical mode strings are never
+ * copied into evidence output: known modes pass through, unknown or
+ * malformed strings map to `other`, absent values map to null. The allowed
+ * known set is exactly the repository's current known allocation modes
+ * (checked through the shared `isKnownV2Mode` helper — no second list).
+ */
+export type SanitizedMode =
+  | 'TIMELINE'
+  | 'CAPACITY_PLAN'
+  | 'EFFORT'
+  | 'FULL_PROJECT'
+  | null
+  | 'other'
+  | 'unavailable'
+
+/** Pure mode normalization for outward-facing evidence only. */
+export function sanitizeMode(value: string | null | undefined): SanitizedMode {
+  if (value == null) return null
+  if (isKnownV2Mode(value)) {
+    // isKnownV2Mode is the shared known-mode check; the result is a known
+    // mode by construction.
+    return value as Exclude<SanitizedMode, null | 'other' | 'unavailable'>
+  }
+  return 'other'
 }
 
 /** Deterministic percentage bucket used for evidence only. */
@@ -663,9 +698,9 @@ export function buildSnapshotEvidenceReport(inputs: SnapshotEvidenceInputs): Sna
     entryKind: OwnerKindCategory
     minusOneField: MinusOneField
     alternateAliasState: AlternateAliasState
-    rawMode: string | null
-    parentMode: string | null
-    effectiveMode: string | null
+    rawMode: SanitizedMode
+    parentMode: SanitizedMode
+    effectiveMode: SanitizedMode
     modeSource: NamedModeSourceCategory
     allocationPercentCategory: PercentCategory
     allocationPctCategory: PercentCategory
@@ -700,15 +735,15 @@ export function buildSnapshotEvidenceReport(inputs: SnapshotEvidenceInputs): Sna
       if (finding.classification !== 'decisionRequired') continue
       if (!finding.message.includes(SINGLE_NEGATIVE_DECISION_MESSAGE)) continue
 
-      let rawMode: string | null
-      let parentMode: string | null
+      let rawMode: SanitizedMode
+      let parentMode: SanitizedMode
       let percent: number | null | undefined
       let pct: number | null | undefined
       let aliasState: AlternateAliasState
       let sanitizedForKey: Record<string, unknown>
       if (kind === 'resourceType') {
         const rt = raw as SnapshotResourceType
-        rawMode = rt.allocationMode ?? null
+        rawMode = sanitizeMode(rt.allocationMode)
         parentMode = null
         percent = rt.allocationPercent
         aliasState = aliasStateFor(rt.allocationStartWeek, rt.allocationEndWeek, null, null, entry.minusOneFields[0])
@@ -721,8 +756,8 @@ export function buildSnapshotEvidenceReport(inputs: SnapshotEvidenceInputs): Sna
         }
       } else {
         const nr = raw as SnapshotNamedResource
-        rawMode = nr.allocationMode ?? null
-        parentMode = rtById.get(nr.resourceTypeId ?? '')?.allocationMode ?? null
+        rawMode = sanitizeMode(nr.allocationMode)
+        parentMode = sanitizeMode(rtById.get(nr.resourceTypeId ?? '')?.allocationMode)
         percent = nr.allocationPercent
         pct = nr.allocationPct
         aliasState = aliasStateFor(
@@ -731,7 +766,7 @@ export function buildSnapshotEvidenceReport(inputs: SnapshotEvidenceInputs): Sna
         )
         sanitizedForKey = {
           kind: entry.kind,
-          mode: nr.allocationMode ?? null,
+          mode: rawMode,
           percent: nr.allocationPercent ?? null,
           pct: nr.allocationPct ?? null,
           asw: nr.allocationStartWeek ?? null,
@@ -748,7 +783,7 @@ export function buildSnapshotEvidenceReport(inputs: SnapshotEvidenceInputs): Sna
         alternateAliasState: aliasState,
         rawMode,
         parentMode,
-        effectiveMode: entry.effectiveMode,
+        effectiveMode: sanitizeMode(entry.effectiveMode),
         modeSource: entry.modeSource,
         allocationPercentCategory: percentCategory(percent),
         allocationPctCategory: percentCategory(pct),
@@ -791,7 +826,7 @@ export function buildSnapshotEvidenceReport(inputs: SnapshotEvidenceInputs): Sna
       for (const category of entry.entryErrorCategories) entryErrors[category]++
       sanitizedEntries.push({
         kind: entry.kind,
-        mode: entry.effectiveMode,
+        mode: sanitizeMode(entry.effectiveMode),
         source: entry.modeSource,
         errors: entry.entryErrorCategories,
       })
@@ -902,6 +937,10 @@ export function buildSnapshotEvidenceReport(inputs: SnapshotEvidenceInputs): Sna
     check('live decisions', liveDecisions, expected.liveDecisions),
     check('unsupported findings', plan.summary.findings.unsupported, expected.unsupported),
     check('rewrite operations', rewriteOperations, expected.rewriteOperations),
+    check('topology 11 subgroup snapshots', elevenRecords.length, expected.topology11Snapshots),
+    check('topology 7 subgroup snapshots', sevenRecords.length, expected.topology7Snapshots),
+    check('expected subgroup snapshot sum = expected defect snapshots', expected.topology11Snapshots + expected.topology7Snapshots, expected.defectSnapshots),
+    check('observed subgroup snapshots = observed defect snapshots', elevenRecords.length + sevenRecords.length, defectSnapshots),
     check('topology 11 subgroup windowless', elevenWindowless, expected.topology11WindowlessDecisions),
     check('topology 7 subgroup windowless', sevenWindowless, expected.topology7WindowlessDecisions),
     check('topology 7 subgroup single -1', sevenSingle, expected.topology7SingleMinusOneDecisions),
@@ -1083,14 +1122,15 @@ export function renderSnapshotEvidenceMarkdown(report: SnapshotEvidenceReport): 
   if (report.singleNegativeEntries.length > 0) {
     lines.push('## Single -1 + null entries')
     lines.push('')
-    lines.push('| Label | Kind | -1 field | Alternate aliases | Raw mode | Parent mode | Effective mode | Mode source | allocationPercent | allocationPct | Entry errors | Independent defect |')
-    lines.push('|---|---|---|---|---|---|---|---|---|---|---|---|')
+    lines.push('| Label | Kind | -1 field | Alternate aliases | Raw mode | Parent mode | Effective mode | Mode source | allocationPercent | allocationPct | Entry errors | Structural errors | Independent defect |')
+    lines.push('|---|---|---|---|---|---|---|---|---|---|---|---|---|')
     for (const entry of report.singleNegativeEntries) {
       lines.push([
         entry.label, entry.entryKind, entry.minusOneField, entry.alternateAliasState,
         entry.rawMode ?? 'null', entry.parentMode ?? 'null', entry.effectiveMode ?? 'null', entry.modeSource,
         entry.allocationPercentCategory, entry.allocationPctCategory,
-        entry.entryErrorCategories.join(','), entry.independentDefect,
+        entry.entryErrorCategories.join(','), entry.structuralErrorCategories.join(','),
+        entry.independentDefect,
       ].join(' | '))
     }
     lines.push('')
@@ -1098,11 +1138,12 @@ export function renderSnapshotEvidenceMarkdown(report: SnapshotEvidenceReport): 
   if (report.defectSnapshots.length > 0) {
     lines.push('## Defect-classified snapshots')
     lines.push('')
-    lines.push('| Label | Subgroup | Windowless decisions | Single -1 decisions | Already valid | Quarantined | Unsupported | Entry error categories | Structural categories | Independent defect |')
-    lines.push('|---|---|---|---|---|---|---|---|---|---|')
+    lines.push('| Label | Subgroup | Windowless decisions | Single -1 decisions | Other decision reasons | Already valid | Quarantined | Unsupported | Entry error categories | Structural categories | Independent defect |')
+    lines.push('|---|---|---|---|---|---|---|---|---|---|---|')
     for (const snapshot of report.defectSnapshots) {
       lines.push([
         snapshot.label, snapshot.subgroup, snapshot.windowlessDecisionCount, snapshot.singleMinusOneDecisionCount,
+        summarizeCounts(snapshot.otherDecisionRequiredCounts),
         snapshot.alreadyValidCount, snapshot.quarantinedCount, snapshot.unsupportedCount,
         summarizeCounts(snapshot.entryErrorCategories), summarizeCounts(snapshot.structuralErrorCategories),
         snapshot.independentDefect,
@@ -1120,6 +1161,20 @@ export function renderSnapshotEvidenceMarkdown(report: SnapshotEvidenceReport): 
   lines.push(`- snapshotsByOwnerKindMix: ${JSON.stringify(report.classAAggregates.snapshotsByOwnerKindMix)}`)
   lines.push(`- entriesByEra: ${JSON.stringify(report.classAAggregates.entriesByEra)} (timestamp is not proof of the exact historical writer)`)
   lines.push(`- snapshotsByEra: ${JSON.stringify(report.classAAggregates.snapshotsByEra)}`)
+  lines.push('')
+  lines.push('### Class A percentage evidence (by owner kind / mode source)')
+  lines.push('')
+  lines.push('| Category | allocationPercent buckets | allocationPct buckets |')
+  lines.push('|---|---|---|')
+  for (const category of ['resourceType', 'explicit', 'inherited', 'other', 'unavailable'] as const) {
+    const byCategory = report.classAAggregates.percentageByCategory[category]
+    if (!byCategory) continue
+    lines.push([
+      category,
+      summarizeCounts(byCategory.allocationPercent),
+      summarizeCounts(byCategory.allocationPct),
+    ].join(' | '))
+  }
   lines.push('')
   lines.push('## Reconciliation')
   lines.push('')

--- a/server/src/lib/snapshotEvidence.ts
+++ b/server/src/lib/snapshotEvidence.ts
@@ -38,6 +38,7 @@ import {
   classifySnapshotRestorability,
   classifyV2QuarantineShape,
   v2NamedResourceAliasConflict,
+  v2NamedResourceEdgeAliasConflict,
   type SnapshotRestorability,
 } from './snapshotRestorability.js'
 import {
@@ -67,6 +68,8 @@ export type PercentCategory =
   | 'invalid-non-finite'
 export type AlternateAliasState = 'all-absent-null' | 'populated' | 'conflicting'
 export type MinusOneField = 'allocationStartWeek' | 'allocationEndWeek' | 'startWeek' | 'endWeek'
+/** Fixed sanitized state vocabulary for one raw window field (no numbers). */
+export type WindowFieldState = 'minus-one' | 'absent-null' | 'populated'
 export type IndependentDefectCategory = 'entry-level' | 'structural' | 'both' | 'unavailable'
 export type DefectSubgroup = 'eleven-windowless-only' | 'seven-single-minus-one'
 export type SnapshotEraCategory =
@@ -187,6 +190,10 @@ export interface SnapshotEvidenceReport {
     label: string
     entryKind: OwnerKindCategory
     minusOneField: MinusOneField
+    /** Sanitized state of every raw window field (never numeric values). */
+    windowFields: Record<MinusOneField, WindowFieldState>
+    /** Per-edge conflicting-populated-alias evidence (shared predicate). */
+    aliasConflicts: { startEdge: boolean; endEdge: boolean }
     alternateAliasState: AlternateAliasState
     /** Sanitized mode values only (fixed evidence vocabulary). */
     rawMode: SanitizedMode
@@ -229,6 +236,10 @@ export interface SnapshotEvidenceReport {
       unavailable: number
     }
     snapshotsByOwnerKindMix: { resourceTypeOnly: number; namedResourceOnly: number; mixed: number }
+    /** Affected snapshots per owner-kind category (deduplicated per snapshot). */
+    affectedSnapshotsByOwnerKind: Record<OwnerKindCategory, number>
+    /** Affected snapshots per NamedResource mode-source category (deduplicated per snapshot). */
+    affectedSnapshotsByNamedModeSource: Record<NamedModeSourceCategory, number>
     entriesByEra: Record<SnapshotEraCategory, number>
     snapshotsByEra: Record<SnapshotEraCategory, number>
   }
@@ -697,6 +708,8 @@ export function buildSnapshotEvidenceReport(inputs: SnapshotEvidenceInputs): Sna
     key: string
     entryKind: OwnerKindCategory
     minusOneField: MinusOneField
+    windowFields: Record<MinusOneField, WindowFieldState>
+    aliasConflicts: { startEdge: boolean; endEdge: boolean }
     alternateAliasState: AlternateAliasState
     rawMode: SanitizedMode
     parentMode: SanitizedMode
@@ -730,7 +743,26 @@ export function buildSnapshotEvidenceReport(inputs: SnapshotEvidenceInputs): Sna
         kind = 'namedResource'
       }
       // Shared plan-level predicate: the entry must be exactly the
-      // "single -1/negative window edge" decision class.
+      // "single -1/negative window edge" decision class. The plan quarantines
+      // CAPACITY_PLAN entries inside quarantined snapshots that match a
+      // shared quarantine shape BEFORE any decision classification; mirror
+      // that precedence so the S record set equals the plan's decision set.
+      if (item.evidence.restorability.kind === 'quarantined' && entry.effectiveMode === 'CAPACITY_PLAN') {
+        const shape = kind === 'resourceType'
+          ? {
+              primaryStart: (raw as SnapshotResourceType).allocationStartWeek ?? null,
+              aliasStart: null,
+              primaryEnd: (raw as SnapshotResourceType).allocationEndWeek ?? null,
+              aliasEnd: null,
+            }
+          : {
+              primaryStart: (raw as SnapshotNamedResource).allocationStartWeek ?? null,
+              aliasStart: (raw as SnapshotNamedResource).startWeek ?? null,
+              primaryEnd: (raw as SnapshotNamedResource).allocationEndWeek ?? null,
+              aliasEnd: (raw as SnapshotNamedResource).endWeek ?? null,
+            }
+        if (classifyV2QuarantineShape(shape) != null) continue
+      }
       const finding = classifySnapshotEntry(planEntryPayload(raw, kind))
       if (finding.classification !== 'decisionRequired') continue
       if (!finding.message.includes(SINGLE_NEGATIVE_DECISION_MESSAGE)) continue
@@ -739,6 +771,8 @@ export function buildSnapshotEvidenceReport(inputs: SnapshotEvidenceInputs): Sna
       let parentMode: SanitizedMode
       let percent: number | null | undefined
       let pct: number | null | undefined
+      let windowFields: Record<MinusOneField, WindowFieldState>
+      let aliasConflicts: { startEdge: boolean; endEdge: boolean }
       let aliasState: AlternateAliasState
       let sanitizedForKey: Record<string, unknown>
       if (kind === 'resourceType') {
@@ -746,7 +780,16 @@ export function buildSnapshotEvidenceReport(inputs: SnapshotEvidenceInputs): Sna
         rawMode = sanitizeMode(rt.allocationMode)
         parentMode = null
         percent = rt.allocationPercent
-        aliasState = aliasStateFor(rt.allocationStartWeek, rt.allocationEndWeek, null, null, entry.minusOneFields[0])
+        // ResourceType entries carry no alternate aliases: every fallback
+        // field is reported absent, and no edge can conflict.
+        windowFields = {
+          allocationStartWeek: windowFieldState(rt.allocationStartWeek),
+          allocationEndWeek: windowFieldState(rt.allocationEndWeek),
+          startWeek: 'absent-null',
+          endWeek: 'absent-null',
+        }
+        aliasConflicts = { startEdge: false, endEdge: false }
+        aliasState = aliasStateFrom(windowFields)
         sanitizedForKey = {
           kind: entry.kind,
           mode: rawMode,
@@ -760,10 +803,21 @@ export function buildSnapshotEvidenceReport(inputs: SnapshotEvidenceInputs): Sna
         parentMode = sanitizeMode(rtById.get(nr.resourceTypeId ?? '')?.allocationMode)
         percent = nr.allocationPercent
         pct = nr.allocationPct
-        aliasState = aliasStateFor(
-          nr.allocationStartWeek, nr.allocationEndWeek, nr.startWeek, nr.endWeek,
-          entry.minusOneFields[0],
-        )
+        windowFields = {
+          allocationStartWeek: windowFieldState(nr.allocationStartWeek),
+          allocationEndWeek: windowFieldState(nr.allocationEndWeek),
+          startWeek: windowFieldState(nr.startWeek),
+          endWeek: windowFieldState(nr.endWeek),
+        }
+        // Shared per-edge alias semantics (same definition the classifier
+        // uses); window-using modes only.
+        aliasConflicts = {
+          startEdge: v2NamedResourceEdgeAliasConflict(nr, entry.effectiveMode, 'start'),
+          endEdge: v2NamedResourceEdgeAliasConflict(nr, entry.effectiveMode, 'end'),
+        }
+        aliasState = aliasConflicts.startEdge || aliasConflicts.endEdge
+          ? 'conflicting'
+          : aliasStateFrom(windowFields)
         sanitizedForKey = {
           kind: entry.kind,
           mode: rawMode,
@@ -780,6 +834,8 @@ export function buildSnapshotEvidenceReport(inputs: SnapshotEvidenceInputs): Sna
         key: contentKey(sanitizedForKey),
         entryKind: entry.kind,
         minusOneField: entry.minusOneFields[0],
+        windowFields,
+        aliasConflicts,
         alternateAliasState: aliasState,
         rawMode,
         parentMode,
@@ -869,6 +925,10 @@ export function buildSnapshotEvidenceReport(inputs: SnapshotEvidenceInputs): Sna
   }
   const aliasShapes = { primaryAbsentNull: 0, fallbackAbsentNull: 0, populatedAgreeing: 0, conflicting: 0, unavailable: 0 }
   const snapshotsByOwnerKindMix = { resourceTypeOnly: 0, namedResourceOnly: 0, mixed: 0 }
+  // Affected-snapshot aggregates: a snapshot counts at most once per
+  // category; mixed snapshots may appear in more than one category.
+  const affectedSnapshotsByOwnerKind: Record<OwnerKindCategory, number> = { resourceType: 0, namedResource: 0, unavailable: 0 }
+  const affectedSnapshotsByNamedModeSource: Record<NamedModeSourceCategory, number> = { explicit: 0, inherited: 0, other: 0, unavailable: 0 }
   const entriesByEra = emptyCounts([ERA_BEFORE, ERA_MID, ERA_AFTER, ERA_UNAVAILABLE])
   const snapshotsByEra = emptyCounts([ERA_BEFORE, ERA_MID, ERA_AFTER, ERA_UNAVAILABLE])
   let classATotalEntries = 0
@@ -882,6 +942,8 @@ export function buildSnapshotEvidenceReport(inputs: SnapshotEvidenceInputs): Sna
     snapshotsByEra[era]++
     let rtCount = 0
     let nrCount = 0
+    const ownerKindsInSnapshot = new Set<OwnerKindCategory>()
+    const modeSourcesInSnapshot = new Set<NamedModeSourceCategory>()
     for (const entry of item.evidence.entries) {
       if (entry.quarantineClass !== 'A') continue
       classATotalEntries++
@@ -889,12 +951,18 @@ export function buildSnapshotEvidenceReport(inputs: SnapshotEvidenceInputs): Sna
       if (entry.kind === 'resourceType') {
         byOwnerKind.resourceType++
         rtCount++
+        ownerKindsInSnapshot.add('resourceType')
+        // ResourceType entries carry no mode-source concept; their snapshots
+        // surface under the unavailable mode-source category.
+        modeSourcesInSnapshot.add('unavailable')
         percentageByCategory.resourceType.allocationPercent[entry.allocationPercentCategory]++
         aliasShapes.primaryAbsentNull++
       } else {
         byOwnerKind.namedResource++
         byNamedModeSource[entry.modeSource]++
         nrCount++
+        ownerKindsInSnapshot.add('namedResource')
+        modeSourcesInSnapshot.add(entry.modeSource)
         percentageByCategory[entry.modeSource].allocationPercent[entry.allocationPercentCategory]++
         percentageByCategory[entry.modeSource].allocationPct[entry.allocationPctCategory]++
         // Every Class A entry has all four window fields absent by the shared
@@ -906,6 +974,8 @@ export function buildSnapshotEvidenceReport(inputs: SnapshotEvidenceInputs): Sna
     if (rtCount > 0 && nrCount > 0) snapshotsByOwnerKindMix.mixed++
     else if (nrCount > 0) snapshotsByOwnerKindMix.namedResourceOnly++
     else if (rtCount > 0) snapshotsByOwnerKindMix.resourceTypeOnly++
+    for (const ownerKind of ownerKindsInSnapshot) affectedSnapshotsByOwnerKind[ownerKind]++
+    for (const modeSource of modeSourcesInSnapshot) affectedSnapshotsByNamedModeSource[modeSource]++
     if (rtCount + nrCount > 0) classATotalSnapshots++
   }
 
@@ -926,6 +996,16 @@ export function buildSnapshotEvidenceReport(inputs: SnapshotEvidenceInputs): Sna
   const elevenWindowless = elevenRecords.reduce((sum, record) => sum + record.windowlessDecisionCount, 0)
   const sevenWindowless = sevenRecords.reduce((sum, record) => sum + record.windowlessDecisionCount, 0)
   const sevenSingle = sevenRecords.reduce((sum, record) => sum + record.singleMinusOneDecisionCount, 0)
+
+  const windowFieldReconciliationViolations = singleNegativeRecords.filter(record => {
+    const fields = Object.keys(record.windowFields) as MinusOneField[]
+    const minusOneFields = fields.filter(field => record.windowFields[field] === 'minus-one')
+    if (minusOneFields.length !== 1) return true
+    if (minusOneFields[0] !== record.minusOneField) return true
+    return fields.some(
+      field => field !== minusOneFields[0] && record.windowFields[field] !== 'absent-null' && record.windowFields[field] !== 'populated',
+    )
+  })
 
   const checks: boolean[] = [
     check('quarantined entries', plan.summary.quarantined, expected.quarantinedEntries),
@@ -949,6 +1029,7 @@ export function buildSnapshotEvidenceReport(inputs: SnapshotEvidenceInputs): Sna
     check('snapshot decisions = windowless + single', snapshotDecisions, windowlessDecisions + singleMinusOneDecisions),
     check('quarantined findings carry no decision/op ids', quarantinedFindingsWithIds, 0),
     check('single-negative records', singleNegativeRecords.length, expected.singleMinusOneDecisions),
+    check('S records window-field reconciliation', windowFieldReconciliationViolations.length, 0),
     check('class A entries reconcile', classATotalEntries, expected.quarantinedEntries),
     check('class A snapshots reconcile', classATotalSnapshots, expected.quarantinedSnapshots),
   ]
@@ -1024,6 +1105,8 @@ export function buildSnapshotEvidenceReport(inputs: SnapshotEvidenceInputs): Sna
       percentageByCategory,
       aliasShapes,
       snapshotsByOwnerKindMix,
+      affectedSnapshotsByOwnerKind,
+      affectedSnapshotsByNamedModeSource,
       entriesByEra,
       snapshotsByEra,
     },
@@ -1040,22 +1123,25 @@ export function buildSnapshotEvidenceReport(inputs: SnapshotEvidenceInputs): Sna
 
 // ─── Small raw-field evidence helpers (no ids, no names) ────────────────────
 
-function aliasStateFor(
-  primaryStart: number | null,
-  primaryEnd: number | null,
-  fallbackStart: number | null | undefined,
-  fallbackEnd: number | null | undefined,
-  _minusOneField: MinusOneField,
-): AlternateAliasState {
-  const pairs: Array<[number | null | undefined, number | null | undefined]> = [
-    [primaryStart, fallbackStart],
-    [primaryEnd, fallbackEnd],
-  ]
-  for (const [primary, fallback] of pairs) {
-    if (primary != null && fallback != null && primary !== fallback) return 'conflicting'
-  }
-  const populated = [primaryStart, primaryEnd, fallbackStart, fallbackEnd].some(value => value != null)
-  return populated ? 'populated' : 'all-absent-null'
+function windowFieldState(value: number | null | undefined): WindowFieldState {
+  if (value === -1) return 'minus-one'
+  if (value == null) return 'absent-null'
+  return 'populated'
+}
+
+/** Aggregate alias state from the per-field states (conflict handled
+ * separately by the per-edge predicate). The minus-one field itself is never
+ * reported as populated: only genuinely populated other fields count. */
+function aliasStateFrom(windowFields: Record<MinusOneField, WindowFieldState>): AlternateAliasState {
+  const states = Object.values(windowFields)
+  if (states.some(state => state === 'populated')) return 'populated'
+  return 'all-absent-null'
+}
+
+function summarizeWindowFields(windowFields: Record<MinusOneField, WindowFieldState>): string {
+  return (Object.keys(windowFields) as MinusOneField[])
+    .map(field => `${field}:${windowFields[field]}`)
+    .join(' ')
 }
 
 function hasNonWindowlessEntryErrors(entryErrors: Record<EntryErrorCategory, number>): boolean {
@@ -1120,13 +1206,23 @@ export function renderSnapshotEvidenceMarkdown(report: SnapshotEvidenceReport): 
   lines.push(`- quarantined findings with decision/op ids: ${report.topology.quarantinedFindingsWithDecisionOrOperationIds}`)
   lines.push('')
   if (report.singleNegativeEntries.length > 0) {
-    lines.push('## Single -1 + null entries')
+    // S records are selected from the plan's single-negative decision class
+    // (shared classifySnapshotEntry predicate). A clean `-1` + null shape may
+    // instead be classified through the windowless branch, so the heading
+    // names the decision class, not an assumed raw shape.
+    lines.push('## Single-negative decision entries')
     lines.push('')
-    lines.push('| Label | Kind | -1 field | Alternate aliases | Raw mode | Parent mode | Effective mode | Mode source | allocationPercent | allocationPct | Entry errors | Structural errors | Independent defect |')
-    lines.push('|---|---|---|---|---|---|---|---|---|---|---|---|---|')
+    lines.push('Each row reports the sanitized state of every raw window field (allocationStartWeek/allocationEndWeek/startWeek/endWeek) and per-edge conflicting-populated-alias evidence (shared predicate; window-using modes only).')
+    lines.push('')
+    lines.push('| Label | Kind | -1 field | Window fields (allocationStartWeek, allocationEndWeek, startWeek, endWeek) | Start edge conflict | End edge conflict | Alternate aliases | Raw mode | Parent mode | Effective mode | Mode source | allocationPercent | allocationPct | Entry errors | Structural errors | Independent defect |')
+    lines.push('|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|')
     for (const entry of report.singleNegativeEntries) {
       lines.push([
-        entry.label, entry.entryKind, entry.minusOneField, entry.alternateAliasState,
+        entry.label, entry.entryKind, entry.minusOneField,
+        summarizeWindowFields(entry.windowFields),
+        entry.aliasConflicts.startEdge ? 'yes' : 'no',
+        entry.aliasConflicts.endEdge ? 'yes' : 'no',
+        entry.alternateAliasState,
         entry.rawMode ?? 'null', entry.parentMode ?? 'null', entry.effectiveMode ?? 'null', entry.modeSource,
         entry.allocationPercentCategory, entry.allocationPctCategory,
         entry.entryErrorCategories.join(','), entry.structuralErrorCategories.join(','),
@@ -1159,6 +1255,8 @@ export function renderSnapshotEvidenceMarkdown(report: SnapshotEvidenceReport): 
   lines.push(`- byNamedModeSource: ${JSON.stringify(report.classAAggregates.byNamedModeSource)}`)
   lines.push(`- aliasShapes: ${JSON.stringify(report.classAAggregates.aliasShapes)}`)
   lines.push(`- snapshotsByOwnerKindMix: ${JSON.stringify(report.classAAggregates.snapshotsByOwnerKindMix)}`)
+  lines.push(`- affectedSnapshotsByOwnerKind: ${JSON.stringify(report.classAAggregates.affectedSnapshotsByOwnerKind)} (a snapshot counts at most once per category; mixed snapshots may appear in both)`)
+  lines.push(`- affectedSnapshotsByNamedModeSource: ${JSON.stringify(report.classAAggregates.affectedSnapshotsByNamedModeSource)} (a snapshot containing explicit and inherited entries counts in both)`)
   lines.push(`- entriesByEra: ${JSON.stringify(report.classAAggregates.entriesByEra)} (timestamp is not proof of the exact historical writer)`)
   lines.push(`- snapshotsByEra: ${JSON.stringify(report.classAAggregates.snapshotsByEra)}`)
   lines.push('')

--- a/server/src/lib/snapshotEvidence.ts
+++ b/server/src/lib/snapshotEvidence.ts
@@ -952,9 +952,9 @@ export function buildSnapshotEvidenceReport(inputs: SnapshotEvidenceInputs): Sna
         byOwnerKind.resourceType++
         rtCount++
         ownerKindsInSnapshot.add('resourceType')
-        // ResourceType entries carry no mode-source concept; their snapshots
-        // surface under the unavailable mode-source category.
-        modeSourcesInSnapshot.add('unavailable')
+        // ResourceType entries carry no NamedResource mode-source category;
+        // affectedSnapshotsByNamedModeSource is fed only by Class A
+        // NamedResource entries below.
         percentageByCategory.resourceType.allocationPercent[entry.allocationPercentCategory]++
         aliasShapes.primaryAbsentNull++
       } else {

--- a/server/src/lib/snapshotRestorability.ts
+++ b/server/src/lib/snapshotRestorability.ts
@@ -189,6 +189,23 @@ function evaluateResourceTypeEntry(rt: SnapshotResourceType, index: number): Ent
   return errors.length > 0 ? { kind: 'defect' } : { kind: 'restorable' }
 }
 
+/**
+ * Conflicting populated aliases (the two captured fields of one edge
+ * disagree) cannot be reconciled under the v2 rules and are a blocking
+ * defect for window-using modes (policy #426, Section 3). Shared by the
+ * classifier and the Issue #432 evidence command (verdict-neutral export).
+ */
+export function v2NamedResourceAliasConflict(
+  nr: Pick<SnapshotNamedResource, 'allocationStartWeek' | 'allocationEndWeek' | 'startWeek' | 'endWeek'>,
+  mode: string | null,
+): boolean {
+  if (mode !== 'TIMELINE' && mode !== 'CAPACITY_PLAN') return false
+  return (
+    (nr.allocationStartWeek != null && nr.startWeek != null && nr.allocationStartWeek !== nr.startWeek) ||
+    (nr.allocationEndWeek != null && nr.endWeek != null && nr.allocationEndWeek !== nr.endWeek)
+  )
+}
+
 function evaluateNamedResourceEntry(
   nr: SnapshotNamedResource,
   parentRt: SnapshotResourceType | undefined,
@@ -218,16 +235,10 @@ function evaluateNamedResourceEntry(
       return { kind: 'quarantined', entryClass }
     }
   }
-  // Conflicting populated aliases (the two captured fields of one edge
-  // disagree) cannot be reconciled under the v2 rules and are a blocking
-  // defect for window-using modes (policy #426, Section 3).
-  if (mode === 'TIMELINE' || mode === 'CAPACITY_PLAN') {
-    if (
-      (nr.allocationStartWeek != null && nr.startWeek != null && nr.allocationStartWeek !== nr.startWeek) ||
-      (nr.allocationEndWeek != null && nr.endWeek != null && nr.allocationEndWeek !== nr.endWeek)
-    ) {
-      return { kind: 'defect' }
-    }
+  // Conflicting populated aliases are a blocking defect for window-using
+  // modes (shared helper; identical predicate to the previous inline check).
+  if (v2NamedResourceAliasConflict(nr, mode)) {
+    return { kind: 'defect' }
   }
   const errors = v2NamedResourceEntryErrors(nr, parentRt, prefix)
   return errors.length > 0 ? { kind: 'defect' } : { kind: 'restorable' }

--- a/server/src/lib/snapshotRestorability.ts
+++ b/server/src/lib/snapshotRestorability.ts
@@ -189,21 +189,37 @@ function evaluateResourceTypeEntry(rt: SnapshotResourceType, index: number): Ent
   return errors.length > 0 ? { kind: 'defect' } : { kind: 'restorable' }
 }
 
+export type V2AliasEdge = 'start' | 'end'
+
+/**
+ * Per-edge conflicting-populated-alias predicate. A conflict exists when
+ * both captured fields of one edge are populated and disagree. Window-using
+ * modes only; any other mode reports no conflict on either edge.
+ */
+export function v2NamedResourceEdgeAliasConflict(
+  nr: Pick<SnapshotNamedResource, 'allocationStartWeek' | 'allocationEndWeek' | 'startWeek' | 'endWeek'>,
+  mode: string | null,
+  edge: V2AliasEdge,
+): boolean {
+  if (mode !== 'TIMELINE' && mode !== 'CAPACITY_PLAN') return false
+  if (edge === 'start') {
+    return nr.allocationStartWeek != null && nr.startWeek != null && nr.allocationStartWeek !== nr.startWeek
+  }
+  return nr.allocationEndWeek != null && nr.endWeek != null && nr.allocationEndWeek !== nr.endWeek
+}
+
 /**
  * Conflicting populated aliases (the two captured fields of one edge
  * disagree) cannot be reconciled under the v2 rules and are a blocking
  * defect for window-using modes (policy #426, Section 3). Shared by the
  * classifier and the Issue #432 evidence command (verdict-neutral export).
+ * Derived from the per-edge predicate so both share one definition.
  */
 export function v2NamedResourceAliasConflict(
   nr: Pick<SnapshotNamedResource, 'allocationStartWeek' | 'allocationEndWeek' | 'startWeek' | 'endWeek'>,
   mode: string | null,
 ): boolean {
-  if (mode !== 'TIMELINE' && mode !== 'CAPACITY_PLAN') return false
-  return (
-    (nr.allocationStartWeek != null && nr.startWeek != null && nr.allocationStartWeek !== nr.startWeek) ||
-    (nr.allocationEndWeek != null && nr.endWeek != null && nr.allocationEndWeek !== nr.endWeek)
-  )
+  return v2NamedResourceEdgeAliasConflict(nr, mode, 'start') || v2NamedResourceEdgeAliasConflict(nr, mode, 'end')
 }
 
 function evaluateNamedResourceEntry(

--- a/server/src/scripts/generateSnapshotEvidence.ts
+++ b/server/src/scripts/generateSnapshotEvidence.ts
@@ -1,0 +1,235 @@
+/**
+ * generateSnapshotEvidence.ts — Issue #432: standalone explicitly-invoked,
+ * read-only command that extracts sanitized aggregate historical snapshot
+ * evidence for the Issue #430 design investigation.
+ *
+ * NEVER runs during application startup or from an HTTP request; exposes no
+ * API or UI. Requires explicit CLI invocation. Performs ZERO database writes:
+ * it loads the existing remediation-plan state and snapshot created-at
+ * metadata with ordinary read queries and aggregates in pure code.
+ *
+ * Usage:
+ *   npx tsx src/scripts/generateSnapshotEvidence.ts \
+ *     --json <output.json> --markdown <output.md> --expected <expected.json>
+ *
+ * Or via the root npm script:
+ *   npm run capacity-profiles:snapshot-evidence -- \
+ *     --json <output.json> --markdown <output.md> --expected <expected.json>
+ *
+ * Expected JSON schema (reviewed production-run values; never hard-coded):
+ *   {
+ *     "fingerprint": "<64-hex>",
+ *     "baselineStateHash": "<64-hex>",
+ *     "quarantinedEntries": 574,
+ *     "quarantinedSnapshots": 49,
+ *     "defectSnapshots": 18,
+ *     "windowlessDecisions": 359,
+ *     "singleMinusOneDecisions": 7,
+ *     "snapshotDecisions": 366,
+ *     "liveDecisions": 130,
+ *     "unsupported": 0,
+ *     "rewriteOperations": 0,
+ *     "topology11WindowlessDecisions": 226,
+ *     "topology7WindowlessDecisions": 133,
+ *     "topology7SingleMinusOneDecisions": 7
+ *   }
+ *
+ * Exit contract:
+ *   0 — evidence produced, all gates passed (fingerprint, baseline, counts,
+ *       reconciliation) and both output files written;
+ *   1 — any refusal: bad arguments, missing/unsafe expected values, existing
+ *       output files (never silently overwritten), snapshot parse failure,
+ *       unsupported schema version, fingerprint/baseline/count mismatch,
+ *       reconciliation failure, or output-write failure.
+ *
+ * No `--dry-run` option exists: the command is inherently read-only.
+ * Credentials and complete database URLs are never printed; runtime errors
+ * are converted to controlled reason codes and concise safe messages.
+ */
+
+import { execSync } from 'node:child_process'
+import { readFileSync, writeFileSync } from 'node:fs'
+import { pathToFileURL } from 'node:url'
+import { PrismaPg } from '@prisma/adapter-pg'
+import { PrismaClient } from '@prisma/client'
+import 'dotenv/config'
+
+import {
+  buildSnapshotEvidenceReport,
+  isExpectedBoundaryShape,
+  renderSnapshotEvidenceMarkdown,
+  SnapshotEvidenceError,
+  type SnapshotEvidenceExpected,
+  type SnapshotEvidenceReport,
+} from '../lib/snapshotEvidence.js'
+import { loadRemediationState } from '../lib/productionRemediationPlan.js'
+
+// ─── CLI argument parsing ──────────────────────────────────────────────────
+
+interface CliOptions {
+  jsonPath: string | null
+  markdownPath: string | null
+  expectedPath: string | null
+}
+
+function parseArgs(args: string[]): CliOptions | { error: string } {
+  const options: CliOptions = { jsonPath: null, markdownPath: null, expectedPath: null }
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i]
+    switch (arg) {
+      case '--json':
+        options.jsonPath = args[++i] ?? null
+        if (!options.jsonPath) return { error: '--json requires an output file path' }
+        break
+      case '--markdown':
+        options.markdownPath = args[++i] ?? null
+        if (!options.markdownPath) return { error: '--markdown requires an output file path' }
+        break
+      case '--expected':
+        options.expectedPath = args[++i] ?? null
+        if (!options.expectedPath) return { error: '--expected requires a reviewed expectations file path' }
+        break
+      default:
+        return { error: `unknown argument "${arg}"` }
+    }
+  }
+  if (!options.jsonPath || !options.markdownPath || !options.expectedPath) {
+    return { error: '--json, --markdown and --expected are all required' }
+  }
+  return options
+}
+
+function currentCommit(): string {
+  try {
+    return execSync('git rev-parse HEAD', { stdio: ['ignore', 'pipe', 'ignore'], encoding: 'utf-8' }).trim()
+  } catch {
+    return 'unknown'
+  }
+}
+
+function usage(): string {
+  return [
+    'Usage:',
+    '  generateSnapshotEvidence.ts --json <output.json> --markdown <output.md> --expected <expected.json>',
+    '',
+    'The command is read-only (zero database writes) and emits sanitized',
+    'aggregate evidence only. It fails closed on drift, mismatch, parse',
+    'failure, unsupported snapshot versions or unsafe output.',
+    'Exit codes: 0 = evidence produced and reconciled; 1 = any refusal.',
+  ].join('\n')
+}
+
+// ─── Controlled error output (never raw payloads or database details) ──────
+
+function controlledFailure(reason: string): number {
+  console.error(`❌ snapshot evidence command refused: ${reason}`)
+  return 1
+}
+
+// ─── Main ──────────────────────────────────────────────────────────────────
+
+export async function main(argv: string[]): Promise<number> {
+  const parsed = parseArgs(argv)
+  if ('error' in parsed) {
+    console.error(`❌ ${parsed.error}`)
+    console.error(usage())
+    return 1
+  }
+  const options = parsed
+
+  console.log('🔎 Sanitized Historical Snapshot Evidence (read-only)')
+  console.log('=====================================================')
+
+  let expected: SnapshotEvidenceExpected
+  try {
+    const raw = readFileSync(options.expectedPath!, 'utf-8')
+    const candidate: unknown = JSON.parse(raw)
+    if (!isExpectedBoundaryShape(candidate)) {
+      return controlledFailure('the reviewed expectations file does not match the required schema')
+    }
+    expected = candidate
+  } catch (error) {
+    return controlledFailure(
+      `cannot read the reviewed expectations file: ${error instanceof Error ? error.message : String(error)}`,
+    )
+  }
+
+  // Output safety: existing files are never silently overwritten.
+  for (const path of [options.jsonPath!, options.markdownPath!]) {
+    try {
+      readFileSync(path)
+      return controlledFailure(`output file already exists (refusing to overwrite): ${path}`)
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+        return controlledFailure(`cannot inspect output path: ${path}`)
+      }
+    }
+  }
+
+  const adapter = new PrismaPg({ connectionString: process.env.DATABASE_URL })
+  const prisma = new PrismaClient({ adapter })
+
+  try {
+    const state = await loadRemediationState(prisma)
+    const snapshotRows = await prisma.backlogSnapshot.findMany({
+      select: { id: true, createdAt: true },
+      orderBy: { id: 'asc' },
+    })
+    const snapshotCreatedAtById = new Map<string, string>(
+      snapshotRows.map(row => [row.id, row.createdAt.toISOString()]),
+    )
+
+    let report: SnapshotEvidenceReport
+    try {
+      report = buildSnapshotEvidenceReport({
+        state,
+        snapshotCreatedAtById,
+        applicationCommit: currentCommit(),
+        generatedAt: new Date().toISOString(),
+        expected,
+      })
+    } catch (error) {
+      if (error instanceof SnapshotEvidenceError) {
+        return controlledFailure(`${error.code}: ${error.message}`)
+      }
+      return controlledFailure('evidence aggregation failed internally')
+    }
+
+    if (!report.integrityResult.reconciliationPassed) {
+      console.error('❌ evidence gates failed — no output emitted:')
+      for (const detail of report.reconciliation.details) {
+        if (detail.includes('MISMATCH')) console.error(`   - ${detail}`)
+      }
+      if (!report.integrityResult.fingerprintMatch) console.error('   - fingerprint mismatch')
+      if (!report.integrityResult.baselineMatch) console.error('   - baseline-state hash mismatch')
+      return 1
+    }
+
+    const json = `${JSON.stringify(report, null, 2)}\n`
+    const markdown = renderSnapshotEvidenceMarkdown(report)
+
+    writeFileSync(options.jsonPath!, json, { encoding: 'utf-8', flag: 'wx' })
+    writeFileSync(options.markdownPath!, markdown, { encoding: 'utf-8', flag: 'wx' })
+
+    console.log(`✅ fingerprint matched (${report.observedBoundary.fingerprint.slice(0, 12)}…)`)
+    console.log(`✅ baseline-state hash matched (${report.observedBoundary.baselineStateHash.slice(0, 12)}…)`)
+    console.log(`✅ all reviewed counts reconciled`)
+    console.log(`✅ JSON written: ${options.jsonPath}`)
+    console.log(`✅ Markdown written: ${options.markdownPath}`)
+    console.log('')
+    console.log('This report is evidence only. It does not authorize remediation, migration, manifest creation or decision selection.')
+    return 0
+  } finally {
+    await prisma.$disconnect().catch(() => undefined)
+  }
+}
+
+// Execute only when run directly as a script; importing `main` for tests
+// must not trigger process.exit.
+const isMain = Boolean(
+  process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href,
+)
+if (isMain) {
+  const exitCode = await main(process.argv.slice(2))
+  process.exit(exitCode)
+}

--- a/server/src/scripts/generateSnapshotEvidence.ts
+++ b/server/src/scripts/generateSnapshotEvidence.ts
@@ -37,8 +37,9 @@
  * Exit contract:
  *   0 — evidence produced, all gates passed (fingerprint, baseline, counts,
  *       reconciliation) and both output files written;
- *   1 — any refusal: bad arguments, missing/unsafe expected values, existing
- *       output files (never silently overwritten), snapshot parse failure,
+ *   1 — any refusal: bad arguments, missing/unsafe expected values, JSON and
+ *       Markdown output paths resolving to the same file, existing output
+ *       files (never silently overwritten), snapshot parse failure,
  *       unsupported schema version, fingerprint/baseline/count mismatch,
  *       reconciliation failure, or output-write failure.
  *
@@ -48,8 +49,7 @@
  */
 
 import { execSync } from 'node:child_process'
-import { closeSync, openSync, readFileSync, renameSync, rmSync, writeFileSync } from 'node:fs'
-import { randomBytes } from 'node:crypto'
+import { readFileSync } from 'node:fs'
 import path from 'node:path'
 import { pathToFileURL } from 'node:url'
 import { PrismaPg } from '@prisma/adapter-pg'
@@ -64,6 +64,7 @@ import {
   type SnapshotEvidenceExpected,
   type SnapshotEvidenceReport,
 } from '../lib/snapshotEvidence.js'
+import { publishEvidenceOutputs } from '../lib/evidenceOutputPublication.js'
 import { loadRemediationState } from '../lib/productionRemediationPlan.js'
 
 // ─── CLI argument parsing ──────────────────────────────────────────────────
@@ -128,87 +129,6 @@ function controlledFailure(reason: string): number {
   return 1
 }
 
-// ─── Two-file publication (all-or-nothing) ─────────────────────────────────
-
-/** Test-only failure injection phases; production callers never pass hooks. */
-export type EvidencePublishPhase =
-  | 'stage-json'
-  | 'stage-markdown'
-  | 'publish-json'
-  | 'publish-markdown'
-
-export interface EvidencePublishHooks {
-  failOn?: (phase: EvidencePublishPhase) => void
-}
-
-/**
- * Publish the JSON and Markdown outputs atomically as a set:
- *
- * 1. both complete strings are staged into exclusive temporary files (mode
- *    0600) inside the corresponding output directories;
- * 2. only after both temporaries are written and closed are the final paths
- *    published with same-directory renames;
- * 3. any staging or publication failure removes every temporary file and any
- *    final file published by THIS run, leaves pre-existing files untouched,
- *    and rethrows (the CLI converts it to a controlled error + exit 1);
- * 4. on success both finals exist with mode 0600 (renames preserve the temp
- *    modes) and no temporary files remain.
- *
- * Final paths are never overwritten: callers preflight existence.
- */
-export function publishEvidenceOutputs(
-  jsonPath: string,
-  markdownPath: string,
-  jsonContent: string,
-  markdownContent: string,
-  hooks?: EvidencePublishHooks,
-): void {
-  const tempPaths: string[] = []
-  const published: string[] = []
-  const fail = (phase: EvidencePublishPhase): void => {
-    if (hooks?.failOn) hooks.failOn(phase)
-  }
-  const cleanup = (): void => {
-    for (const temp of tempPaths) {
-      try { rmSync(temp, { force: true }) } catch { /* best-effort */ }
-    }
-    for (const final of published) {
-      try { rmSync(final, { force: true }) } catch { /* best-effort */ }
-    }
-  }
-  const tempPathFor = (finalPath: string): string => {
-    const dir = path.dirname(finalPath)
-    const base = path.basename(finalPath)
-    return path.join(dir, `.${base}.evidence-${randomBytes(8).toString('hex')}.tmp`)
-  }
-  const stage = (finalPath: string, content: string, phase: EvidencePublishPhase): string => {
-    const temp = tempPathFor(finalPath)
-    tempPaths.push(temp)
-    const fd = openSync(temp, 'wx', 0o600)
-    try {
-      writeFileSync(fd, content, 'utf8')
-    } finally {
-      closeSync(fd)
-    }
-    fail(phase)
-    return temp
-  }
-
-  try {
-    const jsonTemp = stage(jsonPath, jsonContent, 'stage-json')
-    const markdownTemp = stage(markdownPath, markdownContent, 'stage-markdown')
-    renameSync(jsonTemp, jsonPath)
-    published.push(jsonPath)
-    fail('publish-json')
-    renameSync(markdownTemp, markdownPath)
-    published.push(markdownPath)
-    fail('publish-markdown')
-  } catch (error) {
-    cleanup()
-    throw error
-  }
-}
-
 // ─── Main ──────────────────────────────────────────────────────────────────
 
 export async function main(argv: string[]): Promise<number> {
@@ -222,6 +142,18 @@ export async function main(argv: string[]): Promise<number> {
 
   console.log('🔎 Sanitized Historical Snapshot Evidence (read-only)')
   console.log('=====================================================')
+
+  // Output-path safety happens BEFORE any file or database access: the JSON
+  // and Markdown final paths must be distinct. Resolving and normalizing
+  // both paths also guarantees a later no-clobber publication cannot be
+  // bypassed through equivalent spellings of the same destination.
+  const jsonFinalPath = path.resolve(options.jsonPath!)
+  const markdownFinalPath = path.resolve(options.markdownPath!)
+  if (jsonFinalPath === markdownFinalPath) {
+    return controlledFailure(
+      'the JSON and Markdown output paths resolve to the same file (refusing to write one file twice)',
+    )
+  }
 
   let expected: SnapshotEvidenceExpected
   try {
@@ -238,13 +170,13 @@ export async function main(argv: string[]): Promise<number> {
   }
 
   // Output safety: existing files are never silently overwritten.
-  for (const path of [options.jsonPath!, options.markdownPath!]) {
+  for (const outputPath of [jsonFinalPath, markdownFinalPath]) {
     try {
-      readFileSync(path)
-      return controlledFailure(`output file already exists (refusing to overwrite): ${path}`)
+      readFileSync(outputPath)
+      return controlledFailure(`output file already exists (refusing to overwrite): ${outputPath}`)
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
-        return controlledFailure(`cannot inspect output path: ${path}`)
+        return controlledFailure(`cannot inspect output path: ${outputPath}`)
       }
     }
   }
@@ -292,7 +224,7 @@ export async function main(argv: string[]): Promise<number> {
     const markdown = renderSnapshotEvidenceMarkdown(report)
 
     try {
-      publishEvidenceOutputs(options.jsonPath!, options.markdownPath!, json, markdown)
+      publishEvidenceOutputs(jsonFinalPath, markdownFinalPath, json, markdown)
     } catch {
       return controlledFailure('output publication failed — no partial evidence set was left behind')
     }

--- a/server/src/scripts/generateSnapshotEvidence.ts
+++ b/server/src/scripts/generateSnapshotEvidence.ts
@@ -48,7 +48,9 @@
  */
 
 import { execSync } from 'node:child_process'
-import { readFileSync, writeFileSync } from 'node:fs'
+import { closeSync, openSync, readFileSync, renameSync, rmSync, writeFileSync } from 'node:fs'
+import { randomBytes } from 'node:crypto'
+import path from 'node:path'
 import { pathToFileURL } from 'node:url'
 import { PrismaPg } from '@prisma/adapter-pg'
 import { PrismaClient } from '@prisma/client'
@@ -124,6 +126,87 @@ function usage(): string {
 function controlledFailure(reason: string): number {
   console.error(`❌ snapshot evidence command refused: ${reason}`)
   return 1
+}
+
+// ─── Two-file publication (all-or-nothing) ─────────────────────────────────
+
+/** Test-only failure injection phases; production callers never pass hooks. */
+export type EvidencePublishPhase =
+  | 'stage-json'
+  | 'stage-markdown'
+  | 'publish-json'
+  | 'publish-markdown'
+
+export interface EvidencePublishHooks {
+  failOn?: (phase: EvidencePublishPhase) => void
+}
+
+/**
+ * Publish the JSON and Markdown outputs atomically as a set:
+ *
+ * 1. both complete strings are staged into exclusive temporary files (mode
+ *    0600) inside the corresponding output directories;
+ * 2. only after both temporaries are written and closed are the final paths
+ *    published with same-directory renames;
+ * 3. any staging or publication failure removes every temporary file and any
+ *    final file published by THIS run, leaves pre-existing files untouched,
+ *    and rethrows (the CLI converts it to a controlled error + exit 1);
+ * 4. on success both finals exist with mode 0600 (renames preserve the temp
+ *    modes) and no temporary files remain.
+ *
+ * Final paths are never overwritten: callers preflight existence.
+ */
+export function publishEvidenceOutputs(
+  jsonPath: string,
+  markdownPath: string,
+  jsonContent: string,
+  markdownContent: string,
+  hooks?: EvidencePublishHooks,
+): void {
+  const tempPaths: string[] = []
+  const published: string[] = []
+  const fail = (phase: EvidencePublishPhase): void => {
+    if (hooks?.failOn) hooks.failOn(phase)
+  }
+  const cleanup = (): void => {
+    for (const temp of tempPaths) {
+      try { rmSync(temp, { force: true }) } catch { /* best-effort */ }
+    }
+    for (const final of published) {
+      try { rmSync(final, { force: true }) } catch { /* best-effort */ }
+    }
+  }
+  const tempPathFor = (finalPath: string): string => {
+    const dir = path.dirname(finalPath)
+    const base = path.basename(finalPath)
+    return path.join(dir, `.${base}.evidence-${randomBytes(8).toString('hex')}.tmp`)
+  }
+  const stage = (finalPath: string, content: string, phase: EvidencePublishPhase): string => {
+    const temp = tempPathFor(finalPath)
+    tempPaths.push(temp)
+    const fd = openSync(temp, 'wx', 0o600)
+    try {
+      writeFileSync(fd, content, 'utf8')
+    } finally {
+      closeSync(fd)
+    }
+    fail(phase)
+    return temp
+  }
+
+  try {
+    const jsonTemp = stage(jsonPath, jsonContent, 'stage-json')
+    const markdownTemp = stage(markdownPath, markdownContent, 'stage-markdown')
+    renameSync(jsonTemp, jsonPath)
+    published.push(jsonPath)
+    fail('publish-json')
+    renameSync(markdownTemp, markdownPath)
+    published.push(markdownPath)
+    fail('publish-markdown')
+  } catch (error) {
+    cleanup()
+    throw error
+  }
 }
 
 // ─── Main ──────────────────────────────────────────────────────────────────
@@ -208,8 +291,11 @@ export async function main(argv: string[]): Promise<number> {
     const json = `${JSON.stringify(report, null, 2)}\n`
     const markdown = renderSnapshotEvidenceMarkdown(report)
 
-    writeFileSync(options.jsonPath!, json, { encoding: 'utf-8', flag: 'wx' })
-    writeFileSync(options.markdownPath!, markdown, { encoding: 'utf-8', flag: 'wx' })
+    try {
+      publishEvidenceOutputs(options.jsonPath!, options.markdownPath!, json, markdown)
+    } catch {
+      return controlledFailure('output publication failed — no partial evidence set was left behind')
+    }
 
     console.log(`✅ fingerprint matched (${report.observedBoundary.fingerprint.slice(0, 12)}…)`)
     console.log(`✅ baseline-state hash matched (${report.observedBoundary.baselineStateHash.slice(0, 12)}…)`)

--- a/server/src/test/snapshotEvidence.integration.test.ts
+++ b/server/src/test/snapshotEvidence.integration.test.ts
@@ -410,4 +410,16 @@ describeIf('snapshot evidence command (integration)', () => {
     expect(exitUnknown).toBe(1)
     rmSync(dir, { recursive: true, force: true })
   })
+
+  it('refuses identical JSON and Markdown output paths with no database access', async () => {
+    const dir = tempDir()
+    const same = path.join(dir, 'evidence.json')
+    // The expectations file does not exist: reaching path validation before
+    // the expectations read proves the refusal precedes any file or database
+    // access even in the real CLI flow.
+    const exit = await main(['--json', same, '--markdown', same, '--expected', path.join(dir, 'missing.json')])
+    expect(exit).toBe(1)
+    expect(readdirSync(dir)).toEqual([])
+    rmSync(dir, { recursive: true, force: true })
+  })
 })

--- a/server/src/test/snapshotEvidence.integration.test.ts
+++ b/server/src/test/snapshotEvidence.integration.test.ts
@@ -19,7 +19,7 @@
  */
 
 import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest'
-import { mkdtempSync, readFileSync, writeFileSync, rmSync, existsSync } from 'node:fs'
+import { mkdtempSync, readFileSync, writeFileSync, rmSync, existsSync, readdirSync, statSync } from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 import { PrismaPg } from '@prisma/adapter-pg'
@@ -234,6 +234,8 @@ async function expectedBoundary(): Promise<SnapshotEvidenceExpected> {
     liveDecisions: 0,
     unsupported: 0,
     rewriteOperations: 0,
+    topology11Snapshots: 2,
+    topology7Snapshots: 1,
     topology11WindowlessDecisions: 37,
     topology7WindowlessDecisions: 19,
     topology7SingleMinusOneDecisions: 1,
@@ -278,6 +280,13 @@ describeIf('snapshot evidence command (integration)', () => {
       elevenSnapshotSubgroup: { snapshots: 2, windowlessDecisions: 37 },
       sevenSnapshotSubgroup: { snapshots: 1, windowlessDecisions: 19, singleMinusOneDecisions: 1, totalDecisions: 20 },
     })
+
+    // Output file modes (POSIX only) and no temporary residue.
+    if (process.platform !== 'win32') {
+      expect(statSync(jsonPath).mode & 0o777).toBe(0o600)
+      expect(statSync(mdPath).mode & 0o777).toBe(0o600)
+    }
+    expect(readdirSync(dir).filter(name => name.includes('.tmp'))).toEqual([])
     expect(report.classAAggregates.totalEntries).toBe(3)
     expect(report.classAAggregates.byOwnerKind).toEqual({ resourceType: 2, namedResource: 1, unavailable: 0 })
     expect(report.singleNegativeEntries).toHaveLength(1)

--- a/server/src/test/snapshotEvidence.integration.test.ts
+++ b/server/src/test/snapshotEvidence.integration.test.ts
@@ -1,0 +1,404 @@
+/**
+ * snapshotEvidence.integration.test.ts — Real PostgreSQL integration tests
+ * for the Issue #432 sanitized snapshot evidence command
+ * (server/src/scripts/generateSnapshotEvidence.ts).
+ *
+ * Proves against a disposable database (Docker-first lifecycle):
+ *   - the corrected 11-plus-7 snapshot topology and the reviewed counts
+ *     reconcile end to end through the real CLI entry point;
+ *   - entry-level and structural defect categorisation (alias conflict,
+ *     duplicate owners, single -1 edges);
+ *   - current classifier reuse (quarantined/defect/restorable verdicts);
+ *   - fingerprint, baseline and summary-count mismatch refusal;
+ *   - output-file safety (never overwrite);
+ *   - unsupported schema-version refusal;
+ *   - zero writes and exact database-state preservation;
+ *   - identifier/name/payload redaction of seeded sensitive values.
+ *
+ * All tests are skipped unless INTEGRATION_TEST=true.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest'
+import { mkdtempSync, readFileSync, writeFileSync, rmSync, existsSync } from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { PrismaPg } from '@prisma/adapter-pg'
+import { PrismaClient } from '@prisma/client'
+
+import { main } from '../scripts/generateSnapshotEvidence.js'
+import type { SnapshotEvidenceExpected } from '../lib/snapshotEvidence.js'
+import {
+  buildRemediationPlan,
+  computePlanFingerprint,
+  computeStateHash,
+  loadRemediationState,
+} from '../lib/productionRemediationPlan.js'
+
+// ─── Guard ──────────────────────────────────────────────────────────────────
+
+const runIntegration = process.env.INTEGRATION_TEST === 'true'
+const describeIf = runIntegration ? describe : describe.skip
+
+// ─── Shared state ───────────────────────────────────────────────────────────
+
+let prisma: PrismaClient
+const PROJECT_ID = 'fixture-project-42-abc'
+const USER_ID = 'fixture-user-7-xyz'
+const CREATED_SNAPSHOT_IDS: string[] = []
+
+beforeAll(async () => {
+  if (!runIntegration) return
+  prisma = new PrismaClient({
+    adapter: new PrismaPg({ connectionString: process.env.DATABASE_URL }),
+  })
+  await prisma.$connect()
+  // Clean slate for this file's fixtures.
+  await prisma.backlogSnapshot.deleteMany({})
+  await prisma.featureTemplate.deleteMany({})
+  await prisma.project.deleteMany({})
+  await prisma.customer.deleteMany({})
+  await prisma.documentTemplate.deleteMany({})
+  await prisma.user.deleteMany({})
+  await prisma.user.create({ data: { id: USER_ID, email: 'fixture@example.test', name: 'Fixture User', password: '$2b$10$placeholder', role: 'ADMIN' } })
+  await prisma.project.create({ data: { id: PROJECT_ID, name: 'Fixture Secret Project', ownerId: USER_ID } })
+})
+
+afterEach(async () => {
+  if (!runIntegration) return
+  await prisma.backlogSnapshot.deleteMany({})
+  await prisma.project.deleteMany({})
+  await prisma.customer.deleteMany({})
+  await prisma.documentTemplate.deleteMany({})
+  await prisma.user.deleteMany({})
+  await prisma.user.create({ data: { id: USER_ID, email: 'fixture@example.test', name: 'Fixture User', password: '$2b$10$placeholder', role: 'ADMIN' } })
+  await prisma.project.create({ data: { id: PROJECT_ID, name: 'Fixture Secret Project', ownerId: USER_ID } })
+})
+
+afterAll(async () => {
+  if (!runIntegration) return
+  await prisma.backlogSnapshot.deleteMany({})
+  await prisma.project.deleteMany({})
+  await prisma.customer.deleteMany({})
+  await prisma.documentTemplate.deleteMany({})
+  await prisma.user.deleteMany({})
+  await prisma.$disconnect()
+})
+
+// ─── Fixtures ───────────────────────────────────────────────────────────────
+
+function makeRt(o: { id: string; name?: string; allocationMode?: string | null; allocationStartWeek?: number | null; allocationEndWeek?: number | null; allocationPercent?: number | null }) {
+  return {
+    id: o.id,
+    name: o.name ?? `Fixture Secret Role ${o.id}`,
+    category: 'ENGINEERING',
+    count: 1,
+    hoursPerDay: null,
+    dayRate: null,
+    allocationMode: 'allocationMode' in o ? o.allocationMode : 'TIMELINE',
+    globalTypeId: null,
+    allocationPercent: o.allocationPercent ?? 100,
+    allocationStartWeek: o.allocationStartWeek ?? null,
+    allocationEndWeek: o.allocationEndWeek ?? null,
+  }
+}
+
+function makeNr(o: { id: string; resourceTypeId: string; name?: string; allocationMode?: string | null; allocationStartWeek?: number | null; allocationEndWeek?: number | null; startWeek?: number | null; endWeek?: number | null; allocationPercent?: number | null; allocationPct?: number | null }) {
+  return {
+    id: o.id,
+    resourceTypeId: o.resourceTypeId,
+    name: o.name ?? `Fixture Secret Person ${o.id}`,
+    startWeek: o.startWeek ?? null,
+    endWeek: o.endWeek ?? null,
+    allocationPct: o.allocationPct ?? 100,
+    allocationMode: 'allocationMode' in o ? o.allocationMode : 'TIMELINE',
+    allocationPercent: o.allocationPercent ?? 100,
+    allocationStartWeek: o.allocationStartWeek ?? null,
+    allocationEndWeek: o.allocationEndWeek ?? null,
+    pricingModel: 'ACTUAL_DAYS',
+  }
+}
+
+function makeV2Snapshot(resourceTypes: unknown[], namedResources: unknown[]) {
+  return {
+    schemaVersion: 2,
+    epics: [],
+    project: null,
+    resourceTypes,
+    namedResources,
+    timelineEntries: [],
+    storyTimelineEntries: [],
+    epicDependencies: [],
+    featureDependencies: [],
+    overheadItems: [],
+  }
+}
+
+async function createSnapshot(id: string, payload: unknown, createdAtIso: string): Promise<void> {
+  await prisma.backlogSnapshot.create({
+    data: {
+      id,
+      projectId: PROJECT_ID,
+      label: `fixture ${id}`,
+      trigger: 'manual',
+      snapshot: payload as object,
+      createdById: USER_ID,
+      createdAt: new Date(createdAtIso),
+    },
+  })
+  CREATED_SNAPSHOT_IDS.push(id)
+}
+
+/** Corrected-topology fixture set (smaller than production, same rules):
+ * - E1: eleven-subgroup with 21 windowless decisions + alias-conflict NR;
+ * - E2: eleven-subgroup with 16 windowless decisions + alias-conflict NR;
+ * - S7: seven-subgroup with 19 windowless + 1 single-`-1` decision;
+ * - Q1: quarantined snapshot with 2 RT + 1 inherited-NR Class A entries;
+ * - R1: restorable TIMELINE snapshot.
+ * Expected: quarantined 3 entries / 1 snapshot; defect 3; windowless 37+19=56;
+ * single 1; snapshot decisions 57; live 0; unsupported 0; rewrite 0;
+ * topology 11 = 37, topology 7 = 19 windowless + 1 single. */
+async function seedTopologyFixture(): Promise<void> {
+  const conflictNr = (id: string, parentId: string) => makeNr({
+    id, resourceTypeId: parentId, allocationMode: null,
+    allocationStartWeek: 5, allocationEndWeek: 10, startWeek: 5, endWeek: 9,
+  })
+  await createSnapshot(
+    'snap-e1',
+    makeV2Snapshot(
+      Array.from({ length: 21 }, (_, i) => makeRt({ id: `rt-e1-${i}`, allocationMode: 'CAPACITY_PLAN' })),
+      [conflictNr('nr-e1-conflict', 'rt-e1-0')],
+    ),
+    '2026-05-20T00:00:00Z',
+  )
+  await createSnapshot(
+    'snap-e2',
+    makeV2Snapshot(
+      Array.from({ length: 16 }, (_, i) => makeRt({ id: `rt-e2-${i}`, allocationMode: 'CAPACITY_PLAN' })),
+      [conflictNr('nr-e2-conflict', 'rt-e2-0')],
+    ),
+    '2026-05-25T00:00:00Z',
+  )
+  await createSnapshot(
+    'snap-s7',
+    makeV2Snapshot(
+      Array.from({ length: 19 }, (_, i) => makeRt({ id: `rt-s7-${i}`, allocationMode: 'CAPACITY_PLAN' })),
+      [makeNr({
+        id: 'nr-s7-minus-one',
+        resourceTypeId: 'rt-s7-0',
+        allocationMode: 'CAPACITY_PLAN',
+        allocationStartWeek: -1,
+        allocationEndWeek: 5,
+        startWeek: 5,
+        endWeek: null,
+      })],
+    ),
+    '2026-05-10T00:00:00Z',
+  )
+  await createSnapshot(
+    'snap-q1',
+    makeV2Snapshot(
+      [
+        makeRt({ id: 'rt-q1-a', allocationMode: 'CAPACITY_PLAN' }),
+        makeRt({ id: 'rt-q1-b', allocationMode: 'CAPACITY_PLAN' }),
+      ],
+      [makeNr({ id: 'nr-q1-inherited', resourceTypeId: 'rt-q1-a', allocationMode: null })],
+    ),
+    '2026-06-01T00:00:00Z',
+  )
+  await createSnapshot(
+    'snap-r1',
+    makeV2Snapshot(
+      [makeRt({ id: 'rt-r1', allocationMode: 'TIMELINE', allocationStartWeek: 0, allocationEndWeek: 10 })],
+      [],
+    ),
+    '2026-04-01T00:00:00Z',
+  )
+}
+
+async function currentStateHash(): Promise<string> {
+  return computeStateHash(await loadRemediationState(prisma))
+}
+
+async function expectedBoundary(): Promise<SnapshotEvidenceExpected> {
+  const state = await loadRemediationState(prisma)
+  const plan = buildRemediationPlan(state, 'test-commit')
+  return {
+    fingerprint: computePlanFingerprint(plan),
+    baselineStateHash: computeStateHash(state),
+    quarantinedEntries: 3,
+    quarantinedSnapshots: 1,
+    defectSnapshots: 3,
+    windowlessDecisions: 56,
+    singleMinusOneDecisions: 1,
+    snapshotDecisions: 57,
+    liveDecisions: 0,
+    unsupported: 0,
+    rewriteOperations: 0,
+    topology11WindowlessDecisions: 37,
+    topology7WindowlessDecisions: 19,
+    topology7SingleMinusOneDecisions: 1,
+  }
+}
+
+function tempDir(): string {
+  return mkdtempSync(path.join(os.tmpdir(), 'snapshot-evidence-it-'))
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describeIf('snapshot evidence command (integration)', () => {
+  it('reconciles the corrected topology end to end and writes JSON + Markdown', async () => {
+    await seedTopologyFixture()
+    const dir = tempDir()
+    const jsonPath = path.join(dir, 'evidence.json')
+    const mdPath = path.join(dir, 'evidence.md')
+    const expectedPath = path.join(dir, 'expected.json')
+    const expected = await expectedBoundary()
+    writeFileSync(expectedPath, JSON.stringify(expected, null, 2))
+    const stateHashBefore = await currentStateHash()
+
+    const exit = await main(['--json', jsonPath, '--markdown', mdPath, '--expected', expectedPath])
+
+    expect(exit).toBe(0)
+    expect(existsSync(jsonPath)).toBe(true)
+    expect(existsSync(mdPath)).toBe(true)
+    const report = JSON.parse(readFileSync(jsonPath, 'utf-8'))
+    expect(report.formatVersion).toBe(1)
+    expect(report.integrityResult).toEqual({
+      fingerprintMatch: true, baselineMatch: true, countsMatch: true, reconciliationPassed: true,
+    })
+    expect(report.policyDecision).toBe('not-assessed')
+    expect(report.topology).toMatchObject({
+      quarantinedSnapshots: 1,
+      defectSnapshots: 3,
+      windowlessDecisions: 56,
+      singleMinusOneDecisions: 1,
+      snapshotDecisions: 57,
+      liveDecisions: 0,
+      elevenSnapshotSubgroup: { snapshots: 2, windowlessDecisions: 37 },
+      sevenSnapshotSubgroup: { snapshots: 1, windowlessDecisions: 19, singleMinusOneDecisions: 1, totalDecisions: 20 },
+    })
+    expect(report.classAAggregates.totalEntries).toBe(3)
+    expect(report.classAAggregates.byOwnerKind).toEqual({ resourceType: 2, namedResource: 1, unavailable: 0 })
+    expect(report.singleNegativeEntries).toHaveLength(1)
+    expect(report.singleNegativeEntries[0]!.minusOneField).toBe('allocationStartWeek')
+    expect(report.defectSnapshots).toHaveLength(3)
+    const seven = report.defectSnapshots.find((m: { subgroup: string }) => m.subgroup === 'seven-single-minus-one')!
+    expect(seven.windowlessDecisionCount).toBe(19)
+    expect(seven.singleMinusOneDecisionCount).toBe(1)
+
+    // Zero writes: canonical covered-state hash unchanged.
+    const stateHashAfter = await currentStateHash()
+    expect(stateHashAfter).toBe(stateHashBefore)
+
+    // Markdown parity + redaction of seeded sensitive values.
+    const markdown = readFileSync(mdPath, 'utf-8')
+    for (const secret of [
+      'fixture-project-42-abc', 'fixture-user-7-xyz',
+      'snap-e1', 'snap-e2', 'snap-s7', 'snap-q1', 'snap-r1',
+      'rt-e1-0', 'nr-s7-minus-one', 'nr-q1-inherited',
+      'Fixture Secret Project', 'Fixture Secret Role', 'Fixture Secret Person',
+    ]) {
+      expect(readFileSync(jsonPath, 'utf-8')).not.toContain(secret)
+      expect(markdown).not.toContain(secret)
+    }
+    expect(markdown).toContain('windowlessDecisions: 56')
+    expect(markdown).toContain('policyDecision: not-assessed')
+
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('refuses on fingerprint mismatch and writes no output', async () => {
+    await seedTopologyFixture()
+    const dir = tempDir()
+    const jsonPath = path.join(dir, 'evidence.json')
+    const mdPath = path.join(dir, 'evidence.md')
+    const expectedPath = path.join(dir, 'expected.json')
+    const expected = await expectedBoundary()
+    writeFileSync(expectedPath, JSON.stringify({ ...expected, fingerprint: 'f'.repeat(64) }, null, 2))
+
+    const exit = await main(['--json', jsonPath, '--markdown', mdPath, '--expected', expectedPath])
+
+    expect(exit).toBe(1)
+    expect(existsSync(jsonPath)).toBe(false)
+    expect(existsSync(mdPath)).toBe(false)
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('refuses on baseline mismatch and writes no output', async () => {
+    await seedTopologyFixture()
+    const dir = tempDir()
+    const jsonPath = path.join(dir, 'evidence.json')
+    const mdPath = path.join(dir, 'evidence.md')
+    const expectedPath = path.join(dir, 'expected.json')
+    const expected = await expectedBoundary()
+    writeFileSync(expectedPath, JSON.stringify({ ...expected, baselineStateHash: '0'.repeat(64) }, null, 2))
+
+    const exit = await main(['--json', jsonPath, '--markdown', mdPath, '--expected', expectedPath])
+
+    expect(exit).toBe(1)
+    expect(existsSync(jsonPath)).toBe(false)
+    expect(existsSync(mdPath)).toBe(false)
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('refuses on summary-count mismatch and writes no output', async () => {
+    await seedTopologyFixture()
+    const dir = tempDir()
+    const jsonPath = path.join(dir, 'evidence.json')
+    const mdPath = path.join(dir, 'evidence.md')
+    const expectedPath = path.join(dir, 'expected.json')
+    const expected = await expectedBoundary()
+    writeFileSync(expectedPath, JSON.stringify({ ...expected, windowlessDecisions: 999 }, null, 2))
+
+    const exit = await main(['--json', jsonPath, '--markdown', mdPath, '--expected', expectedPath])
+
+    expect(exit).toBe(1)
+    expect(existsSync(jsonPath)).toBe(false)
+    expect(existsSync(mdPath)).toBe(false)
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('refuses to overwrite an existing output file', async () => {
+    await seedTopologyFixture()
+    const dir = tempDir()
+    const jsonPath = path.join(dir, 'evidence.json')
+    const mdPath = path.join(dir, 'evidence.md')
+    const expectedPath = path.join(dir, 'expected.json')
+    writeFileSync(jsonPath, 'existing content')
+    writeFileSync(expectedPath, JSON.stringify(await expectedBoundary(), null, 2))
+
+    const exit = await main(['--json', jsonPath, '--markdown', mdPath, '--expected', expectedPath])
+
+    expect(exit).toBe(1)
+    expect(readFileSync(jsonPath, 'utf-8')).toBe('existing content')
+    expect(existsSync(mdPath)).toBe(false)
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('refuses on unsupported schema versions with a controlled error', async () => {
+    await createSnapshot('snap-unsupported', { schemaVersion: 99, epics: [] }, '2026-06-01T00:00:00Z')
+    const dir = tempDir()
+    const jsonPath = path.join(dir, 'evidence.json')
+    const mdPath = path.join(dir, 'evidence.md')
+    const expectedPath = path.join(dir, 'expected.json')
+    const expected = await expectedBoundary()
+    writeFileSync(expectedPath, JSON.stringify(expected, null, 2))
+
+    const exit = await main(['--json', jsonPath, '--markdown', mdPath, '--expected', expectedPath])
+
+    expect(exit).toBe(1)
+    expect(existsSync(jsonPath)).toBe(false)
+    expect(existsSync(mdPath)).toBe(false)
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('rejects malformed arguments and missing required flags', async () => {
+    const dir = tempDir()
+    const exitMissing = await main(['--json', path.join(dir, 'a.json')])
+    expect(exitMissing).toBe(1)
+    const exitUnknown = await main(['--bogus'])
+    expect(exitUnknown).toBe(1)
+    rmSync(dir, { recursive: true, force: true })
+  })
+})

--- a/server/src/test/snapshotEvidence.test.ts
+++ b/server/src/test/snapshotEvidence.test.ts
@@ -11,6 +11,9 @@
  */
 
 import { describe, it, expect } from 'vitest'
+import { mkdtempSync, readdirSync, readFileSync, rmSync, statSync } from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
 
 import {
   buildSnapshotEvidenceReport,
@@ -18,10 +21,12 @@ import {
   isExpectedBoundaryShape,
   percentCategory,
   renderSnapshotEvidenceMarkdown,
+  sanitizeMode,
   snapshotEraCategory,
   SnapshotEvidenceError,
   type SnapshotEvidenceExpected,
 } from '../lib/snapshotEvidence.js'
+import { publishEvidenceOutputs } from '../scripts/generateSnapshotEvidence.js'
 import {
   buildRemediationPlan,
   computePlanFingerprint,
@@ -251,6 +256,8 @@ const COMPOSITE_COUNTS: Omit<SnapshotEvidenceExpected, 'fingerprint' | 'baseline
   liveDecisions: 0,
   unsupported: 0,
   rewriteOperations: 0,
+  topology11Snapshots: 1,
+  topology7Snapshots: 1,
   topology11WindowlessDecisions: 20,
   topology7WindowlessDecisions: 19,
   topology7SingleMinusOneDecisions: 1,
@@ -291,6 +298,7 @@ describe('isExpectedBoundaryShape', () => {
     quarantinedEntries: 574, quarantinedSnapshots: 49, defectSnapshots: 18,
     windowlessDecisions: 359, singleMinusOneDecisions: 7, snapshotDecisions: 366,
     liveDecisions: 130, unsupported: 0, rewriteOperations: 0,
+    topology11Snapshots: 11, topology7Snapshots: 7,
     topology11WindowlessDecisions: 226, topology7WindowlessDecisions: 133,
     topology7SingleMinusOneDecisions: 7,
   }
@@ -301,6 +309,8 @@ describe('isExpectedBoundaryShape', () => {
     expect(isExpectedBoundaryShape({ ...base, fingerprint: 'zz' })).toBe(false)
     expect(isExpectedBoundaryShape({ ...base, baselineStateHash: 'Z'.repeat(64) })).toBe(false)
     expect(isExpectedBoundaryShape({ ...base, quarantinedEntries: 574.5 })).toBe(false)
+    expect(isExpectedBoundaryShape({ ...base, topology11Snapshots: 11.5 })).toBe(false)
+    expect(isExpectedBoundaryShape({ ...base, topology7Snapshots: -1 })).toBe(false)
     const missing = { ...base }
     delete (missing as Partial<SnapshotEvidenceExpected>).fingerprint
     expect(isExpectedBoundaryShape(missing)).toBe(false)
@@ -440,6 +450,40 @@ describe('buildSnapshotEvidenceReport — composite fixture', () => {
     expect(markdown).toContain('This report is evidence only.')
   })
 
+  it('Markdown carries every required Issue #432/#430 evidence category', () => {
+    const report = buildReport(state, COMPOSITE_COUNTS)
+    const markdown = renderSnapshotEvidenceMarkdown(report)
+    // Topology snapshot and decision counts for both subgroups.
+    expect(markdown).toContain('11-snapshot subgroup: 1 snapshots, 20 windowless decisions')
+    expect(markdown).toContain('7-snapshot subgroup: 1 snapshots, 19 windowless + 1 single-(-1) = 20 total decisions')
+    // S records: entry errors AND structural errors, modes, percentages, defect class.
+    const sRow = markdown.split('\n').find(line => line.startsWith('S1 |'))!
+    expect(sRow).toContain('negative-one-window-value')
+    expect(sRow).toContain('profile-window')
+    expect(sRow).toContain('CAPACITY_PLAN')
+    expect(sRow).toContain('hundred')
+    expect(sRow).toContain('both')
+    // M records: other decision reasons column plus entry/structural categories.
+    expect(markdown).toContain('Other decision reasons')
+    const elevenRow = markdown.split('\n').find(line => line.includes('eleven-windowless-only'))!
+    expect(elevenRow).toContain('alias-conflict:1')
+    // Class A percentage evidence for every category (resourceType/explicit/inherited/other/unavailable).
+    expect(markdown).toContain('### Class A percentage evidence (by owner kind / mode source)')
+    expect(markdown).toContain('| Category | allocationPercent buckets | allocationPct buckets |')
+    const resourceTypeRow = markdown.split('\n').find(line => line.startsWith('resourceType |'))!
+    expect(resourceTypeRow).toContain('hundred:2')
+    const inheritedRow = markdown.split('\n').find(line => line.startsWith('inherited |'))!
+    expect(inheritedRow).toContain('hundred:1')
+    expect(markdown).toContain('explicit |')
+    expect(markdown).toContain('other |')
+    expect(markdown).toContain('unavailable |')
+    // JSON carries the same categories (parity over the same evidence object).
+    const json = JSON.stringify(report)
+    expect(json).toContain('profile-window')
+    expect(json).toContain('alias-conflict')
+    expect(json).toContain('percentageByCategory')
+  })
+
   it('fails closed on fingerprint mismatch without policy involvement', () => {
     const counts = { ...COMPOSITE_COUNTS }
     const plan = buildRemediationPlan(state, 'test-commit')
@@ -525,6 +569,7 @@ describe('all four raw -1 orientations', () => {
         quarantinedEntries: 0, quarantinedSnapshots: 0, defectSnapshots: 1,
         windowlessDecisions: 0, singleMinusOneDecisions: 1, snapshotDecisions: 1,
         liveDecisions: 0, unsupported: 0, rewriteOperations: 0,
+        topology11Snapshots: 0, topology7Snapshots: 1,
         topology11WindowlessDecisions: 0, topology7WindowlessDecisions: 0,
         topology7SingleMinusOneDecisions: 1,
       }
@@ -555,6 +600,7 @@ describe('all four raw -1 orientations', () => {
       quarantinedEntries: 0, quarantinedSnapshots: 0, defectSnapshots: 1,
       windowlessDecisions: 1, singleMinusOneDecisions: 0, snapshotDecisions: 1,
       liveDecisions: 0, unsupported: 0, rewriteOperations: 0,
+      topology11Snapshots: 1, topology7Snapshots: 0,
       topology11WindowlessDecisions: 1, topology7WindowlessDecisions: 0,
       topology7SingleMinusOneDecisions: 0,
     }
@@ -566,8 +612,225 @@ describe('all four raw -1 orientations', () => {
   })
 })
 
-describe('structural defect classification', () => {
-  it('classifies a duplicate-owner structural defect as structural', () => {
+describe('sanitizeMode', () => {
+  it('passes known modes, nulls absent values, maps unknown strings to other', () => {
+    expect(sanitizeMode('TIMELINE')).toBe('TIMELINE')
+    expect(sanitizeMode('CAPACITY_PLAN')).toBe('CAPACITY_PLAN')
+    expect(sanitizeMode('EFFORT')).toBe('EFFORT')
+    expect(sanitizeMode('FULL_PROJECT')).toBe('FULL_PROJECT')
+    expect(sanitizeMode(null)).toBe(null)
+    expect(sanitizeMode(undefined)).toBe(null)
+    expect(sanitizeMode('TOTALLY-BOGUS-MODE-SECRET-1')).toBe('other')
+    expect(sanitizeMode('')).toBe('other')
+  })
+})
+
+describe('subgroup snapshot-count gating', () => {
+  function subgroupMismatchState(): RemediationDatabaseState {
+    // 10 eleven-subgroup snapshots (1 windowless RT + 1 alias-conflict NR
+    // each) + 8 seven-subgroup snapshots (1 windowless RT + 1 single-`-1`
+    // NR each) = 18 defect snapshots.
+    const snapshots: StateSnapshot[] = []
+    for (let i = 0; i < 10; i++) {
+      snapshots.push({
+        id: `snap-eleven-${i}`,
+        projectId: PROJECT_ID,
+        payload: makeV2Snapshot(
+          [makeRt({ id: `rt-e-${i}`, allocationMode: 'CAPACITY_PLAN' })],
+          [makeNr({
+            id: `nr-e-${i}`,
+            resourceTypeId: `rt-e-${i}`,
+            allocationMode: null,
+            allocationStartWeek: 5,
+            allocationEndWeek: 10,
+            startWeek: 5,
+            endWeek: 9,
+          })],
+        ),
+      })
+    }
+    for (let i = 0; i < 8; i++) {
+      snapshots.push({
+        id: `snap-seven-${i}`,
+        projectId: PROJECT_ID,
+        payload: makeV2Snapshot(
+          [makeRt({ id: `rt-s-${i}`, allocationMode: 'CAPACITY_PLAN' })],
+          [makeNr({
+            id: `nr-s-${i}`,
+            resourceTypeId: `rt-s-${i}`,
+            allocationMode: 'CAPACITY_PLAN',
+            allocationStartWeek: -1,
+            allocationEndWeek: 5,
+            startWeek: 5,
+            endWeek: null,
+          })],
+        ),
+      })
+    }
+    return makeState(snapshots)
+  }
+  const SUBGROUP_COUNTS: Omit<SnapshotEvidenceExpected, 'fingerprint' | 'baselineStateHash'> = {
+    quarantinedEntries: 0, quarantinedSnapshots: 0, defectSnapshots: 18,
+    windowlessDecisions: 18, singleMinusOneDecisions: 8, snapshotDecisions: 26,
+    liveDecisions: 0, unsupported: 0, rewriteOperations: 0,
+    topology11Snapshots: 10, topology7Snapshots: 8,
+    topology11WindowlessDecisions: 10, topology7WindowlessDecisions: 8,
+    topology7SingleMinusOneDecisions: 8,
+  }
+
+  it('accepts matching subgroup snapshot counts', () => {
+    const report = buildReport(subgroupMismatchState(), SUBGROUP_COUNTS)
+    expect(report.integrityResult.reconciliationPassed).toBe(true)
+    expect(report.topology.elevenSnapshotSubgroup.snapshots).toBe(10)
+    expect(report.topology.sevenSnapshotSubgroup.snapshots).toBe(8)
+  })
+
+  it('refuses 10/8 observed subgroups against 11/7 expected snapshot counts even with matching decision totals', () => {
+    const report = buildReport(subgroupMismatchState(), {
+      ...SUBGROUP_COUNTS,
+      topology11Snapshots: 11,
+      topology7Snapshots: 7,
+    })
+    expect(report.integrityResult.reconciliationPassed).toBe(false)
+    expect(report.reconciliation.details.some(d => d.includes('topology 11 subgroup snapshots') && d.includes('MISMATCH'))).toBe(true)
+    expect(report.reconciliation.details.some(d => d.includes('topology 7 subgroup snapshots') && d.includes('MISMATCH'))).toBe(true)
+  })
+
+  it('refuses an expected subgroup snapshot sum inconsistent with defectSnapshots', () => {
+    // Expected 10 + 9 = 19 while defectSnapshots = 18: refused even though
+    // the observed 10 + 8 = 18 is internally consistent.
+    const report = buildReport(subgroupMismatchState(), {
+      ...SUBGROUP_COUNTS,
+      topology11Snapshots: 10,
+      topology7Snapshots: 9,
+    })
+    expect(report.integrityResult.reconciliationPassed).toBe(false)
+    expect(report.reconciliation.details.some(d => d.includes('expected subgroup snapshot sum = expected defect snapshots') && d.includes('MISMATCH'))).toBe(true)
+  })
+})
+
+describe('mode redaction', () => {
+  it('never emits arbitrary historical mode strings in JSON or Markdown', () => {
+    const BOGUS_NR = 'TOTALLY-BOGUS-MODE-SECRET-1'
+    const BOGUS_PARENT = 'BOGUS-PARENT-SECRET-2'
+    const state = makeState([{
+      id: 'snap-bogus',
+      projectId: PROJECT_ID,
+      payload: makeV2Snapshot(
+        [makeRt({ id: 'rt-1', allocationMode: BOGUS_PARENT })],
+        [makeNr({ id: 'nr-1', resourceTypeId: 'rt-1', allocationMode: BOGUS_NR, startWeek: 0, endWeek: 5, allocationStartWeek: 0, allocationEndWeek: 5 })],
+      ),
+    }])
+    const counts: Omit<SnapshotEvidenceExpected, 'fingerprint' | 'baselineStateHash'> = {
+      quarantinedEntries: 0, quarantinedSnapshots: 0, defectSnapshots: 1,
+      windowlessDecisions: 0, singleMinusOneDecisions: 0, snapshotDecisions: 0,
+      liveDecisions: 0, unsupported: 2, rewriteOperations: 0,
+      topology11Snapshots: 1, topology7Snapshots: 0,
+      topology11WindowlessDecisions: 0, topology7WindowlessDecisions: 0,
+      topology7SingleMinusOneDecisions: 0,
+    }
+    const report = buildReport(state, counts)
+    expect(report.integrityResult.reconciliationPassed).toBe(true)
+    expect(report.defectSnapshots[0]!.unsupportedCount).toBe(2)
+    expect(report.defectSnapshots[0]!.entryErrorCategories['unknown-mode']).toBe(2)
+    const json = JSON.stringify(report)
+    const markdown = renderSnapshotEvidenceMarkdown(report)
+    expect(json).not.toContain(BOGUS_NR)
+    expect(json).not.toContain(BOGUS_PARENT)
+    expect(markdown).not.toContain(BOGUS_NR)
+    expect(markdown).not.toContain(BOGUS_PARENT)
+  })
+
+  it('sanitizes the S record parent mode (bogus parent string becomes other)', () => {
+    const BOGUS_PARENT = 'BOGUS-PARENT-SECRET-2'
+    const state = makeState([{
+      id: 'snap-p',
+      projectId: PROJECT_ID,
+      payload: makeV2Snapshot(
+        [makeRt({ id: 'rt-1', allocationMode: BOGUS_PARENT })],
+        [makeNr({ id: 'nr-1', resourceTypeId: 'rt-1', allocationMode: 'CAPACITY_PLAN', allocationStartWeek: -1, allocationEndWeek: 5, startWeek: 5, endWeek: null })],
+      ),
+    }])
+    const counts: Omit<SnapshotEvidenceExpected, 'fingerprint' | 'baselineStateHash'> = {
+      quarantinedEntries: 0, quarantinedSnapshots: 0, defectSnapshots: 1,
+      windowlessDecisions: 0, singleMinusOneDecisions: 1, snapshotDecisions: 1,
+      liveDecisions: 0, unsupported: 1, rewriteOperations: 0,
+      topology11Snapshots: 0, topology7Snapshots: 1,
+      topology11WindowlessDecisions: 0, topology7WindowlessDecisions: 0,
+      topology7SingleMinusOneDecisions: 1,
+    }
+    const report = buildReport(state, counts)
+    expect(report.integrityResult.reconciliationPassed).toBe(true)
+    const s = report.singleNegativeEntries[0]!
+    expect(s.parentMode).toBe('other')
+    expect(s.effectiveMode).toBe('CAPACITY_PLAN')
+    expect(JSON.stringify(report)).not.toContain(BOGUS_PARENT)
+  })
+})
+
+describe('publishEvidenceOutputs', () => {
+  it('publishes both files with mode 0600 and leaves no temporaries', () => {
+    const dir = mkdtempSync(path.join(os.tmpdir(), 'evidence-pub-'))
+    try {
+      const json = path.join(dir, 'out.json')
+      const md = path.join(dir, 'out.md')
+      publishEvidenceOutputs(json, md, '{"a":1}', '# markdown')
+      expect(readFileSync(json, 'utf8')).toBe('{"a":1}')
+      expect(readFileSync(md, 'utf8')).toBe('# markdown')
+      if (process.platform !== 'win32') {
+        expect(statSync(json).mode & 0o777).toBe(0o600)
+        expect(statSync(md).mode & 0o777).toBe(0o600)
+      }
+      expect(readdirSync(dir).sort()).toEqual(['out.json', 'out.md'])
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('failure while staging the second output leaves neither final output and no temporaries', () => {
+    const dir = mkdtempSync(path.join(os.tmpdir(), 'evidence-pub-'))
+    try {
+      const json = path.join(dir, 'out.json')
+      const md = path.join(dir, 'out.md')
+      expect(() => publishEvidenceOutputs(json, md, 'json', 'md', {
+        failOn: phase => { if (phase === 'stage-markdown') throw new Error('injected staging failure') },
+      })).toThrow('injected staging failure')
+      expect(readdirSync(dir)).toEqual([])
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('failure while publishing the first output removes it and all temporaries', () => {
+    const dir = mkdtempSync(path.join(os.tmpdir(), 'evidence-pub-'))
+    try {
+      const json = path.join(dir, 'out.json')
+      const md = path.join(dir, 'out.md')
+      expect(() => publishEvidenceOutputs(json, md, 'json', 'md', {
+        failOn: phase => { if (phase === 'publish-json') throw new Error('injected publish failure') },
+      })).toThrow('injected publish failure')
+      expect(readdirSync(dir)).toEqual([])
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('failure while publishing the second output cleans up the first final output and all temporaries', () => {
+    const dir = mkdtempSync(path.join(os.tmpdir(), 'evidence-pub-'))
+    try {
+      const json = path.join(dir, 'out.json')
+      const md = path.join(dir, 'out.md')
+      expect(() => publishEvidenceOutputs(json, md, 'json', 'md', {
+        failOn: phase => { if (phase === 'publish-markdown') throw new Error('injected second publish failure') },
+      })).toThrow('injected second publish failure')
+      expect(readdirSync(dir)).toEqual([])
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+})
+
+describe('structural defect classification', () => {  it('classifies a duplicate-owner structural defect as structural', () => {
     const state = makeState([{
       id: 'snap-dup',
       projectId: PROJECT_ID,
@@ -583,6 +846,7 @@ describe('structural defect classification', () => {
       quarantinedEntries: 0, quarantinedSnapshots: 0, defectSnapshots: 1,
       windowlessDecisions: 0, singleMinusOneDecisions: 0, snapshotDecisions: 0,
       liveDecisions: 0, unsupported: 0, rewriteOperations: 0,
+      topology11Snapshots: 1, topology7Snapshots: 0,
       topology11WindowlessDecisions: 0, topology7WindowlessDecisions: 0,
       topology7SingleMinusOneDecisions: 0,
     }

--- a/server/src/test/snapshotEvidence.test.ts
+++ b/server/src/test/snapshotEvidence.test.ts
@@ -855,7 +855,9 @@ describe('Class A affected-snapshot aggregates', () => {
     const report = buildReport(state, countsFor(1, 1))
     expect(report.integrityResult.reconciliationPassed).toBe(true)
     expect(report.classAAggregates.affectedSnapshotsByOwnerKind).toEqual({ resourceType: 1, namedResource: 0, unavailable: 0 })
-    expect(report.classAAggregates.affectedSnapshotsByNamedModeSource).toEqual({ explicit: 0, inherited: 0, other: 0, unavailable: 1 })
+    // ResourceType-only snapshots contribute zero to every NamedResource
+    // mode-source category.
+    expect(report.classAAggregates.affectedSnapshotsByNamedModeSource).toEqual({ explicit: 0, inherited: 0, other: 0, unavailable: 0 })
     expect(report.classAAggregates.snapshotsByOwnerKindMix).toEqual({ resourceTypeOnly: 1, namedResourceOnly: 0, mixed: 0 })
   })
 
@@ -880,7 +882,9 @@ describe('Class A affected-snapshot aggregates', () => {
     const report = buildReport(state, countsFor(2, 1))
     expect(report.integrityResult.reconciliationPassed).toBe(true)
     expect(report.classAAggregates.affectedSnapshotsByOwnerKind).toEqual({ resourceType: 1, namedResource: 1, unavailable: 0 })
-    expect(report.classAAggregates.affectedSnapshotsByNamedModeSource).toEqual({ explicit: 1, inherited: 0, other: 0, unavailable: 1 })
+    // The ResourceType entry contributes no mode-source category: only the
+    // explicit NamedResource entry does.
+    expect(report.classAAggregates.affectedSnapshotsByNamedModeSource).toEqual({ explicit: 1, inherited: 0, other: 0, unavailable: 0 })
     expect(report.classAAggregates.snapshotsByOwnerKindMix).toEqual({ resourceTypeOnly: 0, namedResourceOnly: 0, mixed: 1 })
   })
 
@@ -901,10 +905,30 @@ describe('Class A affected-snapshot aggregates', () => {
     }])
     const report = buildReport(state, countsFor(3, 1))
     expect(report.integrityResult.reconciliationPassed).toBe(true)
-    // byNamedModeSource counts NamedResource entries only (the ResourceType
-    // entry's unavailable mode source surfaces in the snapshot aggregate).
+    // byNamedModeSource counts NamedResource entries only; the ResourceType
+    // entry contributes no mode-source category to either aggregate.
     expect(report.classAAggregates.byNamedModeSource).toEqual({ explicit: 1, inherited: 1, other: 0, unavailable: 0 })
-    expect(report.classAAggregates.affectedSnapshotsByNamedModeSource).toEqual({ explicit: 1, inherited: 1, other: 0, unavailable: 1 })
+    expect(report.classAAggregates.affectedSnapshotsByNamedModeSource).toEqual({ explicit: 1, inherited: 1, other: 0, unavailable: 0 })
+  })
+
+  it('counts a snapshot with genuine unavailable NamedResource provenance correctly (never Class A)', () => {
+    // Shared predicate boundary: a NamedResource whose mode provenance is
+    // genuinely unavailable (no explicit mode, no CAPACITY_PLAN parent)
+    // resolves to a null effective mode and is therefore NOT Class A, so it
+    // cannot contribute to the unavailable mode-source category. The
+    // category is provably fed only by Class A NamedResource entries.
+    const state = makeState([{
+      id: 'snap-unavailable-provenance',
+      projectId: PROJECT_ID,
+      payload: makeV2Snapshot(
+        [makeRt({ id: 'rt-u', allocationMode: null, allocationPercent: 100, allocationStartWeek: null, allocationEndWeek: null })],
+        [makeNr({ id: 'nr-u', resourceTypeId: 'rt-u', allocationMode: null, allocationPercent: 100, allocationPct: 100, allocationStartWeek: null, allocationEndWeek: null, startWeek: null, endWeek: null })],
+      ),
+    }])
+    const report = buildReport(state, countsFor(0, 0))
+    expect(report.integrityResult.reconciliationPassed).toBe(true)
+    expect(report.classAAggregates.totalEntries).toBe(0)
+    expect(report.classAAggregates.affectedSnapshotsByNamedModeSource).toEqual({ explicit: 0, inherited: 0, other: 0, unavailable: 0 })
   })
 
   it('counts repeated Class A entries in one category as a single affected snapshot', () => {
@@ -923,7 +947,7 @@ describe('Class A affected-snapshot aggregates', () => {
     expect(report.integrityResult.reconciliationPassed).toBe(true)
     expect(report.classAAggregates.totalEntries).toBe(2)
     expect(report.classAAggregates.affectedSnapshotsByOwnerKind.resourceType).toBe(1)
-    expect(report.classAAggregates.affectedSnapshotsByNamedModeSource.unavailable).toBe(1)
+    expect(report.classAAggregates.affectedSnapshotsByNamedModeSource).toEqual({ explicit: 0, inherited: 0, other: 0, unavailable: 0 })
   })
 
   it('renders both aggregates in JSON and Markdown in parity', () => {
@@ -936,7 +960,7 @@ describe('Class A affected-snapshot aggregates', () => {
     const markdown = renderSnapshotEvidenceMarkdown(report)
     expect(json).toContain('"affectedSnapshotsByOwnerKind":{"resourceType":1,"namedResource":1,"unavailable":0}')
     expect(markdown).toContain('affectedSnapshotsByOwnerKind: {"resourceType":1,"namedResource":1,"unavailable":0}')
-    expect(markdown).toContain('affectedSnapshotsByNamedModeSource: {"explicit":1,"inherited":0,"other":0,"unavailable":1}')
+    expect(markdown).toContain('affectedSnapshotsByNamedModeSource: {"explicit":1,"inherited":0,"other":0,"unavailable":0}')
   })
 })
 

--- a/server/src/test/snapshotEvidence.test.ts
+++ b/server/src/test/snapshotEvidence.test.ts
@@ -10,11 +10,12 @@
  * errors, and expectation/mismatch handling.
  */
 
-import { describe, it, expect } from 'vitest'
-import { mkdtempSync, readdirSync, readFileSync, rmSync, statSync } from 'node:fs'
+import { describe, it, expect, vi } from 'vitest'
+import { mkdtempSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 
+import { main } from '../scripts/generateSnapshotEvidence.js'
 import {
   buildSnapshotEvidenceReport,
   classifySnapshotEvidence,
@@ -26,7 +27,7 @@ import {
   SnapshotEvidenceError,
   type SnapshotEvidenceExpected,
 } from '../lib/snapshotEvidence.js'
-import { publishEvidenceOutputs } from '../scripts/generateSnapshotEvidence.js'
+import { publishEvidenceOutputs } from '../lib/evidenceOutputPublication.js'
 import {
   buildRemediationPlan,
   computePlanFingerprint,
@@ -456,11 +457,22 @@ describe('buildSnapshotEvidenceReport — composite fixture', () => {
     // Topology snapshot and decision counts for both subgroups.
     expect(markdown).toContain('11-snapshot subgroup: 1 snapshots, 20 windowless decisions')
     expect(markdown).toContain('7-snapshot subgroup: 1 snapshots, 19 windowless + 1 single-(-1) = 20 total decisions')
-    // S records: entry errors AND structural errors, modes, percentages, defect class.
+    // S records: entry errors AND structural errors, modes, percentages, defect class,
+    // sanitized window-field states and per-edge conflict evidence.
     const sRow = markdown.split('\n').find(line => line.startsWith('S1 |'))!
     expect(sRow).toContain('negative-one-window-value')
     expect(sRow).toContain('profile-window')
     expect(sRow).toContain('CAPACITY_PLAN')
+    expect(sRow).toContain('allocationStartWeek:minus-one')
+    expect(sRow).toContain('allocationEndWeek:populated')
+    expect(sRow).toContain('startWeek:populated')
+    expect(sRow).toContain('endWeek:absent-null')
+    expect(sRow).toContain('| yes | no |')
+    expect(markdown).toContain('## Single-negative decision entries')
+    expect(markdown).not.toContain('Single -1 + null')
+    // Class A affected-snapshot aggregates render in Markdown.
+    expect(markdown).toContain('affectedSnapshotsByOwnerKind:')
+    expect(markdown).toContain('affectedSnapshotsByNamedModeSource:')
     expect(sRow).toContain('hundred')
     expect(sRow).toContain('both')
     // M records: other decision reasons column plus entry/structural categories.
@@ -480,6 +492,10 @@ describe('buildSnapshotEvidenceReport — composite fixture', () => {
     // JSON carries the same categories (parity over the same evidence object).
     const json = JSON.stringify(report)
     expect(json).toContain('profile-window')
+    expect(json).toContain('"windowFields"')
+    expect(json).toContain('"aliasConflicts"')
+    expect(json).toContain('"affectedSnapshotsByOwnerKind"')
+    expect(json).toContain('"affectedSnapshotsByNamedModeSource"')
     expect(json).toContain('alias-conflict')
     expect(json).toContain('percentageByCategory')
   })
@@ -527,35 +543,55 @@ describe('buildSnapshotEvidenceReport — composite fixture', () => {
 })
 
 describe('all four raw -1 orientations', () => {
-  const orientationCases: Array<{ name: string; nr: ReturnType<typeof makeNr>; field: string; aliasState: string }> = [
+  const orientationCases: Array<{
+    name: string
+    nr: ReturnType<typeof makeNr>
+    field: string
+    aliasState: string
+    startEdge: boolean
+    endEdge: boolean
+    windowFields: Record<string, string>
+  }> = [
     {
       name: 'startWeek',
       nr: makeNr({ resourceTypeId: 'rt-o', allocationMode: 'CAPACITY_PLAN', allocationStartWeek: null, startWeek: -1, allocationEndWeek: 4, endWeek: 5 }),
       field: 'startWeek',
       aliasState: 'conflicting',
+      startEdge: false,
+      endEdge: true,
+      windowFields: { allocationStartWeek: 'absent-null', allocationEndWeek: 'populated', startWeek: 'minus-one', endWeek: 'populated' },
     },
     {
       name: 'endWeek',
       nr: makeNr({ resourceTypeId: 'rt-o', allocationMode: 'CAPACITY_PLAN', allocationStartWeek: 4, startWeek: 5, allocationEndWeek: null, endWeek: -1 }),
       field: 'endWeek',
       aliasState: 'conflicting',
+      startEdge: true,
+      endEdge: false,
+      windowFields: { allocationStartWeek: 'populated', allocationEndWeek: 'absent-null', startWeek: 'populated', endWeek: 'minus-one' },
     },
     {
       name: 'allocationStartWeek',
       nr: makeNr({ resourceTypeId: 'rt-o', allocationMode: 'CAPACITY_PLAN', allocationStartWeek: -1, startWeek: 5, allocationEndWeek: 5, endWeek: null }),
       field: 'allocationStartWeek',
       aliasState: 'conflicting',
+      startEdge: true,
+      endEdge: false,
+      windowFields: { allocationStartWeek: 'minus-one', allocationEndWeek: 'populated', startWeek: 'populated', endWeek: 'absent-null' },
     },
     {
       name: 'allocationEndWeek',
       nr: makeNr({ resourceTypeId: 'rt-o', allocationMode: 'CAPACITY_PLAN', allocationStartWeek: 5, startWeek: null, allocationEndWeek: -1, endWeek: 5 }),
       field: 'allocationEndWeek',
       aliasState: 'conflicting',
+      startEdge: false,
+      endEdge: true,
+      windowFields: { allocationStartWeek: 'populated', allocationEndWeek: 'minus-one', startWeek: 'absent-null', endWeek: 'populated' },
     },
   ]
 
-  for (const { name, nr, field, aliasState } of orientationCases) {
-    it(`reports the -1 field for orientation ${name}`, () => {
+  for (const { name, nr, field, aliasState, startEdge, endEdge, windowFields } of orientationCases) {
+    it(`reports the -1 field, all four field states and per-edge conflicts for orientation ${name}`, () => {
       const state = makeState([{
         id: `snap-${name}`,
         projectId: PROJECT_ID,
@@ -578,10 +614,78 @@ describe('all four raw -1 orientations', () => {
       expect(report.singleNegativeEntries).toHaveLength(1)
       const s = report.singleNegativeEntries[0]!
       expect(s.minusOneField).toBe(field)
+      expect(s.windowFields).toEqual(windowFields)
+      expect(s.aliasConflicts).toEqual({ startEdge, endEdge })
       expect(s.alternateAliasState).toBe(aliasState)
       expect(s.modeSource).toBe('explicit')
+      // The sanitized field-state object never carries raw numeric values.
+      expect(JSON.stringify(s.windowFields)).not.toMatch(/\d/)
+      expect(JSON.stringify(s.windowFields)).not.toContain('-1')
     })
   }
+
+  it('reports a clean single -1 shape as Class B quarantine, not an S record (no conflicts to report)', () => {
+    // Classifier boundary: a single -1 with no populated alias on the -1 edge
+    // and agreeing/absent aliases on the other edge matches the shared Class B
+    // quarantine predicate, so the plan makes no single-negative decision and
+    // the evidence command reports no S record and no alias conflicts.
+    const state = makeState([{
+      id: 'snap-class-b',
+      projectId: PROJECT_ID,
+      payload: makeV2Snapshot(
+        [makeRt({ id: 'rt-o', allocationMode: 'TIMELINE', allocationStartWeek: 0, allocationEndWeek: 5 })],
+        [makeNr({ resourceTypeId: 'rt-o', allocationMode: 'CAPACITY_PLAN', allocationStartWeek: -1, startWeek: null, allocationEndWeek: 5, endWeek: null })],
+      ),
+    }])
+    const counts: Omit<SnapshotEvidenceExpected, 'fingerprint' | 'baselineStateHash'> = {
+      quarantinedEntries: 1, quarantinedSnapshots: 1, defectSnapshots: 0,
+      windowlessDecisions: 0, singleMinusOneDecisions: 0, snapshotDecisions: 0,
+      liveDecisions: 0, unsupported: 0, rewriteOperations: 0,
+      topology11Snapshots: 0, topology7Snapshots: 0,
+      topology11WindowlessDecisions: 0, topology7WindowlessDecisions: 0,
+      topology7SingleMinusOneDecisions: 0,
+    }
+    const report = buildReport(state, counts)
+    // No single-negative decision exists for a clean Class B shape: the
+    // evidence command reports no S record. The quarantined Class B entry is
+    // outside the reviewed Class A invariant, so the run refuses (fail
+    // closed) exactly as the production command would.
+    expect(report.singleNegativeEntries).toHaveLength(0)
+    expect(report.integrityResult.reconciliationPassed).toBe(false)
+    const mismatches = report.reconciliation.details.filter(detail => detail.includes('MISMATCH'))
+    expect(mismatches.map(m => m.split(':')[0])).toEqual(['class A entries reconcile', 'class A snapshots reconcile'])
+  })
+
+  it('distinguishes a start-edge conflict from an end-edge conflict', () => {
+    const state = makeState([{
+      id: 'snap-edge-conflicts',
+      projectId: PROJECT_ID,
+      payload: makeV2Snapshot(
+        [makeRt({ id: 'rt-o', allocationMode: 'TIMELINE', allocationStartWeek: 0, allocationEndWeek: 5 })],
+        [
+          // Start edge: primary -1 vs populated fallback 7 → start conflict.
+          makeNr({ resourceTypeId: 'rt-o', allocationMode: 'CAPACITY_PLAN', allocationStartWeek: -1, startWeek: 7, allocationEndWeek: 5, endWeek: null }),
+          // End edge: populated primary 5 vs fallback 9 → end conflict.
+          makeNr({ resourceTypeId: 'rt-o', allocationMode: 'CAPACITY_PLAN', allocationStartWeek: -1, startWeek: null, allocationEndWeek: 5, endWeek: 9 }),
+        ],
+      ),
+    }])
+    const counts: Omit<SnapshotEvidenceExpected, 'fingerprint' | 'baselineStateHash'> = {
+      quarantinedEntries: 0, quarantinedSnapshots: 0, defectSnapshots: 1,
+      windowlessDecisions: 0, singleMinusOneDecisions: 2, snapshotDecisions: 2,
+      liveDecisions: 0, unsupported: 0, rewriteOperations: 0,
+      topology11Snapshots: 0, topology7Snapshots: 1,
+      topology11WindowlessDecisions: 0, topology7WindowlessDecisions: 0,
+      topology7SingleMinusOneDecisions: 2,
+    }
+    const report = buildReport(state, counts)
+    expect(report.integrityResult.reconciliationPassed).toBe(true)
+    expect(report.singleNegativeEntries).toHaveLength(2)
+    const startConflict = report.singleNegativeEntries.find(s => s.windowFields.startWeek === 'populated')!
+    const endConflict = report.singleNegativeEntries.find(s => s.windowFields.endWeek === 'populated')!
+    expect(startConflict.aliasConflicts).toEqual({ startEdge: true, endEdge: false })
+    expect(endConflict.aliasConflicts).toEqual({ startEdge: false, endEdge: true })
+  })
 
   it('a clean -1+null shape is a windowless decision, not a single-negative decision', () => {
     // Empirical contract: the plan-level classifier checks the null edge
@@ -709,6 +813,133 @@ describe('subgroup snapshot-count gating', () => {
   })
 })
 
+describe('Class A affected-snapshot aggregates', () => {
+  /** One Class A RT entry per snapshot with the given windows. */
+  function rtOnlySnapshot(id: string, windowStart: number | null = null): StateSnapshot {
+    return {
+      id,
+      projectId: PROJECT_ID,
+      payload: makeV2Snapshot(
+        [makeRt({ id: `rt-${id}`, allocationMode: 'CAPACITY_PLAN', allocationPercent: 100, allocationStartWeek: windowStart, allocationEndWeek: null })],
+        [],
+      ),
+    }
+  }
+
+  /** One Class A NR entry (explicit CAPACITY_PLAN) with the given windows. */
+  function nrOnlySnapshot(id: string): StateSnapshot {
+    return {
+      id,
+      projectId: PROJECT_ID,
+      payload: makeV2Snapshot(
+        // Restorable windowed parent (not itself Class A).
+        [makeRt({ id: `rt-${id}`, allocationMode: 'TIMELINE', allocationPercent: 100, allocationStartWeek: 0, allocationEndWeek: 5 })],
+        [makeNr({ id: `nr-${id}`, resourceTypeId: `rt-${id}`, allocationMode: 'CAPACITY_PLAN', allocationPercent: 100, allocationPct: 100, allocationStartWeek: null, allocationEndWeek: null, startWeek: null, endWeek: null })],
+      ),
+    }
+  }
+
+  function countsFor(quarantinedEntries: number, quarantinedSnapshots: number): Omit<SnapshotEvidenceExpected, 'fingerprint' | 'baselineStateHash'> {
+    return {
+      quarantinedEntries, quarantinedSnapshots, defectSnapshots: 0,
+      windowlessDecisions: 0, singleMinusOneDecisions: 0, snapshotDecisions: 0,
+      liveDecisions: 0, unsupported: 0, rewriteOperations: 0,
+      topology11Snapshots: 0, topology7Snapshots: 0,
+      topology11WindowlessDecisions: 0, topology7WindowlessDecisions: 0,
+      topology7SingleMinusOneDecisions: 0,
+    }
+  }
+
+  it('counts a ResourceType-only Class A snapshot under resourceType and unavailable mode source', () => {
+    const state = makeState([rtOnlySnapshot('rt-a')])
+    const report = buildReport(state, countsFor(1, 1))
+    expect(report.integrityResult.reconciliationPassed).toBe(true)
+    expect(report.classAAggregates.affectedSnapshotsByOwnerKind).toEqual({ resourceType: 1, namedResource: 0, unavailable: 0 })
+    expect(report.classAAggregates.affectedSnapshotsByNamedModeSource).toEqual({ explicit: 0, inherited: 0, other: 0, unavailable: 1 })
+    expect(report.classAAggregates.snapshotsByOwnerKindMix).toEqual({ resourceTypeOnly: 1, namedResourceOnly: 0, mixed: 0 })
+  })
+
+  it('counts a NamedResource-only Class A snapshot under namedResource and explicit mode source', () => {
+    const state = makeState([nrOnlySnapshot('nr-a')])
+    const report = buildReport(state, countsFor(1, 1))
+    expect(report.integrityResult.reconciliationPassed).toBe(true)
+    expect(report.classAAggregates.affectedSnapshotsByOwnerKind).toEqual({ resourceType: 0, namedResource: 1, unavailable: 0 })
+    expect(report.classAAggregates.affectedSnapshotsByNamedModeSource).toEqual({ explicit: 1, inherited: 0, other: 0, unavailable: 0 })
+    expect(report.classAAggregates.snapshotsByOwnerKindMix).toEqual({ resourceTypeOnly: 0, namedResourceOnly: 1, mixed: 0 })
+  })
+
+  it('counts a mixed ResourceType/NamedResource snapshot once in both owner-kind categories', () => {
+    const state = makeState([{
+      id: 'snap-mixed',
+      projectId: PROJECT_ID,
+      payload: makeV2Snapshot(
+        [makeRt({ id: 'rt-mix', allocationMode: 'CAPACITY_PLAN', allocationPercent: 100, allocationStartWeek: null, allocationEndWeek: null })],
+        [makeNr({ id: 'nr-mix', resourceTypeId: 'rt-mix', allocationMode: 'CAPACITY_PLAN', allocationPercent: 100, allocationPct: 100, allocationStartWeek: null, allocationEndWeek: null, startWeek: null, endWeek: null })],
+      ),
+    }])
+    const report = buildReport(state, countsFor(2, 1))
+    expect(report.integrityResult.reconciliationPassed).toBe(true)
+    expect(report.classAAggregates.affectedSnapshotsByOwnerKind).toEqual({ resourceType: 1, namedResource: 1, unavailable: 0 })
+    expect(report.classAAggregates.affectedSnapshotsByNamedModeSource).toEqual({ explicit: 1, inherited: 0, other: 0, unavailable: 1 })
+    expect(report.classAAggregates.snapshotsByOwnerKindMix).toEqual({ resourceTypeOnly: 0, namedResourceOnly: 0, mixed: 1 })
+  })
+
+  it('counts a snapshot containing explicit and inherited NamedResource Class A entries once in both mode-source categories', () => {
+    const state = makeState([{
+      id: 'snap-both-modes',
+      projectId: PROJECT_ID,
+      payload: makeV2Snapshot(
+        // CAPACITY_PLAN parent with absent windows: itself Class A (its
+        // unavailable mode-source category) and the source of the inherited
+        // mode for the raw-mode-null NamedResource.
+        [makeRt({ id: 'rt-both', allocationMode: 'CAPACITY_PLAN', allocationPercent: 100, allocationStartWeek: null, allocationEndWeek: null })],
+        [
+          makeNr({ id: 'nr-explicit', resourceTypeId: 'rt-both', allocationMode: 'CAPACITY_PLAN', allocationPercent: 100, allocationPct: 100, allocationStartWeek: null, allocationEndWeek: null, startWeek: null, endWeek: null }),
+          makeNr({ id: 'nr-inherited', resourceTypeId: 'rt-both', allocationMode: null, allocationPercent: 100, allocationPct: 100, allocationStartWeek: null, allocationEndWeek: null, startWeek: null, endWeek: null }),
+        ],
+      ),
+    }])
+    const report = buildReport(state, countsFor(3, 1))
+    expect(report.integrityResult.reconciliationPassed).toBe(true)
+    // byNamedModeSource counts NamedResource entries only (the ResourceType
+    // entry's unavailable mode source surfaces in the snapshot aggregate).
+    expect(report.classAAggregates.byNamedModeSource).toEqual({ explicit: 1, inherited: 1, other: 0, unavailable: 0 })
+    expect(report.classAAggregates.affectedSnapshotsByNamedModeSource).toEqual({ explicit: 1, inherited: 1, other: 0, unavailable: 1 })
+  })
+
+  it('counts repeated Class A entries in one category as a single affected snapshot', () => {
+    const state = makeState([{
+      id: 'snap-repeated',
+      projectId: PROJECT_ID,
+      payload: makeV2Snapshot(
+        [
+          makeRt({ id: 'rt-rep-1', allocationMode: 'CAPACITY_PLAN', allocationPercent: 100, allocationStartWeek: null, allocationEndWeek: null }),
+          makeRt({ id: 'rt-rep-2', allocationMode: 'CAPACITY_PLAN', allocationPercent: 80, allocationStartWeek: null, allocationEndWeek: null }),
+        ],
+        [],
+      ),
+    }])
+    const report = buildReport(state, countsFor(2, 1))
+    expect(report.integrityResult.reconciliationPassed).toBe(true)
+    expect(report.classAAggregates.totalEntries).toBe(2)
+    expect(report.classAAggregates.affectedSnapshotsByOwnerKind.resourceType).toBe(1)
+    expect(report.classAAggregates.affectedSnapshotsByNamedModeSource.unavailable).toBe(1)
+  })
+
+  it('renders both aggregates in JSON and Markdown in parity', () => {
+    const state = makeState([
+      rtOnlySnapshot('rt-parity'),
+      nrOnlySnapshot('nr-parity'),
+    ])
+    const report = buildReport(state, countsFor(2, 2))
+    const json = JSON.stringify(report)
+    const markdown = renderSnapshotEvidenceMarkdown(report)
+    expect(json).toContain('"affectedSnapshotsByOwnerKind":{"resourceType":1,"namedResource":1,"unavailable":0}')
+    expect(markdown).toContain('affectedSnapshotsByOwnerKind: {"resourceType":1,"namedResource":1,"unavailable":0}')
+    expect(markdown).toContain('affectedSnapshotsByNamedModeSource: {"explicit":1,"inherited":0,"other":0,"unavailable":1}')
+  })
+})
+
 describe('mode redaction', () => {
   it('never emits arbitrary historical mode strings in JSON or Markdown', () => {
     const BOGUS_NR = 'TOTALLY-BOGUS-MODE-SECRET-1'
@@ -824,6 +1055,132 @@ describe('publishEvidenceOutputs', () => {
         failOn: phase => { if (phase === 'publish-markdown') throw new Error('injected second publish failure') },
       })).toThrow('injected second publish failure')
       expect(readdirSync(dir)).toEqual([])
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('never overwrites a destination created after preflight (first destination race)', () => {
+    const dir = mkdtempSync(path.join(os.tmpdir(), 'evidence-pub-'))
+    try {
+      const json = path.join(dir, 'out.json')
+      const md = path.join(dir, 'out.md')
+      // Simulate another process creating the JSON destination between the
+      // CLI preflight and the final publication step.
+      writeFileSync(json, 'independently created')
+      expect(() => publishEvidenceOutputs(json, md, 'json', 'md')).toThrow(/EEXIST/)
+      // The independently created destination is preserved untouched.
+      expect(readFileSync(json, 'utf8')).toBe('independently created')
+      expect(readdirSync(dir).sort()).toEqual(['out.json'])
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('a second-destination no-clobber refusal removes the first final created by this run and preserves the independent file', () => {
+    const dir = mkdtempSync(path.join(os.tmpdir(), 'evidence-pub-'))
+    try {
+      const json = path.join(dir, 'out.json')
+      const md = path.join(dir, 'out.md')
+      writeFileSync(md, 'independent markdown')
+      expect(() => publishEvidenceOutputs(json, md, 'json', 'md')).toThrow(/EEXIST/)
+      // First final (json) published by this run was removed; the
+      // independently created markdown survives with its original content;
+      // no temporaries remain.
+      expect(readFileSync(md, 'utf8')).toBe('independent markdown')
+      expect(readdirSync(dir).sort()).toEqual(['out.md'])
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('successful publication still produces two distinct 0600 files with no temporaries', () => {
+    const dir = mkdtempSync(path.join(os.tmpdir(), 'evidence-pub-'))
+    try {
+      const json = path.join(dir, 'out.json')
+      const md = path.join(dir, 'out.md')
+      publishEvidenceOutputs(json, md, '{"a":1}', '# markdown')
+      expect(readFileSync(json, 'utf8')).toBe('{"a":1}')
+      expect(readFileSync(md, 'utf8')).toBe('# markdown')
+      if (process.platform !== 'win32') {
+        expect(statSync(json).mode & 0o777).toBe(0o600)
+        expect(statSync(md).mode & 0o777).toBe(0o600)
+      }
+      expect(readdirSync(dir).sort()).toEqual(['out.json', 'out.md'])
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+})
+
+describe('CLI output-path safety (before database access)', () => {
+  async function runMain(args: string[]): Promise<{ code: number; stderr: string }> {
+    const errors: string[] = []
+    const spy = vi.spyOn(console, 'error').mockImplementation(message => errors.push(String(message)))
+    try {
+      const code = await main(args)
+      return { code, stderr: errors.join('\n') }
+    } finally {
+      spy.mockRestore()
+    }
+  }
+
+  it('refuses identical JSON and Markdown output paths before reading the expected file or the database', async () => {
+    const dir = mkdtempSync(path.join(os.tmpdir(), 'evidence-cli-'))
+    try {
+      const same = path.join(dir, 'out.json')
+      // The expected file does not exist: a same-path refusal that still
+      // reaches the expectations read would surface the expectations error;
+      // the observed refusal proves path validation precedes any file or
+      // database access.
+      const { code, stderr } = await runMain(['--json', same, '--markdown', same, '--expected', path.join(dir, 'missing-expected.json')])
+      expect(code).toBe(1)
+      expect(stderr).toContain('resolve to the same file')
+      expect(stderr).not.toContain('expectations file')
+      expect(readdirSync(dir).sort()).toEqual([])
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('refuses normalized-equivalent JSON and Markdown output paths', async () => {
+    const dir = mkdtempSync(path.join(os.tmpdir(), 'evidence-cli-'))
+    try {
+      const direct = path.join(dir, 'out.json')
+      const dotted = path.join(dir, '.', 'out.json')
+      const { code, stderr } = await runMain(['--json', direct, '--markdown', dotted, '--expected', path.join(dir, 'missing-expected.json')])
+      expect(code).toBe(1)
+      expect(stderr).toContain('resolve to the same file')
+      expect(readdirSync(dir).sort()).toEqual([])
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('keeps the existing refusal when a final output path already exists', async () => {
+    const dir = mkdtempSync(path.join(os.tmpdir(), 'evidence-cli-'))
+    try {
+      const json = path.join(dir, 'out.json')
+      writeFileSync(json, 'pre-existing')
+      const md = path.join(dir, 'out.md')
+      // Schema-valid expectations file so the run reaches the output
+      // existence preflight (path validation happens even earlier).
+      const expectedPath = path.join(dir, 'expected.json')
+      writeFileSync(expectedPath, JSON.stringify({
+        fingerprint: 'a'.repeat(64),
+        baselineStateHash: 'b'.repeat(64),
+        quarantinedEntries: 574, quarantinedSnapshots: 49, defectSnapshots: 18,
+        windowlessDecisions: 359, singleMinusOneDecisions: 7, snapshotDecisions: 366,
+        liveDecisions: 130, unsupported: 0, rewriteOperations: 0,
+        topology11Snapshots: 11, topology7Snapshots: 7,
+        topology11WindowlessDecisions: 226, topology7WindowlessDecisions: 133,
+        topology7SingleMinusOneDecisions: 7,
+      }))
+      const { code, stderr } = await runMain(['--json', json, '--markdown', md, '--expected', expectedPath])
+      expect(code).toBe(1)
+      expect(stderr).toContain('already exists')
+      expect(readFileSync(json, 'utf8')).toBe('pre-existing')
+      expect(readdirSync(dir).sort()).toEqual(['expected.json', 'out.json'])
     } finally {
       rmSync(dir, { recursive: true, force: true })
     }

--- a/server/src/test/snapshotEvidence.test.ts
+++ b/server/src/test/snapshotEvidence.test.ts
@@ -1,0 +1,595 @@
+/**
+ * snapshotEvidence.test.ts — Unit tests for the Issue #432 sanitized snapshot
+ * evidence aggregation module (server/src/lib/snapshotEvidence.ts).
+ *
+ * Covers: the four raw `-1` orientations, null/populated/conflicting
+ * alternate aliases, explicit vs inherited NamedResource modes, percentage
+ * bucket boundaries, era categories, ResourceType vs NamedResource Class A
+ * aggregation, deterministic sanitized labelling, deterministic output
+ * ordering, JSON/Markdown parity, identifier/name redaction, controlled safe
+ * errors, and expectation/mismatch handling.
+ */
+
+import { describe, it, expect } from 'vitest'
+
+import {
+  buildSnapshotEvidenceReport,
+  classifySnapshotEvidence,
+  isExpectedBoundaryShape,
+  percentCategory,
+  renderSnapshotEvidenceMarkdown,
+  snapshotEraCategory,
+  SnapshotEvidenceError,
+  type SnapshotEvidenceExpected,
+} from '../lib/snapshotEvidence.js'
+import {
+  buildRemediationPlan,
+  computePlanFingerprint,
+  computeStateHash,
+  type RemediationDatabaseState,
+} from '../lib/productionRemediationPlan.js'
+
+// ─── Fixtures ───────────────────────────────────────────────────────────────
+
+const PROJECT_ID = 'project-secret-42'
+
+interface RtOverrides {
+  id?: string
+  name?: string
+  allocationMode?: string | null
+  allocationPercent?: number | null
+  allocationStartWeek?: number | null
+  allocationEndWeek?: number | null
+}
+
+function makeRt(overrides: RtOverrides = {}) {
+  return {
+    id: overrides.id ?? 'rt-1',
+    name: overrides.name ?? 'Secret Role Name',
+    category: 'ENGINEERING',
+    count: 1,
+    hoursPerDay: null,
+    dayRate: null,
+    allocationMode: 'allocationMode' in overrides ? overrides.allocationMode : 'TIMELINE',
+    globalTypeId: null,
+    allocationPercent: overrides.allocationPercent ?? 100,
+    allocationStartWeek: overrides.allocationStartWeek ?? null,
+    allocationEndWeek: overrides.allocationEndWeek ?? null,
+  }
+}
+
+interface NrOverrides {
+  id?: string
+  name?: string
+  resourceTypeId?: string
+  allocationMode?: string | null
+  allocationPercent?: number | null
+  allocationPct?: number | null
+  allocationStartWeek?: number | null
+  allocationEndWeek?: number | null
+  startWeek?: number | null
+  endWeek?: number | null
+}
+
+function makeNr(overrides: NrOverrides = {}) {
+  return {
+    id: overrides.id ?? 'nr-1',
+    resourceTypeId: overrides.resourceTypeId ?? 'rt-1',
+    name: overrides.name ?? 'Secret Person Name',
+    startWeek: overrides.startWeek ?? null,
+    endWeek: overrides.endWeek ?? null,
+    allocationPct: overrides.allocationPct ?? 100,
+    allocationMode: 'allocationMode' in overrides ? overrides.allocationMode : 'TIMELINE',
+    allocationPercent: overrides.allocationPercent ?? 100,
+    allocationStartWeek: overrides.allocationStartWeek ?? null,
+    allocationEndWeek: overrides.allocationEndWeek ?? null,
+    pricingModel: 'ACTUAL_DAYS',
+  }
+}
+
+function makeV2Snapshot(resourceTypes: unknown[], namedResources: unknown[]) {
+  return {
+    schemaVersion: 2,
+    epics: [],
+    project: null,
+    resourceTypes,
+    namedResources,
+    timelineEntries: [],
+    storyTimelineEntries: [],
+    epicDependencies: [],
+    featureDependencies: [],
+    overheadItems: [],
+  }
+}
+
+interface StateSnapshot {
+  id: string
+  projectId: string
+  payload: unknown
+}
+
+function makeState(snapshots: StateSnapshot[]): RemediationDatabaseState {
+  return { projects: [], snapshots: snapshots.map(s => ({ id: s.id, projectId: s.projectId, snapshot: s.payload })) }
+}
+
+/** Compute the plan's own fingerprint/baseline for the fixture state and
+ * combine them with the caller's reviewed counts. */
+function expectedFor(state: RemediationDatabaseState, counts: Omit<SnapshotEvidenceExpected, 'fingerprint' | 'baselineStateHash'>): SnapshotEvidenceExpected {
+  const plan = buildRemediationPlan(state, 'test-commit')
+  return {
+    fingerprint: computePlanFingerprint(plan),
+    baselineStateHash: computeStateHash(state),
+    ...counts,
+  }
+}
+
+const CREATED_AT: Record<string, string> = {
+  'snap-quarantined': '2026-06-01T00:00:00Z',
+  'snap-eleven': '2026-05-20T00:00:00Z',
+  'snap-seven': '2026-05-10T00:00:00Z',
+  'snap-restorable': '2026-04-01T00:00:00Z',
+}
+
+function createdAtMap(state: RemediationDatabaseState): Map<string, string> {
+  const map = new Map<string, string>()
+  for (const snapshot of state.snapshots) {
+    const iso = CREATED_AT[snapshot.id]
+    if (iso) map.set(snapshot.id, iso)
+  }
+  return map
+}
+
+function buildReport(state: RemediationDatabaseState, counts: Omit<SnapshotEvidenceExpected, 'fingerprint' | 'baselineStateHash'>, generatedAt = '2026-08-04T00:00:00.000Z') {
+  return buildSnapshotEvidenceReport({
+    state,
+    snapshotCreatedAtById: createdAtMap(state),
+    applicationCommit: 'test-commit',
+    generatedAt,
+    expected: expectedFor(state, counts),
+  })
+}
+
+// ─── Shared composite fixture ───────────────────────────────────────────────
+
+function compositeState(): RemediationDatabaseState {
+  return makeState([
+    {
+      id: 'snap-quarantined',
+      projectId: PROJECT_ID,
+      payload: makeV2Snapshot(
+        [
+          makeRt({ id: 'rt-a', allocationMode: 'CAPACITY_PLAN', allocationStartWeek: null, allocationEndWeek: null }),
+          makeRt({ id: 'rt-b', allocationMode: 'CAPACITY_PLAN', allocationStartWeek: null, allocationEndWeek: null }),
+        ],
+        [
+          // Inherited-mode windowless NamedResource Class A entry.
+          makeNr({
+            id: 'nr-inherited',
+            resourceTypeId: 'rt-a',
+            allocationMode: null,
+            allocationPercent: 100,
+            allocationPct: 100,
+          }),
+          // Valid explicit TIMELINE companion (restorable, not quarantined).
+          makeNr({
+            id: 'nr-timeline',
+            resourceTypeId: 'rt-b',
+            allocationMode: 'TIMELINE',
+            allocationStartWeek: 2,
+            allocationEndWeek: 9,
+            startWeek: 2,
+            endWeek: 9,
+          }),
+        ],
+      ),
+    },
+    {
+      id: 'snap-eleven',
+      projectId: PROJECT_ID,
+      payload: makeV2Snapshot(
+        Array.from({ length: 20 }, (_, i) =>
+          makeRt({ id: `rt-w-${i}`, name: `Windowless Role ${i}`, allocationMode: 'CAPACITY_PLAN' })),
+        [
+          // Independent defect invisible to translation errors: conflicting
+          // end aliases on an inherited CAPACITY_PLAN NamedResource.
+          makeNr({
+            id: 'nr-conflict',
+            resourceTypeId: 'rt-w-0',
+            allocationMode: null,
+            allocationPercent: 100,
+            allocationPct: 100,
+            allocationStartWeek: 5,
+            allocationEndWeek: 10,
+            startWeek: 5,
+            endWeek: 9,
+          }),
+        ],
+      ),
+    },
+    {
+      id: 'snap-seven',
+      projectId: PROJECT_ID,
+      payload: makeV2Snapshot(
+        Array.from({ length: 19 }, (_, i) =>
+          makeRt({ id: `rt-s-${i}`, name: `Windowless Role ${i}`, allocationMode: 'CAPACITY_PLAN' })),
+        [
+          // Single -1 edge (allocationStartWeek), other edge populated with a
+          // conflicting fallback alias on the -1 edge — excluded from Class B
+          // by the shared predicate, decision message "single -1/negative…".
+          makeNr({
+            id: 'nr-minus-one',
+            resourceTypeId: 'rt-s-0',
+            allocationMode: 'CAPACITY_PLAN',
+            allocationPercent: 100,
+            allocationPct: 100,
+            allocationStartWeek: -1,
+            allocationEndWeek: 5,
+            startWeek: 5,
+            endWeek: null,
+          }),
+        ],
+      ),
+    },
+    {
+      id: 'snap-restorable',
+      projectId: PROJECT_ID,
+      payload: makeV2Snapshot(
+        [makeRt({ id: 'rt-t', allocationMode: 'TIMELINE', allocationStartWeek: 0, allocationEndWeek: 10 })],
+        [],
+      ),
+    },
+  ])
+}
+
+const COMPOSITE_COUNTS: Omit<SnapshotEvidenceExpected, 'fingerprint' | 'baselineStateHash'> = {
+  quarantinedEntries: 3,
+  quarantinedSnapshots: 1,
+  defectSnapshots: 2,
+  windowlessDecisions: 39,
+  singleMinusOneDecisions: 1,
+  snapshotDecisions: 40,
+  liveDecisions: 0,
+  unsupported: 0,
+  rewriteOperations: 0,
+  topology11WindowlessDecisions: 20,
+  topology7WindowlessDecisions: 19,
+  topology7SingleMinusOneDecisions: 1,
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe('percentCategory buckets', () => {
+  it('maps every bucket boundary', () => {
+    expect(percentCategory(null)).toBe('absent-null')
+    expect(percentCategory(undefined)).toBe('absent-null')
+    expect(percentCategory(0)).toBe('zero')
+    expect(percentCategory(1)).toBe('one-to-ninety-nine')
+    expect(percentCategory(50)).toBe('one-to-ninety-nine')
+    expect(percentCategory(99)).toBe('one-to-ninety-nine')
+    expect(percentCategory(100)).toBe('hundred')
+    expect(percentCategory(101)).toBe('above-hundred')
+    expect(percentCategory(Number.NaN)).toBe('invalid-non-finite')
+    expect(percentCategory(Number.POSITIVE_INFINITY)).toBe('invalid-non-finite')
+  })
+})
+
+describe('snapshotEraCategory', () => {
+  it('groups by the reviewed writer-era boundaries and unavailable', () => {
+    expect(snapshotEraCategory('2026-05-04T23:59:59Z')).toBe('before-2026-05-05')
+    expect(snapshotEraCategory('2026-05-05T00:00:00Z')).toBe('2026-05-05-to-2026-07-13')
+    expect(snapshotEraCategory('2026-07-13T23:59:59Z')).toBe('2026-05-05-to-2026-07-13')
+    expect(snapshotEraCategory('2026-07-14T00:00:00Z')).toBe('2026-07-14-or-later')
+    expect(snapshotEraCategory(null)).toBe('unavailable')
+    expect(snapshotEraCategory('not-a-date')).toBe('unavailable')
+  })
+})
+
+describe('isExpectedBoundaryShape', () => {
+  const base: SnapshotEvidenceExpected = {
+    fingerprint: 'a'.repeat(64),
+    baselineStateHash: 'b'.repeat(64),
+    quarantinedEntries: 574, quarantinedSnapshots: 49, defectSnapshots: 18,
+    windowlessDecisions: 359, singleMinusOneDecisions: 7, snapshotDecisions: 366,
+    liveDecisions: 130, unsupported: 0, rewriteOperations: 0,
+    topology11WindowlessDecisions: 226, topology7WindowlessDecisions: 133,
+    topology7SingleMinusOneDecisions: 7,
+  }
+  it('accepts the reviewed shape', () => {
+    expect(isExpectedBoundaryShape(base)).toBe(true)
+  })
+  it('rejects bad hashes, missing fields and non-integers', () => {
+    expect(isExpectedBoundaryShape({ ...base, fingerprint: 'zz' })).toBe(false)
+    expect(isExpectedBoundaryShape({ ...base, baselineStateHash: 'Z'.repeat(64) })).toBe(false)
+    expect(isExpectedBoundaryShape({ ...base, quarantinedEntries: 574.5 })).toBe(false)
+    const missing = { ...base }
+    delete (missing as Partial<SnapshotEvidenceExpected>).fingerprint
+    expect(isExpectedBoundaryShape(missing)).toBe(false)
+    expect(isExpectedBoundaryShape(null)).toBe(false)
+    expect(isExpectedBoundaryShape('nope')).toBe(false)
+  })
+})
+
+describe('classifySnapshotEvidence', () => {
+  it('throws controlled errors for unsupported versions and malformed payloads', () => {
+    expect(() => classifySnapshotEvidence({ schemaVersion: 99, epics: [] }, PROJECT_ID))
+      .toThrowError(SnapshotEvidenceError)
+    expect(() => classifySnapshotEvidence('not-an-object', PROJECT_ID))
+      .toThrowError(SnapshotEvidenceError)
+  })
+})
+
+describe('buildSnapshotEvidenceReport — composite fixture', () => {
+  const state = compositeState()
+
+  it('reconciles the reviewed boundary, topology and policyDecision', () => {
+    const report = buildReport(state, COMPOSITE_COUNTS)
+    expect(report.integrityResult.reconciliationPassed).toBe(true)
+    expect(report.integrityResult.fingerprintMatch).toBe(true)
+    expect(report.integrityResult.baselineMatch).toBe(true)
+    expect(report.policyDecision).toBe('not-assessed')
+    expect(report.formatVersion).toBe(1)
+    expect(report.topology).toMatchObject({
+      quarantinedSnapshots: 1,
+      defectSnapshots: 2,
+      windowlessDecisions: 39,
+      singleMinusOneDecisions: 1,
+      snapshotDecisions: 40,
+      liveDecisions: 0,
+      elevenSnapshotSubgroup: { snapshots: 1, windowlessDecisions: 20 },
+      sevenSnapshotSubgroup: { snapshots: 1, windowlessDecisions: 19, singleMinusOneDecisions: 1, totalDecisions: 20 },
+      quarantinedFindingsWithDecisionOrOperationIds: 0,
+    })
+    expect(report.observedBoundary.snapshotPopulation).toEqual({
+      totalSnapshots: 4, restorable: 1, quarantined: 1, defect: 2,
+    })
+  })
+
+  it('reports the S entry with the raw -1 field, alias state and mode source', () => {
+    const report = buildReport(state, COMPOSITE_COUNTS)
+    expect(report.singleNegativeEntries).toHaveLength(1)
+    const s = report.singleNegativeEntries[0]!
+    expect(s.label).toBe('S1')
+    expect(s.entryKind).toBe('namedResource')
+    expect(s.minusOneField).toBe('allocationStartWeek')
+    expect(s.alternateAliasState).toBe('conflicting')
+    expect(s.rawMode).toBe('CAPACITY_PLAN')
+    expect(s.parentMode).toBe('CAPACITY_PLAN')
+    expect(s.effectiveMode).toBe('CAPACITY_PLAN')
+    expect(s.modeSource).toBe('explicit')
+    expect(s.allocationPercentCategory).toBe('hundred')
+    expect(s.allocationPctCategory).toBe('hundred')
+    expect(s.entryErrorCategories).toContain('negative-one-window-value')
+    // The translated profile carries the -1 window edge, so the defect has
+    // both entry-level and structural evidence.
+    expect(s.independentDefect).toBe('both')
+  })
+
+  it('reports the M records with subgroup, decision counts and defect categories', () => {
+    const report = buildReport(state, COMPOSITE_COUNTS)
+    expect(report.defectSnapshots).toHaveLength(2)
+    const eleven = report.defectSnapshots.find(m => m.subgroup === 'eleven-windowless-only')!
+    const seven = report.defectSnapshots.find(m => m.subgroup === 'seven-single-minus-one')!
+    expect(eleven.windowlessDecisionCount).toBe(20)
+    expect(eleven.singleMinusOneDecisionCount).toBe(0)
+    expect(eleven.entryErrorCategories['alias-conflict']).toBe(1)
+    expect(eleven.independentDefect).toBe('entry-level')
+    expect(seven.windowlessDecisionCount).toBe(19)
+    expect(seven.singleMinusOneDecisionCount).toBe(1)
+    expect(seven.entryErrorCategories['negative-one-window-value']).toBe(1)
+    // The translated profile carries the -1 window edge, so the snapshot has
+    // BOTH entry-level and structural evidence of the same defect.
+    expect(seven.independentDefect).toBe('both')
+  })
+
+  it('aggregates Class A entries by owner kind, mode source, era and alias shape', () => {
+    const report = buildReport(state, COMPOSITE_COUNTS)
+    expect(report.classAAggregates.totalEntries).toBe(3)
+    expect(report.classAAggregates.totalSnapshots).toBe(1)
+    expect(report.classAAggregates.byOwnerKind).toEqual({ resourceType: 2, namedResource: 1, unavailable: 0 })
+    expect(report.classAAggregates.byNamedModeSource).toEqual({ explicit: 0, inherited: 1, other: 0, unavailable: 0 })
+    expect(report.classAAggregates.percentageByCategory.inherited.allocationPercent.hundred).toBe(1)
+    expect(report.classAAggregates.percentageByCategory.resourceType.allocationPercent.hundred).toBe(2)
+    expect(report.classAAggregates.aliasShapes).toEqual({
+      primaryAbsentNull: 3, fallbackAbsentNull: 1, populatedAgreeing: 0, conflicting: 0, unavailable: 0,
+    })
+    expect(report.classAAggregates.snapshotsByOwnerKindMix).toEqual({ resourceTypeOnly: 0, namedResourceOnly: 0, mixed: 1 })
+    expect(report.classAAggregates.entriesByEra['2026-05-05-to-2026-07-13']).toBe(3)
+    expect(report.classAAggregates.snapshotsByEra['2026-05-05-to-2026-07-13']).toBe(1)
+  })
+
+  it('redacts every seeded identifier, name and payload', () => {
+    const report = buildReport(state, COMPOSITE_COUNTS)
+    const json = JSON.stringify(report)
+    const markdown = renderSnapshotEvidenceMarkdown(report)
+    for (const secret of [
+      'project-secret-42',
+      'snap-quarantined',
+      'snap-eleven',
+      'snap-seven',
+      'rt-a', 'rt-b', 'rt-w-0', 'rt-s-0', 'rt-t',
+      'nr-inherited', 'nr-timeline', 'nr-conflict', 'nr-minus-one',
+      'Secret Role Name', 'Secret Person Name', 'Windowless Role',
+      'snapshot-v2-role', 'snapshot-v2-named',
+    ]) {
+      expect(json).not.toContain(secret)
+      expect(markdown).not.toContain(secret)
+    }
+    expect(json).not.toContain('"snapshotId"')
+    expect(json).not.toContain('"projectId"')
+    expect(json).not.toContain('"ownerId"')
+    expect(json).not.toContain('"entryId"')
+  })
+
+  it('is deterministic: identical runs produce identical JSON and Markdown', () => {
+    const first = buildReport(state, COMPOSITE_COUNTS)
+    const second = buildReport(state, COMPOSITE_COUNTS)
+    expect(JSON.stringify(first)).toBe(JSON.stringify(second))
+    expect(renderSnapshotEvidenceMarkdown(first)).toBe(renderSnapshotEvidenceMarkdown(second))
+  })
+
+  it('keeps JSON and Markdown in parity (Markdown renders the same object)', () => {
+    const report = buildReport(state, COMPOSITE_COUNTS)
+    const markdown = renderSnapshotEvidenceMarkdown(report)
+    expect(markdown).toContain('quarantinedSnapshots: 1')
+    expect(markdown).toContain('defectSnapshots: 2')
+    expect(markdown).toContain('windowlessDecisions: 39')
+    expect(markdown).toContain('singleMinusOneDecisions: 1')
+    expect(markdown).toContain('policyDecision: not-assessed')
+    expect(markdown).toContain('M1')
+    expect(markdown).toContain('S1')
+    expect(markdown).toContain('This report is evidence only.')
+  })
+
+  it('fails closed on fingerprint mismatch without policy involvement', () => {
+    const counts = { ...COMPOSITE_COUNTS }
+    const plan = buildRemediationPlan(state, 'test-commit')
+    const report = buildSnapshotEvidenceReport({
+      state,
+      snapshotCreatedAtById: createdAtMap(state),
+      applicationCommit: 'test-commit',
+      generatedAt: '2026-08-04T00:00:00.000Z',
+      expected: {
+        fingerprint: 'f'.repeat(64),
+        baselineStateHash: computeStateHash(state),
+        ...counts,
+      },
+    })
+    expect(report.integrityResult.fingerprintMatch).toBe(false)
+    expect(report.integrityResult.reconciliationPassed).toBe(false)
+    void plan
+  })
+
+  it('fails closed on baseline mismatch', () => {
+    const report = buildSnapshotEvidenceReport({
+      state,
+      snapshotCreatedAtById: createdAtMap(state),
+      applicationCommit: 'test-commit',
+      generatedAt: '2026-08-04T00:00:00.000Z',
+      expected: {
+        fingerprint: computePlanFingerprint(buildRemediationPlan(state, 'test-commit')),
+        baselineStateHash: '0'.repeat(64),
+        ...COMPOSITE_COUNTS,
+      },
+    })
+    expect(report.integrityResult.baselineMatch).toBe(false)
+    expect(report.integrityResult.reconciliationPassed).toBe(false)
+  })
+
+  it('fails closed on count mismatch', () => {
+    const report = buildReport(state, { ...COMPOSITE_COUNTS, windowlessDecisions: 999 })
+    expect(report.integrityResult.countsMatch).toBe(false)
+    expect(report.integrityResult.reconciliationPassed).toBe(false)
+  })
+})
+
+describe('all four raw -1 orientations', () => {
+  const orientationCases: Array<{ name: string; nr: ReturnType<typeof makeNr>; field: string; aliasState: string }> = [
+    {
+      name: 'startWeek',
+      nr: makeNr({ resourceTypeId: 'rt-o', allocationMode: 'CAPACITY_PLAN', allocationStartWeek: null, startWeek: -1, allocationEndWeek: 4, endWeek: 5 }),
+      field: 'startWeek',
+      aliasState: 'conflicting',
+    },
+    {
+      name: 'endWeek',
+      nr: makeNr({ resourceTypeId: 'rt-o', allocationMode: 'CAPACITY_PLAN', allocationStartWeek: 4, startWeek: 5, allocationEndWeek: null, endWeek: -1 }),
+      field: 'endWeek',
+      aliasState: 'conflicting',
+    },
+    {
+      name: 'allocationStartWeek',
+      nr: makeNr({ resourceTypeId: 'rt-o', allocationMode: 'CAPACITY_PLAN', allocationStartWeek: -1, startWeek: 5, allocationEndWeek: 5, endWeek: null }),
+      field: 'allocationStartWeek',
+      aliasState: 'conflicting',
+    },
+    {
+      name: 'allocationEndWeek',
+      nr: makeNr({ resourceTypeId: 'rt-o', allocationMode: 'CAPACITY_PLAN', allocationStartWeek: 5, startWeek: null, allocationEndWeek: -1, endWeek: 5 }),
+      field: 'allocationEndWeek',
+      aliasState: 'conflicting',
+    },
+  ]
+
+  for (const { name, nr, field, aliasState } of orientationCases) {
+    it(`reports the -1 field for orientation ${name}`, () => {
+      const state = makeState([{
+        id: `snap-${name}`,
+        projectId: PROJECT_ID,
+        payload: makeV2Snapshot(
+          // Valid windowed parent (no windowless decision of its own).
+          [makeRt({ id: 'rt-o', allocationMode: 'TIMELINE', allocationStartWeek: 0, allocationEndWeek: 5 })],
+          [nr],
+        ),
+      }])
+      const counts: Omit<SnapshotEvidenceExpected, 'fingerprint' | 'baselineStateHash'> = {
+        quarantinedEntries: 0, quarantinedSnapshots: 0, defectSnapshots: 1,
+        windowlessDecisions: 0, singleMinusOneDecisions: 1, snapshotDecisions: 1,
+        liveDecisions: 0, unsupported: 0, rewriteOperations: 0,
+        topology11WindowlessDecisions: 0, topology7WindowlessDecisions: 0,
+        topology7SingleMinusOneDecisions: 1,
+      }
+      const report = buildReport(state, counts)
+      expect(report.integrityResult.reconciliationPassed).toBe(true)
+      expect(report.singleNegativeEntries).toHaveLength(1)
+      const s = report.singleNegativeEntries[0]!
+      expect(s.minusOneField).toBe(field)
+      expect(s.alternateAliasState).toBe(aliasState)
+      expect(s.modeSource).toBe('explicit')
+    })
+  }
+
+  it('a clean -1+null shape is a windowless decision, not a single-negative decision', () => {
+    // Empirical contract: the plan-level classifier checks the null edge
+    // before the negative edge, so a -1+null entry carries the windowless
+    // message. The evidence command must report it as such.
+    const state = makeState([{
+      id: 'snap-minus-one-null',
+      projectId: PROJECT_ID,
+      payload: makeV2Snapshot(
+        // Valid windowed parent so the NamedResource is not an orphan.
+        [makeRt({ id: 'rt-1', allocationMode: 'TIMELINE', allocationStartWeek: 0, allocationEndWeek: 5 })],
+        [makeNr({ allocationMode: 'CAPACITY_PLAN', allocationStartWeek: null, startWeek: -1, allocationEndWeek: null, endWeek: null })],
+      ),
+    }])
+    const counts: Omit<SnapshotEvidenceExpected, 'fingerprint' | 'baselineStateHash'> = {
+      quarantinedEntries: 0, quarantinedSnapshots: 0, defectSnapshots: 1,
+      windowlessDecisions: 1, singleMinusOneDecisions: 0, snapshotDecisions: 1,
+      liveDecisions: 0, unsupported: 0, rewriteOperations: 0,
+      topology11WindowlessDecisions: 1, topology7WindowlessDecisions: 0,
+      topology7SingleMinusOneDecisions: 0,
+    }
+    const report = buildReport(state, counts)
+    expect(report.integrityResult.reconciliationPassed).toBe(true)
+    expect(report.singleNegativeEntries).toHaveLength(0)
+    expect(report.topology.windowlessDecisions).toBe(1)
+    expect(report.defectSnapshots[0]!.windowlessDecisionCount).toBe(1)
+  })
+})
+
+describe('structural defect classification', () => {
+  it('classifies a duplicate-owner structural defect as structural', () => {
+    const state = makeState([{
+      id: 'snap-dup',
+      projectId: PROJECT_ID,
+      payload: makeV2Snapshot(
+        [
+          makeRt({ id: 'rt-dupe', allocationMode: 'CAPACITY_PLAN', allocationStartWeek: 0, allocationEndWeek: 5 }),
+          makeRt({ id: 'rt-dupe', allocationMode: 'CAPACITY_PLAN', allocationStartWeek: 1, allocationEndWeek: 6 }),
+        ],
+        [],
+      ),
+    }])
+    const counts: Omit<SnapshotEvidenceExpected, 'fingerprint' | 'baselineStateHash'> = {
+      quarantinedEntries: 0, quarantinedSnapshots: 0, defectSnapshots: 1,
+      windowlessDecisions: 0, singleMinusOneDecisions: 0, snapshotDecisions: 0,
+      liveDecisions: 0, unsupported: 0, rewriteOperations: 0,
+      topology11WindowlessDecisions: 0, topology7WindowlessDecisions: 0,
+      topology7SingleMinusOneDecisions: 0,
+    }
+    const report = buildReport(state, counts)
+    expect(report.integrityResult.reconciliationPassed).toBe(true)
+    const m = report.defectSnapshots[0]!
+    expect(m.independentDefect).toBe('structural')
+    expect(m.structuralErrorCategories['duplicate-owner']).toBe(1)
+  })
+})


### PR DESCRIPTION
# Sanitized Historical Snapshot Evidence (Issue #432)

Read-only evidence command for the Issue #430 design investigation. Closes #432.

## Review remediation (round 3 — three findings)

1. **No-clobber two-output publication.** Output-path validation now resolves
   and normalizes both final paths and refuses (exit 1) when they are equal —
   including equivalent spellings — **before** reading the expectations file,
   touching the database, or creating any temporary/final output. The final
   publication step itself refuses an existing destination: each final path
   is created as a hard link to the staged `0600` temporary (`link` fails
   with `EEXIST`), never a check-then-rename sequence, so a destination
   created between preflight and publication cannot be overwritten.
   Ownership is tracked explicitly (path + inode): on any staging or
   publication failure the command removes every temporary file it created
   and only final files it created itself; independently created
   destinations are preserved. Success leaves two distinct `0600` files with
   no temporaries. Publication lives in
   `server/src/lib/evidenceOutputPublication.ts` (test-only failure hooks
   are not exposed through the production CLI).
2. **Every raw window-field state per S record.** Each S record now reports
   `windowFields` for all four fields (`allocationStartWeek`,
   `allocationEndWeek`, `startWeek`, `endWeek`) with exactly one value from
   the fixed vocabulary `minus-one` / `absent-null` / `populated` — populated
   numeric values are never emitted. `minusOneField` is reconciled
   one-to-one with the single `minus-one` field (reconciliation check).
   Alias conflicts are reported per logical edge
   (`aliasConflicts.startEdge` / `endEdge`) using the shared
   `v2NamedResourceEdgeAliasConflict` predicate (delegated from the existing
   aggregate, so one definition), distinguishing start-edge from end-edge
   conflicts and populated opposite-edge values. The Markdown section is
   retitled **"Single-negative decision entries"** — S records are selected
   from the plan's single-negative decision class and a clean `-1` + null
   shape (Class B quarantine / windowless) is never implied. The S-record
   set mirrors the plan's quarantine-first precedence exactly (verified by
   the Class B boundary test, which also documents the fail-closed refusal).

## Review remediation (round 4 — final correction)

`affectedSnapshotsByNamedModeSource` now counts only snapshots containing
Class A **NamedResource** entries in the applicable mode-source category. The
previous round counted ResourceType presence as an unavailable NamedResource
mode source; that mapping is removed. ResourceType-only Class A snapshots now
contribute zero to all four mode-source categories, mixed
ResourceType + NamedResource snapshots report only the actual NamedResource
categories, and per-snapshot deduplication and the overlapping-category
semantics are unchanged. The aggregate is not expected to sum to 49.
`affectedSnapshotsByOwnerKind`, `snapshotsByOwnerKindMix`, entry counts and
the 574-entry / 49-snapshot reconciliations are unchanged. A focused fixture
documents the shared-predicate boundary: a NamedResource with genuinely
unavailable mode provenance (no explicit mode, no CAPACITY_PLAN parent)
resolves to a null effective mode, is never Class A, and therefore cannot
contribute to the unavailable category.
3. **Class A affected-snapshot counts.** `classAAggregates` now includes
   `affectedSnapshotsByOwnerKind` (`resourceType` / `namedResource` /
   `unavailable`) and `affectedSnapshotsByNamedModeSource` (`explicit` /
   `inherited` / `other` / `unavailable`), deduplicated per snapshot per
   category (a mixed snapshot may count in both owner-kind categories; a
   snapshot with explicit and inherited entries in both mode-source
   categories). `snapshotsByOwnerKindMix` retains the mutually exclusive
   overall mix and the 49-snapshot total reconciliation is unchanged. Both
   aggregates render in versioned JSON and sanitized Markdown.

## Round 1–2 context (already reviewed)

- Expected-file schema gates the corrected 11/7 topology (snapshot counts,
  windowless and single-`-1` decision totals, subgroup sums).
- All verdicts/categories reuse the shared classifier/translator helpers.
- Markdown carries every required #430 evidence category (S entry+structural
  errors, M other-decision reasons, full Class A percentage split).
- Unknown/malformed historical mode strings render only as `other`.
- Fingerprint, baseline, counts and reconciliation must all pass; zero
  database writes; identifier/name/payload redaction.

## Validation

- Unit: `server/src/test/snapshotEvidence.test.ts` — **46 passed** (new:
  same-path and normalized-equivalent refusal before DB access, first/second
  destination no-clobber races, independent-destination preservation, first
  final cleanup after second-final refusal, four-field S states ×4
  orientations, start-edge vs end-edge conflict, Class B boundary, Class A
  snapshot aggregates incl. dedup and parity).
- Integration: `snapshotEvidence.integration.test.ts` — **8 passed** against
  a disposable local PostgreSQL instance (same procedure as round 2; the
  session's Docker socket remains unavailable to the local user — the
  Docker-first lifecycle runs in CI).
- `npm run validate`: **exit 0** — server 1599 passed, client 342 passed,
  lint/typecheck/build clean.
- `git diff --check`: clean.
- CI: pushed head `e2cc90be12c4dd2b27c576d6a2bf903ec4c3a81e`; status will be
  reported once the run completes (previous head was fully green after one
  rerun of an unrelated timing flake).

## Confirmations

- No production access occurred; no classifier policy, quarantine predicate,
  manifest, decision, apply, schema or migration changed; the command stays
  zero-write and evidence-only.
- **#430 remains open**; **#404 and #418 remain blocked** until the evidence
  is reviewed under #430.

**Do not merge — wait for review.**
