### PR TITLE
fix(#432): reconcile shadowed minus-one snapshot evidence

### DIFF
--- a/docs/domain/capacity-profile-readiness-remediation.md
+++ b/docs/domain/capacity-profile-readiness-remediation.md
@@ -477,15 +477,28 @@ Each S record reports the sanitized state of **all four raw window fields**
 (`allocationStartWeek`, `allocationEndWeek`, `startWeek`, `endWeek`) with
 values from the fixed vocabulary `minus-one` / `absent-null` / `populated`
 — populated numeric values are never emitted. Historical payloads may hold
-`-1` on more than one raw field of the same edge (for example both aliases
-of the start edge); every such field is reported as `minus-one`, while
-`minusOneField` names the plan-relevant exact field (the primary of the
-negative effective edge when it holds `-1`, otherwise its fallback).
-Alias-conflict evidence is reported **per logical edge**
+`-1` on more than one raw field: on the same edge (for example both aliases
+of the start edge) or on the **opposite edge when shadowed** by a populated
+primary field. Every such field is reported as `minus-one`, while
+`minusOneField` names the raw field supplying the effective negative edge
+(the primary of the negative effective edge when it holds `-1`, otherwise
+its fallback). Alias-conflict evidence is reported **per logical edge**
 (`aliasConflicts.startEdge` / `aliasConflicts.endEdge`) using the shared
 classifier alias semantics (window-using modes only), so a conflict on the
 start edge is distinguished from a conflict on the end edge. The aggregate
 `alternateAliasState` is derived from the same per-field states.
+
+Window reconciliation follows the **effective primary/fallback semantics**
+shared by the application and the classifier (`effectiveStart =
+allocationStartWeek ?? startWeek`; `effectiveEnd = allocationEndWeek ??
+endWeek`): the correlated entry must re-derive exactly one negative
+**effective** edge supplied by `minusOneField`, and every additional raw
+`-1` field must be shadowed by a non-null primary field on its own edge — a
+raw fallback `-1` whose primary is null is effective, never shadowed.
+Shadowed raw aliases are evidence, not additional effective-negative edges.
+A genuine both-effective-edges-negative or otherwise inconsistently shaped
+entry stays in its shared classifier class and fails closed when it cannot
+re-derive the single-negative decision.
 
 **S-record selection is authoritative from the remediation plan's
 single-negative snapshot decisions** (shared `snapshotDecisionCategory`);
@@ -558,12 +571,21 @@ and assert exact equality.
 
 ### #404 run procedure (Issue #432 handoff)
 
-**Do not retry the production run until this fix is reviewed and merged**: the
-2026-08-04 production run stopped at the evidence boundary
-(`single-negative records: observed 0, expected 7`) because the merged
-command selected S records by an independent raw-entry reclassification that
-dropped the plan's single-negative decisions. The plan-anchored correlation
-fix above is the reviewed replacement.
+**Do not retry the production run until this correction is reviewed and
+merged.** Two production runs stopped at the evidence boundary without
+emitting evidence:
+
+- 2026-08-04: `single-negative records: observed 0, expected 7` — the merged
+  command selected S records by an independent raw-entry reclassification
+  that dropped the plan's single-negative decisions (fixed by the
+  plan-anchored correlation, PR #435).
+- 2026-08-05: `S records window-field reconciliation: observed 7, expected 0`
+  — the seven correlated S records held a raw `-1` fallback on the end edge
+  shadowed by a populated primary end; the reconciliation wrongly required
+  every raw `-1` field to lie on one effective edge (fixed by the
+  effective-edge reconciliation above). The sanitized production shape
+  (`allocationStartWeek` null, `startWeek` -1, `allocationEndWeek`
+  populated, `endWeek` -1) is the regression fixture.
 
 1. Install the reviewed merge commit without running migrations; confirm a
    clean checkout at the exact expected commit and a healthy service.

--- a/server/src/lib/snapshotEvidence.ts
+++ b/server/src/lib/snapshotEvidence.ts
@@ -655,6 +655,86 @@ function deterministicMinusOneField(
   )
 }
 
+/** Effective primary/fallback window edges for a v2 entry (shared
+ * semantics: the primary field supplies the edge when non-null, otherwise
+ * the fallback alias). ResourceType entries have no fallback aliases. */
+function effectiveWindowEdges(
+  raw: SnapshotResourceType | SnapshotNamedResource,
+  kind: 'resourceType' | 'namedResource',
+): { effectiveStart: number | null; effectiveEnd: number | null } {
+  if (kind === 'resourceType') {
+    const rt = raw as SnapshotResourceType
+    return { effectiveStart: rt.allocationStartWeek ?? null, effectiveEnd: rt.allocationEndWeek ?? null }
+  }
+  const nr = raw as SnapshotNamedResource
+  return {
+    effectiveStart: nr.allocationStartWeek ?? nr.startWeek ?? null,
+    effectiveEnd: nr.allocationEndWeek ?? nr.endWeek ?? null,
+  }
+}
+
+function rawWindowFieldValue(
+  raw: SnapshotResourceType | SnapshotNamedResource,
+  kind: 'resourceType' | 'namedResource',
+  field: MinusOneField,
+): number | null {
+  if (kind === 'resourceType') {
+    const rt = raw as SnapshotResourceType
+    if (field === 'allocationStartWeek') return rt.allocationStartWeek ?? null
+    if (field === 'allocationEndWeek') return rt.allocationEndWeek ?? null
+    return null
+  }
+  const nr = raw as SnapshotNamedResource
+  if (field === 'allocationStartWeek') return nr.allocationStartWeek ?? null
+  if (field === 'allocationEndWeek') return nr.allocationEndWeek ?? null
+  if (field === 'startWeek') return nr.startWeek ?? null
+  return nr.endWeek ?? null
+}
+
+const ALL_WINDOW_FIELDS: readonly MinusOneField[] = [
+  'allocationStartWeek', 'allocationEndWeek', 'startWeek', 'endWeek',
+]
+
+/**
+ * Effective-window reconciliation for one correlated single-negative
+ * decision. Validates the RAW entry with the same effective primary/fallback
+ * semantics the shared classifier uses:
+ *   - exactly one effective edge is negative;
+ *   - minusOneField holds -1 and supplies that negative effective edge;
+ *   - every additional raw -1 field is shadowed by a non-null primary field
+ *     on its own edge (a fallback -1 whose primary is null would be an
+ *     effective negative edge and is never shadowed);
+ *   - every raw field is represented truthfully in the emitted windowFields.
+ * Returns a fixed sanitized reason, or null when valid. Never emits raw
+ * values or identifiers.
+ */
+function effectiveWindowReconciliationReason(
+  raw: SnapshotResourceType | SnapshotNamedResource,
+  kind: 'resourceType' | 'namedResource',
+  minusOneField: MinusOneField,
+): string | null {
+  const { effectiveStart, effectiveEnd } = effectiveWindowEdges(raw, kind)
+  const negativeEdges: Array<'start' | 'end'> = []
+  if (effectiveStart != null && effectiveStart < 0) negativeEdges.push('start')
+  if (effectiveEnd != null && effectiveEnd < 0) negativeEdges.push('end')
+  if (negativeEdges.length !== 1) return 'the correlated entry does not have exactly one negative effective edge'
+  if (edgeOfMinusOneField(minusOneField) !== negativeEdges[0]) {
+    return 'the minus-one field does not supply the negative effective edge'
+  }
+  if (rawWindowFieldValue(raw, kind, minusOneField) !== -1) {
+    return 'the minus-one field does not hold -1'
+  }
+  for (const field of ALL_WINDOW_FIELDS) {
+    if (field === minusOneField) continue
+    if (rawWindowFieldValue(raw, kind, field) !== -1) continue
+    const primary = edgeOfMinusOneField(field) === 'start'
+      ? (kind === 'resourceType' ? (raw as SnapshotResourceType).allocationStartWeek : (raw as SnapshotNamedResource).allocationStartWeek)
+      : (kind === 'resourceType' ? (raw as SnapshotResourceType).allocationEndWeek : (raw as SnapshotNamedResource).allocationEndWeek)
+    if (primary == null) return 'a raw -1 field is not shadowed by a populated primary'
+  }
+  return null
+}
+
 /**
  * Correlate every plan single-negative snapshot decision to exactly one raw
  * v2 entry, using the identifiers the plan decision already carries
@@ -717,13 +797,19 @@ export function correlateSingleNegativeDecisions(
       if (parents.length > 1) fail('the named-resource parent matched multiple resource types')
       parentRt = parents[0]
     }
+    // Effective-window reconciliation: the raw entry must re-derive exactly
+    // one negative effective edge supplied by minusOneField; any additional
+    // raw -1 field must be shadowed by a populated primary on its own edge.
+    const minusOneField = deterministicMinusOneField(rawEntry, kind)
+    const windowReason = effectiveWindowReconciliationReason(rawEntry, kind, minusOneField)
+    if (windowReason != null) fail(windowReason)
     correlations.push({
       decision,
       snapshotIndex,
       kind,
       rawEntry,
       parentRt,
-      minusOneField: deterministicMinusOneField(rawEntry, kind),
+      minusOneField,
     })
   })
   return correlations
@@ -1106,14 +1192,13 @@ export function buildSnapshotEvidenceReport(inputs: SnapshotEvidenceInputs): Sna
   const windowFieldReconciliationViolations = singleNegativeRecords.filter(record => {
     const fields = Object.keys(record.windowFields) as MinusOneField[]
     const minusOneFields = fields.filter(field => record.windowFields[field] === 'minus-one')
-    // At least one raw field must hold -1, minusOneField must be among them,
-    // every minus-one field must lie on the same effective edge (historical
-    // payloads may hold -1 on both aliases of one edge), and every other
-    // field must be absent-null or populated.
+    // Structural invariants on the emitted records: at least one raw field
+    // holds -1, minusOneField must be among the minus-one fields, and every
+    // other field must be absent-null or populated. Effective-edge and
+    // shadowing semantics are validated earlier on the raw correlated entry
+    // (effectiveWindowReconciliationReason), which has the raw values.
     if (minusOneFields.length === 0) return true
     if (!minusOneFields.includes(record.minusOneField)) return true
-    const edge = edgeOfMinusOneField(record.minusOneField)
-    if (minusOneFields.some(field => edgeOfMinusOneField(field) !== edge)) return true
     return fields.some(
       field => !minusOneFields.includes(field) && record.windowFields[field] !== 'absent-null' && record.windowFields[field] !== 'populated',
     )

--- a/server/src/lib/snapshotEvidence.ts
+++ b/server/src/lib/snapshotEvidence.ts
@@ -626,33 +626,33 @@ function edgeOfMinusOneField(field: MinusOneField): 'start' | 'end' {
 }
 
 /** Deterministic exact-field pick for a plan single-negative decision: the
- * primary of the negative effective edge when it holds `-1`, otherwise its
- * fallback. Historical payloads may hold `-1` on more than one raw field of
- * the same edge; every such field is still reported as `minus-one` in
- * `windowFields`, while `minusOneField` names the plan-relevant exact field. */
+ * raw field that SUPPLIED the negative effective edge (primary when
+ * non-null, otherwise its fallback). A shadowed fallback alias is never
+ * selected, even when it contains -1 and the primary effective value is
+ * negative-but-not-minus-one. */
 function deterministicMinusOneField(
   raw: SnapshotResourceType | SnapshotNamedResource,
   kind: 'resourceType' | 'namedResource',
 ): MinusOneField {
-  if (kind === 'resourceType') {
-    const rt = raw as SnapshotResourceType
-    if (rt.allocationStartWeek != null && rt.allocationStartWeek < 0) return 'allocationStartWeek'
-    if (rt.allocationEndWeek != null && rt.allocationEndWeek < 0) return 'allocationEndWeek'
-  } else {
-    const nr = raw as SnapshotNamedResource
-    const effectiveStart = nr.allocationStartWeek ?? nr.startWeek ?? null
-    const effectiveEnd = nr.allocationEndWeek ?? nr.endWeek ?? null
-    if (effectiveStart != null && effectiveStart < 0) {
-      return nr.allocationStartWeek === -1 ? 'allocationStartWeek' : 'startWeek'
-    }
-    if (effectiveEnd != null && effectiveEnd < 0) {
-      return nr.allocationEndWeek === -1 ? 'allocationEndWeek' : 'endWeek'
-    }
+  const edges = effectiveWindowEdges(raw, kind)
+  if (edges.start.value != null && edges.start.value < 0 && edges.start.sourceField != null) {
+    return edges.start.sourceField
+  }
+  if (edges.end.value != null && edges.end.value < 0 && edges.end.sourceField != null) {
+    return edges.end.sourceField
   }
   throw new SnapshotEvidenceError(
     'decision-correlation-failure',
     'cannot determine the negative window edge of a correlated single-negative decision',
   )
+}
+
+/** Effective edge result: the effective value plus the exact raw field that
+ * supplied it (primary when non-null, otherwise the fallback alias; null
+ * source when no raw field supplies the edge). */
+interface EffectiveWindowEdge {
+  value: number | null
+  sourceField: MinusOneField | null
 }
 
 /** Effective primary/fallback window edges for a v2 entry (shared
@@ -661,15 +661,30 @@ function deterministicMinusOneField(
 function effectiveWindowEdges(
   raw: SnapshotResourceType | SnapshotNamedResource,
   kind: 'resourceType' | 'namedResource',
-): { effectiveStart: number | null; effectiveEnd: number | null } {
+): { start: EffectiveWindowEdge; end: EffectiveWindowEdge } {
   if (kind === 'resourceType') {
     const rt = raw as SnapshotResourceType
-    return { effectiveStart: rt.allocationStartWeek ?? null, effectiveEnd: rt.allocationEndWeek ?? null }
+    return {
+      start: {
+        value: rt.allocationStartWeek ?? null,
+        sourceField: rt.allocationStartWeek != null ? 'allocationStartWeek' : null,
+      },
+      end: {
+        value: rt.allocationEndWeek ?? null,
+        sourceField: rt.allocationEndWeek != null ? 'allocationEndWeek' : null,
+      },
+    }
   }
   const nr = raw as SnapshotNamedResource
   return {
-    effectiveStart: nr.allocationStartWeek ?? nr.startWeek ?? null,
-    effectiveEnd: nr.allocationEndWeek ?? nr.endWeek ?? null,
+    start: {
+      value: nr.allocationStartWeek ?? nr.startWeek ?? null,
+      sourceField: nr.allocationStartWeek != null ? 'allocationStartWeek' : nr.startWeek != null ? 'startWeek' : null,
+    },
+    end: {
+      value: nr.allocationEndWeek ?? nr.endWeek ?? null,
+      sourceField: nr.allocationEndWeek != null ? 'allocationEndWeek' : nr.endWeek != null ? 'endWeek' : null,
+    },
   }
 }
 
@@ -700,7 +715,10 @@ const ALL_WINDOW_FIELDS: readonly MinusOneField[] = [
  * decision. Validates the RAW entry with the same effective primary/fallback
  * semantics the shared classifier uses:
  *   - exactly one effective edge is negative;
- *   - minusOneField holds -1 and supplies that negative effective edge;
+ *   - the raw field that supplied that negative effective edge is known and
+ *     equals minusOneField;
+ *   - the supplied effective value is exactly -1 (an effective value below
+ *     -1 fails closed even when a shadowed fallback alias holds -1);
  *   - every additional raw -1 field is shadowed by a non-null primary field
  *     on its own edge (a fallback -1 whose primary is null would be an
  *     effective negative edge and is never shadowed);
@@ -713,17 +731,17 @@ function effectiveWindowReconciliationReason(
   kind: 'resourceType' | 'namedResource',
   minusOneField: MinusOneField,
 ): string | null {
-  const { effectiveStart, effectiveEnd } = effectiveWindowEdges(raw, kind)
+  const edges = effectiveWindowEdges(raw, kind)
   const negativeEdges: Array<'start' | 'end'> = []
-  if (effectiveStart != null && effectiveStart < 0) negativeEdges.push('start')
-  if (effectiveEnd != null && effectiveEnd < 0) negativeEdges.push('end')
+  if (edges.start.value != null && edges.start.value < 0) negativeEdges.push('start')
+  if (edges.end.value != null && edges.end.value < 0) negativeEdges.push('end')
   if (negativeEdges.length !== 1) return 'the correlated entry does not have exactly one negative effective edge'
-  if (edgeOfMinusOneField(minusOneField) !== negativeEdges[0]) {
-    return 'the minus-one field does not supply the negative effective edge'
-  }
-  if (rawWindowFieldValue(raw, kind, minusOneField) !== -1) {
-    return 'the minus-one field does not hold -1'
-  }
+  const negativeEdge = negativeEdges[0]!
+  const sourceField = negativeEdge === 'start' ? edges.start.sourceField : edges.end.sourceField
+  if (sourceField == null) return 'the negative effective edge is not supplied by a raw field'
+  if (sourceField !== minusOneField) return 'the negative effective edge is not supplied by the minus-one field'
+  const negativeValue = negativeEdge === 'start' ? edges.start.value : edges.end.value
+  if (negativeValue !== -1) return 'the negative effective value is not exactly minus one'
   for (const field of ALL_WINDOW_FIELDS) {
     if (field === minusOneField) continue
     if (rawWindowFieldValue(raw, kind, field) !== -1) continue

--- a/server/src/test/snapshotEvidence.integration.test.ts
+++ b/server/src/test/snapshotEvidence.integration.test.ts
@@ -18,7 +18,7 @@
  * All tests are skipped unless INTEGRATION_TEST=true.
  */
 
-import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest'
+import { describe, it, expect, beforeAll, afterAll, afterEach, vi } from 'vitest'
 import { mkdtempSync, readFileSync, writeFileSync, rmSync, existsSync, readdirSync, statSync } from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
@@ -476,6 +476,50 @@ describeIf('snapshot evidence command (integration)', () => {
     // Zero writes: canonical covered-state hash unchanged.
     const stateHashAfter = await currentStateHash()
     expect(stateHashAfter).toBe(stateHashBefore)
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('refuses when the negative effective source is below -1 with a shadowed fallback -1 (no output, no writes)', async () => {
+    // allocationStartWeek -2 supplies the effective start; startWeek -1 is
+    // shadowed and must never be selected as the minus-one field.
+    await createSnapshot(
+      'snap-source-mismatch',
+      makeV2Snapshot(
+        [makeRt({ id: 'rt-p', allocationMode: 'CAPACITY_PLAN', allocationStartWeek: 0, allocationEndWeek: 5 })],
+        [makeNr({ id: 'nr-mismatch', resourceTypeId: 'rt-p', allocationMode: 'CAPACITY_PLAN', allocationStartWeek: -2, startWeek: -1, allocationEndWeek: 5, endWeek: null })],
+      ),
+      '2026-06-01T00:00:00Z',
+    )
+    const stateHashBefore = await currentStateHash()
+    const dir = tempDir()
+    const jsonPath = path.join(dir, 'evidence.json')
+    const mdPath = path.join(dir, 'evidence.md')
+    const expectedPath = path.join(dir, 'expected.json')
+    const expected = await expectedBoundary()
+    writeFileSync(expectedPath, JSON.stringify(expected, null, 2))
+
+    const errors: string[] = []
+    const spy = vi.spyOn(console, 'error').mockImplementation(message => errors.push(String(message)))
+    let exit: number
+    try {
+      exit = await main(['--json', jsonPath, '--markdown', mdPath, '--expected', expectedPath])
+    } finally {
+      spy.mockRestore()
+    }
+
+    expect(exit).toBe(1)
+    expect(existsSync(jsonPath)).toBe(false)
+    expect(existsSync(mdPath)).toBe(false)
+    expect(readdirSync(dir).filter(name => name.includes('.tmp'))).toEqual([])
+    // Zero writes: canonical covered-state hash unchanged.
+    expect(await currentStateHash()).toBe(stateHashBefore)
+    // The controlled error contains no seeded identifier, name, mode, raw
+    // numeric value or payload fragment.
+    const stderr = errors.join('\n')
+    expect(stderr).toContain('not exactly minus one')
+    for (const secret of ['nr-mismatch', 'rt-p', 'snap-source-mismatch', 'CAPACITY_PLAN', '-2', 'Secret']) {
+      expect(stderr).not.toContain(secret)
+    }
     rmSync(dir, { recursive: true, force: true })
   })
 

--- a/server/src/test/snapshotEvidence.integration.test.ts
+++ b/server/src/test/snapshotEvidence.integration.test.ts
@@ -186,10 +186,10 @@ async function seedTopologyFixture(): Promise<void> {
         id: 'nr-s7-minus-one',
         resourceTypeId: 'rt-s7-0',
         allocationMode: 'CAPACITY_PLAN',
-        allocationStartWeek: -1,
+        allocationStartWeek: null,
         allocationEndWeek: 5,
         startWeek: -1,
-        endWeek: null,
+        endWeek: -1,
       })],
     ),
     '2026-05-10T00:00:00Z',
@@ -290,16 +290,15 @@ describeIf('snapshot evidence command (integration)', () => {
     expect(report.classAAggregates.totalEntries).toBe(3)
     expect(report.classAAggregates.byOwnerKind).toEqual({ resourceType: 2, namedResource: 1, unavailable: 0 })
     expect(report.singleNegativeEntries).toHaveLength(1)
-    // Sanitized reproducer of the former selection-path divergence: -1 on
-    // both aliases of the start edge is a plan single-negative decision whose
-    // evidence is emitted end to end. The exact production raw layout remains
-    // unknown until the corrected #404 run.
-    expect(report.singleNegativeEntries[0]!.minusOneField).toBe('allocationStartWeek')
+    // The seeded sanitized production shape: -1 fallback on the start edge
+    // (effective negative start) plus a shadowed -1 fallback on the end edge
+    // (populated primary end) — both reported, reconciliation passes.
+    expect(report.singleNegativeEntries[0]!.minusOneField).toBe('startWeek')
     expect(report.singleNegativeEntries[0]!.windowFields).toEqual({
-      allocationStartWeek: 'minus-one',
+      allocationStartWeek: 'absent-null',
       allocationEndWeek: 'populated',
       startWeek: 'minus-one',
-      endWeek: 'absent-null',
+      endWeek: 'minus-one',
     })
     expect(report.defectSnapshots).toHaveLength(3)
     const seven = report.defectSnapshots.find((m: { subgroup: string }) => m.subgroup === 'seven-single-minus-one')!

--- a/server/src/test/snapshotEvidence.test.ts
+++ b/server/src/test/snapshotEvidence.test.ts
@@ -1859,3 +1859,109 @@ describe('effective-edge window reconciliation (shadowed minus-one)', () => {
     }
   })
 })
+
+describe('effective-source reconciliation (minusOneField must supply the effective value)', () => {
+  const MISMATCH_COUNTS: Omit<SnapshotEvidenceExpected, 'fingerprint' | 'baselineStateHash'> = {
+    quarantinedEntries: 0, quarantinedSnapshots: 0, defectSnapshots: 1,
+    windowlessDecisions: 0, singleMinusOneDecisions: 1, snapshotDecisions: 1,
+    liveDecisions: 0, unsupported: 0, rewriteOperations: 0,
+    topology11Snapshots: 0, topology7Snapshots: 1,
+    topology11WindowlessDecisions: 0, topology7WindowlessDecisions: 0,
+    topology7SingleMinusOneDecisions: 1,
+  }
+
+  it('fails closed when a negative effective source below -1 has a shadowed fallback -1 (start edge)', () => {
+    // allocationStartWeek -2 supplies the effective start (below -1);
+    // startWeek -1 is shadowed and must NOT be selected as minusOneField.
+    const state = makeState([{
+      id: 'snap-source-mismatch',
+      projectId: PROJECT_ID,
+      payload: makeV2Snapshot(
+        [makeRt({ id: 'rt-p', allocationMode: 'CAPACITY_PLAN', allocationStartWeek: 0, allocationEndWeek: 5 })],
+        [makeNr({ id: 'nr-mismatch', resourceTypeId: 'rt-p', allocationMode: 'CAPACITY_PLAN', allocationStartWeek: -2, startWeek: -1, allocationEndWeek: 5, endWeek: null })],
+      ),
+    }])
+    try {
+      buildReport(state, MISMATCH_COUNTS)
+      throw new Error('expected refusal')
+    } catch (error) {
+      expect(error).toBeInstanceOf(SnapshotEvidenceError)
+      const message = error instanceof Error ? error.message : String(error)
+      expect(message).toContain('the negative effective value is not exactly minus one')
+      expect(message).not.toContain('-2')
+      expect(message).not.toContain('-1')
+      expect(message).not.toContain('nr-mismatch')
+      expect(message).not.toContain('rt-p')
+      expect(message).not.toContain('snap-source-mismatch')
+      expect(message).not.toContain('CAPACITY_PLAN')
+    }
+  })
+
+  it('fails closed for the end-edge mirror (effective source below -1, shadowed fallback -1)', () => {
+    const state = makeState([{
+      id: 'snap-source-mismatch-end',
+      projectId: PROJECT_ID,
+      payload: makeV2Snapshot(
+        [makeRt({ id: 'rt-p', allocationMode: 'CAPACITY_PLAN', allocationStartWeek: 0, allocationEndWeek: 5 })],
+        [makeNr({ id: 'nr-mismatch-end', resourceTypeId: 'rt-p', allocationMode: 'CAPACITY_PLAN', allocationStartWeek: 0, startWeek: null, allocationEndWeek: -2, endWeek: -1 })],
+      ),
+    }])
+    try {
+      buildReport(state, MISMATCH_COUNTS)
+      throw new Error('expected refusal')
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      expect(message).toContain('the negative effective value is not exactly minus one')
+      expect(message).not.toContain('-2')
+      expect(message).not.toContain('-1')
+      expect(message).not.toContain('nr-mismatch-end')
+    }
+  })
+
+  it('a primary effective -1 with a same-edge fallback -1 selects the primary (source-based)', () => {
+    const state = makeState([{
+      id: 'snap-primary-fallback',
+      projectId: PROJECT_ID,
+      payload: makeV2Snapshot(
+        [makeRt({ id: 'rt-p', allocationMode: 'CAPACITY_PLAN', allocationStartWeek: 0, allocationEndWeek: 5 })],
+        [makeNr({ id: 'nr-pf', resourceTypeId: 'rt-p', allocationMode: 'CAPACITY_PLAN', allocationStartWeek: -1, startWeek: -1, allocationEndWeek: 5, endWeek: null })],
+      ),
+    }])
+    const report = buildReport(state, MISMATCH_COUNTS)
+    expect(report.integrityResult.reconciliationPassed).toBe(true)
+    const s = report.singleNegativeEntries[0]!
+    // The primary supplied the effective value; the fallback is shadowed.
+    expect(s.minusOneField).toBe('allocationStartWeek')
+    expect(s.windowFields.startWeek).toBe('minus-one')
+  })
+
+  it('a fallback effective -1 with a null primary selects the fallback (source-based)', () => {
+    const state = makeState([{
+      id: 'snap-fallback-effective',
+      projectId: PROJECT_ID,
+      payload: makeV2Snapshot(
+        [makeRt({ id: 'rt-p', allocationMode: 'CAPACITY_PLAN', allocationStartWeek: 0, allocationEndWeek: 5 })],
+        [makeNr({ id: 'nr-fe', resourceTypeId: 'rt-p', allocationMode: 'CAPACITY_PLAN', allocationStartWeek: null, startWeek: -1, allocationEndWeek: 4, endWeek: 5 })],
+      ),
+    }])
+    const report = buildReport(state, MISMATCH_COUNTS)
+    expect(report.integrityResult.reconciliationPassed).toBe(true)
+    expect(report.singleNegativeEntries[0]!.minusOneField).toBe('startWeek')
+  })
+
+  it('keeps the shadowed opposite-edge fallback -1 valid (production shape)', () => {
+    const state = makeState([{
+      id: 'snap-shadow-valid',
+      projectId: PROJECT_ID,
+      payload: makeV2Snapshot(
+        [makeRt({ id: 'rt-p', allocationMode: 'CAPACITY_PLAN', allocationStartWeek: 0, allocationEndWeek: 5 })],
+        [makeNr({ id: 'nr-sv', resourceTypeId: 'rt-p', allocationMode: 'CAPACITY_PLAN', allocationStartWeek: null, startWeek: -1, allocationEndWeek: 5, endWeek: -1 })],
+      ),
+    }])
+    const report = buildReport(state, MISMATCH_COUNTS)
+    expect(report.integrityResult.reconciliationPassed).toBe(true)
+    const s = report.singleNegativeEntries[0]!
+    expect(s.minusOneField).toBe('startWeek')
+    expect(s.windowFields.endWeek).toBe('minus-one')
+  })
+})

--- a/server/src/test/snapshotEvidence.test.ts
+++ b/server/src/test/snapshotEvidence.test.ts
@@ -1441,7 +1441,7 @@ describe('plan-decision-anchored S-record correlation', () => {
         projectId: PROJECT_ID,
         payload: makeV2Snapshot(
           Array.from({ length: 19 }, (_, j) => makeRt({ id: `rt-s-${i}-${j}`, allocationMode: 'CAPACITY_PLAN' })),
-          [makeNr({ id: `nr-s-${i}`, resourceTypeId: rtId, allocationMode: 'CAPACITY_PLAN', allocationStartWeek: -1, startWeek: -1, allocationEndWeek: 5, endWeek: null })],
+          [makeNr({ id: `nr-s-${i}`, resourceTypeId: rtId, allocationMode: 'CAPACITY_PLAN', allocationStartWeek: null, startWeek: -1, allocationEndWeek: 5, endWeek: -1 })],
         ),
       })
     }
@@ -1666,6 +1666,196 @@ describe('plan-decision-anchored S-record correlation', () => {
       expect(message).not.toContain('nr-1')
       expect(message).not.toContain(PROJECT_ID)
       expect(message).not.toContain('Secret')
+    }
+  })
+})
+
+describe('effective-edge window reconciliation (shadowed minus-one)', () => {
+  /** One explicit CAPACITY_PLAN NR with a unique parent in a defect snapshot. */
+  function shadowState(nrOverrides: Parameters<typeof makeNr>[0], id = 'snap-shadow'): RemediationDatabaseState {
+    return makeState([{
+      id,
+      projectId: PROJECT_ID,
+      payload: makeV2Snapshot(
+        [makeRt({ id: 'rt-p', allocationMode: 'CAPACITY_PLAN', allocationStartWeek: 0, allocationEndWeek: 5 })],
+        [makeNr({ id: 'nr-shadow', resourceTypeId: 'rt-p', allocationMode: 'CAPACITY_PLAN', allocationPercent: 100, allocationPct: 100, ...nrOverrides })],
+      ),
+    }])
+  }
+
+  const SINGLE_COUNTS: Omit<SnapshotEvidenceExpected, 'fingerprint' | 'baselineStateHash'> = {
+    quarantinedEntries: 0, quarantinedSnapshots: 0, defectSnapshots: 1,
+    windowlessDecisions: 0, singleMinusOneDecisions: 1, snapshotDecisions: 1,
+    liveDecisions: 0, unsupported: 0, rewriteOperations: 0,
+    topology11Snapshots: 0, topology7Snapshots: 1,
+    topology11WindowlessDecisions: 0, topology7WindowlessDecisions: 0,
+    topology7SingleMinusOneDecisions: 1,
+  }
+
+  it('accepts the sanitized production shape: shadowed opposite-edge fallback -1 (startWeek and endWeek both -1)', () => {
+    // Production shape: allocationStartWeek null, startWeek -1 (effective
+    // negative start), allocationEndWeek 5 (populated primary end), endWeek -1
+    // (shadowed fallback — reported, not rejected).
+    const state = shadowState({ allocationStartWeek: null, startWeek: -1, allocationEndWeek: 5, endWeek: -1 })
+    const report = buildReport(state, SINGLE_COUNTS)
+    expect(report.integrityResult.reconciliationPassed).toBe(true)
+    expect(report.singleNegativeEntries).toHaveLength(1)
+    const s = report.singleNegativeEntries[0]!
+    expect(s.minusOneField).toBe('startWeek')
+    expect(s.windowFields).toEqual({
+      allocationStartWeek: 'absent-null',
+      allocationEndWeek: 'populated',
+      startWeek: 'minus-one',
+      endWeek: 'minus-one',
+    })
+    // JSON and Markdown carry the same sanitized evidence.
+    const json = JSON.stringify(report)
+    const markdown = renderSnapshotEvidenceMarkdown(report)
+    expect(json).toContain('"startWeek":"minus-one","endWeek":"minus-one"')
+    expect(markdown).toContain('startWeek:minus-one')
+    expect(markdown).toContain('endWeek:minus-one')
+  })
+
+  it('accepts the effective-end mirror: populated primary start shadows a fallback -1', () => {
+    // allocationStartWeek 5 (populated primary start), startWeek -1 (shadowed
+    // fallback), allocationEndWeek null, endWeek -1 (effective negative end).
+    const state = shadowState({ allocationStartWeek: 5, startWeek: -1, allocationEndWeek: null, endWeek: -1 })
+    const report = buildReport(state, SINGLE_COUNTS)
+    expect(report.integrityResult.reconciliationPassed).toBe(true)
+    const s = report.singleNegativeEntries[0]!
+    expect(s.minusOneField).toBe('endWeek')
+    expect(s.windowFields).toEqual({
+      allocationStartWeek: 'populated',
+      allocationEndWeek: 'absent-null',
+      startWeek: 'minus-one',
+      endWeek: 'minus-one',
+    })
+  })
+
+  it('accepts a primary -1 with an opposite-edge shadowed fallback -1', () => {
+    const state = shadowState({ allocationStartWeek: -1, startWeek: null, allocationEndWeek: 5, endWeek: -1 })
+    const report = buildReport(state, SINGLE_COUNTS)
+    expect(report.integrityResult.reconciliationPassed).toBe(true)
+    const s = report.singleNegativeEntries[0]!
+    expect(s.minusOneField).toBe('allocationStartWeek')
+    expect(s.windowFields.endWeek).toBe('minus-one')
+    expect(s.windowFields.allocationEndWeek).toBe('populated')
+  })
+
+  it('keeps the same-edge dual-alias -1 fixture valid', () => {
+    const state = shadowState({ allocationStartWeek: -1, startWeek: -1, allocationEndWeek: 5, endWeek: null })
+    const report = buildReport(state, SINGLE_COUNTS)
+    expect(report.integrityResult.reconciliationPassed).toBe(true)
+    const s = report.singleNegativeEntries[0]!
+    expect(s.minusOneField).toBe('allocationStartWeek')
+    expect(s.windowFields).toEqual({
+      allocationStartWeek: 'minus-one',
+      allocationEndWeek: 'populated',
+      startWeek: 'minus-one',
+      endWeek: 'absent-null',
+    })
+  })
+
+  it('keeps a ResourceType single-negative entry valid (no fallback aliases)', () => {
+    const state = makeState([{
+      id: 'snap-rt-single',
+      projectId: PROJECT_ID,
+      payload: makeV2Snapshot(
+        [
+          makeRt({ id: 'rt-a', allocationMode: 'CAPACITY_PLAN', allocationStartWeek: -1, allocationEndWeek: 5 }),
+          makeRt({ id: 'rt-b', allocationMode: 'CAPACITY_PLAN', allocationStartWeek: -1, allocationEndWeek: 5 }),
+          makeRt({ id: 'rt-conf', allocationMode: 'CAPACITY_PLAN', allocationStartWeek: 0, allocationEndWeek: 5 }),
+        ],
+        [
+          // Defect-inducing conflicting-alias NamedResource (no decision of
+          // its own; keeps the snapshot defect-classified so the RTs are
+          // evaluated as decisions rather than Class B quarantines).
+          makeNr({ id: 'nr-conf', resourceTypeId: 'rt-conf', allocationMode: null, allocationPercent: 100, allocationPct: 100, allocationStartWeek: 5, allocationEndWeek: 10, startWeek: 5, endWeek: 9 }),
+        ],
+      ),
+    }])
+    const counts: Omit<SnapshotEvidenceExpected, 'fingerprint' | 'baselineStateHash'> = {
+      quarantinedEntries: 0, quarantinedSnapshots: 0, defectSnapshots: 1,
+      windowlessDecisions: 0, singleMinusOneDecisions: 2, snapshotDecisions: 2,
+      liveDecisions: 0, unsupported: 0, rewriteOperations: 0,
+      topology11Snapshots: 0, topology7Snapshots: 1,
+      topology11WindowlessDecisions: 0, topology7WindowlessDecisions: 0,
+      topology7SingleMinusOneDecisions: 2,
+    }
+    const report = buildReport(state, counts)
+    expect(report.integrityResult.reconciliationPassed).toBe(true)
+    expect(report.singleNegativeEntries).toHaveLength(2)
+    for (const s of report.singleNegativeEntries) {
+      expect(s.entryKind).toBe('resourceType')
+      expect(s.minusOneField).toBe('allocationStartWeek')
+    }
+  })
+
+  it('does not select a both-effective-edges-negative entry (never-active class, no plan decision)', () => {
+    const state = shadowState({ allocationStartWeek: null, startWeek: -1, allocationEndWeek: null, endWeek: -1 })
+    const counts: Omit<SnapshotEvidenceExpected, 'fingerprint' | 'baselineStateHash'> = {
+      quarantinedEntries: 0, quarantinedSnapshots: 0, defectSnapshots: 0,
+      windowlessDecisions: 0, singleMinusOneDecisions: 0, snapshotDecisions: 0,
+      liveDecisions: 0, unsupported: 0, rewriteOperations: 0,
+      topology11Snapshots: 0, topology7Snapshots: 0,
+      topology11WindowlessDecisions: 0, topology7WindowlessDecisions: 0,
+      topology7SingleMinusOneDecisions: 0,
+    }
+    const report = buildReport(state, counts)
+    expect(report.integrityResult.reconciliationPassed).toBe(true)
+    expect(report.singleNegativeEntries).toHaveLength(0)
+  })
+
+  it('fails closed on an incoherent both-negative shape even with a supplied decision', () => {
+    // (-2, -1): the shared classifier still emits the single-negative message,
+    // but the fixed minus-one vocabulary cannot represent the -2 effective
+    // start — the effective-window reconciliation refuses.
+    const state = shadowState({ allocationStartWeek: -2, startWeek: null, allocationEndWeek: -1, endWeek: null })
+    const classified = classifyAllSnapshots(state)
+    const plan = buildRemediationPlan(state, 'test-commit')
+    const decision = {
+      id: 'd', projectId: PROJECT_ID, ownerId: 'o', ownerKind: 'namedPerson' as const,
+      profileId: null, snapshotId: 'snap-shadow', entryId: 'nr-shadow', legacyBase: null,
+      evidenceHash: 'h', allowedResolutions: ['snapshot-window-interpretation'],
+      message: 'single -1/negative window edge without established meaning — explicit window interpretation required',
+    }
+    try {
+      correlateSingleNegativeDecisions({ ...plan, decisions: [decision] }, state, classified)
+      throw new Error('expected refusal')
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      expect(message).toContain('does not have exactly one negative effective edge')
+      expect(message).not.toContain('nr-shadow')
+      expect(message).not.toContain('rt-p')
+      expect(message).not.toContain('-2')
+      expect(message).not.toContain('-1')
+    }
+  })
+
+  it('emits seven S records for seven production-shaped entries with zero reconciliation violations', () => {
+    const snapshots = Array.from({ length: 7 }, (_, i) => ({
+      id: `snap-${i}`,
+      projectId: PROJECT_ID,
+      payload: makeV2Snapshot(
+        [makeRt({ id: `rt-w-${i}`, allocationMode: 'CAPACITY_PLAN' })],
+        [makeNr({ id: `nr-m-${i}`, resourceTypeId: `rt-w-${i}`, allocationMode: 'CAPACITY_PLAN', allocationStartWeek: null, startWeek: -1, allocationEndWeek: 5, endWeek: -1 })],
+      ),
+    }))
+    const state = makeState(snapshots)
+    const counts: Omit<SnapshotEvidenceExpected, 'fingerprint' | 'baselineStateHash'> = {
+      quarantinedEntries: 0, quarantinedSnapshots: 0, defectSnapshots: 7,
+      windowlessDecisions: 7, singleMinusOneDecisions: 7, snapshotDecisions: 14,
+      liveDecisions: 0, unsupported: 0, rewriteOperations: 0,
+      topology11Snapshots: 0, topology7Snapshots: 7,
+      topology11WindowlessDecisions: 0, topology7WindowlessDecisions: 7,
+      topology7SingleMinusOneDecisions: 7,
+    }
+    const report = buildReport(state, counts)
+    expect(report.integrityResult.reconciliationPassed).toBe(true)
+    expect(report.singleNegativeEntries).toHaveLength(7)
+    for (const s of report.singleNegativeEntries) {
+      expect(s.minusOneField).toBe('startWeek')
+      expect(s.windowFields.endWeek).toBe('minus-one')
     }
   })
 })


### PR DESCRIPTION
# fix(#432): reconcile shadowed minus-one snapshot evidence

Closes #432.

## Production failure

The corrected evidence command (PR #435 merge `9e8a71ebdea479b58d2e9e59a890e121482cbdb7`) was installed and run once against the production database ([#404 comment `5186860376`](https://github.com/NickMonrad/monrad-estimator/issues/404#issuecomment-5186860376)). The correlation fix worked end to end:

```text
7 plan single-negative decisions
=
7 uniquely correlated raw entries
=
7 internally constructed S records
```

but the command then failed its own gate and emitted **no** JSON or Markdown:

```text
S records window-field reconciliation: observed 7, expected 0 — MISMATCH
```

Sanitized production shape (NamedResource, CAPACITY_PLAN):

```text
allocationStartWeek: absent/null
startWeek:           -1
allocationEndWeek:   populated
endWeek:             -1
```

Effective values (shared primary/fallback semantics): `effective start = startWeek = -1` (negative, the decision edge); `effective end = allocationEndWeek` (populated). The fallback `endWeek: -1` is **shadowed** by the populated primary end — raw evidence, not an additional effective-negative edge.

Starting `origin/main`: `9e8a71ebdea479b58d2e9e59a890e121482cbdb7`.

## Confirmed root cause

The S-record window reconciliation predicate (added with the PR #435 correlation) required **every raw `-1` field to lie on the same logical edge** as `minusOneField`. The seven production entries carry `-1` on the fallback aliases of **both** edges (`startWeek` and `endWeek`) while the primary end alias is populated; the plan-authoritative classifier triggers on the effective start edge only, so correlation passes, but the evidence predicate rejected all seven emitted records. This is an evidence-reconciliation defect only — classifier policy, plan decisions, and the reviewed expected count of seven are unchanged.

## Fix — reconcile effective edges, not raw-field location

- New small focused helper `effectiveWindowReconciliationReason` validates each correlated **raw** entry with the same effective primary/fallback semantics the application and shared classifier use (`effectiveStart = allocationStartWeek ?? startWeek`; `effectiveEnd = allocationEndWeek ?? endWeek`). Each edge now derives **both the effective value and the exact raw field that supplied it** (primary when non-null, otherwise the fallback alias):
  1. the entry still re-derives the plan's single-negative decision (existing shared-classifier check);
  2. exactly one **effective** edge is negative;
  3. the raw field that supplied that negative effective edge is known and equals `minusOneField` — a shadowed fallback alias is never selected, even when it contains `-1` and the primary effective value is negative but not exactly `-1`;
  4. the supplied effective value is exactly `-1` (an effective value below `-1` fails closed even when a shadowed fallback alias holds `-1`);
  5. every additional raw `-1` field is **shadowed** by a non-null primary field on its own edge — a fallback `-1` whose primary is null is effective, never shadowed;
  6. every raw field remains represented truthfully in `windowFields`.
- The emitted-record check is relaxed to structural invariants only (at least one `minus-one` field, `minusOneField` among them, other fields absent-null/populated); effective-edge and shadowing semantics are validated on the raw entry where the values exist.
- Any genuine mismatch (both effective edges negative, an incoherent shape such as `-2`/`-1`, a stale decision that no longer re-derives) fails closed with a fixed sanitized reason; the CLI exits 1 with no output.
- Plan-authoritative selection, one-to-one correlation, unique-parent correlation, `minusOneField` selection, S/M per-snapshot reconciliation, the output schema and all reviewed counts are unchanged.

## Regression coverage

- Sanitized production shape (`startWeek` -1 effective + `endWeek` -1 shadowed): 1 decision → 1 S record, `minusOneField` = `startWeek`, both `startWeek` and `endWeek` reported `minus-one`, `allocationEndWeek` `populated`, reconciliation passes, JSON/Markdown parity.
- Effective-end mirror (`allocationStartWeek` populated, `startWeek` -1 shadowed, `endWeek` -1 effective): `minusOneField` = `endWeek`.
- Primary `-1` with opposite-edge shadowed fallback `-1`; same-edge dual-alias fixture remains valid; ResourceType single-negative unchanged.
- Both-effective-edges-negative (`-1`/`-1`) stays in its never-active class — no plan decision, no S record; safe messages contain no IDs, names, modes or raw numeric values.
- **Effective-source mismatch (new):** a negative effective source below `-1` with a shadowed fallback `-1` on the same edge (`allocationStartWeek: -2, startWeek: -1, allocationEndWeek: 5`) fails closed with `the negative effective value is not exactly minus one` — the shadowed `startWeek` is never selected. The earlier `-2`/`-1` test covered only the both-effective-negative boundary; this remediation additionally proves the selected field is the actual effective source. End-edge mirror covered symmetrically. Production established the dual-edge-fallback `-1` shape only — no `-2` entry has ever been observed.
- Exactly seven production-shaped entries → seven decisions, seven correlations, seven S records, zero reconciliation violations; 11/7 topology (226 + 133/7 = 366 decisions, 359 windowless) preserved.
- Deterministic ordering, redaction, no-output-on-refusal, no-temp-residue, zero writes, root CLI forwarding and no-clobber publication tests remain green.

## Validation

- Unit: `snapshotEvidence.test.ts` — **70 passed** (8 new).
- Integration: `snapshotEvidence.integration.test.ts` — **10 passed** against a disposable local PostgreSQL instance seeded with the sanitized production shape (session Docker socket unavailable; the Docker-first lifecycle runs in CI).
- `npm run validate`: **exit 0** — server 1623 passed, client 342 passed, lint/typecheck/build clean.
- `git diff --check`: clean.
- CI: status will be reported once the run completes.

## Confirmations

- **Zero production access** — work performed only on the development machine with sanitized fixtures and disposable databases.
- No classifier policy, remediation-plan decision, quarantine/readiness policy, scheduler semantics, schema or migration changed; expected count stays **seven**.
- **#430 remains open** (no policy conclusion); **#404 and #418 remain blocked**; the #404 production run must not be retried until this correction is reviewed and merged (documented in the handoff).

**Do not merge — wait for review.**
