### PR TITLE
docs(#444): make backup the pre-purge safety gate

### DIFF
--- a/docs/domain/legacy-capacity-column-runtime-cutover.md
+++ b/docs/domain/legacy-capacity-column-runtime-cutover.md
@@ -1,5 +1,27 @@
 # Legacy capacity-column runtime cutover (Issue #418 — PR 1)
 
+## Sequencing correction after #404 Stage 4 evidence (2026-08-07)
+
+Production evidence from #404 showed that requiring a fresh V4 snapshot for every current project before the pre-V4 purge is not a useful safety gate: the useful database currently has no V4 snapshots and still contains known live CapacityProfile completeness/shape blockers. A V4 snapshot would preserve that current state but would not prove that the state is migration-ready.
+
+This correction supersedes the older sequencing text later in this document under **Fresh V4 safety snapshots**, **Revised #404 production sequence**, and the first bullet under **Sequencing and rollback** wherever those sections require V4 snapshot creation/restoration before the pre-V4 purge.
+
+The corrected production contract is:
+
+1. install the exact reviewed non-destructive release and verify service/database health;
+2. run `npm run capacity-profiles:purge-pre-v4-snapshots` in dry-run mode and require malformed/unsupported = 0;
+3. enter maintenance mode;
+4. create a fresh PostgreSQL backup of the useful database and successfully restore-test it before any purge write; retain this backup through migration acceptance;
+5. rerun the purge dry-run and require the pre-V4 counts to reconcile;
+6. run `npm run capacity-profiles:purge-pre-v4-snapshots -- --apply`;
+7. prove V1 = 0, V2 = 0, V3 = 0, malformed/unsupported = 0, and that current project/backlog/resource/profile/timeline state is unchanged apart from the deliberate `BacklogSnapshot` deletion;
+8. restart the application and rerun `npm run capacity-profiles:readiness`;
+9. remediate only the remaining current/live CapacityProfile blockers under the reviewed #421 process;
+10. once live-state readiness passes, create a fresh V4 snapshot on a representative useful project and prove supported V4 restore succeeds with CapacityProfile ownership/integrity still valid;
+11. authorize #418 PR 2 only after readiness passes, the restore-tested backup is retained, pre-V4 snapshot count is zero, and representative V4 create/restore has passed.
+
+The restore-tested PostgreSQL backup is the authoritative pre-purge rollback mechanism because it captures the complete useful database, including the legacy snapshots being deliberately deleted. Do not build or run a bulk 134-project snapshot mechanism solely for this migration gate. The purge command remains unchanged and must never create snapshots itself.
+
 ## Status after PR 1
 
 - The candidate legacy capacity columns **still physically exist** in the

--- a/docs/domain/legacy-capacity-column-runtime-cutover.md
+++ b/docs/domain/legacy-capacity-column-runtime-cutover.md
@@ -16,9 +16,10 @@ The corrected production contract is:
 6. run `npm run capacity-profiles:purge-pre-v4-snapshots -- --apply`;
 7. prove V1 = 0, V2 = 0, V3 = 0, malformed/unsupported = 0, and that current project/backlog/resource/profile/timeline state is unchanged apart from the deliberate `BacklogSnapshot` deletion;
 8. restart the application and rerun `npm run capacity-profiles:readiness`;
-9. remediate only the remaining current/live CapacityProfile blockers under the reviewed #421 process;
-10. once live-state readiness passes, create a fresh V4 snapshot on a representative useful project and prove supported V4 restore succeeds with CapacityProfile ownership/integrity still valid;
-11. authorize #418 PR 2 only after readiness passes, the restore-tested backup is retained, pre-V4 snapshot count is zero, and representative V4 create/restore has passed.
+9. remediate only the remaining current/live CapacityProfile blockers under the reviewed #421 process until readiness passes;
+10. create a fresh V4 snapshot on a representative useful project and prove supported V4 restore succeeds with CapacityProfile ownership/integrity still valid;
+11. rerun `npm run capacity-profiles:readiness` against the post-restore database state and require exit 0;
+12. authorize #418 PR 2 only after that final post-restore readiness pass, the restore-tested backup is retained, pre-V4 snapshot count is zero, and representative V4 create/restore has passed.
 
 The restore-tested PostgreSQL backup is the authoritative pre-purge rollback mechanism because it captures the complete useful database, including the legacy snapshots being deliberately deleted. Do not build or run a bulk 134-project snapshot mechanism solely for this migration gate. The purge command remains unchanged and must never create snapshots itself.
 


### PR DESCRIPTION
## Summary

Records the agreed sequencing correction after the #404 Stage 4 production evidence.

The existing pre-purge requirement to create a fresh V4 snapshot for every current project is removed as a safety gate. The restore-tested PostgreSQL backup is the authoritative pre-purge rollback mechanism because it captures the complete useful database, including the 105 legacy snapshots being deliberately deleted.

Representative V4 create/restore validation moves to after live CapacityProfile remediation. Because that restore is itself a material database write, the permanent readiness command must then pass again against the post-restore state before PR 2 can be authorized.

## Scope

- docs only;
- one canonical runbook file changed;
- no application code;
- no purge logic change;
- no readiness logic change;
- no schema or migration change;
- no production execution.

## Corrected production sequence

1. install reviewed non-destructive release;
2. purge dry-run and require malformed/unsupported = 0;
3. maintenance mode;
4. fresh PostgreSQL backup + successful restore test;
5. rerun purge dry-run and reconcile;
6. purge pre-V4 snapshots;
7. verify pre-V4 = 0 and current data unchanged;
8. rerun readiness;
9. remediate only remaining live-state blockers under #421 until readiness passes;
10. prove representative V4 create/restore;
11. rerun permanent readiness against the post-restore state and require exit 0;
12. only then authorize #418 PR 2.

Do not merge until reviewed.