### PR TITLE
chore(#440): add sanitized Class A companion evidence

### DIFF
--- a/docs/domain/capacity-profile-readiness-remediation.md
+++ b/docs/domain/capacity-profile-readiness-remediation.md
@@ -487,7 +487,14 @@ current plan classification) plus a count, aggregate companion totals by
 current remediation-plan classification, and snapshot-level flags answering
 the three production questions (all entries / all companions windowless;
 all entries / all companions at the approved 100% categories defined
-per entry kind; any companion using inherited mode). Companions are
+per entry kind; any companion using inherited mode). Companion mode-source
+categories are companion-specific (all known allocation modes, not only
+CAPACITY_PLAN): `explicit` — a known mode exists on the companion entry;
+`inherited` — the raw mode is absent and a known mode comes from its parent;
+`other` — a populated mode source is unknown or unsupported; `unavailable`
+— no raw or parent mode source exists, or not applicable to the entry kind.
+The raw, parent and effective modes are sanitized independently (unknown
+strings render only as `other`). Companions are
 correlated internally to exactly one existing remediation-plan
 snapshot-entry finding; any missing, ambiguous or duplicate match, unresolvable
 ownership or reconciliation failure refuses output with a controlled safe

--- a/docs/domain/capacity-profile-readiness-remediation.md
+++ b/docs/domain/capacity-profile-readiness-remediation.md
@@ -437,21 +437,21 @@ No evidence is emitted until every gate passes.
 
 ### Output schema and redaction guarantees
 
-Versioned JSON (`formatVersion: 1`) with `runMetadata`, `expectedBoundary`,
+Versioned JSON (`formatVersion: 2`) with `runMetadata`, `expectedBoundary`,
 `observedBoundary`, `integrityResult`, `topology`, `singleNegativeEntries`
 (S1… labels), `defectSnapshots` (M1… labels), `classAAggregates`,
-`unavailableEvidence`, `reconciliation` and `policyDecision:
-"not-assessed"`. Markdown is rendered from the same evidence object and
-carries **all** evidence categories required by the #430 review: S-record
-entry and structural error categories, exact sanitized mode categories,
-percentage categories and the independent-defect classification; M-record
-subgroup, per-snapshot decision counts (windowless, single-`-1`, and other
-decision-required reasons), alreadyValid/quarantined/unsupported counts,
-entry and structural error categories; and the complete Class A percentage
-evidence split by owner kind / mode source (`resourceType`, `explicit`,
-`inherited`, `other`, `unavailable` × `allocationPercent`/`allocationPct` ×
-every bucket). Output ordering is deterministic apart from the explicit run
-timestamp.
+`classACompanionEvidence`, `unavailableEvidence`, `reconciliation` and
+`policyDecision: "not-assessed"`. Markdown is rendered from the same evidence
+object and carries **all** evidence categories required by the #430 review:
+S-record entry and structural error categories, exact sanitized mode
+categories, percentage categories and the independent-defect
+classification; M-record subgroup, per-snapshot decision counts
+(windowless, single-`-1`, and other decision-required reasons),
+alreadyValid/quarantined/unsupported counts, entry and structural error
+categories; and the complete Class A percentage evidence split by owner kind
+/ mode source (`resourceType`, `explicit`, `inherited`, `other`,
+`unavailable` × `allocationPercent`/`allocationPct` × every bucket). Output
+ordering is deterministic apart from the explicit run timestamp.
 
 Class A aggregates also include **affected-snapshot counts** in addition to
 entry counts: `affectedSnapshotsByOwnerKind` (`resourceType` /
@@ -466,6 +466,34 @@ aggregate is not expected to sum to the 49 Class A snapshots. A snapshot
 counts at most once per category.
 `snapshotsByOwnerKindMix` retains the mutually exclusive overall mix and the
 total Class A snapshot reconciliation stays at 49.
+
+The `classACompanionEvidence` section (issue #440) is sanitized
+**observational evidence** for the #438 companion-rule review — it never
+decides or implements the future companion predicate. Selection uses the
+currently merged policy only: stored V2 snapshots whose shared
+`classifySnapshotRestorability` verdict is `quarantined` with quarantine
+classes exactly `['A']`. Within a selected snapshot, an entry is exact Class
+A iff it satisfies the existing `isClassAResourceTypeEntry` /
+`isClassANamedResourceEntry` predicates with its current captured parent;
+every other captured entry is a companion. Restorable, defect and
+Class-B-only snapshots are excluded; mixed Class-A/Class-B quarantined
+snapshots are counted separately in `excludedMixedClassABSnapshots` and are
+never mixed into the companion population. The section reports population
+totals, deterministic sorted aggregate shape rows (fixed sanitized
+vocabularies only: entry kind, raw/parent/effective mode, mode source,
+per-field window state `unavailable` / `absent-null` / `minus-one` /
+`populated-nonnegative-integer` / `populated-other`, percent categories,
+current plan classification) plus a count, aggregate companion totals by
+current remediation-plan classification, and snapshot-level flags answering
+the three production questions (all entries / all companions windowless;
+all entries / all companions at the approved 100% categories defined
+per entry kind; any companion using inherited mode). Companions are
+correlated internally to exactly one existing remediation-plan
+snapshot-entry finding; any missing, ambiguous or duplicate match, unresolvable
+ownership or reconciliation failure refuses output with a controlled safe
+reason. The companion values are observational and are NOT required in the
+reviewed expected file; the existing fingerprint, baseline, count and
+topology gates remain required.
 
 Unknown or malformed historical mode strings are never copied into evidence
 output: the command normalizes every outward-facing mode value to the fixed

--- a/server/src/lib/snapshotEvidence.ts
+++ b/server/src/lib/snapshotEvidence.ts
@@ -22,6 +22,16 @@
  * `not-assessed`. It emits aggregate evidence only — no project/snapshot/
  * owner/finding/decision identifiers, no names, no payloads.
  *
+ * Issue #440 adds the `classACompanionEvidence` section: sanitized
+ * observational evidence about the non-Class-A companion entries inside
+ * currently Class-A-quarantined snapshots (selection uses the currently
+ * merged classifier only; exact Class A uses the existing per-entry
+ * predicates; every other entry is a companion). Companions are correlated
+ * to exactly one existing remediation-plan finding and aggregated into
+ * fixed-category rows plus population/plan/flag totals with internal
+ * reconciliation — this is evidence for the #438 companion-rule review, not
+ * a predicate implementation.
+ *
  * Pure function of its inputs (database state, snapshot created-at
  * metadata, reviewed expectations); performs zero writes; contains no I/O.
  */
@@ -39,6 +49,7 @@ import {
   isClassAResourceTypeEntry,
   isClassANamedResourceEntry,
   isClassASnapshot,
+  isNonNegativeInteger,
 } from './projectSnapshotCapacity.js'
 import {
   classifySnapshotRestorability,
@@ -62,7 +73,7 @@ import {
 
 // ─── Version and schema ─────────────────────────────────────────────────────
 
-export const SNAPSHOT_EVIDENCE_FORMAT_VERSION = 1 as const
+export const SNAPSHOT_EVIDENCE_FORMAT_VERSION = 2 as const
 
 /** Stable evidence categories; never raw identifiers or payloads. */
 export type OwnerKindCategory = 'resourceType' | 'namedResource' | 'unavailable'
@@ -146,6 +157,85 @@ export interface SnapshotEvidenceExpected {
 }
 
 // ─── Report schema (versioned, evidence-only) ───────────────────────────────
+
+/** Fixed sanitized state vocabulary for one raw window field of a companion
+ * entry (never numeric values). `unavailable` means the field does not exist
+ * on that entry kind (e.g. startWeek/endWeek on a ResourceType);
+ * `populated-other` covers populated values that are not non-negative
+ * integers (negative other than -1, fractional, non-finite). */
+export type CompanionWindowFieldState =
+  | 'unavailable'
+  | 'absent-null'
+  | 'minus-one'
+  | 'populated-nonnegative-integer'
+  | 'populated-other'
+
+/** Current remediation-plan finding classification of a companion entry
+ * (exactly the shared FindingClassification vocabulary). */
+export type CompanionPlanClassification =
+  | 'deterministic'
+  | 'decisionRequired'
+  | 'unsupported'
+  | 'alreadyValid'
+  | 'quarantined'
+
+/** One deterministic aggregate row of companion entries. Fixed sanitized
+ * categories only, plus a count; never identifiers or raw values. */
+export interface ClassACompanionShapeRow {
+  entryKind: 'resourceType' | 'namedResource'
+  rawMode: SanitizedMode
+  /** The same sanitized vocabulary; `unavailable` for ResourceType entries. */
+  parentMode: SanitizedMode
+  effectiveMode: SanitizedMode
+  modeSource: NamedModeSourceCategory
+  allocationStartWeekState: CompanionWindowFieldState
+  allocationEndWeekState: CompanionWindowFieldState
+  startWeekState: CompanionWindowFieldState
+  endWeekState: CompanionWindowFieldState
+  allocationPercentCategory: PercentCategory
+  /** `unavailable` for ResourceType entries (the field does not exist);
+   * otherwise the fixed percentage vocabulary. */
+  allocationPctCategory: PercentCategory | 'unavailable'
+  currentPlanClassification: CompanionPlanClassification
+  count: number
+}
+
+/** Issue #440 — sanitized observational evidence about the non-Class-A
+ * companion entries inside currently Class-A-quarantined snapshots. This is
+ * evidence for the #438 companion-rule review only; it never decides or
+ * implements the future companion predicate. */
+export interface ClassACompanionEvidence {
+  population: {
+    /** Selected snapshots: current verdict quarantined with classes exactly A. */
+    classAQuarantinedSnapshots: number
+    /** Selected snapshots containing at least one companion entry. */
+    snapshotsWithCompanions: number
+    exactClassAResourceTypeEntries: number
+    exactClassANamedResourceEntries: number
+    companionResourceTypeEntries: number
+    companionNamedResourceEntries: number
+    totalCompanionEntries: number
+    /** Excluded quarantined snapshots carrying BOTH Class A and Class B. */
+    excludedMixedClassABSnapshots: number
+  }
+  /** Deterministic sorted aggregate rows (fixed categories + count). */
+  shapeRows: ClassACompanionShapeRow[]
+  /** Aggregate companion totals by current remediation-plan classification. */
+  planClassifications: Record<CompanionPlanClassification, number>
+  /** Aggregate snapshot counts answering the three production questions. */
+  snapshotFlags: {
+    allEntriesWindowless: number
+    notAllEntriesWindowless: number
+    allEntriesApproved100: number
+    notAllEntriesApproved100: number
+    allCompanionsWindowless: number
+    notAllCompanionsWindowless: number
+    allCompanionsApproved100: number
+    notAllCompanionsApproved100: number
+    anyCompanionInheritedMode: number
+    noCompanionInheritedMode: number
+  }
+}
 
 /** One sanitized S record (single-negative decision evidence). Key is a
  * content-derived internal label input; never emitted. */
@@ -255,6 +345,8 @@ export interface SnapshotEvidenceReport {
     entriesByEra: Record<SnapshotEraCategory, number>
     snapshotsByEra: Record<SnapshotEraCategory, number>
   }
+  /** Issue #440 — sanitized companion-entry evidence for the #438 review. */
+  classACompanionEvidence: ClassACompanionEvidence
   unavailableEvidence: {
     singleEntriesModeSourceUnavailable: number
     defectSnapshotsIndependentDefectUnavailable: number
@@ -270,7 +362,7 @@ export interface SnapshotEvidenceReport {
 
 // ─── Controlled error ───────────────────────────────────────────────────────
 
-export type EvidenceErrorCode = 'unsupported-snapshot' | 'snapshot-parse-failure' | 'decision-correlation-failure'
+export type EvidenceErrorCode = 'unsupported-snapshot' | 'snapshot-parse-failure' | 'decision-correlation-failure' | 'companion-correlation-failure'
 
 export class SnapshotEvidenceError extends Error {
   readonly code: EvidenceErrorCode
@@ -998,6 +1090,318 @@ export function classifyAllSnapshots(state: RemediationDatabaseState): Classifie
   })
 }
 
+// ─── Issue #440 Class A companion evidence ──────────────────────────────────
+
+/** Fixed sanitized state of one raw window field (never numeric values).
+ * `unavailable` for fields that do not exist on the entry kind. */
+function companionWindowFieldState(
+  kind: 'resourceType' | 'namedResource',
+  field: 'allocationStartWeek' | 'allocationEndWeek' | 'startWeek' | 'endWeek',
+  value: number | null | undefined,
+): CompanionWindowFieldState {
+  if (kind === 'resourceType' && (field === 'startWeek' || field === 'endWeek')) return 'unavailable'
+  if (value == null) return 'absent-null'
+  if (value === -1) return 'minus-one'
+  if (isNonNegativeInteger(value)) return 'populated-nonnegative-integer'
+  return 'populated-other'
+}
+
+/** Raw-windowless predicate for one captured entry (all its existing window
+ * fields absent-null). Defined from the raw captured fields, never from
+ * translated output. */
+function companionEntryWindowless(
+  kind: 'resourceType' | 'namedResource',
+  rt: SnapshotResourceType,
+  nr: SnapshotNamedResource,
+): boolean {
+  if (kind === 'resourceType') {
+    return rt.allocationStartWeek == null && rt.allocationEndWeek == null
+  }
+  return (
+    nr.allocationStartWeek == null &&
+    nr.allocationEndWeek == null &&
+    nr.startWeek == null &&
+    nr.endWeek == null
+  )
+}
+
+/** Approved-100 category per entry kind (observational definition, issue
+ * #440): ResourceType — allocationPercent hundred (allocationPct does not
+ * exist); NamedResource — allocationPercent AND allocationPct both hundred.
+ * This is NOT the future companion predicate. */
+function companionEntryApproved100(
+  kind: 'resourceType' | 'namedResource',
+  rt: SnapshotResourceType,
+  nr: SnapshotNamedResource,
+): boolean {
+  if (kind === 'resourceType') return rt.allocationPercent === 100
+  return nr.allocationPercent === 100 && nr.allocationPct === 100
+}
+
+/** Aggregate key of one companion shape row (fixed categories only). */
+interface CompanionAggregateKey {
+  entryKind: 'resourceType' | 'namedResource'
+  rawMode: SanitizedMode
+  parentMode: SanitizedMode
+  effectiveMode: SanitizedMode
+  modeSource: NamedModeSourceCategory
+  allocationStartWeekState: CompanionWindowFieldState
+  allocationEndWeekState: CompanionWindowFieldState
+  startWeekState: CompanionWindowFieldState
+  endWeekState: CompanionWindowFieldState
+  allocationPercentCategory: PercentCategory
+  allocationPctCategory: PercentCategory | 'unavailable'
+  currentPlanClassification: CompanionPlanClassification
+}
+
+/** Deterministic sort key over the fixed categories of one shape row. */
+function companionAggregateKey(categories: CompanionAggregateKey): string {
+  return canonicalJson(categories)
+}
+
+/**
+ * Issue #440 — build the sanitized Class A companion evidence section using
+ * the CURRENTLY MERGED policy only.
+ *
+ * Selection: every stored V2 snapshot whose shared
+ * `classifySnapshotRestorability` verdict is `quarantined` with quarantine
+ * classes exactly `['A']`. Restorable, defect and Class-B-only snapshots are
+ * excluded; mixed Class-A/Class-B snapshots are counted separately in the
+ * excluded-population aggregate. Within a selected snapshot an entry is
+ * exact Class A iff it satisfies the existing `isClassAResourceTypeEntry` /
+ * `isClassANamedResourceEntry` predicates with its current captured parent;
+ * every other entry is a companion. The predicates themselves are NOT
+ * modified or broadened here.
+ *
+ * Every companion is correlated to exactly one existing remediation-plan
+ * snapshot-entry finding (snapshotId + entryId; the plan is the selection
+ * authority). Any missing, ambiguous or duplicate match, unresolvable
+ * ownership or aggregate reconciliation failure fails closed with a
+ * controlled safe reason — never identifiers or payloads.
+ *
+ * The section is observational evidence for the #438 companion-rule review;
+ * it never decides the future companion predicate and its values are NOT
+ * part of the reviewed expected file.
+ */
+function buildClassACompanionEvidence(
+  state: RemediationDatabaseState,
+  plan: RemediationPlan,
+  classified: readonly ClassifiedSnapshot[],
+): { section: ClassACompanionEvidence; checks: Array<{ label: string; observed: number; expected: number }> } {
+  const checks: Array<{ label: string; observed: number; expected: number }> = []
+  const pushCheck = (label: string, observed: number, expected: number): void => {
+    checks.push({ label, observed, expected })
+  }
+  // Function declaration (not an arrow constant): TypeScript narrows control
+  // flow past `never`-returning calls only for function declarations.
+  function fail(reason: string): never {
+    throw new SnapshotEvidenceError(
+      'companion-correlation-failure',
+      `cannot aggregate Class A companion evidence: ${reason}`,
+    )
+  }
+
+  const population = {
+    classAQuarantinedSnapshots: 0,
+    snapshotsWithCompanions: 0,
+    exactClassAResourceTypeEntries: 0,
+    exactClassANamedResourceEntries: 0,
+    companionResourceTypeEntries: 0,
+    companionNamedResourceEntries: 0,
+    totalCompanionEntries: 0,
+    excludedMixedClassABSnapshots: 0,
+  }
+  const planClassifications: Record<CompanionPlanClassification, number> = {
+    deterministic: 0,
+    decisionRequired: 0,
+    unsupported: 0,
+    alreadyValid: 0,
+    quarantined: 0,
+  }
+  const snapshotFlags = {
+    allEntriesWindowless: 0,
+    notAllEntriesWindowless: 0,
+    allEntriesApproved100: 0,
+    notAllEntriesApproved100: 0,
+    allCompanionsWindowless: 0,
+    notAllCompanionsWindowless: 0,
+    allCompanionsApproved100: 0,
+    notAllCompanionsApproved100: 0,
+    anyCompanionInheritedMode: 0,
+    noCompanionInheritedMode: 0,
+  }
+  const rowCounts = new Map<string, { key: CompanionAggregateKey; count: number }>()
+  const companionKeys = new Set<string>()
+  let capturedEntriesTotal = 0
+
+  for (let snapshotIndex = 0; snapshotIndex < state.snapshots.length; snapshotIndex++) {
+    const snapshot = state.snapshots[snapshotIndex]!
+    const item = classified[snapshotIndex]!
+    const restorability = item.evidence.restorability
+    if (restorability.kind !== 'quarantined') continue
+    const classes = restorability.quarantineClasses
+    const hasA = classes.includes('A')
+    const hasB = classes.includes('B')
+    if (hasA && hasB) {
+      // Mixed Class-A/Class-B quarantine: reported separately, never mixed
+      // into the Class A companion population.
+      population.excludedMixedClassABSnapshots++
+      continue
+    }
+    if (!hasA) continue // Class-B-only quarantine: excluded.
+    // Selected: quarantine classes exactly Class A.
+    const parsed = item.parsedV2
+    if (parsed == null) fail(`selected snapshot ${snapshotIndex + 1} of ${state.snapshots.length} is not a parseable v2 payload`)
+    const rtById = new Map(parsed.resourceTypes.map(rt => [rt.id, rt]))
+
+    const captured = parsed.resourceTypes.length + parsed.namedResources.length
+    capturedEntriesTotal += captured
+    population.classAQuarantinedSnapshots++
+
+    let snapshotHasCompanion = false
+    let snapshotAllEntriesWindowless = true
+    let snapshotAllEntriesApproved100 = true
+    let snapshotAllCompanionsWindowless = true
+    let snapshotAllCompanionsApproved100 = true
+    let snapshotAnyCompanionInherited = false
+
+    const considerEntry = (
+      kind: 'resourceType' | 'namedResource',
+      rt: SnapshotResourceType | null,
+      nr: SnapshotNamedResource | null,
+      exact: boolean,
+    ): void => {
+      const entryId = kind === 'resourceType' ? rt!.id : nr!.id
+      const windowless = companionEntryWindowless(kind, rt!, nr!)
+      const approved100 = companionEntryApproved100(kind, rt!, nr!)
+      if (!windowless) snapshotAllEntriesWindowless = false
+      if (!approved100) snapshotAllEntriesApproved100 = false
+      if (exact) {
+        if (kind === 'resourceType') population.exactClassAResourceTypeEntries++
+        else population.exactClassANamedResourceEntries++
+        return
+      }
+      // Companion entry.
+      snapshotHasCompanion = true
+      const companionKey = `${snapshotIndex}\u0000${kind}\u0000${entryId}`
+      if (companionKeys.has(companionKey)) fail('an entry was counted more than once')
+      companionKeys.add(companionKey)
+      if (!windowless) snapshotAllCompanionsWindowless = false
+      if (!approved100) snapshotAllCompanionsApproved100 = false
+
+      // Correlation to the current remediation plan: exactly one
+      // snapshot-entry finding for this entry (the plan is the selection
+      // authority; no second policy engine).
+      const matches = plan.findings.filter(
+        finding =>
+          finding.category === 'snapshot-entry' &&
+          finding.snapshotId === snapshot.id &&
+          finding.entryId === entryId,
+      )
+      if (matches.length !== 1) {
+        fail(`companion entry has ${matches.length} uniquely matching plan findings (exactly one required)`)
+      }
+      const classification = matches[0]!.classification as CompanionPlanClassification
+      planClassifications[classification]++
+      if (kind === 'namedResource') population.companionNamedResourceEntries++
+      else population.companionResourceTypeEntries++
+      population.totalCompanionEntries++
+
+      // Sanitized shape categories (fixed vocabularies only).
+      const rawMode = kind === 'resourceType'
+        ? sanitizeMode(rt!.allocationMode)
+        : sanitizeMode(nr!.allocationMode)
+      const parentMode = kind === 'resourceType'
+        ? 'unavailable'
+        : sanitizeMode(rtById.get(nr!.resourceTypeId ?? '')?.allocationMode)
+      const effectiveMode = kind === 'resourceType'
+        ? rawMode
+        : sanitizeMode(v2EffectiveNamedMode(nr!, rtById.get(nr!.resourceTypeId ?? '')))
+      const modeSource = kind === 'resourceType'
+        ? 'unavailable'
+        : namedModeSourceCategory(nr!.allocationMode ?? null, rtById.get(nr!.resourceTypeId ?? '')?.allocationMode ?? null)
+      if (modeSource === 'inherited') snapshotAnyCompanionInherited = true
+
+      const key: CompanionAggregateKey = {
+        entryKind: kind,
+        rawMode,
+        parentMode,
+        effectiveMode,
+        modeSource,
+        allocationStartWeekState: companionWindowFieldState(kind, 'allocationStartWeek', kind === 'resourceType' ? rt!.allocationStartWeek : nr!.allocationStartWeek),
+        allocationEndWeekState: companionWindowFieldState(kind, 'allocationEndWeek', kind === 'resourceType' ? rt!.allocationEndWeek : nr!.allocationEndWeek),
+        startWeekState: companionWindowFieldState(kind, 'startWeek', kind === 'namedResource' ? nr!.startWeek : null),
+        endWeekState: companionWindowFieldState(kind, 'endWeek', kind === 'namedResource' ? nr!.endWeek : null),
+        allocationPercentCategory: percentCategory(kind === 'resourceType' ? rt!.allocationPercent : nr!.allocationPercent),
+        allocationPctCategory: kind === 'resourceType' ? 'unavailable' : percentCategory(nr!.allocationPct),
+        currentPlanClassification: classification,
+      }
+      const sortKey = companionAggregateKey(key)
+      const existing = rowCounts.get(sortKey)
+      if (existing) existing.count++
+      else rowCounts.set(sortKey, { key, count: 1 })
+    }
+
+    for (const rt of parsed.resourceTypes) {
+      considerEntry('resourceType', rt, null, isClassAResourceTypeEntry(rt))
+    }
+    for (const nr of parsed.namedResources) {
+      // Strict parent resolution: exactly one captured ResourceType. An
+      // absent, unmatched or duplicated parent fails closed (never resolved
+      // with find/Map/positional picks).
+      const parentId = nr.resourceTypeId
+      if (parentId == null || parentId === '') fail('a named-resource entry carries no parent reference')
+      const parents = parsed.resourceTypes.filter(rt => rt.id === parentId)
+      if (parents.length !== 1) fail(`a named-resource entry parent matched ${parents.length} resource types`)
+      const parentRt = parents[0]!
+      considerEntry('namedResource', null, nr, isClassANamedResourceEntry(nr, parentRt))
+    }
+
+    population.snapshotsWithCompanions += snapshotHasCompanion ? 1 : 0
+    snapshotFlags.allEntriesWindowless += snapshotAllEntriesWindowless ? 1 : 0
+    snapshotFlags.notAllEntriesWindowless += snapshotAllEntriesWindowless ? 0 : 1
+    snapshotFlags.allEntriesApproved100 += snapshotAllEntriesApproved100 ? 1 : 0
+    snapshotFlags.notAllEntriesApproved100 += snapshotAllEntriesApproved100 ? 0 : 1
+    snapshotFlags.allCompanionsWindowless += snapshotAllCompanionsWindowless ? 1 : 0
+    snapshotFlags.notAllCompanionsWindowless += snapshotAllCompanionsWindowless ? 0 : 1
+    snapshotFlags.allCompanionsApproved100 += snapshotAllCompanionsApproved100 ? 1 : 0
+    snapshotFlags.notAllCompanionsApproved100 += snapshotAllCompanionsApproved100 ? 0 : 1
+    snapshotFlags.anyCompanionInheritedMode += snapshotAnyCompanionInherited ? 1 : 0
+    snapshotFlags.noCompanionInheritedMode += snapshotAnyCompanionInherited ? 0 : 1
+  }
+
+  // ── Internal reconciliation (observational; refuses output on failure) ──
+  const exactTotal = population.exactClassAResourceTypeEntries + population.exactClassANamedResourceEntries
+  const companionTotal = population.totalCompanionEntries
+  pushCheck('exact Class A entries plus companions equal captured entries', exactTotal + companionTotal, capturedEntriesTotal)
+  pushCheck('companion by-kind totals reconcile', population.companionResourceTypeEntries + population.companionNamedResourceEntries, companionTotal)
+  let rowSum = 0
+  for (const { count } of rowCounts.values()) rowSum += count
+  pushCheck('companion shape-row counts reconcile', rowSum, companionTotal)
+  let planSum = 0
+  for (const value of Object.values(planClassifications)) planSum += value
+  pushCheck('companion plan-classification totals reconcile', planSum, companionTotal)
+  pushCheck('companion entries are unique', companionKeys.size, companionTotal)
+  pushCheck('no selected entry is omitted', companionTotal, capturedEntriesTotal - exactTotal)
+  pushCheck('snapshot flag pair: entries windowless', snapshotFlags.allEntriesWindowless + snapshotFlags.notAllEntriesWindowless, population.classAQuarantinedSnapshots)
+  pushCheck('snapshot flag pair: entries approved 100', snapshotFlags.allEntriesApproved100 + snapshotFlags.notAllEntriesApproved100, population.classAQuarantinedSnapshots)
+  pushCheck('snapshot flag pair: companions windowless', snapshotFlags.allCompanionsWindowless + snapshotFlags.notAllCompanionsWindowless, population.classAQuarantinedSnapshots)
+  pushCheck('snapshot flag pair: companions approved 100', snapshotFlags.allCompanionsApproved100 + snapshotFlags.notAllCompanionsApproved100, population.classAQuarantinedSnapshots)
+  pushCheck('snapshot flag pair: companion inherited mode', snapshotFlags.anyCompanionInheritedMode + snapshotFlags.noCompanionInheritedMode, population.classAQuarantinedSnapshots)
+
+  const sortedRows = [...rowCounts.entries()]
+    .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
+    .map(([, { key, count }]) => ({ ...key, count }))
+
+  const section: ClassACompanionEvidence = {
+    population,
+    shapeRows: sortedRows,
+    planClassifications,
+    snapshotFlags,
+  }
+  return { section, checks }
+}
+
 /**
  * Build the complete sanitized evidence report. Pure: no I/O, no writes, no
  * policy decisions. Throws SnapshotEvidenceError on unsupported/malformed
@@ -1279,6 +1683,13 @@ export function buildSnapshotEvidenceReport(inputs: SnapshotEvidenceInputs): Sna
     check('class A entries reconcile', classATotalEntries, expected.quarantinedEntries),
     check('class A snapshots reconcile', classATotalSnapshots, expected.quarantinedSnapshots),
   ]
+  // Issue #440 companion evidence: internal reconciliation checks are
+  // observational (no reviewed expected-file values exist yet); any failure
+  // refuses output through the same reconciliation gate.
+  const companionEvidence = buildClassACompanionEvidence(state, plan, classified)
+  for (const companionCheck of companionEvidence.checks) {
+    checks.push(check(companionCheck.label, companionCheck.observed, companionCheck.expected))
+  }
   const countsMatch = checks.every(ok => ok)
   const fingerprintMatch = observedFingerprint === expected.fingerprint
   const baselineMatch = observedBaseline === expected.baselineStateHash
@@ -1356,6 +1767,7 @@ export function buildSnapshotEvidenceReport(inputs: SnapshotEvidenceInputs): Sna
       entriesByEra,
       snapshotsByEra,
     },
+    classACompanionEvidence: companionEvidence.section,
     unavailableEvidence: {
       singleEntriesModeSourceUnavailable: sortedS.filter(record => record.modeSource === 'unavailable').length,
       defectSnapshotsIndependentDefectUnavailable: sortedM.filter(record => record.independentDefect === 'unavailable').length,
@@ -1531,6 +1943,51 @@ export function renderSnapshotEvidenceMarkdown(report: SnapshotEvidenceReport): 
       summarizeCounts(byCategory.allocationPercent),
       summarizeCounts(byCategory.allocationPct),
     ].join(' | '))
+  }
+  lines.push('')
+  lines.push('## Class A companion evidence')
+  lines.push('')
+  lines.push('Observational evidence about the non-Class-A companion entries inside currently Class-A-quarantined snapshots (issue #440). Fixed sanitized categories only; no identifiers, names or raw values. It does not decide the future companion predicate.')
+  lines.push('')
+  lines.push('### Population')
+  lines.push('')
+  const companion = report.classACompanionEvidence
+  for (const [key, value] of Object.entries(companion.population)) {
+    lines.push(`- ${key}: ${value}`)
+  }
+  lines.push('')
+  lines.push('### Companion shape rows')
+  lines.push('')
+  lines.push('| Entry kind | Raw mode | Parent mode | Effective mode | Mode source | allocationStartWeek | allocationEndWeek | startWeek | endWeek | allocationPercent | allocationPct | Plan classification | Count |')
+  lines.push('|---|---|---|---|---|---|---|---|---|---|---|---|---|')
+  for (const row of companion.shapeRows) {
+    lines.push([
+      row.entryKind,
+      row.rawMode ?? 'null',
+      row.parentMode ?? 'null',
+      row.effectiveMode ?? 'null',
+      row.modeSource,
+      row.allocationStartWeekState,
+      row.allocationEndWeekState,
+      row.startWeekState,
+      row.endWeekState,
+      row.allocationPercentCategory,
+      row.allocationPctCategory,
+      row.currentPlanClassification,
+      row.count,
+    ].join(' | '))
+  }
+  lines.push('')
+  lines.push('### Plan classifications')
+  lines.push('')
+  for (const [classification, count] of Object.entries(companion.planClassifications)) {
+    lines.push(`- ${classification}: ${count}`)
+  }
+  lines.push('')
+  lines.push('### Snapshot-level flags')
+  lines.push('')
+  for (const [flag, count] of Object.entries(companion.snapshotFlags)) {
+    lines.push(`- ${flag}: ${count}`)
   }
   lines.push('')
   lines.push('## Reconciliation')

--- a/server/src/lib/snapshotEvidence.ts
+++ b/server/src/lib/snapshotEvidence.ts
@@ -1319,7 +1319,7 @@ function buildClassACompanionEvidence(
         : sanitizeMode(v2EffectiveNamedMode(nr!, rtById.get(nr!.resourceTypeId ?? '')))
       const modeSource = kind === 'resourceType'
         ? 'unavailable'
-        : namedModeSourceCategory(nr!.allocationMode ?? null, rtById.get(nr!.resourceTypeId ?? '')?.allocationMode ?? null)
+        : companionModeSourceCategory(nr!.allocationMode ?? null, rtById.get(nr!.resourceTypeId ?? '')?.allocationMode ?? null)
       if (modeSource === 'inherited') snapshotAnyCompanionInherited = true
 
       const key: CompanionAggregateKey = {
@@ -1785,13 +1785,46 @@ export function buildSnapshotEvidenceReport(inputs: SnapshotEvidenceInputs): Sna
  * mode wins when present; a CAPACITY_PLAN parent provides inherited
  * provenance; otherwise the source is unavailable (or other for a
  * non-CAPACITY_PLAN parent). Single definition shared by the entry evidence
- * and the correlated S records. */
+ * and the correlated S records. CAPACITY_PLAN-specific on purpose — its
+ * existing consumers (S records and the Class A aggregates) rely on it; do
+ * not reuse it for the generic companion evidence (see
+ * `companionModeSourceCategory`). */
 function namedModeSourceCategory(rawMode: string | null, parentMode: string | null): NamedModeSourceCategory {
   if (rawMode === 'CAPACITY_PLAN') return 'explicit'
   if (rawMode != null) return 'other'
   if (parentMode === 'CAPACITY_PLAN') return 'inherited'
   if (parentMode == null) return 'unavailable'
   return 'other'
+}
+
+/** Companion-specific mode-source categorisation (issue #440 review): the
+ * generic companion evidence must report whether a companion mode is
+ * explicitly stored or inherited for ALL known allocation modes, not only
+ * CAPACITY_PLAN:
+ *
+ *   - any populated known raw mode → explicit (TIMELINE, CAPACITY_PLAN,
+ *     EFFORT, FULL_PROJECT);
+ *   - absent raw mode with a populated known parent mode → inherited;
+ *   - populated unknown/unsupported raw mode → other;
+ *   - absent raw mode with a populated unknown/unsupported parent mode →
+ *     other;
+ *   - both raw and parent modes absent → unavailable.
+ *
+ * Used only when building `ClassACompanionShapeRow.modeSource`. The raw,
+ * parent and effective modes themselves are still sanitized independently
+ * through `sanitizeMode`, so arbitrary unknown strings never reach output.
+ * Exported so the categorisation is directly testable for the states a
+ * selected (Class-A-quarantined) snapshot cannot reach (unknown modes make
+ * the snapshot a defect and are therefore excluded from the population). */
+export function companionModeSourceCategory(
+  rawMode: string | null | undefined,
+  parentMode: string | null | undefined,
+): NamedModeSourceCategory {
+  if (rawMode != null) {
+    return isKnownV2Mode(rawMode) ? 'explicit' : 'other'
+  }
+  if (parentMode == null) return 'unavailable'
+  return isKnownV2Mode(parentMode) ? 'inherited' : 'other'
 }
 
 function windowFieldStateFor(value: number | null | undefined): WindowFieldState {

--- a/server/src/test/snapshotEvidence.integration.test.ts
+++ b/server/src/test/snapshotEvidence.integration.test.ts
@@ -217,8 +217,15 @@ async function seedTopologyFixture(): Promise<void> {
       [
         makeRt({ id: 'rt-q1-a', allocationMode: 'CAPACITY_PLAN' }),
         makeRt({ id: 'rt-q1-b', allocationMode: 'CAPACITY_PLAN' }),
+        // Issue #440 companion: windowless EFFORT at 100% (alreadyValid).
+        makeRt({ id: 'rt-q1-effort', allocationMode: 'EFFORT' }),
       ],
-      [makeNr({ id: 'nr-q1-inherited', resourceTypeId: 'rt-q1-a', allocationMode: null })],
+      [
+        makeNr({ id: 'nr-q1-inherited', resourceTypeId: 'rt-q1-a', allocationMode: null }),
+        // Issue #440 companion: explicit windowed TIMELINE at 100/100
+        // (alreadyValid; populated non-negative window states).
+        makeNr({ id: 'nr-q1-timeline', resourceTypeId: 'rt-q1-b', allocationMode: 'TIMELINE', allocationStartWeek: 2, allocationEndWeek: 9, startWeek: 2, endWeek: 9 }),
+      ],
     ),
     '2026-06-01T00:00:00Z',
   )
@@ -282,7 +289,7 @@ describeIf('snapshot evidence command (integration)', () => {
     expect(existsSync(jsonPath)).toBe(true)
     expect(existsSync(mdPath)).toBe(true)
     const report = JSON.parse(readFileSync(jsonPath, 'utf-8'))
-    expect(report.formatVersion).toBe(1)
+    expect(report.formatVersion).toBe(2)
     expect(report.integrityResult).toEqual({
       fingerprintMatch: true, baselineMatch: true, countsMatch: true, reconciliationPassed: true,
     })
@@ -306,6 +313,69 @@ describeIf('snapshot evidence command (integration)', () => {
     expect(readdirSync(dir).filter(name => name.includes('.tmp'))).toEqual([])
     expect(report.classAAggregates.totalEntries).toBe(3)
     expect(report.classAAggregates.byOwnerKind).toEqual({ resourceType: 2, namedResource: 1, unavailable: 0 })
+    // Issue #440: sanitized Class A companion evidence for the quarantined
+    // snapshot (exact RTs stay exact; every other entry is a companion).
+    expect(report.classACompanionEvidence.population).toEqual({
+      classAQuarantinedSnapshots: 1,
+      snapshotsWithCompanions: 1,
+      exactClassAResourceTypeEntries: 2,
+      exactClassANamedResourceEntries: 0,
+      companionResourceTypeEntries: 1,
+      companionNamedResourceEntries: 2,
+      totalCompanionEntries: 3,
+      excludedMixedClassABSnapshots: 0,
+    })
+    expect(report.classACompanionEvidence.planClassifications).toEqual({
+      deterministic: 0,
+      decisionRequired: 0,
+      unsupported: 0,
+      alreadyValid: 2,
+      quarantined: 1,
+    })
+    expect(report.classACompanionEvidence.snapshotFlags).toEqual({
+      allEntriesWindowless: 0,
+      notAllEntriesWindowless: 1,
+      allEntriesApproved100: 1,
+      notAllEntriesApproved100: 0,
+      allCompanionsWindowless: 0,
+      notAllCompanionsWindowless: 1,
+      allCompanionsApproved100: 1,
+      notAllCompanionsApproved100: 0,
+      anyCompanionInheritedMode: 1,
+      noCompanionInheritedMode: 0,
+    })
+    const companionRows = report.classACompanionEvidence.shapeRows
+    const rowSum = companionRows.reduce((sum: number, row: { count: number }) => sum + row.count, 0)
+    expect(rowSum).toBe(3)
+    // Inherited-mode windowless companion row (current plan: quarantined).
+    const inheritedRow = companionRows.find((row: { modeSource: string }) => row.modeSource === 'inherited')!
+    expect(inheritedRow).toMatchObject({
+      entryKind: 'namedResource',
+      rawMode: null,
+      parentMode: 'CAPACITY_PLAN',
+      effectiveMode: 'CAPACITY_PLAN',
+      allocationStartWeekState: 'absent-null',
+      allocationEndWeekState: 'absent-null',
+      startWeekState: 'absent-null',
+      endWeekState: 'absent-null',
+      allocationPercentCategory: 'hundred',
+      allocationPctCategory: 'hundred',
+      currentPlanClassification: 'quarantined',
+      count: 1,
+    })
+    // Windowed TIMELINE companion row (current plan: alreadyValid).
+    const timelineRow = companionRows.find((row: { rawMode: string | null }) => row.rawMode === 'TIMELINE')!
+    expect(timelineRow).toMatchObject({
+      entryKind: 'namedResource',
+      effectiveMode: 'TIMELINE',
+      allocationStartWeekState: 'populated-nonnegative-integer',
+      allocationEndWeekState: 'populated-nonnegative-integer',
+      startWeekState: 'populated-nonnegative-integer',
+      endWeekState: 'populated-nonnegative-integer',
+      currentPlanClassification: 'alreadyValid',
+    })
+    // The current quarantine boundary is unchanged by the tooling.
+    expect(report.observedBoundary.summary.quarantined).toBe(3)
     // Issue #438: the seeded S entry is deterministic zero — no single-
     // negative decision exists, so no S record is emitted.
     expect(report.singleNegativeEntries).toHaveLength(0)
@@ -325,6 +395,7 @@ describeIf('snapshot evidence command (integration)', () => {
       'fixture-project-42-abc', 'fixture-user-7-xyz',
       'snap-e1', 'snap-e2', 'snap-s7', 'snap-q1', 'snap-r1',
       'rt-e1-0', 'nr-s7-minus-one', 'nr-q1-inherited',
+      'rt-q1-effort', 'nr-q1-timeline',
       'Fixture Secret Project', 'Fixture Secret Role', 'Fixture Secret Person',
     ]) {
       expect(readFileSync(jsonPath, 'utf-8')).not.toContain(secret)
@@ -332,6 +403,10 @@ describeIf('snapshot evidence command (integration)', () => {
     }
     expect(markdown).toContain('windowlessDecisions: 56')
     expect(markdown).toContain('policyDecision: not-assessed')
+    // Issue #440 companion section is mirrored in Markdown.
+    expect(markdown).toContain('## Class A companion evidence')
+    expect(markdown).toContain('- totalCompanionEntries: 3')
+    expect(markdown).toContain('- anyCompanionInheritedMode: 1')
 
     rmSync(dir, { recursive: true, force: true })
   })

--- a/server/src/test/snapshotEvidence.integration.test.ts
+++ b/server/src/test/snapshotEvidence.integration.test.ts
@@ -368,6 +368,7 @@ describeIf('snapshot evidence command (integration)', () => {
     expect(timelineRow).toMatchObject({
       entryKind: 'namedResource',
       effectiveMode: 'TIMELINE',
+      modeSource: 'explicit',
       allocationStartWeekState: 'populated-nonnegative-integer',
       allocationEndWeekState: 'populated-nonnegative-integer',
       startWeekState: 'populated-nonnegative-integer',

--- a/server/src/test/snapshotEvidence.test.ts
+++ b/server/src/test/snapshotEvidence.test.ts
@@ -33,6 +33,7 @@ import {
 import { publishEvidenceOutputs } from '../lib/evidenceOutputPublication.js'
 import {
   buildRemediationPlan,
+  canonicalJson,
   computePlanFingerprint,
   computeStateHash,
   type PlanDecisionEntry,
@@ -342,7 +343,7 @@ describe('buildSnapshotEvidenceReport — composite fixture', () => {
     expect(report.integrityResult.fingerprintMatch).toBe(true)
     expect(report.integrityResult.baselineMatch).toBe(true)
     expect(report.policyDecision).toBe('not-assessed')
-    expect(report.formatVersion).toBe(1)
+    expect(report.formatVersion).toBe(2)
     expect(report.topology).toMatchObject({
       quarantinedSnapshots: 1,
       defectSnapshots: 2,
@@ -994,6 +995,543 @@ describe('Class A affected-snapshot aggregates', () => {
     expect(json).toContain('"affectedSnapshotsByOwnerKind":{"resourceType":1,"namedResource":1,"unavailable":0}')
     expect(markdown).toContain('affectedSnapshotsByOwnerKind: {"resourceType":1,"namedResource":1,"unavailable":0}')
     expect(markdown).toContain('affectedSnapshotsByNamedModeSource: {"explicit":1,"inherited":0,"other":0,"unavailable":0}')
+  })
+})
+
+// ═════════════════════════════════════════════════════════════════════════════
+// Issue #440 — sanitized Class A companion evidence (evidence for the #438
+// companion-rule review; never a predicate implementation)
+// ═════════════════════════════════════════════════════════════════════════════
+
+describe('Class A companion evidence (issue #440)', () => {
+  /** Comprehensive selected fixture: one Class-A-quarantined snapshot
+   * containing one exact Class A RT and six companions covering the
+   * reachable shape categories (windowless/populated/minus-one fields,
+   * explicit/inherited/absent modes, 100% and finite non-100%). */
+  function companionState(): RemediationDatabaseState {
+    return makeState([
+      {
+        id: 'snap-companions',
+        projectId: PROJECT_ID,
+        payload: makeV2Snapshot(
+          [
+            // Exact Class A ResourceType entry.
+            makeRt({ id: 'rt-a', name: 'Engineers Role', allocationMode: 'CAPACITY_PLAN', allocationStartWeek: null, allocationEndWeek: null }),
+            // Companion: windowless CAPACITY_PLAN at 80% (quarantine-shaped,
+            // non-exact → current plan classification quarantined).
+            makeRt({ id: 'rt-b', name: 'Partial Role', allocationMode: 'CAPACITY_PLAN', allocationStartWeek: null, allocationEndWeek: null, allocationPercent: 80 }),
+            // Companion: windowless EFFORT at 100% (alreadyValid).
+            makeRt({ id: 'rt-c', name: 'Effort Role', allocationMode: 'EFFORT', allocationStartWeek: null, allocationEndWeek: null }),
+          ],
+          [
+            // Companion: exact S shape (raw (-1,-1) alias pair with populated
+            // primary end) → deterministic zero classification.
+            makeNr({ id: 'nr-s', resourceTypeId: 'rt-a', name: 'Shadowed Person', allocationMode: 'CAPACITY_PLAN', allocationPercent: 100, allocationPct: 100, allocationStartWeek: null, allocationEndWeek: 5, startWeek: -1, endWeek: -1 }),
+            // Companion: explicit windowed TIMELINE at 100/100 (alreadyValid).
+            makeNr({ id: 'nr-tl', resourceTypeId: 'rt-c', name: 'Timeline Person', allocationMode: 'TIMELINE', allocationPercent: 100, allocationPct: 100, allocationStartWeek: 2, allocationEndWeek: 9, startWeek: 2, endWeek: 9 }),
+            // Companion: inherited CAPACITY_PLAN windowless 100/100
+            // (quarantine-shaped, non-exact → quarantined).
+            makeNr({ id: 'nr-inherited', resourceTypeId: 'rt-a', name: 'Inherited Person', allocationMode: null, allocationPercent: 100, allocationPct: 100, allocationStartWeek: null, allocationEndWeek: null, startWeek: null, endWeek: null }),
+            // Companion: explicit EFFORT windowless 100/100 (alreadyValid).
+            makeNr({ id: 'nr-effort', resourceTypeId: 'rt-c', name: 'Effort Person', allocationMode: 'EFFORT', allocationPercent: 100, allocationPct: 100, allocationStartWeek: null, allocationEndWeek: null, startWeek: null, endWeek: null }),
+          ],
+        ),
+      },
+    ])
+  }
+
+  const COMPANION_COUNTS: Omit<SnapshotEvidenceExpected, 'fingerprint' | 'baselineStateHash'> = {
+    quarantinedEntries: 3,
+    quarantinedSnapshots: 1,
+    defectSnapshots: 0,
+    windowlessDecisions: 0,
+    singleMinusOneDecisions: 0,
+    snapshotDecisions: 0,
+    liveDecisions: 0,
+    unsupported: 0,
+    rewriteOperations: 0,
+    topology11Snapshots: 0,
+    topology7Snapshots: 0,
+    topology11WindowlessDecisions: 0,
+    topology7WindowlessDecisions: 0,
+    topology7SingleMinusOneDecisions: 0,
+  }
+
+  it('selects the mixed Class-A-quarantined snapshot and reports population totals', () => {
+    const report = buildReport(companionState(), COMPANION_COUNTS)
+    expect(report.integrityResult.reconciliationPassed).toBe(true)
+    expect(report.formatVersion).toBe(2)
+    expect(report.classACompanionEvidence.population).toEqual({
+      classAQuarantinedSnapshots: 1,
+      snapshotsWithCompanions: 1,
+      exactClassAResourceTypeEntries: 1,
+      exactClassANamedResourceEntries: 0,
+      companionResourceTypeEntries: 2,
+      companionNamedResourceEntries: 4,
+      totalCompanionEntries: 6,
+      excludedMixedClassABSnapshots: 0,
+    })
+    // The current quarantine boundary of the fixture is unchanged by the
+    // tooling: the same 3 entries / 1 snapshot stay quarantined.
+    expect(report.observedBoundary.summary.quarantined).toBe(3)
+    expect(report.observedBoundary.snapshotPopulation).toEqual({ totalSnapshots: 1, restorable: 0, quarantined: 1, defect: 0 })
+  })
+
+  it('emits deterministic sorted shape rows with fixed sanitized categories only', () => {
+    const report = buildReport(companionState(), COMPANION_COUNTS)
+    const rows = report.classACompanionEvidence.shapeRows
+    expect(rows).toHaveLength(6)
+    const rowByKind = (kind: 'resourceType' | 'namedResource', rawMode: unknown, classification: string) =>
+      rows.find(row => row.entryKind === kind && (row.rawMode ?? 'null') === (rawMode ?? 'null') && row.currentPlanClassification === classification)
+
+    // RT companion: windowless CAPACITY_PLAN at 80% → quarantined, unavailable aliases/pct.
+    const rt80 = rowByKind('resourceType', 'CAPACITY_PLAN', 'quarantined')!
+    expect(rt80).toMatchObject({
+      parentMode: 'unavailable',
+      effectiveMode: 'CAPACITY_PLAN',
+      modeSource: 'unavailable',
+      allocationStartWeekState: 'absent-null',
+      allocationEndWeekState: 'absent-null',
+      startWeekState: 'unavailable',
+      endWeekState: 'unavailable',
+      allocationPercentCategory: 'one-to-ninety-nine',
+      allocationPctCategory: 'unavailable',
+      count: 1,
+    })
+    // RT companion: windowless EFFORT at 100% → alreadyValid.
+    const rtEffort = rowByKind('resourceType', 'EFFORT', 'alreadyValid')!
+    expect(rtEffort.allocationPercentCategory).toBe('hundred')
+    // NR companion: exact S shape → minus-one aliases, populated non-negative
+    // primary end, explicit mode, deterministic.
+    const nrS = rowByKind('namedResource', 'CAPACITY_PLAN', 'deterministic')!
+    expect(nrS).toMatchObject({
+      parentMode: 'CAPACITY_PLAN',
+      effectiveMode: 'CAPACITY_PLAN',
+      modeSource: 'explicit',
+      allocationStartWeekState: 'absent-null',
+      allocationEndWeekState: 'populated-nonnegative-integer',
+      startWeekState: 'minus-one',
+      endWeekState: 'minus-one',
+      allocationPercentCategory: 'hundred',
+      allocationPctCategory: 'hundred',
+    })
+    // NR companion: explicit windowed TIMELINE → populated non-negative
+    // states, modeSource other (raw explicit non-CAPACITY_PLAN mode), alreadyValid.
+    const nrTl = rowByKind('namedResource', 'TIMELINE', 'alreadyValid')!
+    expect(nrTl).toMatchObject({
+      parentMode: 'EFFORT',
+      effectiveMode: 'TIMELINE',
+      modeSource: 'other',
+      allocationStartWeekState: 'populated-nonnegative-integer',
+      allocationEndWeekState: 'populated-nonnegative-integer',
+      startWeekState: 'populated-nonnegative-integer',
+      endWeekState: 'populated-nonnegative-integer',
+      allocationPercentCategory: 'hundred',
+      allocationPctCategory: 'hundred',
+    })
+    // NR companion: inherited CAPACITY_PLAN windowless → inherited source, quarantined.
+    const nrInherited = rows.find(row => row.modeSource === 'inherited')!
+    expect(nrInherited).toMatchObject({
+      entryKind: 'namedResource',
+      rawMode: null,
+      parentMode: 'CAPACITY_PLAN',
+      effectiveMode: 'CAPACITY_PLAN',
+      allocationStartWeekState: 'absent-null',
+      allocationEndWeekState: 'absent-null',
+      startWeekState: 'absent-null',
+      endWeekState: 'absent-null',
+      allocationPercentCategory: 'hundred',
+      allocationPctCategory: 'hundred',
+      currentPlanClassification: 'quarantined',
+    })
+    // NR companion: explicit EFFORT windowless → alreadyValid.
+    const nrEffort = rowByKind('namedResource', 'EFFORT', 'alreadyValid')!
+    expect(nrEffort.modeSource).toBe('other')
+
+    // Deterministic ordering: sorted by the same canonical fixed-category
+    // key the builder uses.
+    const keyOf = (row: (typeof rows)[number]): string => canonicalJson({
+      entryKind: row.entryKind,
+      rawMode: row.rawMode,
+      parentMode: row.parentMode,
+      effectiveMode: row.effectiveMode,
+      modeSource: row.modeSource,
+      allocationStartWeekState: row.allocationStartWeekState,
+      allocationEndWeekState: row.allocationEndWeekState,
+      startWeekState: row.startWeekState,
+      endWeekState: row.endWeekState,
+      allocationPercentCategory: row.allocationPercentCategory,
+      allocationPctCategory: row.allocationPctCategory,
+      currentPlanClassification: row.currentPlanClassification,
+    })
+    const keys = rows.map(keyOf)
+    expect([...keys].sort()).toEqual(keys)
+    expect(rows.every(row => row.count === 1)).toBe(true)
+  })
+
+  it('reports plan classifications and snapshot-level flags', () => {
+    const report = buildReport(companionState(), COMPANION_COUNTS)
+    expect(report.classACompanionEvidence.planClassifications).toEqual({
+      deterministic: 1,
+      decisionRequired: 0,
+      unsupported: 0,
+      alreadyValid: 3,
+      quarantined: 2,
+    })
+    expect(report.classACompanionEvidence.snapshotFlags).toEqual({
+      allEntriesWindowless: 0,
+      notAllEntriesWindowless: 1,
+      allEntriesApproved100: 0,
+      notAllEntriesApproved100: 1,
+      allCompanionsWindowless: 0,
+      notAllCompanionsWindowless: 1,
+      allCompanionsApproved100: 0,
+      notAllCompanionsApproved100: 1,
+      anyCompanionInheritedMode: 1,
+      noCompanionInheritedMode: 0,
+    })
+  })
+
+  it('reconciles every aggregate and refuses on any mismatch via the shared gate', () => {
+    const report = buildReport(companionState(), COMPANION_COUNTS)
+    expect(report.integrityResult.countsMatch).toBe(true)
+    expect(report.reconciliation.passed).toBe(true)
+    const details = report.reconciliation.details.join('\n')
+    expect(details).toContain('exact Class A entries plus companions equal captured entries: observed 7, expected 7 — OK')
+    expect(details).toContain('companion by-kind totals reconcile: observed 6, expected 6 — OK')
+    expect(details).toContain('companion shape-row counts reconcile: observed 6, expected 6 — OK')
+    expect(details).toContain('companion plan-classification totals reconcile: observed 6, expected 6 — OK')
+    expect(details).toContain('companion entries are unique: observed 6, expected 6 — OK')
+    expect(details).toContain('no selected entry is omitted: observed 6, expected 6 — OK')
+    expect(details).toContain('snapshot flag pair: entries windowless: observed 1, expected 1 — OK')
+    expect(details).toContain('snapshot flag pair: companion inherited mode: observed 1, expected 1 — OK')
+  })
+
+  it('is deterministic across repeated runs', () => {
+    const first = buildReport(companionState(), COMPANION_COUNTS)
+    const second = buildReport(companionState(), COMPANION_COUNTS)
+    expect(JSON.stringify(first.classACompanionEvidence)).toBe(JSON.stringify(second.classACompanionEvidence))
+  })
+
+  it('excludes restorable and defect snapshots from the companion population', () => {
+    const state = makeState([
+      {
+        id: 'snap-exact',
+        projectId: PROJECT_ID,
+        // Exact all-Class-A snapshot → restorable under current policy, never
+        // a companion population member.
+        payload: makeV2Snapshot(
+          [makeRt({ id: 'rt-e1', allocationMode: 'CAPACITY_PLAN', allocationStartWeek: null, allocationEndWeek: null })],
+          [makeNr({ id: 'nr-e1', resourceTypeId: 'rt-e1', allocationMode: 'CAPACITY_PLAN', allocationPercent: 100, allocationPct: 100, allocationStartWeek: null, allocationEndWeek: null, startWeek: null, endWeek: null })],
+        ),
+      },
+      {
+        id: 'snap-defect',
+        projectId: PROJECT_ID,
+        // Independent defect (partial window) → defect snapshot, excluded.
+        payload: makeV2Snapshot(
+          [makeRt({ id: 'rt-d1', allocationMode: 'CAPACITY_PLAN', allocationStartWeek: 3, allocationEndWeek: null })],
+          [],
+        ),
+      },
+      {
+        id: 'snap-q',
+        projectId: PROJECT_ID,
+        // Selected Class-A-quarantined snapshot with one companion.
+        payload: makeV2Snapshot(
+          [
+            makeRt({ id: 'rt-q1', allocationMode: 'CAPACITY_PLAN', allocationStartWeek: null, allocationEndWeek: null }),
+            makeRt({ id: 'rt-q2', allocationMode: 'CAPACITY_PLAN', allocationStartWeek: null, allocationEndWeek: null, allocationPercent: 80 }),
+          ],
+          [],
+        ),
+      },
+    ])
+    const counts: Omit<SnapshotEvidenceExpected, 'fingerprint' | 'baselineStateHash'> = {
+      quarantinedEntries: 2,
+      quarantinedSnapshots: 1,
+      defectSnapshots: 1,
+      windowlessDecisions: 1, // snap-defect partial-window RT
+      singleMinusOneDecisions: 0,
+      snapshotDecisions: 1,
+      liveDecisions: 0,
+      unsupported: 0,
+      rewriteOperations: 0,
+      topology11Snapshots: 1,
+      topology7Snapshots: 0,
+      topology11WindowlessDecisions: 1,
+      topology7WindowlessDecisions: 0,
+      topology7SingleMinusOneDecisions: 0,
+    }
+    const report = buildReport(state, counts)
+    expect(report.integrityResult.reconciliationPassed).toBe(true)
+    expect(report.observedBoundary.snapshotPopulation).toEqual({ totalSnapshots: 3, restorable: 1, quarantined: 1, defect: 1 })
+    expect(report.classACompanionEvidence.population).toEqual({
+      classAQuarantinedSnapshots: 1,
+      snapshotsWithCompanions: 1,
+      exactClassAResourceTypeEntries: 1,
+      exactClassANamedResourceEntries: 0,
+      companionResourceTypeEntries: 1,
+      companionNamedResourceEntries: 0,
+      totalCompanionEntries: 1,
+      excludedMixedClassABSnapshots: 0,
+    })
+  })
+
+  it('excludes Class-B-only and mixed Class-A/Class-B quarantined snapshots and reports the mixed count separately', () => {
+    const state = makeState([
+      {
+        id: 'snap-b',
+        projectId: PROJECT_ID,
+        // Class-B-only quarantine (single -1 edge with non-negative other).
+        payload: makeV2Snapshot(
+          [makeRt({ id: 'rt-b1', allocationMode: 'CAPACITY_PLAN', allocationStartWeek: -1, allocationEndWeek: 5 })],
+          [],
+        ),
+      },
+      {
+        id: 'snap-mixed-ab',
+        projectId: PROJECT_ID,
+        // Mixed Class A + Class B quarantine: reported separately, excluded
+        // from the companion population.
+        payload: makeV2Snapshot(
+          [
+            makeRt({ id: 'rt-m1', allocationMode: 'CAPACITY_PLAN', allocationStartWeek: null, allocationEndWeek: null }),
+            makeRt({ id: 'rt-m2', allocationMode: 'CAPACITY_PLAN', allocationStartWeek: -1, allocationEndWeek: 5 }),
+          ],
+          [],
+        ),
+      },
+    ])
+    const counts: Omit<SnapshotEvidenceExpected, 'fingerprint' | 'baselineStateHash'> = {
+      quarantinedEntries: 3,
+      quarantinedSnapshots: 2,
+      defectSnapshots: 0,
+      windowlessDecisions: 0,
+      singleMinusOneDecisions: 0,
+      snapshotDecisions: 0,
+      liveDecisions: 0,
+      unsupported: 0,
+      rewriteOperations: 0,
+      topology11Snapshots: 0,
+      topology7Snapshots: 0,
+      topology11WindowlessDecisions: 0,
+      topology7WindowlessDecisions: 0,
+      topology7SingleMinusOneDecisions: 0,
+    }
+    const report = buildReport(state, counts)
+    // The reviewed Class A invariant (class A entries/snapshots reconcile to
+    // the expected quarantine totals) intentionally refuses when quarantined
+    // Class-B entries exist — the companion section is observational and must
+    // not mask that refusal (mirrors the existing Class-B fixture contract).
+    expect(report.integrityResult.reconciliationPassed).toBe(false)
+    const mismatches = report.reconciliation.details.filter(detail => detail.includes('MISMATCH'))
+    expect(mismatches.map(m => m.split(':')[0])).toEqual(['class A entries reconcile', 'class A snapshots reconcile'])
+    expect(report.classACompanionEvidence.population).toEqual({
+      classAQuarantinedSnapshots: 0,
+      snapshotsWithCompanions: 0,
+      exactClassAResourceTypeEntries: 0,
+      exactClassANamedResourceEntries: 0,
+      companionResourceTypeEntries: 0,
+      companionNamedResourceEntries: 0,
+      totalCompanionEntries: 0,
+      excludedMixedClassABSnapshots: 1,
+    })
+    expect(report.classACompanionEvidence.shapeRows).toEqual([])
+  })
+
+  it('selects a Class-A-quarantined snapshot while excluding a restorable one', () => {
+    const state = makeState([
+      {
+        id: 'snap-q',
+        projectId: PROJECT_ID,
+        payload: makeV2Snapshot(
+          [
+            makeRt({ id: 'rt-q1', allocationMode: 'CAPACITY_PLAN', allocationStartWeek: null, allocationEndWeek: null }),
+            makeRt({ id: 'rt-q2', allocationMode: 'CAPACITY_PLAN', allocationStartWeek: null, allocationEndWeek: null, allocationPercent: 80 }),
+          ],
+          [],
+        ),
+      },
+      {
+        id: 'snap-r',
+        projectId: PROJECT_ID,
+        payload: makeV2Snapshot(
+          [makeRt({ id: 'rt-r1', allocationMode: 'CAPACITY_PLAN', allocationStartWeek: null, allocationEndWeek: null })],
+          [],
+        ),
+      },
+    ])
+    const counts: Omit<SnapshotEvidenceExpected, 'fingerprint' | 'baselineStateHash'> = {
+      quarantinedEntries: 2,
+      quarantinedSnapshots: 1,
+      defectSnapshots: 0,
+      windowlessDecisions: 0,
+      singleMinusOneDecisions: 0,
+      snapshotDecisions: 0,
+      liveDecisions: 0,
+      unsupported: 0,
+      rewriteOperations: 0,
+      topology11Snapshots: 0,
+      topology7Snapshots: 0,
+      topology11WindowlessDecisions: 0,
+      topology7WindowlessDecisions: 0,
+      topology7SingleMinusOneDecisions: 0,
+    }
+    const report = buildReport(state, counts)
+    expect(report.integrityResult.reconciliationPassed).toBe(true)
+    expect(report.classACompanionEvidence.population).toEqual({
+      classAQuarantinedSnapshots: 1,
+      snapshotsWithCompanions: 1,
+      exactClassAResourceTypeEntries: 1,
+      exactClassANamedResourceEntries: 0,
+      companionResourceTypeEntries: 1,
+      companionNamedResourceEntries: 0,
+      totalCompanionEntries: 1,
+      excludedMixedClassABSnapshots: 0,
+    })
+    expect(report.observedBoundary.snapshotPopulation).toEqual({ totalSnapshots: 2, restorable: 1, quarantined: 1, defect: 0 })
+  })
+
+  it('fails closed when companion correlation is ambiguous (shared id across kinds)', () => {
+    const state = makeState([{
+      id: 'snap-ambig',
+      projectId: PROJECT_ID,
+      payload: makeV2Snapshot(
+        [makeRt({ id: 'same-id', allocationMode: 'CAPACITY_PLAN', allocationStartWeek: null, allocationEndWeek: null })],
+        [
+          // Companion whose entryId collides with the exact RT entry's id:
+          // two snapshot-entry findings match the same entryId → ambiguous.
+          makeNr({ id: 'same-id', resourceTypeId: 'same-id', allocationMode: null, allocationPercent: 100, allocationPct: 100, allocationStartWeek: null, allocationEndWeek: null, startWeek: null, endWeek: null }),
+        ],
+      ),
+    }])
+    const counts: Omit<SnapshotEvidenceExpected, 'fingerprint' | 'baselineStateHash'> = {
+      quarantinedEntries: 2,
+      quarantinedSnapshots: 1,
+      defectSnapshots: 0,
+      windowlessDecisions: 0,
+      singleMinusOneDecisions: 0,
+      snapshotDecisions: 0,
+      liveDecisions: 0,
+      unsupported: 0,
+      rewriteOperations: 0,
+      topology11Snapshots: 0,
+      topology7Snapshots: 0,
+      topology11WindowlessDecisions: 0,
+      topology7WindowlessDecisions: 0,
+      topology7SingleMinusOneDecisions: 0,
+    }
+    expect(() => buildReport(state, counts)).toThrowError(SnapshotEvidenceError)
+    try {
+      buildReport(state, counts)
+      expect.unreachable()
+    } catch (error) {
+      expect(error).toBeInstanceOf(SnapshotEvidenceError)
+      expect((error as SnapshotEvidenceError).code).toBe('companion-correlation-failure')
+      expect(String((error as SnapshotEvidenceError).message)).not.toContain('same-id')
+    }
+  })
+
+  it('never emits identifiers, names, raw week values or unknown mode strings', () => {
+    const state = makeState([
+      {
+        id: 'snap-privacy',
+        projectId: PROJECT_ID,
+        payload: makeV2Snapshot(
+          [
+            makeRt({ id: 'rt-ALPHA-SECRET-ROLE', name: 'Project Aurora Confidential Role', allocationMode: 'CAPACITY_PLAN', allocationStartWeek: null, allocationEndWeek: null }),
+            makeRt({ id: 'rt-windowed', name: 'Windowed Role', allocationMode: 'EFFORT', allocationStartWeek: 17, allocationEndWeek: 23 }),
+          ],
+          [
+            makeNr({ id: 'nr-BETA-PRIVATE-PERSON', resourceTypeId: 'rt-ALPHA-SECRET-ROLE', name: 'Project Aurora Confidential Person', allocationMode: null, allocationPercent: 100, allocationPct: 100, allocationStartWeek: null, allocationEndWeek: null, startWeek: null, endWeek: null }),
+          ],
+        ),
+      },
+      {
+        id: 'snap-bogus-mode',
+        projectId: PROJECT_ID,
+        // Unknown mode → defect snapshot (excluded population); the arbitrary
+        // string must never reach either output.
+        payload: makeV2Snapshot(
+          [makeRt({ id: 'rt-9', allocationMode: 'WARP_DRIVE-TOP-SECRET', allocationStartWeek: 2, allocationEndWeek: 9 })],
+          [],
+        ),
+      },
+    ])
+    const counts: Omit<SnapshotEvidenceExpected, 'fingerprint' | 'baselineStateHash'> = {
+      quarantinedEntries: 2,
+      quarantinedSnapshots: 1,
+      defectSnapshots: 1,
+      windowlessDecisions: 0,
+      singleMinusOneDecisions: 0,
+      snapshotDecisions: 0,
+      liveDecisions: 0,
+      unsupported: 1,
+      rewriteOperations: 0,
+      topology11Snapshots: 1,
+      topology7Snapshots: 0,
+      topology11WindowlessDecisions: 0,
+      topology7WindowlessDecisions: 0,
+      topology7SingleMinusOneDecisions: 0,
+    }
+    const report = buildReport(state, counts)
+    expect(report.integrityResult.reconciliationPassed).toBe(true)
+    const json = JSON.stringify(report)
+    const markdown = renderSnapshotEvidenceMarkdown(report)
+    const sectionJson = JSON.stringify(report.classACompanionEvidence)
+    for (const secret of [
+      'rt-ALPHA-SECRET-ROLE', 'nr-BETA-PRIVATE-PERSON',
+      'Project Aurora Confidential Role', 'Project Aurora Confidential Person',
+      'snap-privacy', 'WARP_DRIVE-TOP-SECRET', 'snap-bogus-mode',
+    ]) {
+      expect(json).not.toContain(secret)
+      expect(markdown).not.toContain(secret)
+    }
+    // Populated week numbers are reduced to sanitized categories: the raw -1
+    // sentinel and the populated weeks never appear in the companion section.
+    expect(sectionJson).not.toContain('-1')
+    expect(sectionJson).not.toContain('17')
+    expect(sectionJson).not.toContain('23')
+    // Every shape-row category uses the fixed vocabularies only.
+    const windowStates = ['unavailable', 'absent-null', 'minus-one', 'populated-nonnegative-integer', 'populated-other']
+    const percentCategories = ['unavailable', 'absent-null', 'zero', 'one-to-ninety-nine', 'hundred', 'above-hundred', 'invalid-non-finite']
+    const modes = ['TIMELINE', 'CAPACITY_PLAN', 'EFFORT', 'FULL_PROJECT', null, 'other', 'unavailable']
+    const classifications = ['deterministic', 'decisionRequired', 'unsupported', 'alreadyValid', 'quarantined']
+    for (const row of report.classACompanionEvidence.shapeRows) {
+      expect(['resourceType', 'namedResource']).toContain(row.entryKind)
+      expect(modes).toContain(row.rawMode)
+      expect(modes).toContain(row.parentMode)
+      expect(modes).toContain(row.effectiveMode)
+      expect(['explicit', 'inherited', 'other', 'unavailable']).toContain(row.modeSource)
+      expect(windowStates).toContain(row.allocationStartWeekState)
+      expect(windowStates).toContain(row.allocationEndWeekState)
+      expect(windowStates).toContain(row.startWeekState)
+      expect(windowStates).toContain(row.endWeekState)
+      expect(percentCategories).toContain(row.allocationPercentCategory)
+      expect(percentCategories).toContain(row.allocationPctCategory)
+      expect(classifications).toContain(row.currentPlanClassification)
+      expect(Number.isInteger(row.count) && row.count >= 0).toBe(true)
+    }
+  })
+
+  it('mirrors the companion evidence in Markdown (JSON/Markdown parity)', () => {
+    const report = buildReport(companionState(), COMPANION_COUNTS)
+    const markdown = renderSnapshotEvidenceMarkdown(report)
+    expect(markdown).toContain('## Class A companion evidence')
+    expect(markdown).toContain('### Population')
+    expect(markdown).toContain('- classAQuarantinedSnapshots: 1')
+    expect(markdown).toContain('- totalCompanionEntries: 6')
+    expect(markdown).toContain('- excludedMixedClassABSnapshots: 0')
+    expect(markdown).toContain('### Companion shape rows')
+    expect(markdown).toContain('| Entry kind | Raw mode | Parent mode | Effective mode | Mode source | allocationStartWeek | allocationEndWeek | startWeek | endWeek | allocationPercent | allocationPct | Plan classification | Count |')
+    expect(markdown).toContain('namedResource | CAPACITY_PLAN | CAPACITY_PLAN | CAPACITY_PLAN | explicit | absent-null | populated-nonnegative-integer | minus-one | minus-one | hundred | hundred | deterministic | 1')
+    expect(markdown).toContain('### Plan classifications')
+    expect(markdown).toContain('- alreadyValid: 3')
+    expect(markdown).toContain('- quarantined: 2')
+    expect(markdown).toContain('### Snapshot-level flags')
+    expect(markdown).toContain('- anyCompanionInheritedMode: 1')
+    expect(markdown).toContain('- noCompanionInheritedMode: 0')
   })
 })
 

--- a/server/src/test/snapshotEvidence.test.ts
+++ b/server/src/test/snapshotEvidence.test.ts
@@ -21,6 +21,7 @@ import {
   buildSingleNegativeEvidenceEntry,
   classifyAllSnapshots,
   classifySnapshotEvidence,
+  companionModeSourceCategory,
   correlateSingleNegativeDecisions,
   isExpectedBoundaryShape,
   percentCategory,
@@ -1116,12 +1117,12 @@ describe('Class A companion evidence (issue #440)', () => {
       allocationPctCategory: 'hundred',
     })
     // NR companion: explicit windowed TIMELINE → populated non-negative
-    // states, modeSource other (raw explicit non-CAPACITY_PLAN mode), alreadyValid.
+    // states, modeSource explicit (raw known mode), alreadyValid.
     const nrTl = rowByKind('namedResource', 'TIMELINE', 'alreadyValid')!
     expect(nrTl).toMatchObject({
       parentMode: 'EFFORT',
       effectiveMode: 'TIMELINE',
-      modeSource: 'other',
+      modeSource: 'explicit',
       allocationStartWeekState: 'populated-nonnegative-integer',
       allocationEndWeekState: 'populated-nonnegative-integer',
       startWeekState: 'populated-nonnegative-integer',
@@ -1144,9 +1145,9 @@ describe('Class A companion evidence (issue #440)', () => {
       allocationPctCategory: 'hundred',
       currentPlanClassification: 'quarantined',
     })
-    // NR companion: explicit EFFORT windowless → alreadyValid.
+    // NR companion: explicit EFFORT windowless → modeSource explicit.
     const nrEffort = rowByKind('namedResource', 'EFFORT', 'alreadyValid')!
-    expect(nrEffort.modeSource).toBe('other')
+    expect(nrEffort.modeSource).toBe('explicit')
 
     // Deterministic ordering: sorted by the same canonical fixed-category
     // key the builder uses.
@@ -1532,6 +1533,142 @@ describe('Class A companion evidence (issue #440)', () => {
     expect(markdown).toContain('### Snapshot-level flags')
     expect(markdown).toContain('- anyCompanionInheritedMode: 1')
     expect(markdown).toContain('- noCompanionInheritedMode: 0')
+  })
+
+  it('companionModeSourceCategory distinguishes explicit and inherited modes for all known modes', () => {
+    // Explicit known raw modes (issue #440 review: the companion evidence
+    // must not reuse the CAPACITY_PLAN-specific namedModeSourceCategory).
+    expect(companionModeSourceCategory('TIMELINE', null)).toBe('explicit')
+    expect(companionModeSourceCategory('CAPACITY_PLAN', null)).toBe('explicit')
+    expect(companionModeSourceCategory('EFFORT', null)).toBe('explicit')
+    expect(companionModeSourceCategory('FULL_PROJECT', null)).toBe('explicit')
+    expect(companionModeSourceCategory('TIMELINE', 'WARP_DRIVE')).toBe('explicit')
+    // Inherited known parent modes (including the missed non-CAPACITY_PLAN
+    // regression).
+    expect(companionModeSourceCategory(null, 'TIMELINE')).toBe('inherited')
+    expect(companionModeSourceCategory(null, 'CAPACITY_PLAN')).toBe('inherited')
+    expect(companionModeSourceCategory(null, 'EFFORT')).toBe('inherited')
+    expect(companionModeSourceCategory(null, 'FULL_PROJECT')).toBe('inherited')
+    expect(companionModeSourceCategory(undefined, 'TIMELINE')).toBe('inherited')
+    // Unknown/unsupported populated sources map to other.
+    expect(companionModeSourceCategory('WARP_DRIVE', null)).toBe('other')
+    expect(companionModeSourceCategory(null, 'WARP_DRIVE')).toBe('other')
+    // Both raw and parent modes absent → unavailable.
+    expect(companionModeSourceCategory(null, null)).toBe('unavailable')
+    expect(companionModeSourceCategory(undefined, undefined)).toBe('unavailable')
+  })
+
+  it('reports explicit and inherited mode sources through the builder, including non-CAPACITY_PLAN inheritance', () => {
+    // One selected Class-A-quarantined snapshot whose companions cover the
+    // reachable mode-source categories. No classifier or predicate is
+    // weakened: every entry is valid under the current policy and the
+    // snapshot stays quarantined via the non-100 windowless RT.
+    const state = makeState([{
+      id: 'snap-modes',
+      projectId: PROJECT_ID,
+      payload: makeV2Snapshot(
+        [
+          // Quarantine Class A shape (non-exact: 80%) keeps the snapshot
+          // selected; this RT companion itself reports modeSource unavailable.
+          makeRt({ id: 'rt-q', allocationMode: 'CAPACITY_PLAN', allocationStartWeek: null, allocationEndWeek: null, allocationPercent: 80 }),
+          makeRt({ id: 'rt-t', name: 'Timeline Role', allocationMode: 'TIMELINE', allocationStartWeek: null, allocationEndWeek: null }),
+          makeRt({ id: 'rt-e', name: 'Effort Role', allocationMode: 'EFFORT', allocationStartWeek: null, allocationEndWeek: null }),
+          makeRt({ id: 'rt-f', name: 'Full Project Role', allocationMode: 'FULL_PROJECT', allocationStartWeek: null, allocationEndWeek: null }),
+          makeRt({ id: 'rt-null', name: 'Null Mode Role', allocationMode: null, allocationStartWeek: null, allocationEndWeek: null }),
+        ],
+        [
+          // Inherited known modes with raw allocationMode absent.
+          makeNr({ id: 'nr-inh-tl', resourceTypeId: 'rt-t', allocationMode: null }),
+          makeNr({ id: 'nr-inh-eff', resourceTypeId: 'rt-e', allocationMode: null }),
+          makeNr({ id: 'nr-inh-fp', resourceTypeId: 'rt-f', allocationMode: null }),
+          makeNr({ id: 'nr-inh-cp', resourceTypeId: 'rt-q', allocationMode: null }),
+          // Explicit known raw mode.
+          makeNr({ id: 'nr-exp-tl', resourceTypeId: 'rt-t', allocationMode: 'TIMELINE' }),
+          // Absent raw and absent parent mode → unavailable.
+          makeNr({ id: 'nr-none', resourceTypeId: 'rt-null', allocationMode: null }),
+        ],
+      ),
+    }])
+    const counts: Omit<SnapshotEvidenceExpected, 'fingerprint' | 'baselineStateHash'> = {
+      quarantinedEntries: 2,
+      quarantinedSnapshots: 1,
+      defectSnapshots: 0,
+      windowlessDecisions: 0,
+      singleMinusOneDecisions: 0,
+      snapshotDecisions: 0,
+      liveDecisions: 0,
+      unsupported: 0,
+      rewriteOperations: 0,
+      topology11Snapshots: 0,
+      topology7Snapshots: 0,
+      topology11WindowlessDecisions: 0,
+      topology7WindowlessDecisions: 0,
+      topology7SingleMinusOneDecisions: 0,
+    }
+    const report = buildReport(state, counts)
+    expect(report.integrityResult.reconciliationPassed).toBe(true)
+    const rows = report.classACompanionEvidence.shapeRows
+    const inheritedRow = (parentMode: 'TIMELINE' | 'EFFORT' | 'FULL_PROJECT' | 'CAPACITY_PLAN' | null, effectiveMode: string | null) =>
+      rows.find(row => row.entryKind === 'namedResource' && row.modeSource === 'inherited' && row.parentMode === parentMode && row.effectiveMode === effectiveMode)
+    // Inherited known modes from non-CAPACITY_PLAN parents (the missed
+    // regression) and from CAPACITY_PLAN.
+    expect(inheritedRow('TIMELINE', 'TIMELINE')).toMatchObject({ modeSource: 'inherited', rawMode: null })
+    expect(inheritedRow('EFFORT', 'EFFORT')).toMatchObject({ modeSource: 'inherited', rawMode: null })
+    expect(inheritedRow('FULL_PROJECT', 'FULL_PROJECT')).toMatchObject({ modeSource: 'inherited', rawMode: null })
+    expect(inheritedRow('CAPACITY_PLAN', 'CAPACITY_PLAN')).toMatchObject({ modeSource: 'inherited', rawMode: null })
+    // Explicit known raw mode.
+    const explicitTimeline = rows.find(row => row.entryKind === 'namedResource' && row.rawMode === 'TIMELINE' && row.modeSource === 'explicit')!
+    expect(explicitTimeline).toMatchObject({ effectiveMode: 'TIMELINE', parentMode: 'TIMELINE' })
+    // Absent raw + absent parent → unavailable (fixture-reachable state).
+    const unavailable = rows.find(row => row.entryKind === 'namedResource' && row.modeSource === 'unavailable')!
+    expect(unavailable).toMatchObject({ rawMode: null, parentMode: null, effectiveMode: null })
+    // ResourceType companions keep modeSource unavailable.
+    const rtCompanion = rows.find(row => row.entryKind === 'resourceType')!
+    expect(rtCompanion.modeSource).toBe('unavailable')
+    // Snapshot-level flag: inheritance from non-CAPACITY_PLAN parents counts.
+    expect(report.classACompanionEvidence.snapshotFlags.anyCompanionInheritedMode).toBe(1)
+    expect(report.classACompanionEvidence.snapshotFlags.noCompanionInheritedMode).toBe(0)
+  })
+
+  it('reports the complementary no-inherited flag for a snapshot without inherited companions', () => {
+    const state = makeState([{
+      id: 'snap-no-inherited',
+      projectId: PROJECT_ID,
+      payload: makeV2Snapshot(
+        [
+          makeRt({ id: 'rt-q', allocationMode: 'CAPACITY_PLAN', allocationStartWeek: null, allocationEndWeek: null, allocationPercent: 80 }),
+          makeRt({ id: 'rt-t', allocationMode: 'TIMELINE', allocationStartWeek: null, allocationEndWeek: null }),
+        ],
+        [
+          // Explicit known mode only — no inherited companion in this snapshot.
+          makeNr({ id: 'nr-exp', resourceTypeId: 'rt-t', allocationMode: 'TIMELINE' }),
+        ],
+      ),
+    }])
+    const counts: Omit<SnapshotEvidenceExpected, 'fingerprint' | 'baselineStateHash'> = {
+      quarantinedEntries: 1,
+      quarantinedSnapshots: 1,
+      defectSnapshots: 0,
+      windowlessDecisions: 0,
+      singleMinusOneDecisions: 0,
+      snapshotDecisions: 0,
+      liveDecisions: 0,
+      unsupported: 0,
+      rewriteOperations: 0,
+      topology11Snapshots: 0,
+      topology7Snapshots: 0,
+      topology11WindowlessDecisions: 0,
+      topology7WindowlessDecisions: 0,
+      topology7SingleMinusOneDecisions: 0,
+    }
+    const report = buildReport(state, counts)
+    expect(report.integrityResult.reconciliationPassed).toBe(true)
+    expect(report.classACompanionEvidence.snapshotFlags.anyCompanionInheritedMode).toBe(0)
+    expect(report.classACompanionEvidence.snapshotFlags.noCompanionInheritedMode).toBe(1)
+    const explicit = report.classACompanionEvidence.shapeRows.find(
+      row => row.entryKind === 'namedResource' && row.rawMode === 'TIMELINE',
+    )!
+    expect(explicit.modeSource).toBe('explicit')
   })
 })
 


### PR DESCRIPTION
Closes #440 — Refs #438.

## What changed and why

PR #439 merged the deterministic historical snapshot translations, but the #404 production revalidation ([stop report](https://github.com/NickMonrad/monrad-estimator/issues/404#issuecomment-5190985354)) showed the Class A path never engages: all 49 Class A snapshots still verdict quarantined. The shared `isClassASnapshot` snapshot-wide predicate cannot safely be corrected because the approved design does not define the raw predicate for the permitted companion entries, and the existing sanitized evidence reports only the 574 Class A entries — not the mode / window-state / percentage categories of the companion entries inside those snapshots.

This PR extends the existing read-only snapshot-evidence command (`npm run capacity-profiles:snapshot-evidence`) with a versioned, sanitized, aggregate-only `classACompanionEvidence` report section so a later reviewed #404 production run can answer exactly which companion shapes exist. Evidence tooling only — no classification, translation, rollback, retention, readiness, remediation or scheduler behaviour changes.

## Exact target population (currently merged policy only)

For every stored V2 snapshot, parse through the shared parser, classify through the current shared `classifySnapshotRestorability`, and select only snapshots whose verdict is `quarantined` with `quarantineClasses` exactly `[A]`. Restorable, defect and Class-B-only snapshots are excluded; mixed Class-A/Class-B quarantined snapshots are counted separately in `excludedMixedClassABSnapshots` and never mixed in. Within a selected snapshot, an entry is exact Class A iff it satisfies the existing `isClassAResourceTypeEntry` / `isClassANamedResourceEntry` predicates with its current captured parent; every other entry is a companion. Those predicates are NOT modified.

## Report schema added (format version 1 -> 2)

`classACompanionEvidence` contains:

- **Population totals** — `classAQuarantinedSnapshots`, `snapshotsWithCompanions`, `exactClassAResourceTypeEntries`, `exactClassANamedResourceEntries`, `companionResourceTypeEntries`, `companionNamedResourceEntries`, `totalCompanionEntries`, `excludedMixedClassABSnapshots`.
- **Deterministic sorted aggregate shape rows** — fixed sanitized categories only plus a count: `entryKind`, `rawMode` / `parentMode` / `effectiveMode` (fixed mode vocabulary, unknown → `other`), `modeSource` (explicit / inherited / other / unavailable), per-field window state (`unavailable` / `absent-null` / `minus-one` / `populated-nonnegative-integer` / `populated-other`), `allocationPercentCategory` / `allocationPctCategory` (fixed percent buckets), `currentPlanClassification` (deterministic / decisionRequired / unsupported / alreadyValid / quarantined).
- **Plan-classification totals** — companion counts by current remediation-plan classification.
- **Snapshot-level flags** — aggregate snapshot counts answering: all entries windowless / not; all entries at the approved 100% categories / not (ResourceType: `allocationPercent` hundred; NamedResource: both hundred); all companions windowless / not; all companions at approved 100% / not; any companion uses inherited mode / none.

The companion values are observational and are NOT required in the reviewed expected file; the existing fingerprint, baseline, count and topology gates remain required.

## Privacy and reconciliation guarantees

- Companions are correlated internally to exactly one existing remediation-plan snapshot-entry finding; any missing, ambiguous or duplicate match, unresolvable ownership or reconciliation failure refuses output with a controlled safe reason (new `companion-correlation-failure` error code).
- Internal reconciliation proves: exact + companions = captured entries; by-kind totals; shape-row totals; plan-classification totals; snapshot flag pairs; no double counting; no omission; JSON/Markdown parity. Any failure refuses output through the existing gate.
- No IDs, names, raw values, payload fragments, exact week numbers or arbitrary mode strings are emitted; populated weeks are reduced to sanitized categories; JSON and Markdown remain atomically published, never overwrite existing outputs, and `policyDecision` stays `not-assessed`.

## Tests and validation

**Review remediation (mode-source categorisation):** the companion evidence now uses a companion-specific `companionModeSourceCategory` helper (all known allocation modes, not only CAPACITY_PLAN). Explicit TIMELINE/EFFORT/FULL_PROJECT companions report `modeSource: explicit`; raw-null companions inheriting TIMELINE/EFFORT/FULL_PROJECT (and CAPACITY_PLAN) report `inherited` and now set `anyCompanionInheritedMode`; unknown populated sources report `other`; absent raw+parent reports `unavailable`; ResourceType companions stay `unavailable`. `namedModeSourceCategory` is unchanged for the existing S/Class A evidence paths. Re-validation: snapshotEvidence unit 90/90, snapshotEvidence integration 11/11, full integration runner exit 0 (293 tests), `npm run validate` exit 0, forwarding 6/6, CI all green on the final SHA.
## Tests and validation

- Unit (`snapshotEvidence.test.ts`): population selection (mixed selected; exact all-Class-A restorable excluded; defect excluded; Class-B-only excluded; mixed A+B reported separately), shape categories (RT/NR companions, explicit/inherited/absent modes, windowless/populated/minus-one/non-negative window states, 100% and finite non-100%, unavailable fields, alreadyValid/quarantined/deterministic plan classifications), reconciliation, deterministic ordering, correlation-failure refusal, privacy (identifying ids/names/weeks/unknown modes absent; fixed vocabularies only), Markdown parity, format version 2.
- Integration (`snapshotEvidence.integration.test.ts`, disposable PostgreSQL): seed extended with companion entries; emission, population totals, rows, flags, zero-write (state hash unchanged), no-clobber/atomic publication, privacy.
- `git diff --check` — clean. `npm run validate` — exit 0 (lint, typecheck, builds, server 1,680 + client 342 tests, backup regression). `npm run test:integration:local` — exit 0, all 12 suites pass (293 tests; one transient clone-suite failure on a first runner pass was not reproducible in isolation or on rerun and does not reproduce on the merge base). Command-forwarding tests — 6/6.

## Confirmations

- Classification policy unchanged: `isClassASnapshot`, `isClassAResourceTypeEntry`, `isClassANamedResourceEntry`, `isDeterministicZeroSnapshotEntry`, `translateV2SnapshotProfiles`, restorability, remediation decisions, rollback/retention eligibility, scheduler and Resource Profile behaviour are untouched. Current-policy fixtures still produce the 574 quarantined entries / 49 quarantined snapshots.
- No Prisma schema or migration change; no manifest, apply, repair or decision resolution; no production machine or production database access (disposable PostgreSQL only).
- #438, #404 and #418 PR 2 remain blocked pending this evidence.

## Production handoff

After review and merge, #404 may install the exact reviewed commit and run the command read-only:

```bash
npm run capacity-profiles:snapshot-evidence -- --json <out.json> --markdown <out.md> --expected <reviewed-expected.json>
```

and return the sanitized aggregate companion categories for the #438 companion-rule review.

**Do not merge — wait for review.**
