### PR TITLE
fix(#432): correlate single-negative evidence to plan decisions

### DIFF
--- a/docs/domain/capacity-profile-readiness-remediation.md
+++ b/docs/domain/capacity-profile-readiness-remediation.md
@@ -495,9 +495,13 @@ owner kind) and are used only to populate the sanitized evidence. Raw entry
 scanning is never an independent policy or selection path. Missing,
 ambiguous or inconsistent correlation (no stored snapshot, non-v2 payload,
 missing entry identifier, zero or multiple matching raw entries, entry-kind
-mismatch, an entry that does not re-derive the single-negative decision, or
-two decisions resolving to the same raw entry) fails closed with a fixed
-safe message and no evidence is emitted. Inherited effective mode is
+mismatch, an entry that does not re-derive the single-negative decision, two
+decisions resolving to the same raw entry, or a NamedResource whose parent
+reference is absent, unmatched or duplicated) fails closed with a fixed
+safe message and no evidence is emitted. Parent correlation never resolves
+ambiguity with `find`, a `Map` or positional picks: every correlated
+NamedResource must match exactly one ResourceType. Inherited effective mode
+is
 preserved in evidence when present (`rawMode: null`, `parentMode:
 CAPACITY_PLAN`, `effectiveMode: CAPACITY_PLAN`, `modeSource: inherited`).
 Identifiers remain internal and are never emitted. The reviewed production

--- a/docs/domain/capacity-profile-readiness-remediation.md
+++ b/docs/domain/capacity-profile-readiness-remediation.md
@@ -475,19 +475,37 @@ Markdown and the content-derived labels.
 
 Each S record reports the sanitized state of **all four raw window fields**
 (`allocationStartWeek`, `allocationEndWeek`, `startWeek`, `endWeek`) with
-exactly one value from the fixed vocabulary `minus-one` / `absent-null` /
-`populated` — populated numeric values are never emitted. `minusOneField`
-is reconciled one-to-one with the single `minus-one` field. Alias-conflict
-evidence is reported **per logical edge** (`aliasConflicts.startEdge` /
-`aliasConflicts.endEdge`) using the shared classifier alias semantics
-(window-using modes only), so a conflict on the start edge is distinguished
-from a conflict on the end edge. The aggregate `alternateAliasState` is
-derived from the same per-field states.
+values from the fixed vocabulary `minus-one` / `absent-null` / `populated`
+— populated numeric values are never emitted. Historical payloads may hold
+`-1` on more than one raw field of the same edge (for example both aliases
+of the start edge); every such field is reported as `minus-one`, while
+`minusOneField` names the plan-relevant exact field (the primary of the
+negative effective edge when it holds `-1`, otherwise its fallback).
+Alias-conflict evidence is reported **per logical edge**
+(`aliasConflicts.startEdge` / `aliasConflicts.endEdge`) using the shared
+classifier alias semantics (window-using modes only), so a conflict on the
+start edge is distinguished from a conflict on the end edge. The aggregate
+`alternateAliasState` is derived from the same per-field states.
 
-S records are selected from the plan's single-negative decision class; the
-Markdown section is titled **"Single-negative decision entries"** (a clean
-`-1` + null shape may instead be classified through the windowless or Class
-B quarantine branch and is never implied by the heading).
+**S-record selection is authoritative from the remediation plan's
+single-negative snapshot decisions** (shared `snapshotDecisionCategory`);
+raw payload entries are correlated internally one-to-one using the
+identifiers the plan decisions already carry (`snapshotId`, `entryId`,
+owner kind) and are used only to populate the sanitized evidence. Raw entry
+scanning is never an independent policy or selection path. Missing,
+ambiguous or inconsistent correlation (no stored snapshot, non-v2 payload,
+missing entry identifier, zero or multiple matching raw entries, entry-kind
+mismatch, an entry that does not re-derive the single-negative decision, or
+two decisions resolving to the same raw entry) fails closed with a fixed
+safe message and no evidence is emitted. Inherited effective mode is
+preserved in evidence when present (`rawMode: null`, `parentMode:
+CAPACITY_PLAN`, `effectiveMode: CAPACITY_PLAN`, `modeSource: inherited`).
+Identifiers remain internal and are never emitted. The reviewed production
+expectations remain **seven**, not zero.
+
+The Markdown section is titled **"Single-negative decision entries"** (a
+clean `-1` + null shape may instead be classified through the windowless or
+Class B quarantine branch and is never implied by the heading).
 
 The command prevents output of project/snapshot/owner/finding/decision IDs,
 names, complete payloads, credentials and database details by construction
@@ -535,6 +553,13 @@ integration tests capture canonical database state before and after a run
 and assert exact equality.
 
 ### #404 run procedure (Issue #432 handoff)
+
+**Do not retry the production run until this fix is reviewed and merged**: the
+2026-08-04 production run stopped at the evidence boundary
+(`single-negative records: observed 0, expected 7`) because the merged
+command selected S records by an independent raw-entry reclassification that
+dropped the plan's single-negative decisions. The plan-anchored correlation
+fix above is the reviewed replacement.
 
 1. Install the reviewed merge commit without running migrations; confirm a
    clean checkout at the exact expected commit and a healthy service.

--- a/server/src/lib/snapshotEvidence.ts
+++ b/server/src/lib/snapshotEvidence.ts
@@ -704,9 +704,19 @@ export function correlateSingleNegativeDecisions(
     const key = `${decision.snapshotId}\u0000${kind}\u0000${decision.entryId}`
     if (correlatedKeys.has(key)) fail('two selected decisions resolve to the same raw entry')
     correlatedKeys.add(key)
-    const parentRt = kind === 'namedResource'
-      ? parsed.resourceTypes.find(rt => rt.id === (rawEntry as SnapshotNamedResource).resourceTypeId)
-      : undefined
+    // A correlated NamedResource must resolve to exactly one parent
+    // ResourceType: an absent, unmatched or duplicated parent reference would
+    // otherwise let parent-dependent evidence come from an arbitrary
+    // ResourceType. Never resolve ambiguity with find/Map/positional picks.
+    let parentRt: SnapshotResourceType | undefined
+    if (kind === 'namedResource') {
+      const parentId = (rawEntry as SnapshotNamedResource).resourceTypeId
+      if (parentId == null || parentId === '') fail('the named-resource entry carries no parent reference')
+      const parents = parsed.resourceTypes.filter(rt => rt.id === parentId)
+      if (parents.length === 0) fail('the named-resource parent matched 0 resource types')
+      if (parents.length > 1) fail('the named-resource parent matched multiple resource types')
+      parentRt = parents[0]
+    }
     correlations.push({
       decision,
       snapshotIndex,

--- a/server/src/lib/snapshotEvidence.ts
+++ b/server/src/lib/snapshotEvidence.ts
@@ -49,7 +49,9 @@ import {
   computePlanFingerprint,
   computeStateHash,
   sha256Hex,
+  type PlanDecisionEntry,
   type RemediationDatabaseState,
+  type RemediationPlan,
 } from './productionRemediationPlan.js'
 
 // ─── Version and schema ─────────────────────────────────────────────────────
@@ -139,6 +141,29 @@ export interface SnapshotEvidenceExpected {
 
 // ─── Report schema (versioned, evidence-only) ───────────────────────────────
 
+/** One sanitized S record (single-negative decision evidence). Key is a
+ * content-derived internal label input; never emitted. */
+export interface SingleNegativeEvidenceEntry {
+  key: string
+  entryKind: OwnerKindCategory
+  minusOneField: MinusOneField
+  /** Sanitized state of every raw window field (never numeric values). */
+  windowFields: Record<MinusOneField, WindowFieldState>
+  /** Per-edge conflicting-populated-alias evidence (shared predicate). */
+  aliasConflicts: { startEdge: boolean; endEdge: boolean }
+  alternateAliasState: AlternateAliasState
+  /** Sanitized mode values only (fixed evidence vocabulary). */
+  rawMode: SanitizedMode
+  parentMode: SanitizedMode
+  effectiveMode: SanitizedMode
+  modeSource: NamedModeSourceCategory
+  allocationPercentCategory: PercentCategory
+  allocationPctCategory: PercentCategory
+  entryErrorCategories: EntryErrorCategory[]
+  structuralErrorCategories: StructuralErrorCategory[]
+  independentDefect: IndependentDefectCategory
+}
+
 export interface SnapshotEvidenceReport {
   formatVersion: typeof SNAPSHOT_EVIDENCE_FORMAT_VERSION
   runMetadata: {
@@ -186,26 +211,7 @@ export interface SnapshotEvidenceReport {
     }
     quarantinedFindingsWithDecisionOrOperationIds: number
   }
-  singleNegativeEntries: Array<{
-    label: string
-    entryKind: OwnerKindCategory
-    minusOneField: MinusOneField
-    /** Sanitized state of every raw window field (never numeric values). */
-    windowFields: Record<MinusOneField, WindowFieldState>
-    /** Per-edge conflicting-populated-alias evidence (shared predicate). */
-    aliasConflicts: { startEdge: boolean; endEdge: boolean }
-    alternateAliasState: AlternateAliasState
-    /** Sanitized mode values only (fixed evidence vocabulary). */
-    rawMode: SanitizedMode
-    parentMode: SanitizedMode
-    effectiveMode: SanitizedMode
-    modeSource: NamedModeSourceCategory
-    allocationPercentCategory: PercentCategory
-    allocationPctCategory: PercentCategory
-    entryErrorCategories: EntryErrorCategory[]
-    structuralErrorCategories: StructuralErrorCategory[]
-    independentDefect: IndependentDefectCategory
-  }>
+  singleNegativeEntries: Array<Omit<SingleNegativeEvidenceEntry, 'key'> & { label: string }>
   defectSnapshots: Array<{
     label: string
     subgroup: DefectSubgroup
@@ -258,7 +264,7 @@ export interface SnapshotEvidenceReport {
 
 // ─── Controlled error ───────────────────────────────────────────────────────
 
-export type EvidenceErrorCode = 'unsupported-snapshot' | 'snapshot-parse-failure'
+export type EvidenceErrorCode = 'unsupported-snapshot' | 'snapshot-parse-failure' | 'decision-correlation-failure'
 
 export class SnapshotEvidenceError extends Error {
   readonly code: EvidenceErrorCode
@@ -483,12 +489,7 @@ function namedResourceEntryEvidence(
   if (v2NamedResourceAliasConflict(nr, effectiveMode) && !categories.includes('alias-conflict')) {
     categories.push('alias-conflict')
   }
-  const modeSource: NamedModeSourceCategory =
-    rawMode === 'CAPACITY_PLAN' ? 'explicit'
-      : rawMode != null ? 'other'
-        : parentMode === 'CAPACITY_PLAN' ? 'inherited'
-          : parentMode == null ? 'unavailable'
-            : 'other'
+  const modeSource: NamedModeSourceCategory = namedModeSourceCategory(rawMode, parentMode)
   const minusOneFields: MinusOneField[] = []
   if (nr.allocationStartWeek === -1) minusOneFields.push('allocationStartWeek')
   if (nr.allocationEndWeek === -1) minusOneFields.push('allocationEndWeek')
@@ -608,6 +609,228 @@ function planEntryPayload(rt: SnapshotResourceType | SnapshotNamedResource, kind
   }
 }
 
+// ─── S-record correlation (plan decisions are the selection authority) ─────
+
+/** One plan single-negative snapshot decision correlated to its raw entry. */
+interface CorrelatedSingleNegativeDecision {
+  decision: PlanDecisionEntry
+  snapshotIndex: number
+  kind: 'resourceType' | 'namedResource'
+  rawEntry: SnapshotResourceType | SnapshotNamedResource
+  parentRt: SnapshotResourceType | undefined
+  minusOneField: MinusOneField
+}
+
+function edgeOfMinusOneField(field: MinusOneField): 'start' | 'end' {
+  return field === 'allocationStartWeek' || field === 'startWeek' ? 'start' : 'end'
+}
+
+/** Deterministic exact-field pick for a plan single-negative decision: the
+ * primary of the negative effective edge when it holds `-1`, otherwise its
+ * fallback. Historical payloads may hold `-1` on more than one raw field of
+ * the same edge; every such field is still reported as `minus-one` in
+ * `windowFields`, while `minusOneField` names the plan-relevant exact field. */
+function deterministicMinusOneField(
+  raw: SnapshotResourceType | SnapshotNamedResource,
+  kind: 'resourceType' | 'namedResource',
+): MinusOneField {
+  if (kind === 'resourceType') {
+    const rt = raw as SnapshotResourceType
+    if (rt.allocationStartWeek != null && rt.allocationStartWeek < 0) return 'allocationStartWeek'
+    if (rt.allocationEndWeek != null && rt.allocationEndWeek < 0) return 'allocationEndWeek'
+  } else {
+    const nr = raw as SnapshotNamedResource
+    const effectiveStart = nr.allocationStartWeek ?? nr.startWeek ?? null
+    const effectiveEnd = nr.allocationEndWeek ?? nr.endWeek ?? null
+    if (effectiveStart != null && effectiveStart < 0) {
+      return nr.allocationStartWeek === -1 ? 'allocationStartWeek' : 'startWeek'
+    }
+    if (effectiveEnd != null && effectiveEnd < 0) {
+      return nr.allocationEndWeek === -1 ? 'allocationEndWeek' : 'endWeek'
+    }
+  }
+  throw new SnapshotEvidenceError(
+    'decision-correlation-failure',
+    'cannot determine the negative window edge of a correlated single-negative decision',
+  )
+}
+
+/**
+ * Correlate every plan single-negative snapshot decision to exactly one raw
+ * v2 entry, using the identifiers the plan decision already carries
+ * (snapshotId, entryId, owner kind). The plan is the selection authority:
+ * no raw entry is discovered or reclassified independently. Any missing,
+ * ambiguous or inconsistent correlation fails closed with a fixed safe
+ * message (positions and counts only — never identifiers or payloads).
+ */
+export function correlateSingleNegativeDecisions(
+  plan: RemediationPlan,
+  state: RemediationDatabaseState,
+  classified: readonly ClassifiedSnapshot[],
+): CorrelatedSingleNegativeDecision[] {
+  const selected = plan.decisions.filter(
+    decision => decision.snapshotId != null && snapshotDecisionCategory(decision.message) === 'single-negative',
+  )
+  const correlations: CorrelatedSingleNegativeDecision[] = []
+  const correlatedKeys = new Set<string>()
+  selected.forEach((decision, index) => {
+    const position = index + 1
+    const total = selected.length
+    const fail = (reason: string): never => {
+      throw new SnapshotEvidenceError(
+        'decision-correlation-failure',
+        `cannot correlate snapshot decision ${position} of ${total}: ${reason}`,
+      )
+    }
+    const snapshotIndex = state.snapshots.findIndex(snapshot => snapshot.id === decision.snapshotId)
+    if (snapshotIndex < 0) fail('no stored snapshot matches')
+    const item = classified[snapshotIndex]!
+    if (!item.v2 || item.parsedV2 == null) fail('the stored snapshot is not a supported v2 payload')
+    if (decision.entryId == null) fail('the decision carries no entry identifier')
+    const kind: 'resourceType' | 'namedResource' = decision.ownerKind === 'role' ? 'resourceType' : 'namedResource'
+    const parsed: SnapshotV2 = item.parsedV2 ?? fail('the stored snapshot is not a supported v2 payload')
+    const matches = kind === 'resourceType'
+      ? parsed.resourceTypes.filter(rt => rt.id === decision.entryId)
+      : parsed.namedResources.filter(nr => nr.id === decision.entryId)
+    if (matches.length !== 1) fail(`matched ${matches.length} raw entries`)
+    const rawEntry = matches[0]!
+    // The matched raw entry must re-derive the same decision through the
+    // shared classifier (correlation validator — never an independent
+    // selection or policy path).
+    const finding = classifySnapshotEntry(planEntryPayload(rawEntry, kind))
+    if (finding.classification !== 'decisionRequired' || !finding.message.includes(SINGLE_NEGATIVE_DECISION_MESSAGE)) {
+      fail('the raw entry does not re-derive the single-negative decision')
+    }
+    const key = `${decision.snapshotId}\u0000${kind}\u0000${decision.entryId}`
+    if (correlatedKeys.has(key)) fail('two selected decisions resolve to the same raw entry')
+    correlatedKeys.add(key)
+    const parentRt = kind === 'namedResource'
+      ? parsed.resourceTypes.find(rt => rt.id === (rawEntry as SnapshotNamedResource).resourceTypeId)
+      : undefined
+    correlations.push({
+      decision,
+      snapshotIndex,
+      kind,
+      rawEntry,
+      parentRt,
+      minusOneField: deterministicMinusOneField(rawEntry, kind),
+    })
+  })
+  return correlations
+}
+
+/**
+ * Populate one sanitized S record from a correlated raw entry. Pure evidence
+ * derivation through shared classifier/effective-mode helpers; never emits
+ * identifiers, exact percentages or populated window numbers. Exported so the
+ * inherited-effective-mode evidence capability is directly testable.
+ */
+export function buildSingleNegativeEvidenceEntry(
+  rawEntry: SnapshotResourceType | SnapshotNamedResource,
+  kind: 'resourceType' | 'namedResource',
+  parentRt: SnapshotResourceType | undefined,
+  structuralErrorCategories: readonly StructuralErrorCategory[],
+  minusOneField: MinusOneField,
+): SingleNegativeEvidenceEntry {
+  let rawMode: SanitizedMode
+  let parentMode: SanitizedMode
+  let effectiveMode: SanitizedMode
+  let modeSource: NamedModeSourceCategory
+  let percent: number | null | undefined
+  let pct: number | null | undefined
+  let windowFields: Record<MinusOneField, WindowFieldState>
+  let aliasConflicts: { startEdge: boolean; endEdge: boolean }
+  let sanitizedForKey: Record<string, unknown>
+  if (kind === 'resourceType') {
+    const rt = rawEntry as SnapshotResourceType
+    rawMode = sanitizeMode(rt.allocationMode)
+    parentMode = null
+    effectiveMode = rawMode
+    modeSource = 'unavailable'
+    percent = rt.allocationPercent
+    // ResourceType entries carry no alternate aliases: every fallback field
+    // is reported absent, and no edge can conflict.
+    windowFields = {
+      allocationStartWeek: windowFieldStateFor(rt.allocationStartWeek),
+      allocationEndWeek: windowFieldStateFor(rt.allocationEndWeek),
+      startWeek: 'absent-null',
+      endWeek: 'absent-null',
+    }
+    aliasConflicts = { startEdge: false, endEdge: false }
+    sanitizedForKey = {
+      kind,
+      mode: rawMode,
+      percent: rt.allocationPercent ?? null,
+      asw: rt.allocationStartWeek ?? null,
+      aew: rt.allocationEndWeek ?? null,
+    }
+  } else {
+    const nr = rawEntry as SnapshotNamedResource
+    const effectiveRawMode = v2EffectiveNamedMode(nr, parentRt)
+    rawMode = sanitizeMode(nr.allocationMode)
+    parentMode = sanitizeMode(parentRt?.allocationMode)
+    effectiveMode = sanitizeMode(effectiveRawMode)
+    modeSource = namedModeSourceCategory(nr.allocationMode ?? null, parentRt?.allocationMode ?? null)
+    percent = nr.allocationPercent
+    pct = nr.allocationPct
+    windowFields = {
+      allocationStartWeek: windowFieldStateFor(nr.allocationStartWeek),
+      allocationEndWeek: windowFieldStateFor(nr.allocationEndWeek),
+      startWeek: windowFieldStateFor(nr.startWeek),
+      endWeek: windowFieldStateFor(nr.endWeek),
+    }
+    // Shared per-edge alias semantics (same definition the classifier uses);
+    // window-using modes only.
+    aliasConflicts = {
+      startEdge: v2NamedResourceEdgeAliasConflict(nr, effectiveRawMode, 'start'),
+      endEdge: v2NamedResourceEdgeAliasConflict(nr, effectiveRawMode, 'end'),
+    }
+    sanitizedForKey = {
+      kind,
+      mode: rawMode,
+      percent: nr.allocationPercent ?? null,
+      pct: nr.allocationPct ?? null,
+      asw: nr.allocationStartWeek ?? null,
+      aew: nr.allocationEndWeek ?? null,
+      sw: nr.startWeek ?? null,
+      ew: nr.endWeek ?? null,
+    }
+  }
+  const entryErrorCategories: EntryErrorCategory[] = []
+  const errorMessages = kind === 'resourceType'
+    ? v2ResourceTypeEntryErrors(rawEntry as SnapshotResourceType, 'v2 snapshot resourceTypes[?]')
+    : v2NamedResourceEntryErrors(rawEntry as SnapshotNamedResource, parentRt, 'v2 snapshot namedResources[?]')
+  for (const message of errorMessages) {
+    const category = entryErrorCategory(message, rawEntry)
+    if (!entryErrorCategories.includes(category)) entryErrorCategories.push(category)
+  }
+  if (kind === 'namedResource') {
+    const nr = rawEntry as SnapshotNamedResource
+    const effectiveRawMode = v2EffectiveNamedMode(nr, parentRt)
+    if (v2NamedResourceAliasConflict(nr, effectiveRawMode) && !entryErrorCategories.includes('alias-conflict')) {
+      entryErrorCategories.push('alias-conflict')
+    }
+  }
+  const conflict = aliasConflicts.startEdge || aliasConflicts.endEdge
+  return {
+    key: contentKey(sanitizedForKey),
+    entryKind: kind,
+    minusOneField,
+    windowFields,
+    aliasConflicts,
+    alternateAliasState: conflict ? 'conflicting' : aliasStateFrom(windowFields),
+    rawMode,
+    parentMode,
+    effectiveMode,
+    modeSource,
+    allocationPercentCategory: percentCategory(percent),
+    allocationPctCategory: percentCategory(pct),
+    entryErrorCategories,
+    structuralErrorCategories: [...structuralErrorCategories],
+    independentDefect: structuralErrorCategories.length > 0 ? 'both' : 'entry-level',
+  }
+}
+
 export interface SnapshotEvidenceInputs {
   state: RemediationDatabaseState
   /** snapshot id → ISO created-at timestamp (separate read-only query;
@@ -626,7 +849,7 @@ interface ClassifiedSnapshot {
   parsedV2: SnapshotV2 | null
 }
 
-function classifyAllSnapshots(state: RemediationDatabaseState): ClassifiedSnapshot[] {
+export function classifyAllSnapshots(state: RemediationDatabaseState): ClassifiedSnapshot[] {
   return state.snapshots.map(snapshot => {
     const evidence = classifySnapshotEvidence(snapshot.snapshot, snapshot.projectId)
     let parsed: SnapshotData | null = null
@@ -699,155 +922,28 @@ export function buildSnapshotEvidenceReport(inputs: SnapshotEvidenceInputs): Sna
     findingCountsBySnapshot.set(finding.snapshotId, entry)
   }
 
-  // ── S entries: raw `-1` edge decisions — the exact entries the plan
-  // classifies as "single -1/negative window edge" (shared predicate via
-  // classifySnapshotEntry; the observed production shape is a single `-1`
-  // raw field; the other-edge state is reported as raw evidence, not
-  // assumed). Evidence, not policy.
-  interface SingleNegativeRecord {
-    key: string
-    entryKind: OwnerKindCategory
-    minusOneField: MinusOneField
-    windowFields: Record<MinusOneField, WindowFieldState>
-    aliasConflicts: { startEdge: boolean; endEdge: boolean }
-    alternateAliasState: AlternateAliasState
-    rawMode: SanitizedMode
-    parentMode: SanitizedMode
-    effectiveMode: SanitizedMode
-    modeSource: NamedModeSourceCategory
-    allocationPercentCategory: PercentCategory
-    allocationPctCategory: PercentCategory
-    entryErrorCategories: EntryErrorCategory[]
-    structuralErrorCategories: StructuralErrorCategory[]
-    independentDefect: IndependentDefectCategory
-  }
-  const singleNegativeRecords: SingleNegativeRecord[] = []
-
-  for (let snapshotIndex = 0; snapshotIndex < state.snapshots.length; snapshotIndex++) {
-    const item = classified[snapshotIndex]!
-    if (!item.v2 || !item.parsedV2) continue
-    const parsed = item.parsedV2
-    const rtById = new Map(parsed.resourceTypes.map(rt => [rt.id, rt]))
-    const evidence = item.evidence
-    // Entry evidence is in payload order: RTs then NRs.
-    for (let i = 0; i < evidence.entries.length; i++) {
-      const entry = evidence.entries[i]!
-      if (entry.minusOneFields.length !== 1) continue
-      let raw: SnapshotResourceType | SnapshotNamedResource
-      let kind: 'resourceType' | 'namedResource'
-      if (entry.kind === 'resourceType') {
-        raw = parsed.resourceTypes[i]!
-        kind = 'resourceType'
-      } else {
-        raw = parsed.namedResources[i - parsed.resourceTypes.length]!
-        kind = 'namedResource'
-      }
-      // Shared plan-level predicate: the entry must be exactly the
-      // "single -1/negative window edge" decision class. The plan quarantines
-      // CAPACITY_PLAN entries inside quarantined snapshots that match a
-      // shared quarantine shape BEFORE any decision classification; mirror
-      // that precedence so the S record set equals the plan's decision set.
-      if (item.evidence.restorability.kind === 'quarantined' && entry.effectiveMode === 'CAPACITY_PLAN') {
-        const shape = kind === 'resourceType'
-          ? {
-              primaryStart: (raw as SnapshotResourceType).allocationStartWeek ?? null,
-              aliasStart: null,
-              primaryEnd: (raw as SnapshotResourceType).allocationEndWeek ?? null,
-              aliasEnd: null,
-            }
-          : {
-              primaryStart: (raw as SnapshotNamedResource).allocationStartWeek ?? null,
-              aliasStart: (raw as SnapshotNamedResource).startWeek ?? null,
-              primaryEnd: (raw as SnapshotNamedResource).allocationEndWeek ?? null,
-              aliasEnd: (raw as SnapshotNamedResource).endWeek ?? null,
-            }
-        if (classifyV2QuarantineShape(shape) != null) continue
-      }
-      const finding = classifySnapshotEntry(planEntryPayload(raw, kind))
-      if (finding.classification !== 'decisionRequired') continue
-      if (!finding.message.includes(SINGLE_NEGATIVE_DECISION_MESSAGE)) continue
-
-      let rawMode: SanitizedMode
-      let parentMode: SanitizedMode
-      let percent: number | null | undefined
-      let pct: number | null | undefined
-      let windowFields: Record<MinusOneField, WindowFieldState>
-      let aliasConflicts: { startEdge: boolean; endEdge: boolean }
-      let aliasState: AlternateAliasState
-      let sanitizedForKey: Record<string, unknown>
-      if (kind === 'resourceType') {
-        const rt = raw as SnapshotResourceType
-        rawMode = sanitizeMode(rt.allocationMode)
-        parentMode = null
-        percent = rt.allocationPercent
-        // ResourceType entries carry no alternate aliases: every fallback
-        // field is reported absent, and no edge can conflict.
-        windowFields = {
-          allocationStartWeek: windowFieldState(rt.allocationStartWeek),
-          allocationEndWeek: windowFieldState(rt.allocationEndWeek),
-          startWeek: 'absent-null',
-          endWeek: 'absent-null',
-        }
-        aliasConflicts = { startEdge: false, endEdge: false }
-        aliasState = aliasStateFrom(windowFields)
-        sanitizedForKey = {
-          kind: entry.kind,
-          mode: rawMode,
-          percent: rt.allocationPercent ?? null,
-          asw: rt.allocationStartWeek ?? null,
-          aew: rt.allocationEndWeek ?? null,
-        }
-      } else {
-        const nr = raw as SnapshotNamedResource
-        rawMode = sanitizeMode(nr.allocationMode)
-        parentMode = sanitizeMode(rtById.get(nr.resourceTypeId ?? '')?.allocationMode)
-        percent = nr.allocationPercent
-        pct = nr.allocationPct
-        windowFields = {
-          allocationStartWeek: windowFieldState(nr.allocationStartWeek),
-          allocationEndWeek: windowFieldState(nr.allocationEndWeek),
-          startWeek: windowFieldState(nr.startWeek),
-          endWeek: windowFieldState(nr.endWeek),
-        }
-        // Shared per-edge alias semantics (same definition the classifier
-        // uses); window-using modes only.
-        aliasConflicts = {
-          startEdge: v2NamedResourceEdgeAliasConflict(nr, entry.effectiveMode, 'start'),
-          endEdge: v2NamedResourceEdgeAliasConflict(nr, entry.effectiveMode, 'end'),
-        }
-        aliasState = aliasConflicts.startEdge || aliasConflicts.endEdge
-          ? 'conflicting'
-          : aliasStateFrom(windowFields)
-        sanitizedForKey = {
-          kind: entry.kind,
-          mode: rawMode,
-          percent: nr.allocationPercent ?? null,
-          pct: nr.allocationPct ?? null,
-          asw: nr.allocationStartWeek ?? null,
-          aew: nr.allocationEndWeek ?? null,
-          sw: nr.startWeek ?? null,
-          ew: nr.endWeek ?? null,
-        }
-      }
-
-      singleNegativeRecords.push({
-        key: contentKey(sanitizedForKey),
-        entryKind: entry.kind,
-        minusOneField: entry.minusOneFields[0],
-        windowFields,
-        aliasConflicts,
-        alternateAliasState: aliasState,
-        rawMode,
-        parentMode,
-        effectiveMode: sanitizeMode(entry.effectiveMode),
-        modeSource: entry.modeSource,
-        allocationPercentCategory: percentCategory(percent),
-        allocationPctCategory: percentCategory(pct),
-        entryErrorCategories: entry.entryErrorCategories,
-        structuralErrorCategories: evidence.structuralErrorCategories,
-        independentDefect: evidence.structuralErrorCategories.length > 0 ? 'both' : 'entry-level',
-      })
-    }
+  // ── S records: correlated one-to-one with the plan's single-negative
+  // snapshot decisions. The remediation plan is the selection authority
+  // (shared snapshotDecisionCategory); raw payload entries are correlated
+  // internally by snapshotId + entryId + owner kind and are used ONLY to
+  // populate the sanitized evidence. Any missing, ambiguous or inconsistent
+  // correlation fails closed before any evidence is emitted. Raw entry
+  // scanning is never an independent policy or selection path.
+  const correlations = correlateSingleNegativeDecisions(plan, state, classified)
+  const singleNegativeRecords: SingleNegativeEvidenceEntry[] = correlations.map(correlation => {
+    const item = classified[correlation.snapshotIndex]!
+    return buildSingleNegativeEvidenceEntry(
+      correlation.rawEntry,
+      correlation.kind,
+      correlation.parentRt,
+      item.evidence.structuralErrorCategories,
+      correlation.minusOneField,
+    )
+  })
+  const singleNegativeBySnapshot = new Map<string, number>()
+  for (const correlation of correlations) {
+    const snapshotId = correlation.decision.snapshotId!
+    singleNegativeBySnapshot.set(snapshotId, (singleNegativeBySnapshot.get(snapshotId) ?? 0) + 1)
   }
 
   // ── M records: the defect-classified snapshots ───────────────────────────
@@ -1000,12 +1096,25 @@ export function buildSnapshotEvidenceReport(inputs: SnapshotEvidenceInputs): Sna
   const windowFieldReconciliationViolations = singleNegativeRecords.filter(record => {
     const fields = Object.keys(record.windowFields) as MinusOneField[]
     const minusOneFields = fields.filter(field => record.windowFields[field] === 'minus-one')
-    if (minusOneFields.length !== 1) return true
-    if (minusOneFields[0] !== record.minusOneField) return true
+    // At least one raw field must hold -1, minusOneField must be among them,
+    // every minus-one field must lie on the same effective edge (historical
+    // payloads may hold -1 on both aliases of one edge), and every other
+    // field must be absent-null or populated.
+    if (minusOneFields.length === 0) return true
+    if (!minusOneFields.includes(record.minusOneField)) return true
+    const edge = edgeOfMinusOneField(record.minusOneField)
+    if (minusOneFields.some(field => edgeOfMinusOneField(field) !== edge)) return true
     return fields.some(
-      field => field !== minusOneFields[0] && record.windowFields[field] !== 'absent-null' && record.windowFields[field] !== 'populated',
+      field => !minusOneFields.includes(field) && record.windowFields[field] !== 'absent-null' && record.windowFields[field] !== 'populated',
     )
   })
+
+  // Per-snapshot consistency: every seven-subgroup M record's single-negative
+  // decision count must equal the number of S records correlated to that
+  // snapshot (both derive from the same plan decisions; asserted explicitly).
+  const sRecordSubgroupViolations = defectSnapshotRecords.filter(record =>
+    record.singleMinusOneDecisionCount !== (singleNegativeBySnapshot.get(record.snapshotId) ?? 0),
+  ).length
 
   const checks: boolean[] = [
     check('quarantined entries', plan.summary.quarantined, expected.quarantinedEntries),
@@ -1028,8 +1137,11 @@ export function buildSnapshotEvidenceReport(inputs: SnapshotEvidenceInputs): Sna
     check('topology 7 total = windowless + single', sevenWindowless + sevenSingle, expected.topology7WindowlessDecisions + expected.topology7SingleMinusOneDecisions),
     check('snapshot decisions = windowless + single', snapshotDecisions, windowlessDecisions + singleMinusOneDecisions),
     check('quarantined findings carry no decision/op ids', quarantinedFindingsWithIds, 0),
+    check('plan single-negative snapshot decisions', correlations.length, expected.singleMinusOneDecisions),
+    check('correlated single-negative decisions match records', correlations.length, singleNegativeRecords.length),
     check('single-negative records', singleNegativeRecords.length, expected.singleMinusOneDecisions),
     check('S records window-field reconciliation', windowFieldReconciliationViolations.length, 0),
+    check('S records reconcile to per-snapshot subgroup counts', sRecordSubgroupViolations, 0),
     check('class A entries reconcile', classATotalEntries, expected.quarantinedEntries),
     check('class A snapshots reconcile', classATotalSnapshots, expected.quarantinedSnapshots),
   ]
@@ -1123,7 +1235,20 @@ export function buildSnapshotEvidenceReport(inputs: SnapshotEvidenceInputs): Sna
 
 // ─── Small raw-field evidence helpers (no ids, no names) ────────────────────
 
-function windowFieldState(value: number | null | undefined): WindowFieldState {
+/** Fixed evidence mode-source category for a NamedResource entry: the raw
+ * mode wins when present; a CAPACITY_PLAN parent provides inherited
+ * provenance; otherwise the source is unavailable (or other for a
+ * non-CAPACITY_PLAN parent). Single definition shared by the entry evidence
+ * and the correlated S records. */
+function namedModeSourceCategory(rawMode: string | null, parentMode: string | null): NamedModeSourceCategory {
+  if (rawMode === 'CAPACITY_PLAN') return 'explicit'
+  if (rawMode != null) return 'other'
+  if (parentMode === 'CAPACITY_PLAN') return 'inherited'
+  if (parentMode == null) return 'unavailable'
+  return 'other'
+}
+
+function windowFieldStateFor(value: number | null | undefined): WindowFieldState {
   if (value === -1) return 'minus-one'
   if (value == null) return 'absent-null'
   return 'populated'

--- a/server/src/test/snapshotEvidence.integration.test.ts
+++ b/server/src/test/snapshotEvidence.integration.test.ts
@@ -290,9 +290,10 @@ describeIf('snapshot evidence command (integration)', () => {
     expect(report.classAAggregates.totalEntries).toBe(3)
     expect(report.classAAggregates.byOwnerKind).toEqual({ resourceType: 2, namedResource: 1, unavailable: 0 })
     expect(report.singleNegativeEntries).toHaveLength(1)
-    // Production regression: -1 on both aliases of the start edge is a plan
-    // single-negative decision; the correlated S record reports both fields
-    // truthfully and names the plan-relevant exact field.
+    // Sanitized reproducer of the former selection-path divergence: -1 on
+    // both aliases of the start edge is a plan single-negative decision whose
+    // evidence is emitted end to end. The exact production raw layout remains
+    // unknown until the corrected #404 run.
     expect(report.singleNegativeEntries[0]!.minusOneField).toBe('allocationStartWeek')
     expect(report.singleNegativeEntries[0]!.windowFields).toEqual({
       allocationStartWeek: 'minus-one',
@@ -441,6 +442,41 @@ describeIf('snapshot evidence command (integration)', () => {
     expect(readdirSync(dir).filter(name => name.includes('.tmp'))).toEqual([])
     // No identifiers or payload names leak into the refusal.
     expect(readFileSync(expectedPath, 'utf-8')).toBeTruthy()
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('refuses when a correlated NamedResource parent is duplicated with different modes (no output, no writes)', async () => {
+    // One explicit CAPACITY_PLAN NamedResource with a plan-derived
+    // single-negative decision; two ResourceTypes share the referenced id
+    // with different allocation modes — the parent correlation must refuse.
+    await createSnapshot(
+      'snap-dup-parent',
+      makeV2Snapshot(
+        [
+          makeRt({ id: 'rt-dup-parent', allocationMode: 'CAPACITY_PLAN', allocationStartWeek: 0, allocationEndWeek: 5 }),
+          makeRt({ id: 'rt-dup-parent', allocationMode: 'TIMELINE', allocationStartWeek: 0, allocationEndWeek: 5 }),
+        ],
+        [makeNr({ id: 'nr-child', resourceTypeId: 'rt-dup-parent', allocationMode: 'CAPACITY_PLAN', allocationStartWeek: -1, startWeek: 5, allocationEndWeek: 5, endWeek: null })],
+      ),
+      '2026-06-01T00:00:00Z',
+    )
+    const stateHashBefore = await currentStateHash()
+    const dir = tempDir()
+    const jsonPath = path.join(dir, 'evidence.json')
+    const mdPath = path.join(dir, 'evidence.md')
+    const expectedPath = path.join(dir, 'expected.json')
+    const expected = await expectedBoundary()
+    writeFileSync(expectedPath, JSON.stringify(expected, null, 2))
+
+    const exit = await main(['--json', jsonPath, '--markdown', mdPath, '--expected', expectedPath])
+
+    expect(exit).toBe(1)
+    expect(existsSync(jsonPath)).toBe(false)
+    expect(existsSync(mdPath)).toBe(false)
+    expect(readdirSync(dir).filter(name => name.includes('.tmp'))).toEqual([])
+    // Zero writes: canonical covered-state hash unchanged.
+    const stateHashAfter = await currentStateHash()
+    expect(stateHashAfter).toBe(stateHashBefore)
     rmSync(dir, { recursive: true, force: true })
   })
 

--- a/server/src/test/snapshotEvidence.integration.test.ts
+++ b/server/src/test/snapshotEvidence.integration.test.ts
@@ -188,7 +188,7 @@ async function seedTopologyFixture(): Promise<void> {
         allocationMode: 'CAPACITY_PLAN',
         allocationStartWeek: -1,
         allocationEndWeek: 5,
-        startWeek: 5,
+        startWeek: -1,
         endWeek: null,
       })],
     ),
@@ -290,7 +290,16 @@ describeIf('snapshot evidence command (integration)', () => {
     expect(report.classAAggregates.totalEntries).toBe(3)
     expect(report.classAAggregates.byOwnerKind).toEqual({ resourceType: 2, namedResource: 1, unavailable: 0 })
     expect(report.singleNegativeEntries).toHaveLength(1)
+    // Production regression: -1 on both aliases of the start edge is a plan
+    // single-negative decision; the correlated S record reports both fields
+    // truthfully and names the plan-relevant exact field.
     expect(report.singleNegativeEntries[0]!.minusOneField).toBe('allocationStartWeek')
+    expect(report.singleNegativeEntries[0]!.windowFields).toEqual({
+      allocationStartWeek: 'minus-one',
+      allocationEndWeek: 'populated',
+      startWeek: 'minus-one',
+      endWeek: 'absent-null',
+    })
     expect(report.defectSnapshots).toHaveLength(3)
     const seven = report.defectSnapshots.find((m: { subgroup: string }) => m.subgroup === 'seven-single-minus-one')!
     expect(seven.windowlessDecisionCount).toBe(19)
@@ -399,6 +408,39 @@ describeIf('snapshot evidence command (integration)', () => {
     expect(exit).toBe(1)
     expect(existsSync(jsonPath)).toBe(false)
     expect(existsSync(mdPath)).toBe(false)
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('refuses on decision correlation failure with no output files and a safe message', async () => {
+    // Two raw entries sharing one id: the plan produces single-negative
+    // decisions whose correlation is ambiguous — the command fails closed
+    // with no evidence emitted.
+    await createSnapshot(
+      'snap-correlation-ambiguous',
+      makeV2Snapshot(
+        [
+          makeRt({ id: 'rt-dupe', allocationMode: 'CAPACITY_PLAN', allocationStartWeek: -1, allocationEndWeek: 5 }),
+          makeRt({ id: 'rt-dupe', allocationMode: 'CAPACITY_PLAN', allocationStartWeek: -1, allocationEndWeek: 5 }),
+        ],
+        [],
+      ),
+      '2026-06-01T00:00:00Z',
+    )
+    const dir = tempDir()
+    const jsonPath = path.join(dir, 'evidence.json')
+    const mdPath = path.join(dir, 'evidence.md')
+    const expectedPath = path.join(dir, 'expected.json')
+    const expected = await expectedBoundary()
+    writeFileSync(expectedPath, JSON.stringify(expected, null, 2))
+
+    const exit = await main(['--json', jsonPath, '--markdown', mdPath, '--expected', expectedPath])
+
+    expect(exit).toBe(1)
+    expect(existsSync(jsonPath)).toBe(false)
+    expect(existsSync(mdPath)).toBe(false)
+    expect(readdirSync(dir).filter(name => name.includes('.tmp'))).toEqual([])
+    // No identifiers or payload names leak into the refusal.
+    expect(readFileSync(expectedPath, 'utf-8')).toBeTruthy()
     rmSync(dir, { recursive: true, force: true })
   })
 

--- a/server/src/test/snapshotEvidence.test.ts
+++ b/server/src/test/snapshotEvidence.test.ts
@@ -1272,11 +1272,16 @@ describe('plan-decision-anchored S-record correlation', () => {
     }])
   }
 
-  it('reproduces the production failure shape: dual-alias -1 is a plan decision that now emits one S record', () => {
-    // Production regression: a raw payload holding -1 on both aliases of the
-    // start edge (allocationStartWeek AND startWeek) is a plan single-negative
-    // decision; the pre-fix independent raw-entry scan dropped it via the
-    // one-minus-one prefilter and reported observed 0 against expected 7.
+  it('emits one S record for the sanitized dual-alias reproducer of the former selection divergence', () => {
+    // Sanitized regression reproducer (NOT confirmed production evidence):
+    // production observed zero S records against seven plan-derived
+    // single-negative decisions, and the confirmed code defect is the
+    // independent raw selection path (its one-minus-one prefilter could
+    // diverge from the plan-authoritative set). This fixture — -1 on both
+    // aliases of the start edge — is one concrete raw shape capable of
+    // causing that mismatch; the corrected implementation emits its
+    // sanitized evidence. The exact production raw layout remains unknown
+    // until the corrected #404 run.
     const state = correlateFixtureState()
     const counts: Omit<SnapshotEvidenceExpected, 'fingerprint' | 'baselineStateHash'> = {
       quarantinedEntries: 0, quarantinedSnapshots: 0, defectSnapshots: 1,
@@ -1535,6 +1540,112 @@ describe('plan-decision-anchored S-record correlation', () => {
       state,
       classified,
     )).toThrowError(/does not re-derive the single-negative decision/)
+  })
+
+  it('correlates a NamedResource only when exactly one parent ResourceType matches', () => {
+    const state = makeState([{
+      id: 'snap-parent',
+      projectId: PROJECT_ID,
+      payload: makeV2Snapshot(
+        [makeRt({ id: 'rt-p', allocationMode: 'CAPACITY_PLAN', allocationStartWeek: 0, allocationEndWeek: 5 })],
+        [makeNr({ id: 'nr-child', resourceTypeId: 'rt-p', allocationMode: 'CAPACITY_PLAN', allocationStartWeek: -1, startWeek: 5, allocationEndWeek: 5, endWeek: null })],
+      ),
+    }])
+    const counts: Omit<SnapshotEvidenceExpected, 'fingerprint' | 'baselineStateHash'> = {
+      quarantinedEntries: 0, quarantinedSnapshots: 0, defectSnapshots: 1,
+      windowlessDecisions: 0, singleMinusOneDecisions: 1, snapshotDecisions: 1,
+      liveDecisions: 0, unsupported: 0, rewriteOperations: 0,
+      topology11Snapshots: 0, topology7Snapshots: 1,
+      topology11WindowlessDecisions: 0, topology7WindowlessDecisions: 0,
+      topology7SingleMinusOneDecisions: 1,
+    }
+    const report = buildReport(state, counts)
+    expect(report.integrityResult.reconciliationPassed).toBe(true)
+    expect(report.singleNegativeEntries).toHaveLength(1)
+    expect(report.singleNegativeEntries[0]!.modeSource).toBe('explicit')
+  })
+
+  it('fails closed on an absent parent reference', () => {
+    const state = makeState([{
+      id: 'snap-no-parent-ref',
+      projectId: PROJECT_ID,
+      payload: makeV2Snapshot(
+        [makeRt({ id: 'rt-p', allocationMode: 'CAPACITY_PLAN', allocationStartWeek: 0, allocationEndWeek: 5 })],
+        [{
+          id: 'nr-orphan',
+          resourceTypeId: null,
+          name: 'Secret Person Name',
+          startWeek: null,
+          endWeek: null,
+          allocationPct: 100,
+          allocationMode: 'CAPACITY_PLAN',
+          allocationPercent: 100,
+          allocationStartWeek: -1,
+          allocationEndWeek: 5,
+          pricingModel: 'ACTUAL_DAYS',
+        }],
+      ),
+    }])
+    const classified = classifyAllSnapshots(state)
+    const plan = buildRemediationPlan(state, 'test-commit')
+    expect(() => correlateSingleNegativeDecisions(
+      { ...plan, decisions: [fakeDecision({ snapshotId: 'snap-no-parent-ref', entryId: 'nr-orphan' })] },
+      state,
+      classified,
+    )).toThrowError(/carries no parent reference/)
+  })
+
+  it('fails closed when no parent ResourceType matches', () => {
+    const state = makeState([{
+      id: 'snap-no-parent',
+      projectId: PROJECT_ID,
+      payload: makeV2Snapshot(
+        [makeRt({ id: 'rt-other', allocationMode: 'CAPACITY_PLAN', allocationStartWeek: 0, allocationEndWeek: 5 })],
+        [makeNr({ id: 'nr-child', resourceTypeId: 'rt-ghost', allocationMode: 'CAPACITY_PLAN', allocationStartWeek: -1, startWeek: null, allocationEndWeek: 5, endWeek: null })],
+      ),
+    }])
+    const classified = classifyAllSnapshots(state)
+    const plan = buildRemediationPlan(state, 'test-commit')
+    expect(() => correlateSingleNegativeDecisions(
+      { ...plan, decisions: [fakeDecision({ snapshotId: 'snap-no-parent', entryId: 'nr-child' })] },
+      state,
+      classified,
+    )).toThrowError(/matched 0 resource types/)
+  })
+
+  it('fails closed on duplicate parents even with different allocation modes', () => {
+    const state = makeState([{
+      id: 'snap-dup-parents',
+      projectId: PROJECT_ID,
+      payload: makeV2Snapshot(
+        [
+          makeRt({ id: 'rt-p', allocationMode: 'CAPACITY_PLAN', allocationStartWeek: 0, allocationEndWeek: 5 }),
+          makeRt({ id: 'rt-p', allocationMode: 'TIMELINE', allocationStartWeek: 0, allocationEndWeek: 5 }),
+        ],
+        [makeNr({ id: 'nr-child', resourceTypeId: 'rt-p', allocationMode: 'CAPACITY_PLAN', allocationStartWeek: -1, startWeek: null, allocationEndWeek: 5, endWeek: null })],
+      ),
+    }])
+    const classified = classifyAllSnapshots(state)
+    const plan = buildRemediationPlan(state, 'test-commit')
+    try {
+      correlateSingleNegativeDecisions(
+        { ...plan, decisions: [fakeDecision({ snapshotId: 'snap-dup-parents', entryId: 'nr-child' })] },
+        state,
+        classified,
+      )
+      throw new Error('expected refusal')
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      expect(message).toContain('matched multiple resource types')
+      // Controlled messages expose no identifiers, names, modes or payload
+      // values — the duplicate parents held different allocation modes and
+      // neither may influence evidence.
+      expect(message).not.toContain('rt-p')
+      expect(message).not.toContain('nr-child')
+      expect(message).not.toContain('CAPACITY_PLAN')
+      expect(message).not.toContain('TIMELINE')
+      expect(message).not.toContain('snap-dup-parents')
+    }
   })
 
   it('correlation errors carry only fixed safe reasons and counts (no ids or payloads)', () => {

--- a/server/src/test/snapshotEvidence.test.ts
+++ b/server/src/test/snapshotEvidence.test.ts
@@ -18,7 +18,10 @@ import path from 'node:path'
 import { main } from '../scripts/generateSnapshotEvidence.js'
 import {
   buildSnapshotEvidenceReport,
+  buildSingleNegativeEvidenceEntry,
+  classifyAllSnapshots,
   classifySnapshotEvidence,
+  correlateSingleNegativeDecisions,
   isExpectedBoundaryShape,
   percentCategory,
   renderSnapshotEvidenceMarkdown,
@@ -32,6 +35,7 @@ import {
   buildRemediationPlan,
   computePlanFingerprint,
   computeStateHash,
+  type PlanDecisionEntry,
   type RemediationDatabaseState,
 } from '../lib/productionRemediationPlan.js'
 
@@ -664,9 +668,9 @@ describe('all four raw -1 orientations', () => {
         [makeRt({ id: 'rt-o', allocationMode: 'TIMELINE', allocationStartWeek: 0, allocationEndWeek: 5 })],
         [
           // Start edge: primary -1 vs populated fallback 7 → start conflict.
-          makeNr({ resourceTypeId: 'rt-o', allocationMode: 'CAPACITY_PLAN', allocationStartWeek: -1, startWeek: 7, allocationEndWeek: 5, endWeek: null }),
+          makeNr({ id: 'nr-start-conflict', resourceTypeId: 'rt-o', allocationMode: 'CAPACITY_PLAN', allocationStartWeek: -1, startWeek: 7, allocationEndWeek: 5, endWeek: null }),
           // End edge: populated primary 5 vs fallback 9 → end conflict.
-          makeNr({ resourceTypeId: 'rt-o', allocationMode: 'CAPACITY_PLAN', allocationStartWeek: -1, startWeek: null, allocationEndWeek: 5, endWeek: 9 }),
+          makeNr({ id: 'nr-end-conflict', resourceTypeId: 'rt-o', allocationMode: 'CAPACITY_PLAN', allocationStartWeek: -1, startWeek: null, allocationEndWeek: 5, endWeek: 9 }),
         ],
       ),
     }])
@@ -1236,5 +1240,321 @@ describe('structural defect classification', () => {  it('classifies a duplicate
     const m = report.defectSnapshots[0]!
     expect(m.independentDefect).toBe('structural')
     expect(m.structuralErrorCategories['duplicate-owner']).toBe(1)
+  })
+})
+
+describe('plan-decision-anchored S-record correlation', () => {
+  function fakeDecision(overrides: Partial<PlanDecisionEntry>): PlanDecisionEntry {
+    return {
+      id: 'decision-id',
+      projectId: PROJECT_ID,
+      ownerId: 'owner',
+      ownerKind: 'namedPerson',
+      profileId: null,
+      snapshotId: 'snap-correlate',
+      entryId: 'nr-1',
+      legacyBase: null,
+      evidenceHash: 'hash',
+      allowedResolutions: ['snapshot-window-interpretation'],
+      message: 'single -1/negative window edge without established meaning — explicit window interpretation required',
+      ...overrides,
+    }
+  }
+
+  function correlateFixtureState(): RemediationDatabaseState {
+    return makeState([{
+      id: 'snap-correlate',
+      projectId: PROJECT_ID,
+      payload: makeV2Snapshot(
+        [makeRt({ id: 'rt-w', allocationMode: 'CAPACITY_PLAN' })],
+        [makeNr({ id: 'nr-1', resourceTypeId: 'rt-w', allocationMode: 'CAPACITY_PLAN', allocationStartWeek: -1, startWeek: -1, allocationEndWeek: 5, endWeek: null })],
+      ),
+    }])
+  }
+
+  it('reproduces the production failure shape: dual-alias -1 is a plan decision that now emits one S record', () => {
+    // Production regression: a raw payload holding -1 on both aliases of the
+    // start edge (allocationStartWeek AND startWeek) is a plan single-negative
+    // decision; the pre-fix independent raw-entry scan dropped it via the
+    // one-minus-one prefilter and reported observed 0 against expected 7.
+    const state = correlateFixtureState()
+    const counts: Omit<SnapshotEvidenceExpected, 'fingerprint' | 'baselineStateHash'> = {
+      quarantinedEntries: 0, quarantinedSnapshots: 0, defectSnapshots: 1,
+      windowlessDecisions: 1, singleMinusOneDecisions: 1, snapshotDecisions: 2,
+      liveDecisions: 0, unsupported: 0, rewriteOperations: 0,
+      topology11Snapshots: 0, topology7Snapshots: 1,
+      topology11WindowlessDecisions: 0, topology7WindowlessDecisions: 1,
+      topology7SingleMinusOneDecisions: 1,
+    }
+    const report = buildReport(state, counts)
+    expect(report.integrityResult.reconciliationPassed).toBe(true)
+    expect(report.singleNegativeEntries).toHaveLength(1)
+    const s = report.singleNegativeEntries[0]!
+    expect(s.entryKind).toBe('namedResource')
+    // The plan-relevant exact field is the primary of the negative edge; the
+    // fallback alias is still reported truthfully as minus-one.
+    expect(s.minusOneField).toBe('allocationStartWeek')
+    expect(s.windowFields).toEqual({
+      allocationStartWeek: 'minus-one',
+      allocationEndWeek: 'populated',
+      startWeek: 'minus-one',
+      endWeek: 'absent-null',
+    })
+    expect(s.aliasConflicts).toEqual({ startEdge: false, endEdge: false })
+    expect(s.modeSource).toBe('explicit')
+    // JSON and Markdown parity for the sanitized field states.
+    const json = JSON.stringify(report)
+    const markdown = renderSnapshotEvidenceMarkdown(report)
+    expect(json).toContain('"allocationStartWeek":"minus-one","allocationEndWeek":"populated","startWeek":"minus-one","endWeek":"absent-null"')
+    expect(markdown).toContain('allocationStartWeek:minus-one')
+    expect(markdown).toContain('startWeek:minus-one')
+  })
+
+  it('populates inherited effective-mode evidence (raw null / parent CAPACITY_PLAN / effective CAPACITY_PLAN / inherited)', () => {
+    // The S schema must be capable of showing inherited provenance. This is
+    // the pure population path; a real plan decision for such an entry cannot
+    // exist because the plan classifies NamedResources by their own raw mode
+    // (traced contract), so the capability is proven directly.
+    const entry = buildSingleNegativeEvidenceEntry(
+      makeNr({ id: 'nr-inherited', resourceTypeId: 'rt-parent', allocationMode: null, allocationPercent: 100, allocationPct: 100, allocationStartWeek: null, startWeek: -1, allocationEndWeek: 5, endWeek: null }) as unknown as Parameters<typeof buildSingleNegativeEvidenceEntry>[0],
+      'namedResource',
+      makeRt({ id: 'rt-parent', allocationMode: 'CAPACITY_PLAN', allocationStartWeek: 0, allocationEndWeek: 5 }) as unknown as Parameters<typeof buildSingleNegativeEvidenceEntry>[2],
+      [],
+      'startWeek',
+    )
+    expect(entry.rawMode).toBe(null)
+    expect(entry.parentMode).toBe('CAPACITY_PLAN')
+    expect(entry.effectiveMode).toBe('CAPACITY_PLAN')
+    expect(entry.modeSource).toBe('inherited')
+    expect(entry.windowFields).toEqual({
+      allocationStartWeek: 'absent-null',
+      allocationEndWeek: 'populated',
+      startWeek: 'minus-one',
+      endWeek: 'absent-null',
+    })
+  })
+
+  it('keeps inherited-mode single-negative entries out of the S set (plan classifies by raw mode)', () => {
+    // Plan-faithful boundary: the plan derives decisions from the raw own
+    // mode, so an inherited CAPACITY_PLAN NamedResource (own mode null) is
+    // never a single-negative decision or S record. The entry instead matches
+    // the shared Class B quarantine shape, so the run also refuses on the
+    // reviewed Class A invariant (fail closed) exactly as on production.
+    const state = makeState([{
+      id: 'snap-inherited',
+      projectId: PROJECT_ID,
+      payload: makeV2Snapshot(
+        [makeRt({ id: 'rt-parent', allocationMode: 'CAPACITY_PLAN', allocationStartWeek: 0, allocationEndWeek: 5 })],
+        [makeNr({ id: 'nr-inherited', resourceTypeId: 'rt-parent', allocationMode: null, allocationPercent: 100, allocationPct: 100, allocationStartWeek: null, startWeek: -1, allocationEndWeek: 5, endWeek: null })],
+      ),
+    }])
+    const counts: Omit<SnapshotEvidenceExpected, 'fingerprint' | 'baselineStateHash'> = {
+      quarantinedEntries: 1, quarantinedSnapshots: 1, defectSnapshots: 0,
+      windowlessDecisions: 0, singleMinusOneDecisions: 0, snapshotDecisions: 0,
+      liveDecisions: 0, unsupported: 0, rewriteOperations: 0,
+      topology11Snapshots: 0, topology7Snapshots: 0,
+      topology11WindowlessDecisions: 0, topology7WindowlessDecisions: 0,
+      topology7SingleMinusOneDecisions: 0,
+    }
+    const report = buildReport(state, counts)
+    expect(report.singleNegativeEntries).toHaveLength(0)
+    expect(report.integrityResult.reconciliationPassed).toBe(false)
+    const mismatches = report.reconciliation.details.filter(detail => detail.includes('MISMATCH'))
+    expect(mismatches.map(m => m.split(':')[0])).toEqual(['class A entries reconcile', 'class A snapshots reconcile'])
+  })
+
+  it('emits exactly seven S records for seven synthetic defect snapshots', () => {
+    const snapshots = Array.from({ length: 7 }, (_, i) => ({
+      id: `snap-${i}`,
+      projectId: PROJECT_ID,
+      payload: makeV2Snapshot(
+        [makeRt({ id: `rt-w-${i}`, allocationMode: 'CAPACITY_PLAN' })],
+        [makeNr({ id: `nr-m-${i}`, resourceTypeId: `rt-w-${i}`, allocationMode: 'CAPACITY_PLAN', allocationStartWeek: -1, startWeek: -1, allocationEndWeek: 5, endWeek: null })],
+      ),
+    }))
+    const state = makeState(snapshots)
+    const counts: Omit<SnapshotEvidenceExpected, 'fingerprint' | 'baselineStateHash'> = {
+      quarantinedEntries: 0, quarantinedSnapshots: 0, defectSnapshots: 7,
+      windowlessDecisions: 7, singleMinusOneDecisions: 7, snapshotDecisions: 14,
+      liveDecisions: 0, unsupported: 0, rewriteOperations: 0,
+      topology11Snapshots: 0, topology7Snapshots: 7,
+      topology11WindowlessDecisions: 0, topology7WindowlessDecisions: 7,
+      topology7SingleMinusOneDecisions: 7,
+    }
+    const report = buildReport(state, counts)
+    expect(report.integrityResult.reconciliationPassed).toBe(true)
+    expect(report.singleNegativeEntries).toHaveLength(7)
+    // Every seven-subgroup M record reports exactly one correlated S record.
+    for (const m of report.defectSnapshots) {
+      expect(m.singleMinusOneDecisionCount).toBe(1)
+    }
+    const seven = report.topology.sevenSnapshotSubgroup
+    expect(seven.snapshots).toBe(7)
+    expect(seven.singleMinusOneDecisions).toBe(7)
+  })
+
+  it('reconciles the reviewed 18-snapshot topology shape (226 + 133/7 decisions)', () => {
+    // Production-shaped topology: 10 eleven-subgroup snapshots with 21
+    // windowless decisions, 1 with 16, and 7 seven-subgroup snapshots with 19
+    // windowless + 1 single-negative decision each. 359 windowless + 7
+    // single-negative = 366 snapshot decisions across 18 defect snapshots.
+    const conflictNr = (rtId: string, i: number) => makeNr({
+      id: `nr-c-${i}`,
+      resourceTypeId: rtId,
+      allocationMode: null,
+      allocationPercent: 100,
+      allocationPct: 100,
+      allocationStartWeek: 5,
+      allocationEndWeek: 10,
+      startWeek: 5,
+      endWeek: 9,
+    })
+    const snapshots = []
+    for (let i = 0; i < 10; i++) {
+      const rtId = `rt-e-${i}-0`
+      snapshots.push({
+        id: `snap-eleven-${i}`,
+        projectId: PROJECT_ID,
+        payload: makeV2Snapshot(
+          Array.from({ length: 21 }, (_, j) => makeRt({ id: `rt-e-${i}-${j}`, allocationMode: 'CAPACITY_PLAN' })),
+          [conflictNr(rtId, i)],
+        ),
+      })
+    }
+    snapshots.push({
+      id: 'snap-eleven-16',
+      projectId: PROJECT_ID,
+      payload: makeV2Snapshot(
+        Array.from({ length: 16 }, (_, j) => makeRt({ id: `rt-e16-${j}`, allocationMode: 'CAPACITY_PLAN' })),
+        [conflictNr('rt-e16-0', 99)],
+      ),
+    })
+    for (let i = 0; i < 7; i++) {
+      const rtId = `rt-s-${i}-0`
+      snapshots.push({
+        id: `snap-seven-${i}`,
+        projectId: PROJECT_ID,
+        payload: makeV2Snapshot(
+          Array.from({ length: 19 }, (_, j) => makeRt({ id: `rt-s-${i}-${j}`, allocationMode: 'CAPACITY_PLAN' })),
+          [makeNr({ id: `nr-s-${i}`, resourceTypeId: rtId, allocationMode: 'CAPACITY_PLAN', allocationStartWeek: -1, startWeek: -1, allocationEndWeek: 5, endWeek: null })],
+        ),
+      })
+    }
+    const state = makeState(snapshots)
+    const counts: Omit<SnapshotEvidenceExpected, 'fingerprint' | 'baselineStateHash'> = {
+      quarantinedEntries: 0, quarantinedSnapshots: 0, defectSnapshots: 18,
+      windowlessDecisions: 359, singleMinusOneDecisions: 7, snapshotDecisions: 366,
+      liveDecisions: 0, unsupported: 0, rewriteOperations: 0,
+      topology11Snapshots: 11, topology7Snapshots: 7,
+      topology11WindowlessDecisions: 226, topology7WindowlessDecisions: 133,
+      topology7SingleMinusOneDecisions: 7,
+    }
+    const report = buildReport(state, counts)
+    expect(report.integrityResult.reconciliationPassed).toBe(true)
+    expect(report.singleNegativeEntries).toHaveLength(7)
+    expect(report.topology.elevenSnapshotSubgroup.snapshots).toBe(11)
+    expect(report.topology.elevenSnapshotSubgroup.windowlessDecisions).toBe(226)
+    expect(report.topology.sevenSnapshotSubgroup.windowlessDecisions).toBe(133)
+    expect(report.topology.sevenSnapshotSubgroup.singleMinusOneDecisions).toBe(7)
+    expect(report.topology.snapshotDecisions).toBe(366)
+  })
+
+  it('fails closed on a missing stored snapshot', () => {
+    const state = correlateFixtureState()
+    const classified = classifyAllSnapshots(state)
+    const plan = buildRemediationPlan(state, 'test-commit')
+    const decisions = [fakeDecision({ snapshotId: 'ghost-snapshot' })]
+    const fakePlan = { ...plan, decisions }
+    expect(() => correlateSingleNegativeDecisions(fakePlan, state, classified))
+      .toThrowError(SnapshotEvidenceError)
+  })
+
+  it('fails closed on a missing entry identifier and on a missing raw entry', () => {
+    const state = correlateFixtureState()
+    const classified = classifyAllSnapshots(state)
+    const plan = buildRemediationPlan(state, 'test-commit')
+    expect(() => correlateSingleNegativeDecisions({ ...plan, decisions: [fakeDecision({ entryId: null })] }, state, classified))
+      .toThrowError(/carries no entry identifier/)
+    expect(() => correlateSingleNegativeDecisions({ ...plan, decisions: [fakeDecision({ entryId: 'nr-ghost' })] }, state, classified))
+      .toThrowError(/matched 0 raw entries/)
+  })
+
+  it('fails closed on duplicate raw entry IDs and on entry-kind mismatch', () => {
+    const state = makeState([{
+      id: 'snap-dupe',
+      projectId: PROJECT_ID,
+      payload: makeV2Snapshot(
+        [
+          makeRt({ id: 'rt-dupe', allocationMode: 'CAPACITY_PLAN', allocationStartWeek: -1, allocationEndWeek: 5 }),
+          makeRt({ id: 'rt-dupe', allocationMode: 'CAPACITY_PLAN', allocationStartWeek: -1, allocationEndWeek: 5 }),
+        ],
+        [],
+      ),
+    }])
+    const classified = classifyAllSnapshots(state)
+    const plan = buildRemediationPlan(state, 'test-commit')
+    expect(() => correlateSingleNegativeDecisions(
+      { ...plan, decisions: [fakeDecision({ snapshotId: 'snap-dupe', ownerKind: 'role', entryId: 'rt-dupe' })] },
+      state,
+      classified,
+    )).toThrowError(/matched 2 raw entries/)
+    // Kind mismatch: a namedPerson decision for a ResourceType id matches no
+    // NamedResource.
+    expect(() => correlateSingleNegativeDecisions(
+      { ...plan, decisions: [fakeDecision({ snapshotId: 'snap-dupe', ownerKind: 'namedPerson', entryId: 'rt-dupe' })] },
+      state,
+      classified,
+    )).toThrowError(/matched 0 raw entries/)
+  })
+
+  it('fails closed when two selected decisions resolve to the same raw entry', () => {
+    const state = correlateFixtureState()
+    const classified = classifyAllSnapshots(state)
+    const plan = buildRemediationPlan(state, 'test-commit')
+    const decision = fakeDecision({})
+    expect(() => correlateSingleNegativeDecisions(
+      { ...plan, decisions: [decision, decision] },
+      state,
+      classified,
+    )).toThrowError(/two selected decisions resolve to the same raw entry/)
+  })
+
+  it('fails closed when the matched raw entry does not re-derive the single-negative decision', () => {
+    const state = makeState([{
+      id: 'snap-windowless',
+      projectId: PROJECT_ID,
+      payload: makeV2Snapshot(
+        [makeRt({ id: 'rt-w', allocationMode: 'CAPACITY_PLAN' })],
+        [],
+      ),
+    }])
+    const classified = classifyAllSnapshots(state)
+    const plan = buildRemediationPlan(state, 'test-commit')
+    expect(() => correlateSingleNegativeDecisions(
+      { ...plan, decisions: [fakeDecision({ snapshotId: 'snap-windowless', ownerKind: 'role', entryId: 'rt-w' })] },
+      state,
+      classified,
+    )).toThrowError(/does not re-derive the single-negative decision/)
+  })
+
+  it('correlation errors carry only fixed safe reasons and counts (no ids or payloads)', () => {
+    const state = correlateFixtureState()
+    const classified = classifyAllSnapshots(state)
+    const plan = buildRemediationPlan(state, 'test-commit')
+    try {
+      correlateSingleNegativeDecisions(
+        { ...plan, decisions: [fakeDecision({ snapshotId: 'ghost-snapshot', entryId: 'nr-1' })] },
+        state,
+        classified,
+      )
+      throw new Error('expected refusal')
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      expect(message).toContain('cannot correlate snapshot decision 1 of 1')
+      expect(message).not.toContain('ghost-snapshot')
+      expect(message).not.toContain('nr-1')
+      expect(message).not.toContain(PROJECT_ID)
+      expect(message).not.toContain('Secret')
+    }
   })
 })


### PR DESCRIPTION
# fix(#432): correlate single-negative evidence to plan decisions

Closes #432.

## Production failure

The merged evidence command (PR #433) ran once against the production database and its own integrity gate rejected the result with **`single-negative records: observed 0, expected 7 — MISMATCH`** — no evidence was emitted, no expectation values were edited, zero writes (Issue #404 comment `5184481734`). The same run's remediation plan still contains the reviewed seven single-negative snapshot decisions. Reopened defect record: Issue #432 comment `5184931861`; #430 records that no policy evidence was emitted (comment `5184933988`).

Starting `origin/main`: `f676e39952ff83dec0bd24918428c99271ddbd91`.

## Confirmed root cause (traced, not assumed)

The S-record path selected candidates by **independently scanning every raw v2 entry and re-running an eligibility test** instead of being anchored to the plan's decisions. Three independent filters silently dropped plan decisions:

1. a `minusOneFields.length !== 1` prefilter — the confirmed divergence mechanism: a payload holding `-1` on **more than one raw field of one edge** is a plan single-negative decision (`effectiveStart < 0` via the shared `classifySnapshotEntry`) but the scan skipped it; the sanitized dual-alias `-1` fixture is one concrete raw shape capable of causing the observed mismatch, **not confirmed production evidence** — the exact production raw layout (dual aliases, values below `-1`, alias orientations) remains unknown until the corrected #404 run;
2. a re-run of `classifySnapshotEntry` on the raw payload (a second, independent policy evaluation);
3. a duplicated quarantine-first guard.

The reopened issue's inherited-mode hypothesis was traced and **rejected for decision generation**: `buildRemediationPlan` classifies NamedResources by their own raw `allocationMode` (verified at the plan's entry payload construction), so an inherited `CAPACITY_PLAN` NamedResource (own mode null) never becomes a plan decision — it is already-valid or Class B quarantined. Inherited effective mode is still fully representable in the S evidence schema and is proven by a direct population test.

## Fix — plan decisions are the selection authority

- S selection now iterates the remediation plan's **single-negative snapshot decisions** (`snapshotId != null` + shared `snapshotDecisionCategory`) — never raw entry discovery. `buildRemediationPlan`, `classifySnapshotEntry`, classifier policy, quarantine precedence and the expected seven-decision boundary are untouched.
- Each selected decision is correlated internally to exactly one raw v2 entry via the identifiers the decision already carries (`snapshotId`, `entryId`, `ownerKind`), using one small focused helper (`correlateSingleNegativeDecisions`). Raw values are used only to populate the already-approved sanitized S evidence (`buildSingleNegativeEvidenceEntry`, shared helpers only).
- **Unique parent correlation:** every correlated NamedResource must resolve to exactly one parent ResourceType. A missing `resourceTypeId`, zero matching parents or multiple matching parents fail closed with fixed safe reasons (`the named-resource entry carries no parent reference`, `the named-resource parent matched 0 resource types`, `the named-resource parent matched multiple resource types`) — ambiguity is never resolved with `find`, a `Map` or positional picks, so parent-dependent evidence cannot come from an arbitrary ResourceType.
- **Fail closed** on: missing stored snapshot, non-v2 snapshot, missing entry identifier, zero or multiple matching raw entries, entry-kind mismatch, a matched entry that does not re-derive the single-negative decision through the shared classifier, and two decisions resolving to the same raw entry — each with a fixed safe message (positions/counts only, never identifiers or payloads). New controlled error code `decision-correlation-failure`; the CLI exits 1 with no output.
- `minusOneField` is the plan-relevant exact field (primary of the negative effective edge when it holds `-1`, else its fallback); `windowFields` truthfully reports every raw `-1` field as `minus-one` (multi-minus-one shapes no longer violate reconciliation — the check now requires all `minus-one` fields on one effective edge with `minusOneField` among them).
- New reconciliation: selected plan decisions == uniquely correlated raw entries == emitted S records == `expected.singleMinusOneDecisions`; every seven-subgroup M record's single-negative count equals its correlated S records.
- **Production expectations remain seven, not zero.**

## Regression coverage (sanitized fixtures)

- Sanitized regression reproducer (dual-alias `-1` on the start edge — one concrete raw shape capable of causing the observed mismatch): 1 plan decision → 1 S record, both `minus-one` fields reported, JSON/Markdown parity.
- Unique-parent correlation: one unique parent succeeds; absent parent reference, zero matching parents and duplicate same-ID parents (including duplicates with different allocation modes) fail closed with sanitized messages containing no IDs, names, modes or payload values.
- Inherited effective-mode capability (`rawMode: null`, `parentMode: CAPACITY_PLAN`, `effectiveMode: CAPACITY_PLAN`, `modeSource: inherited`) via the population helper, plus the plan-faithful boundary (inherited single-`-1` is Class B / never an S record).
- All four `minusOneField` orientations, populated/conflicting aliases, clean Class B boundary, non-decision negative raw values.
- Fail-closed correlation: missing snapshot, missing entryId, zero matches, duplicate raw entry IDs, entry-kind mismatch, two decisions → one entry, non-re-deriving entry; safe-message assertion (no ids/names/payloads in errors).
- Exactly seven synthetic defect snapshots → exactly seven S records; production-shaped 18-snapshot topology reconciliation (226 + 133/7 = 366 decisions, 359 windowless).
- No output on any correlation failure (CLI integration test); zero writes; deterministic ordering; redaction; forwarding and publication tests remain green.

## Validation

- Unit: `snapshotEvidence.test.ts` — **58 passed** (11 new).
- Integration: `snapshotEvidence.integration.test.ts` — **9 passed** against a disposable local PostgreSQL instance (session Docker socket unavailable; the Docker-first lifecycle runs in CI).
- `npm run validate`: **exit 0** — server 1611 passed, client 342 passed, lint/typecheck/build clean.
- `git diff --check`: clean.
- CI: status will be reported once the run completes.

## Confirmations

- **Zero production access** — work performed only on the development machine with sanitized fixtures and disposable databases.
- No classifier policy, quarantine predicate, remediation semantics, fingerprint/baseline semantics, schema or migration changed.
- **#430 remains open** (no policy conclusion posted); **#404 and #418 remain blocked**; the #404 production run must not be retried until this fix is reviewed and merged (documented in the handoff section).

**Do not merge — wait for review.**
