### PR TITLE
feat(#449): add planning reset and replan workflow

### DIFF
--- a/client/src/components/shared/PlanningNeedsAttentionBanner.tsx
+++ b/client/src/components/shared/PlanningNeedsAttentionBanner.tsx
@@ -1,0 +1,113 @@
+/**
+ * PlanningNeedsAttentionBanner.tsx — Explicit NEEDS_REPLAN state (issue #449).
+ *
+ * Shown on planning surfaces when the project's planning state is
+ * NEEDS_REPLAN. Explains that the resource planning is no longer current and
+ * offers the single obvious **Replan project** action:
+ *
+ *   - the server validates the canonical planning state (complete replanning);
+ *   - when valid, the project atomically returns to CURRENT and the banner
+ *     disappears;
+ *   - when incomplete, the server's actionable findings are shown inline and
+ *     the user is routed into the existing Resource Profile surface to build
+ *     the new plan (no wizard, no automatic defaults).
+ *
+ * The banner never fabricates capacity or clears the flag by itself — only
+ * the server-side canonical validation completes replanning.
+ */
+
+import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+
+import {
+  completeReplanning,
+  apiErrorMessage,
+  type ReplanIncompleteResponse,
+} from '../../lib/api'
+import { invalidateProjectPlanning } from '../../lib/projectInvalidation'
+
+interface PlanningNeedsAttentionBannerProps {
+  projectId: string
+}
+
+export default function PlanningNeedsAttentionBanner({ projectId }: PlanningNeedsAttentionBannerProps) {
+  const navigate = useNavigate()
+  const qc = useQueryClient()
+  const [findings, setFindings] = useState<string[] | null>(null)
+  const [actionError, setActionError] = useState<string | null>(null)
+
+  const completeMutation = useMutation({
+    mutationFn: () => completeReplanning(projectId),
+    onSuccess: () => {
+      setFindings(null)
+      setActionError(null)
+      invalidateProjectPlanning(qc, projectId)
+    },
+    onError: (err: unknown) => {
+      const data = (err as { response?: { data?: ReplanIncompleteResponse } })?.response?.data
+      if (data?.code === 'REPLAN_INCOMPLETE') {
+        setFindings(data.findings)
+        setActionError(null)
+      } else {
+        setFindings(null)
+        setActionError(apiErrorMessage(err, 'Could not complete replanning'))
+      }
+    },
+  })
+
+  return (
+    <div
+      className="rounded-xl border border-amber-300 dark:border-amber-700 bg-amber-50 dark:bg-amber-950/30 px-5 py-4"
+      data-testid="planning-needs-attention"
+    >
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+        <div className="space-y-1.5">
+          <h2 className="text-base font-semibold text-amber-900 dark:text-amber-200">
+            Planning needs attention
+          </h2>
+          <p className="text-sm text-amber-800 dark:text-amber-300">
+            This project&apos;s resource planning is no longer current. Review the resource
+            inputs and replan from the existing backlog. The project and backlog remain fully
+            accessible; planning actions are paused until replanning is complete.
+          </p>
+        </div>
+        <button
+          onClick={() => completeMutation.mutate()}
+          disabled={completeMutation.isPending}
+          className="shrink-0 bg-lab3-navy text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-lab3-blue transition-colors disabled:opacity-50"
+          data-testid="replan-project-button"
+        >
+          {completeMutation.isPending ? 'Checking plan…' : 'Replan project'}
+        </button>
+      </div>
+
+      {findings && findings.length > 0 && (
+        <div className="mt-3 rounded-lg bg-white dark:bg-gray-800 border border-amber-200 dark:border-amber-800 px-4 py-3 space-y-2">
+          <p className="text-sm font-medium text-amber-900 dark:text-amber-200">
+            Replanning is not complete yet. Fix the following in Resource Profile:
+          </p>
+          <ul className="list-disc pl-5 space-y-1">
+            {findings.map((finding, index) => (
+              <li key={index} className="text-xs text-amber-800 dark:text-amber-300">
+                {finding}
+              </li>
+            ))}
+          </ul>
+          <button
+            onClick={() => navigate(`/projects/${projectId}/resource-profile`)}
+            className="text-xs font-medium text-lab3-navy dark:text-lab3-blue underline hover:text-lab3-blue dark:hover:text-lab3-blue"
+          >
+            Open Resource Profile to review inputs
+          </button>
+        </div>
+      )}
+
+      {actionError && (
+        <p role="alert" className="mt-3 text-sm text-red-700 dark:text-red-400">
+          {actionError}
+        </p>
+      )}
+    </div>
+  )
+}

--- a/client/src/hooks/useCommercialData.ts
+++ b/client/src/hooks/useCommercialData.ts
@@ -58,6 +58,11 @@ export function useCommercialData(
 
   const filteredResourceRows = useMemo(() => {
     if (!profile) return []
+    // While NEEDS_REPLAN every preserved role must stay visible for
+    // replanning — including zero-demand roles — so the user can create
+    // their chosen capacity profile for each role before completing
+    // replanning (issue #449). Normal CURRENT filtering is unchanged.
+    if (profile.planningState === 'NEEDS_REPLAN') return profile.resourceRows
     const overheadLinkedRtIds = new Set(
       profile.overheadRows
         .filter(r => r.resourceTypeId)

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -150,3 +150,43 @@ export const transferToManualCapacity = (
       resourceTypeId,
     })
     .then(r => r.data)
+
+// ---------------------------------------------------------------------------
+// Reset Planning / Replan project (issue #449)
+// ---------------------------------------------------------------------------
+
+export interface ResetPlanningResult {
+  projectId: string
+  planningState: 'NEEDS_REPLAN'
+}
+
+/**
+ * Deliberately discard the project's planning state (Reset Planning).
+ * Requires explicit `{ confirm: true }` on the wire; preserves the backlog,
+ * estimation and business/commercial data and marks the project NEEDS_REPLAN.
+ */
+export const resetProjectPlanning = (projectId: string): Promise<ResetPlanningResult> =>
+  api
+    .post<ResetPlanningResult>(`/projects/${projectId}/planning/reset`, { confirm: true })
+    .then(r => r.data)
+
+export interface CompleteReplanningResult {
+  projectId: string
+  planningState: 'CURRENT'
+}
+
+export interface ReplanIncompleteResponse {
+  error: string
+  code: 'REPLAN_INCOMPLETE'
+  findings: string[]
+}
+
+/**
+ * Complete replanning: the server validates the canonical project planning
+ * state and atomically returns the project to CURRENT only when valid.
+ * Rejects with `ReplanIncompleteResponse` (422) when the plan is incomplete.
+ */
+export const completeReplanning = (projectId: string): Promise<CompleteReplanningResult> =>
+  api
+    .post<CompleteReplanningResult>(`/projects/${projectId}/planning/complete`)
+    .then(r => r.data)

--- a/client/src/pages/ResourceProfilePage.tsx
+++ b/client/src/pages/ResourceProfilePage.tsx
@@ -1,8 +1,13 @@
+import { useRef, useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import AppLayout from '../components/layout/AppLayout'
 import { useResourceProfile, formatNumber } from '../hooks/useResourceProfile'
 import ResourceProfileTab from '../components/resource-profile/ResourceProfileTab'
 import CommercialTab from '../components/resource-profile/CommercialTab'
+import PlanningNeedsAttentionBanner from '../components/shared/PlanningNeedsAttentionBanner'
+import { resetProjectPlanning, apiErrorMessage } from '../lib/api'
+import { invalidateProjectAll } from '../lib/projectInvalidation'
 
 export default function ResourceProfilePage() {
   const state = useResourceProfile()
@@ -12,6 +17,24 @@ export default function ResourceProfilePage() {
     handleExportProfile, handleExportFull,
   } = state
   const navigate = useNavigate()
+  const qc = useQueryClient()
+  const [resetConfirmOpen, setResetConfirmOpen] = useState(false)
+  const [resetFeedback, setResetFeedback] = useState<string | null>(null)
+
+  const needsReplan = profile?.planningState === 'NEEDS_REPLAN' || project?.planningState === 'NEEDS_REPLAN'
+
+  const resetMutation = useMutation({
+    mutationFn: () => resetProjectPlanning(projectId!),
+    onSuccess: () => {
+      setResetConfirmOpen(false)
+      setResetFeedback('Planning reset — the project now needs replanning. Build the new plan from the existing backlog.')
+      invalidateProjectAll(qc, projectId)
+    },
+    onError: (err: unknown) => {
+      setResetConfirmOpen(false)
+      setResetFeedback(apiErrorMessage(err, 'Reset planning failed'))
+    },
+  })
 
   if (!projectId) return null
 
@@ -45,6 +68,14 @@ export default function ResourceProfilePage() {
             )}
           </div>
           <div className="flex flex-wrap gap-2">
+            {!needsReplan && (
+              <button
+                onClick={() => setResetConfirmOpen(true)}
+                className="border border-red-300 text-red-700 dark:text-red-300 dark:border-red-800 px-4 py-2 rounded-lg text-sm font-medium hover:bg-red-50 dark:hover:bg-red-950 transition-colors"
+              >
+                Reset planning…
+              </button>
+            )}
             <button
               onClick={handleExportProfile}
               disabled={!profile}
@@ -61,6 +92,14 @@ export default function ResourceProfilePage() {
             </button>
           </div>
         </div>
+
+        {resetFeedback && (
+          <div className="rounded-xl border border-blue-200 dark:border-blue-800 bg-blue-50 dark:bg-blue-950/30 px-4 py-3 text-sm text-blue-800 dark:text-blue-300" role="status" data-testid="reset-feedback">
+            {resetFeedback}
+          </div>
+        )}
+
+        {needsReplan && <PlanningNeedsAttentionBanner projectId={projectId} />}
 
         {/* ── Tab bar ── */}
         <div className="border-b border-gray-200 dark:border-gray-700">
@@ -89,8 +128,145 @@ export default function ResourceProfilePage() {
         </div>
 
         {activeTab === 'profile' && <ResourceProfileTab {...state} projectId={projectId} />}
-        {activeTab === 'commercial' && <CommercialTab {...state} projectId={projectId} />}
+        {activeTab === 'commercial' && (needsReplan
+          ? (
+            <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 p-8 text-center">
+              <h2 className="text-base font-semibold text-gray-900 dark:text-white mb-2">Commercial totals need a current plan</h2>
+              <p className="text-sm text-gray-500 dark:text-gray-400 max-w-md mx-auto">
+                This project&apos;s resource planning is no longer current. Replan from the
+                existing backlog first; commercial totals will be calculated once the project
+                is current again.
+              </p>
+            </div>
+          )
+          : <CommercialTab {...state} projectId={projectId} />)}
+
+        {resetConfirmOpen && (
+          <ResetPlanningConfirmDialog
+            isPending={resetMutation.isPending}
+            error={resetMutation.isError ? apiErrorMessage(resetMutation.error, 'Reset planning failed') : null}
+            onConfirm={() => resetMutation.mutate()}
+            onCancel={() => { if (!resetMutation.isPending) setResetConfirmOpen(false) }}
+          />
+        )}
       </main>
     </AppLayout>
+  )
+}
+
+// ─── Reset Planning confirmation dialog (full focus/keyboard lifecycle) ────
+
+interface ResetPlanningConfirmDialogProps {
+  isPending: boolean
+  error: string | null
+  onConfirm: () => void
+  onCancel: () => void
+}
+
+function ResetPlanningConfirmDialog({
+  isPending,
+  error,
+  onConfirm,
+  onCancel,
+}: ResetPlanningConfirmDialogProps) {
+  const dialogRef = useRef<HTMLDivElement>(null)
+  const confirmRef = useRef<HTMLButtonElement>(null)
+  const previouslyFocused = useRef<HTMLElement | null>(null)
+
+  useEffect(() => {
+    previouslyFocused.current = document.activeElement as HTMLElement | null
+    confirmRef.current?.focus()
+  }, [])
+
+  useEffect(() => {
+    return () => {
+      previouslyFocused.current?.focus()
+    }
+  }, [])
+
+  function handleKeyDown(e: React.KeyboardEvent) {
+    if (e.key === 'Escape' && !isPending) {
+      onCancel()
+      return
+    }
+    if (e.key === 'Tab') {
+      const dialog = dialogRef.current
+      if (!dialog) return
+      const focusable = dialog.querySelectorAll<HTMLElement>(
+        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
+      )
+      const firstFocusable = focusable[0]
+      const lastFocusable = focusable[focusable.length - 1]
+      if (e.shiftKey) {
+        if (document.activeElement === firstFocusable) {
+          e.preventDefault()
+          lastFocusable?.focus()
+        }
+      } else {
+        if (document.activeElement === lastFocusable) {
+          e.preventDefault()
+          firstFocusable?.focus()
+        }
+      }
+    }
+  }
+
+  function handleBackdropClick(e: React.MouseEvent) {
+    if (isPending) return
+    if (e.target === e.currentTarget) {
+      onCancel()
+    }
+  }
+
+  return (
+    <div
+      ref={dialogRef}
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+      onClick={handleBackdropClick}
+      onKeyDown={handleKeyDown}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="reset-planning-dialog-title"
+    >
+      <div className="bg-white dark:bg-gray-800 rounded-xl shadow-xl border border-gray-200 dark:border-gray-700 w-full max-w-md mx-4 p-6">
+        <h3 id="reset-planning-dialog-title" className="text-base font-semibold text-gray-900 dark:text-white mb-2">
+          Reset planning?
+        </h3>
+        <div className="text-sm text-gray-600 dark:text-gray-400 space-y-2">
+          <p>
+            Reset planning discards this project&apos;s current resource/capacity planning and
+            generated schedule.
+          </p>
+          <ul className="list-disc pl-5 space-y-1">
+            <li>The project, backlog, effort estimates and dependencies are kept.</li>
+            <li>Business and commercial data — rates, discounts, tax, billing basis — are kept.</li>
+            <li>Capacity profiles, capacity plans, planned resources and schedule output are removed.</li>
+            <li>The project must then be replanned from the existing backlog.</li>
+          </ul>
+        </div>
+        <div className="flex items-center justify-end gap-3 mt-6">
+          <button
+            onClick={onCancel}
+            disabled={isPending}
+            className="px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 bg-gray-100 dark:bg-gray-700 rounded-lg hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors disabled:opacity-50"
+          >
+            Cancel
+          </button>
+          <button
+            ref={confirmRef}
+            onClick={onConfirm}
+            disabled={isPending}
+            className="px-4 py-2 text-sm font-medium text-white bg-red-600 rounded-lg hover:bg-red-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {isPending ? 'Resetting…' : 'Reset planning'}
+          </button>
+        </div>
+        {error && (
+          <p className="mt-3 text-sm text-red-600 dark:text-red-400" role="alert">
+            Error: {error}
+          </p>
+        )}
+      </div>
+    </div>
   )
 }

--- a/client/src/pages/ResourceProfilePage.tsx
+++ b/client/src/pages/ResourceProfilePage.tsx
@@ -78,20 +78,30 @@ export default function ResourceProfilePage() {
             )}
             <button
               onClick={handleExportProfile}
-              disabled={!profile}
+              disabled={!profile || needsReplan}
+              title={needsReplan ? 'Replan the project before exporting planning data.' : undefined}
+              aria-disabled={needsReplan || !profile}
               className="border border-gray-300 text-gray-700 dark:text-gray-300 px-4 py-2 rounded-lg text-sm font-medium hover:bg-gray-100 dark:hover:bg-gray-700 disabled:opacity-50"
             >
               ⬇ Export Resource Profile
             </button>
             <button
               onClick={handleExportFull}
-              disabled={!profile}
+              disabled={!profile || needsReplan}
+              title={needsReplan ? 'Replan the project before exporting planning data.' : undefined}
+              aria-disabled={needsReplan || !profile}
               className="bg-lab3-navy text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-lab3-blue disabled:opacity-50"
             >
               ⬇ Export Full Project
             </button>
           </div>
         </div>
+
+        {needsReplan && (
+          <div className="rounded-xl border border-amber-200 dark:border-amber-800 bg-amber-50 dark:bg-amber-950/30 px-4 py-3 text-sm text-amber-800 dark:text-amber-300" role="status" data-testid="export-quarantine-notice">
+            Exports are paused while planning is not current. Replan the project before exporting planning data.
+          </div>
+        )}
 
         {resetFeedback && (
           <div className="rounded-xl border border-blue-200 dark:border-blue-800 bg-blue-50 dark:bg-blue-950/30 px-4 py-3 text-sm text-blue-800 dark:text-blue-300" role="status" data-testid="reset-feedback">

--- a/client/src/pages/TimelinePage.tsx
+++ b/client/src/pages/TimelinePage.tsx
@@ -3,6 +3,7 @@ import { useParams, useNavigate, useSearchParams } from 'react-router-dom'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { toPng } from 'html-to-image'
 import { api, apiErrorMessage } from '../lib/api'
+import PlanningNeedsAttentionBanner from '../components/shared/PlanningNeedsAttentionBanner'
 import type { OptimiserCandidate } from '../lib/api'
 import { useIsDark } from '../hooks/useIsDark'
 import AppLayout from '../components/layout/AppLayout'
@@ -477,7 +478,7 @@ export default function TimelinePage() {
     }
   }, [editingFeatureId, timeline])
 
-  const { mutate: scheduleTimelineMutate, isPending: isSchedulePending } = useMutation({
+  const { mutate: scheduleTimelineMutate, isPending: isSchedulePending, error: scheduleError } = useMutation({
     mutationFn: (body: { startDate?: string; resourceLevel?: boolean }) =>
       api.post(`/projects/${projectId}/timeline/schedule`, body).then(r => r.data),
     onSuccess: (data) => {
@@ -488,9 +489,12 @@ export default function TimelinePage() {
 
   // Auto-schedule on page load ONLY if no entries exist yet (first run for new projects).
   // For projects with existing entries, the user drives rescheduling via the button.
+  // A NEEDS_REPLAN project is intentionally unscheduled; never auto-schedule it
+  // (the server rejects planning actions until replanning completes).
   useEffect(() => {
     if (!initialScheduleDone.current && timeline !== undefined && project !== undefined) {
       initialScheduleDone.current = true
+      if (project.planningState === 'NEEDS_REPLAN') return
       if (timeline.entries.length === 0) {
         const body = project.startDate ? { startDate: project.startDate.slice(0, 10), resourceLevel } : { resourceLevel }
         scheduleTimelineMutate(body)
@@ -912,6 +916,14 @@ export default function TimelinePage() {
         <div className="flex items-center justify-between">
           <h1 className="text-xl font-semibold text-gray-900 dark:text-white">Timeline Planner</h1>
         </div>
+
+        {project?.planningState === 'NEEDS_REPLAN' && <PlanningNeedsAttentionBanner projectId={projectId!} />}
+
+        {scheduleError && (
+          <div className="bg-red-50 dark:bg-red-950/40 border border-red-200 dark:border-red-900 rounded-xl px-4 py-3 text-sm text-red-800 dark:text-red-300" role="alert" data-testid="schedule-error">
+            {apiErrorMessage(scheduleError, 'Failed to update the timeline')}
+          </div>
+        )}
 
         {/* Setup bar */}
         <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 p-4">

--- a/client/src/test/PlanningNeedsAttentionBanner.test.tsx
+++ b/client/src/test/PlanningNeedsAttentionBanner.test.tsx
@@ -1,0 +1,87 @@
+/**
+ * PlanningNeedsAttentionBanner.test.tsx — Unit tests for the NEEDS_REPLAN
+ * banner (issue #449): copy, the single Replan project action, actionable
+ * incomplete findings, success invalidation, and error handling.
+ */
+
+import React from 'react'
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+import PlanningNeedsAttentionBanner from '@/components/shared/PlanningNeedsAttentionBanner'
+import { completeReplanning } from '@/lib/api'
+
+vi.mock('@/lib/api', async importOriginal => {
+  const actual = await importOriginal<typeof import('@/lib/api')>()
+  return { ...actual, completeReplanning: vi.fn() }
+})
+
+function createTestQueryClient() {
+  return new QueryClient({ defaultOptions: { queries: { retry: false } } })
+}
+
+function renderBanner(projectId = 'project-1') {
+  const qc = createTestQueryClient()
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter initialEntries={[`/projects/${projectId}/resource-profile`]}>
+        <Routes>
+          <Route path="/projects/:id/resource-profile" element={<PlanningNeedsAttentionBanner projectId={projectId} />} />
+          <Route path="/projects/:id/*" element={<PlanningNeedsAttentionBanner projectId={projectId} />} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  )
+}
+
+beforeEach(() => vi.clearAllMocks())
+
+describe('PlanningNeedsAttentionBanner', () => {
+  it('shows the planning-needs-attention state and copy', () => {
+    renderBanner()
+    expect(screen.getByTestId('planning-needs-attention')).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Planning needs attention' })).toBeInTheDocument()
+    expect(screen.getByText(/resource planning is no longer current/i)).toBeInTheDocument()
+  })
+
+  it('calls complete replanning from the Replan project action', async () => {
+    vi.mocked(completeReplanning).mockResolvedValue({ projectId: 'project-1', planningState: 'CURRENT' })
+    renderBanner()
+
+    fireEvent.click(screen.getByTestId('replan-project-button'))
+
+    await waitFor(() => expect(completeReplanning).toHaveBeenCalledWith('project-1'))
+  })
+
+  it('shows actionable findings and offers the Resource Profile route when incomplete', async () => {
+    vi.mocked(completeReplanning).mockRejectedValue({
+      response: {
+        data: {
+          code: 'REPLAN_INCOMPLETE',
+          error: 'Replanning is incomplete: project "X": resource type "Engineer" lacks a ROLE profile',
+          findings: ['project "X": resource type "Engineer" lacks a ROLE profile'],
+        },
+      },
+    })
+    renderBanner()
+
+    fireEvent.click(screen.getByTestId('replan-project-button'))
+
+    await waitFor(() => {
+      expect(screen.getByText(/Replanning is not complete yet/i)).toBeInTheDocument()
+      expect(screen.getByText(/lacks a ROLE profile/)).toBeInTheDocument()
+    })
+    expect(screen.getByRole('button', { name: 'Open Resource Profile to review inputs' })).toBeInTheDocument()
+  })
+
+  it('surfaces unexpected completion errors', async () => {
+    vi.mocked(completeReplanning).mockRejectedValue({ response: { data: { error: 'Boom' } } })
+    renderBanner()
+
+    fireEvent.click(screen.getByTestId('replan-project-button'))
+
+    await waitFor(() => expect(screen.getByRole('alert')).toHaveTextContent('Boom'))
+  })
+})

--- a/client/src/test/ResourceProfilePage.reset.test.tsx
+++ b/client/src/test/ResourceProfilePage.reset.test.tsx
@@ -154,6 +154,29 @@ describe('Reset Planning on the Resource Profile page', () => {
     expect(screen.getByText('Commercial totals need a current plan')).toBeInTheDocument()
     expect(screen.getByText(/Replan from the existing backlog first/i)).toBeInTheDocument()
   })
+
+  it('keeps export buttons enabled for a CURRENT project', () => {
+    vi.mocked(useResourceProfile).mockReturnValue(baseState() as never)
+    renderPage()
+    expect(screen.getByRole('button', { name: '⬇ Export Resource Profile' })).toBeEnabled()
+    expect(screen.getByRole('button', { name: '⬇ Export Full Project' })).toBeEnabled()
+    expect(screen.queryByTestId('export-quarantine-notice')).not.toBeInTheDocument()
+  })
+
+  it('disables planning exports with replan guidance while NEEDS_REPLAN', () => {
+    vi.mocked(useResourceProfile).mockReturnValue(
+      baseState({ project: { id: 'project-1', name: 'Alpha', planningState: 'NEEDS_REPLAN' }, profile: undefined }) as never,
+    )
+    renderPage()
+
+    const exportProfile = screen.getByRole('button', { name: '⬇ Export Resource Profile' })
+    const exportFull = screen.getByRole('button', { name: '⬇ Export Full Project' })
+    expect(exportProfile).toBeDisabled()
+    expect(exportFull).toBeDisabled()
+    expect(exportProfile).toHaveAttribute('title', 'Replan the project before exporting planning data.')
+    expect(exportFull).toHaveAttribute('title', 'Replan the project before exporting planning data.')
+    expect(screen.getByTestId('export-quarantine-notice')).toHaveTextContent(/Replan the project before exporting planning data/i)
+  })
 })
 
 // Keep the import used for type-level re-export parity.

--- a/client/src/test/ResourceProfilePage.reset.test.tsx
+++ b/client/src/test/ResourceProfilePage.reset.test.tsx
@@ -1,0 +1,160 @@
+/**
+ * ResourceProfilePage.reset.test.tsx — Unit tests for the Reset Planning
+ * workflow on the Resource Profile page (issue #449):
+ *
+ *   - "Reset planning…" is exposed for a CURRENT project and hidden when the
+ *     project already needs replanning;
+ *   - confirmation dialog copy explains preserve/discard;
+ *   - cancel does nothing; confirm calls the reset API and shows feedback;
+ *   - reset failure surfaces an actionable error;
+ *   - the NEEDS_REPLAN banner is rendered and the Commercial tab is replaced
+ *     by the planning-required notice while quarantined.
+ */
+
+import React from 'react'
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+import ResourceProfilePage from '@/pages/ResourceProfilePage'
+import { resetProjectPlanning } from '@/lib/api'
+
+vi.mock('@/lib/api', async importOriginal => {
+  const actual = await importOriginal<typeof import('@/lib/api')>()
+  return { ...actual, resetProjectPlanning: vi.fn() }
+})
+
+vi.mock('@/hooks/useResourceProfile', async importOriginal => {
+  const actual = await importOriginal<typeof import('@/hooks/useResourceProfile')>()
+  return { ...actual, useResourceProfile: vi.fn() }
+})
+
+vi.mock('@/hooks/useAuth', () => ({
+  useAuth: () => ({ user: { name: 'Test User', email: 'test@example.com' }, logout: vi.fn() }),
+}))
+
+// The page-level tests exercise reset/banner/commercial gating only; the tab
+// internals are covered by their own test suites.
+vi.mock('@/components/resource-profile/ResourceProfileTab', () => ({
+  default: () => <div data-testid="resource-profile-tab" />,
+}))
+vi.mock('@/components/resource-profile/CommercialTab', () => ({
+  default: () => <div data-testid="commercial-tab" />,
+}))
+
+import { useResourceProfile, formatNumber } from '@/hooks/useResourceProfile'
+
+function baseState(overrides: Record<string, unknown> = {}) {
+  return {
+    projectId: 'project-1',
+    navigate: vi.fn(),
+    qc: new QueryClient(),
+    project: { id: 'project-1', name: 'Alpha', planningState: 'CURRENT' },
+    profile: {
+      projectId: 'project-1',
+      planningState: 'CURRENT',
+      hoursPerDay: 8,
+      projectDurationWeeks: 12,
+      bufferWeeks: 0,
+      onboardingWeeks: 0,
+      resourceRows: [],
+      overheadRows: [],
+      summary: { totalHours: 0, totalDays: 0, totalCost: null, hasCost: false },
+    },
+    profileLoading: false,
+    overheadItems: [],
+    resourceTypes: [],
+    discounts: [],
+    rateCards: [],
+    activeTab: 'profile' as const,
+    setActiveTab: vi.fn(),
+    handleExportProfile: vi.fn(),
+    handleExportFull: vi.fn(),
+    ...overrides,
+  }
+}
+
+function renderPage() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter initialEntries={['/projects/project-1/resource-profile']}>
+        <Routes>
+          <Route path="/projects/:id/resource-profile" element={<ResourceProfilePage />} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  )
+}
+
+beforeEach(() => vi.clearAllMocks())
+
+describe('Reset Planning on the Resource Profile page', () => {
+  it('exposes Reset planning… for a CURRENT project', () => {
+    vi.mocked(useResourceProfile).mockReturnValue(baseState() as never)
+    renderPage()
+    expect(screen.getByRole('button', { name: 'Reset planning…' })).toBeInTheDocument()
+    expect(screen.queryByTestId('planning-needs-attention')).not.toBeInTheDocument()
+  })
+
+  it('hides Reset planning… and shows the banner when the project needs replanning', () => {
+    vi.mocked(useResourceProfile).mockReturnValue(
+      baseState({ project: { id: 'project-1', name: 'Alpha', planningState: 'NEEDS_REPLAN' }, profile: undefined }) as never,
+    )
+    renderPage()
+    expect(screen.queryByRole('button', { name: 'Reset planning…' })).not.toBeInTheDocument()
+    expect(screen.getByTestId('planning-needs-attention')).toBeInTheDocument()
+  })
+
+  it('cancel closes the confirmation dialog without calling the API', () => {
+    vi.mocked(useResourceProfile).mockReturnValue(baseState() as never)
+    renderPage()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Reset planning…' }))
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+    expect(screen.getByText(/capacity profiles, capacity plans, planned resources and schedule output are removed/i)).toBeInTheDocument()
+    expect(screen.getByText(/The project, backlog, effort estimates and dependencies are kept/i)).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    expect(resetProjectPlanning).not.toHaveBeenCalled()
+  })
+
+  it('confirm calls the reset API and reports the new state', async () => {
+    vi.mocked(useResourceProfile).mockReturnValue(baseState() as never)
+    vi.mocked(resetProjectPlanning).mockResolvedValue({ projectId: 'project-1', planningState: 'NEEDS_REPLAN' })
+    renderPage()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Reset planning…' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Reset planning' }))
+
+    await waitFor(() => expect(resetProjectPlanning).toHaveBeenCalledWith('project-1'))
+    await waitFor(() => {
+      expect(screen.getByTestId('reset-feedback')).toHaveTextContent(/Planning reset/)
+    })
+  })
+
+  it('surfaces a reset failure instead of failing silently', async () => {
+    vi.mocked(useResourceProfile).mockReturnValue(baseState() as never)
+    vi.mocked(resetProjectPlanning).mockRejectedValue({ response: { data: { error: 'Reset failed hard' } } })
+    renderPage()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Reset planning…' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Reset planning' }))
+
+    await waitFor(() => expect(screen.getByTestId('reset-feedback')).toHaveTextContent('Reset failed hard'))
+  })
+
+  it('replaces the Commercial tab with the planning-required notice while NEEDS_REPLAN', () => {
+    vi.mocked(useResourceProfile).mockReturnValue(
+      baseState({ project: { id: 'project-1', name: 'Alpha', planningState: 'NEEDS_REPLAN' }, profile: undefined, activeTab: 'commercial' as const }) as never,
+    )
+    renderPage()
+    expect(screen.getByText('Commercial totals need a current plan')).toBeInTheDocument()
+    expect(screen.getByText(/Replan from the existing backlog first/i)).toBeInTheDocument()
+  })
+})
+
+// Keep the import used for type-level re-export parity.
+void formatNumber

--- a/client/src/test/useCommercialData.needsReplan.test.tsx
+++ b/client/src/test/useCommercialData.needsReplan.test.tsx
@@ -1,0 +1,112 @@
+/**
+ * useCommercialData.needsReplan.test.tsx — The zero-demand role row filter
+ * (issue #449):
+ *
+ *   - while NEEDS_REPLAN every preserved role row stays visible, including
+ *     zero-demand rows, so the user can create its profile before
+ *     completing replanning;
+ *   - normal CURRENT filtering is unchanged (zero-demand rows without an
+ *     overhead link stay hidden).
+ */
+
+import React from 'react'
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+import { useCommercialData } from '@/hooks/useCommercialData'
+import type { ResourceProfile, Project } from '@/types'
+
+vi.mock('@/lib/api', () => ({
+  api: { get: vi.fn().mockResolvedValue({ data: [] }) },
+}))
+
+const BASE_PROFILE: ResourceProfile = {
+  projectId: 'project-1',
+  planningState: 'CURRENT',
+  hoursPerDay: 8,
+  projectDurationWeeks: 12,
+  bufferWeeks: 0,
+  onboardingWeeks: 0,
+  resourceRows: [],
+  overheadRows: [],
+  summary: { totalHours: 0, totalDays: 0, totalCost: null, hasCost: false },
+}
+
+const PROJECT: Project = { id: 'project-1', name: 'Alpha', planningState: 'CURRENT' } as Project
+
+const zeroDemandRow = {
+  resourceTypeId: 'rt-2',
+  name: 'Designer',
+  category: 'DESIGN',
+  count: 1,
+  hoursPerDay: 7.6,
+  dayRate: 400,
+  totalHours: 0,
+  effortDays: 0,
+  totalDays: 0,
+  allocatedDays: 0,
+  allocationMode: 'EFFORT',
+  allocationPercent: 100,
+  allocationStartWeek: null,
+  allocationEndWeek: null,
+  derivedStartWeek: null,
+  derivedEndWeek: null,
+  estimatedCost: null,
+  epics: [],
+  namedResources: [],
+} as ResourceProfile['resourceRows'][number]
+
+const demandRow = {
+  resourceTypeId: 'rt-1',
+  name: 'Engineer',
+  category: 'ENGINEERING',
+  count: 2,
+  hoursPerDay: 7.6,
+  dayRate: 500,
+  totalHours: 16,
+  effortDays: 2,
+  totalDays: 0,
+  allocatedDays: 0,
+  allocationMode: 'EFFORT',
+  allocationPercent: 100,
+  allocationStartWeek: null,
+  allocationEndWeek: null,
+  derivedStartWeek: null,
+  derivedEndWeek: null,
+  estimatedCost: null,
+  epics: [],
+  namedResources: [],
+} as ResourceProfile['resourceRows'][number]
+
+function renderFilter(profile: ResourceProfile) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return renderHook(
+    () => useCommercialData('project-1', 'profile', profile, PROJECT),
+    { wrapper: ({ children }) => <QueryClientProvider client={qc}>{children}</QueryClientProvider> },
+  )
+}
+
+beforeEach(() => vi.clearAllMocks())
+
+describe('useCommercialData filteredResourceRows', () => {
+  it('keeps every preserved row visible while NEEDS_REPLAN, including zero-demand roles', async () => {
+    const { result } = renderFilter({
+      ...BASE_PROFILE,
+      planningState: 'NEEDS_REPLAN',
+      resourceRows: [demandRow, zeroDemandRow],
+    })
+    await waitFor(() => expect(result.current.filteredResourceRows).toHaveLength(2))
+    expect(result.current.filteredResourceRows.map(r => r.resourceTypeId)).toEqual(['rt-1', 'rt-2'])
+  })
+
+  it('hides zero-demand rows for CURRENT projects (unchanged behaviour)', async () => {
+    const { result } = renderFilter({
+      ...BASE_PROFILE,
+      planningState: 'CURRENT',
+      resourceRows: [demandRow, zeroDemandRow],
+    })
+    await waitFor(() => expect(result.current.filteredResourceRows).toHaveLength(1))
+    expect(result.current.filteredResourceRows[0].resourceTypeId).toBe('rt-1')
+  })
+})

--- a/client/src/types/backlog.ts
+++ b/client/src/types/backlog.ts
@@ -104,6 +104,8 @@ export interface Project {
   description?: string
   customer?: string | ProjectCustomer | null
   status: string
+  /** Explicit project-level planning state (issue #449). */
+  planningState?: 'CURRENT' | 'NEEDS_REPLAN'
   hoursPerDay: number
   bufferWeeks?: number
   onboardingWeeks?: number
@@ -358,6 +360,8 @@ export interface OverheadProfileRow {
 
 export interface ResourceProfile {
   projectId: string
+  /** Explicit project-level planning state (issue #449). */
+  planningState?: 'CURRENT' | 'NEEDS_REPLAN'
   hoursPerDay: number
   projectDurationWeeks: number
   bufferWeeks: number

--- a/docs/domain/planning-reset-replan.md
+++ b/docs/domain/planning-reset-replan.md
@@ -161,20 +161,46 @@ user actions and are never merged into one "detach/reset" operation.
 `lib/classifyNeedsReplan.ts`):
 
 ```
-npx tsx src/scripts/classifyNeedsReplan.ts --manifest manifest.json            # DRY RUN (default)
-npx tsx src/scripts/classifyNeedsReplan.ts --manifest manifest.json --apply    # apply
+npx tsx src/scripts/classifyNeedsReplan.ts --manifest manifest.json                          # DRY RUN (default)
+npx tsx src/scripts/classifyNeedsReplan.ts --manifest manifest.json --apply \
+     --expected-fingerprint <sha256>                                                          # apply
 ```
 
 - Manifest shape: `{ "projectIds": ["<id>", ...] }` — an explicitly reviewed input,
   never invented selection rules on production.
-- Dry-run by default; `--apply` required to write.
+- Dry-run by default; `--apply` required to write. Every dry-run prints
+  `stateFingerprint: <sha256>`.
+- **Reviewed-state fingerprint.** The fingerprint is a deterministic SHA-256 over
+  exactly the reset-relevant state of the manifest set: manifest project IDs and
+  existence, `planningState`, `weeklyDemandCache`, `CapacityProfile`
+  ownership/provenance fields, `CapacitySegment`s, `CapacityPlan`/period/entry
+  rows, `TimelineEntry`/`StoryTimelineEntry` rows, and the `NamedResource` identity
+  linkage that (with profile ownerKind) determines which rows are proven
+  `PLANNED_RESOURCE` planner artefacts. Ordering is canonicalised (sorted IDs and
+  rows, sorted JSON object keys), so unchanged state always yields the same
+  fingerprint. Unrelated backlog/business fields are never included.
+- **Apply contract.** `--apply` REQUIRES the reviewed fingerprint
+  (`--expected-fingerprint <sha256>` from a dry-run on unchanged state). The
+  fingerprint is recomputed INSIDE the apply transaction immediately before any
+  write; any mismatch aborts with zero writes and an explicit drift error telling
+  the operator to rerun the dry-run and review the new state. A project changed
+  after review can never be destructively reset on stale evidence.
+- **Atomic batch.** The complete manifest apply runs in ONE Prisma transaction:
+  either every to-classify project is reset (via the same reset transaction body
+  the product uses) or none is. A failure on any project rolls the whole batch
+  back — no partial classification.
+- **Idempotence.** Already-`NEEDS_REPLAN` projects are skipped, but only when that
+  state is part of the reviewed fingerprint; the drift check still refuses every
+  other unexpected change.
 - Each classified project goes through the same atomic reset transaction as the
   product action: planning state discarded, business data preserved, marked
   `NEEDS_REPLAN`.
-- Fails closed: malformed manifest, unknown arguments, or a manifest project that no
-  longer exists abort with nothing changed.
+- Fails closed: malformed manifest, unknown arguments, missing or malformed
+  fingerprint for apply, fingerprint drift, or a manifest project that no longer
+  exists abort with nothing changed.
 - No capacity inference, profile reconstruction, percentage, window or owner-kind
-  decisions. Output is sanitized (operator-supplied IDs and aggregate counts only).
+  decisions. Output is sanitized (operator-supplied IDs, the reviewed hash, and
+  aggregate counts only).
 - Production execution under #404 remains owned by the production agent; the
   restore-tested backup retained by #404 is untouched by this command.
 
@@ -198,16 +224,45 @@ available in both states (a pre-replan snapshot is a useful safety net).
 
 ## Migration sequencing
 
-Once merged and proven on production (under #404's process):
+### Deployment prerequisite: the ownership-invariants migration must be applied first
 
-1. Classify the affected legacy projects as `NEEDS_REPLAN` via the reviewed
-   maintenance command.
-2. Run permanent readiness: `CURRENT` projects must pass; `NEEDS_REPLAN` projects
-   are explicitly quarantined.
-3. Prove the normal Reset/Replan workflow on a representative project and return it
-   to `CURRENT`.
-4. Create/restore a representative V4 snapshot and rerun readiness.
-5. Only then authorize #418 PR 2 legacy-column removal.
+The new #450 migration `20260808221539_add_project_planning_state` sits AFTER
+`20260721000001_enforce_capacity_profile_ownership_invariants` in Prisma migration
+order. Production evidence (#404) records `20260721000001` as the single pending
+migration (37 found, 36 applied). A normal `prisma migrate deploy` therefore
+applies `20260721000001` before the #450 migration, and it must already be applied
+before the #450 release is installed.
+
+The #450 release must NOT be installed on production while
+`20260721000001_enforce_capacity_profile_ownership_invariants` is still pending.
+
+Required production sequence:
+
+1. **#404 executes the reviewed pending migration as its own controlled step**
+   (before the #450 release is installed), using the #404 production safety
+   process:
+   - exact reviewed commit containing `20260721000001_enforce_capacity_profile_ownership_invariants`;
+   - maintenance window with no application writes as required;
+   - current ownership audit/preflight clean;
+   - appropriate current backup/rollback protection;
+   - `prisma migrate deploy`;
+   - verify ONLY that migration was newly applied;
+   - rerun the ownership audit / required validation;
+   - stop on any failure.
+2. Only after production migration state confirms
+   `20260721000001_enforce_capacity_profile_ownership_invariants` is applied may
+   the #450 release be installed; its `20260808221539_add_project_planning_state`
+   migration then deploys in order.
+3. Continue the approved #449/#404 sequence:
+
+   a. Classify the affected legacy projects as `NEEDS_REPLAN` via the reviewed
+      maintenance command (dry-run → reviewed fingerprint → `--apply` with it).
+   b. Run permanent readiness: `CURRENT` projects must pass; `NEEDS_REPLAN`
+      projects are explicitly quarantined.
+   c. Prove the normal Reset/Replan workflow on a representative project and
+      return it to `CURRENT`.
+   d. Create/restore a representative V4 snapshot and rerun readiness.
+   e. Only then authorize #418 PR 2 legacy-column removal.
 
 The #421 2,011-write/130-decision preservation plan is superseded and must not be
 applied.

--- a/docs/domain/planning-reset-replan.md
+++ b/docs/domain/planning-reset-replan.md
@@ -52,7 +52,7 @@ Prisma transaction. Any failure rolls the whole reset back.
 | `CapacityPlan` / `CapacityPlanPeriod` / `CapacityPlanEntry` | Planning inputs/outputs |
 | `TimelineEntry` / `StoryTimelineEntry` (generated and manual) | Generated schedule output; Timeline/Planning owns manual overrides as planning state |
 | `Project.weeklyDemandCache` | Derived planning cache |
-| NamedResource rows with a `PLANNED_RESOURCE` profile | Proven planner-generated placeholders: Squad Planner's `findOrCreatePlannedResources` writes those rows and marks them with a `PLANNED_RESOURCE` profile; user-authored named resources always carry `NAMED_PERSON` profiles |
+| NamedResource rows with proven planner provenance | Proven planner-generated placeholders, matched ONLY by exact provenance markers: (a) a `CapacityProfile` with `ownerKind = PLANNED_RESOURCE` (what Squad Planner's `findOrCreatePlannedResources` writes), or (b) the established legacy planner form `NAMED_PERSON` + `SQUAD_PLANNER` + `CAPACITY_PROFILE` (`isLegacyPlannerProfile` — the same safe provenance rule the Squad Planner adoption path uses). User-authored named resources always carry `NAMED_PERSON` profiles outside those exact markers |
 | `Project.planningState` → `NEEDS_REPLAN` | Explicit quarantine |
 
 ### Preserved (never touched)
@@ -144,6 +144,19 @@ historical timeline viewer is out of scope for this issue.
   runs the completion validation; on success the project returns to `CURRENT`; on
   `REPLAN_INCOMPLETE` the actionable findings are shown inline with a link into
   Resource Profile.
+- **Zero-demand roles stay visible while NEEDS_REPLAN.** Reset preserves every
+  ResourceType, and canonical completion requires a profile per preserved role.
+  While `NEEDS_REPLAN` the Resource Profile surface therefore exposes EVERY
+  preserved role — including roles with no task demand — with real identity and
+  non-planning metadata, zero effort/demand, and no fabricated capacity, editable
+  through the existing capacity-profile editor. The client's normal
+  zero-demand-row filtering is suspended only while `NEEDS_REPLAN`; `CURRENT`
+  behaviour is unchanged.
+- **Planning exports are quarantined.** Export Resource Profile and Export Full
+  Project are disabled while `NEEDS_REPLAN` with the guidance "Replan the project
+  before exporting planning data." (the timeline CSV endpoint inside the full
+  export is additionally protected by the server-side `REPLAN_REQUIRED` guard).
+  `CURRENT` export is unchanged.
 - No planning option is automatically selected because of migration history; the
   user picks the approach (As needed, fixed whole project, fixed selected weeks,
   manually shaped, Squad Planner) in the existing surfaces.
@@ -170,25 +183,36 @@ npx tsx src/scripts/classifyNeedsReplan.ts --manifest manifest.json --apply \
   never invented selection rules on production.
 - Dry-run by default; `--apply` required to write. Every dry-run prints
   `stateFingerprint: <sha256>`.
+- **Dry-run snapshot consistency.** The classification entries/counts AND the
+  fingerprint are generated inside ONE Prisma transaction at repeatable-read
+  isolation, so the report and the reviewed fingerprint always describe the same
+  database snapshot. The dry run performs zero writes (the transaction is
+  nominally read-write only because Prisma has no read-only transaction option).
+  A concurrent change cannot produce a report whose entries describe one state
+  and whose fingerprint describes another.
 - **Reviewed-state fingerprint.** The fingerprint is a deterministic SHA-256 over
   exactly the reset-relevant state of the manifest set: manifest project IDs and
   existence, `planningState`, `weeklyDemandCache`, `CapacityProfile`
   ownership/provenance fields, `CapacitySegment`s, `CapacityPlan`/period/entry
   rows, `TimelineEntry`/`StoryTimelineEntry` rows, and the `NamedResource` identity
-  linkage that (with profile ownerKind) determines which rows are proven
-  `PLANNED_RESOURCE` planner artefacts. Ordering is canonicalised (sorted IDs and
-  rows, sorted JSON object keys), so unchanged state always yields the same
-  fingerprint. Unrelated backlog/business fields are never included.
+  linkage that (with profile ownerKind + the legacy `isLegacyPlannerProfile` form)
+  determines which rows are proven planner artefacts. Ordering is canonicalised
+  (sorted IDs and rows, sorted JSON object keys), so unchanged state always yields
+  the same fingerprint. Unrelated backlog/business fields are never included.
 - **Apply contract.** `--apply` REQUIRES the reviewed fingerprint
   (`--expected-fingerprint <sha256>` from a dry-run on unchanged state). The
   fingerprint is recomputed INSIDE the apply transaction immediately before any
   write; any mismatch aborts with zero writes and an explicit drift error telling
   the operator to rerun the dry-run and review the new state. A project changed
   after review can never be destructively reset on stale evidence.
-- **Atomic batch.** The complete manifest apply runs in ONE Prisma transaction:
-  either every to-classify project is reset (via the same reset transaction body
-  the product uses) or none is. A failure on any project rolls the whole batch
-  back — no partial classification.
+- **Atomic batch, Serializable isolation.** The complete manifest apply runs in
+  ONE Prisma transaction at SERIALIZABLE isolation: either every to-classify
+  project is reset (via the same reset transaction body the product uses) or none
+  is. A failure on any project rolls the whole batch back — no partial
+  classification. A serialization conflict (concurrent reset-relevant write
+  between review and apply) aborts with a typed error and is NEVER retried
+  automatically with the stale reviewed fingerprint — the operator reruns the
+  dry-run and reviews the new fingerprint.
 - **Idempotence.** Already-`NEEDS_REPLAN` projects are skipped, but only when that
   state is part of the reviewed fingerprint; the drift check still refuses every
   other unexpected change.

--- a/docs/domain/planning-reset-replan.md
+++ b/docs/domain/planning-reset-replan.md
@@ -1,0 +1,213 @@
+# Planning Reset / Replan Project (issue #449)
+
+Parent: #342 — capacity-profile adoption / legacy-column retirement
+Related: #404 — production migration execution, #418 — legacy capacity-column migration,
+#411 — Squad Planner → manual transfer (distinct, non-destructive)
+
+## Problem
+
+Monrad Estimator can accumulate planning state that is difficult or unsafe to unwind
+incrementally: Capacity Plans, manual profile edits, planner-generated resources,
+schedule outputs, manual timeline overrides and later planning changes can leave a
+project in a state where reconstructing the user's historical intent is harder than
+planning again from the current backlog.
+
+Issue #421 proposed a 2,011-write / 130-human-decision preservation remediation.
+It is closed as not planned and must NOT be resumed. This feature replaces that path
+with an explicit, supported recovery workflow.
+
+## Product decision
+
+> Preserve estimation and business inputs; discard planning state; let the user
+> build a new plan from the current backlog using the planning inputs they choose now.
+
+Reset Planning is deliberately NOT an automatic repair system. There is no inverse
+operation for every combination of Capacity Plans, manual capacity edits, Squad
+Planner, Resource Optimiser, manual timeline overrides, profile ownership transfers
+or future planning tools. A project may intentionally be incomplete from a planning
+perspective; that state is explicit and supported rather than confused with corruption.
+
+## Explicit project planning state
+
+`Project.planningState` (enum `ProjectPlanningState`):
+
+| State | Meaning |
+|---|---|
+| `CURRENT` | Planning is expected to be canonical. Missing, duplicate, malformed or conflicting profile state remains a real integrity failure (fail closed exactly as before). |
+| `NEEDS_REPLAN` | The project deliberately discarded its planning state (Reset Planning or the reviewed maintenance classification). Planning incompleteness is expected and capacity-dependent execution is quarantined until the user replans. |
+
+`NEEDS_REPLAN` is never inferred from malformed or missing data — only the persisted
+field, set by the atomic reset operation, quarantines a project.
+
+## Reset boundary
+
+One atomic server-side operation (`lib/resetProjectPlanning.ts`) inside a single
+Prisma transaction. Any failure rolls the whole reset back.
+
+### Cleared (planning-owned state)
+
+| State | Evidence |
+|---|---|
+| `CapacityProfile` / `CapacitySegment` rows | Planning state being reset (issue #449 boundary) |
+| `CapacityPlan` / `CapacityPlanPeriod` / `CapacityPlanEntry` | Planning inputs/outputs |
+| `TimelineEntry` / `StoryTimelineEntry` (generated and manual) | Generated schedule output; Timeline/Planning owns manual overrides as planning state |
+| `Project.weeklyDemandCache` | Derived planning cache |
+| NamedResource rows with a `PLANNED_RESOURCE` profile | Proven planner-generated placeholders: Squad Planner's `findOrCreatePlannedResources` writes those rows and marks them with a `PLANNED_RESOURCE` profile; user-authored named resources always carry `NAMED_PERSON` profiles |
+| `Project.planningState` → `NEEDS_REPLAN` | Explicit quarantine |
+
+### Preserved (never touched)
+
+- Project identity, description, customer/org links, status, `hoursPerDay`,
+  onboarding/buffer weeks, `startDate`, tax settings.
+- Backlog hierarchy, task effort/duration/resource-type assignment, dependencies.
+- ResourceType identity, count, `hoursPerDay`, `dayRate`, category, global-type links.
+- User-authored NamedResource identity and `pricingModel` (billing basis).
+- `ProjectDiscount`, `ProjectOverhead`, snapshots, generated documents.
+
+The candidate legacy capacity columns on `ResourceType`/`NamedResource` are NOT
+removed or rewritten by reset (issue #418 PR 2 owns those columns). Runtime readers
+are `NEEDS_REPLAN`-aware, so stale legacy values are never projected as capacity
+while quarantined.
+
+If provenance is ambiguous, the row is preserved. Names alone ("Developer 1") are
+never treated as provenance.
+
+## Reset API
+
+```
+POST /api/projects/:projectId/planning/reset   body: { confirm: true }
+→ 200 { projectId, planningState: "NEEDS_REPLAN" }
+```
+
+- Requires project ownership (`authenticate` + `ownedProject`).
+- Requires explicit `{ confirm: true }` (explicit destructive intent).
+- Never creates replacement capacity; the user builds the new plan through the
+  existing planning surfaces (Resource Profile capacity editor, Squad Planner).
+
+## Replanning completion
+
+```
+POST /api/projects/:projectId/planning/complete
+→ 200 { projectId, planningState: "CURRENT" }      (canonical state valid)
+→ 422 { code: "REPLAN_INCOMPLETE", findings: [...] } (actionable validation findings)
+```
+
+The completion rule: the project returns to `CURRENT` only when the persisted
+planning state passes the existing canonical validation
+(`validatePersistedCapacityProfiles` + `checkPersistedCompleteness` — the same rules
+readiness and `GET /capacity-profiles` enforce). Validation runs inside the same
+transaction that flips the state, so the flag is never cleared without a canonical
+plan, and no profile is ever fabricated. `CURRENT` projects are a no-op.
+
+## Planning-dependent guards
+
+While `NEEDS_REPLAN`, capacity-dependent operations return
+`409 { code: "REPLAN_REQUIRED", error: ... }` (typed, actionable — no legacy
+fallback, no auto-repair, no invented capacity, no opaque 500):
+
+- `POST /timeline/schedule` (Update Timeline) and `POST /timeline/level`
+- `GET /timeline/export/csv`
+- Manual timeline overrides (`PUT`/`DELETE` feature and story entries, clear-all)
+- `POST /optimise` and `POST /optimise/apply`
+- `GET /timeline` returns an explicit neutral empty payload (schedule output was
+  cleared by reset; never derived from stale state)
+
+Surfaces the user needs to replan stay accessible:
+
+- `GET /resource-profile` returns effort/inputs with no planning-derived values
+  (no capacity-plan materialisation, no profile/legacy projection, no assignments,
+  no commercial totals) plus `planningState: "NEEDS_REPLAN"`.
+- `GET /capacity-profiles` serves the persisted set without the completeness check
+  (expected missing state) but still fails closed on genuinely malformed rows.
+- Profile writes (`PUT /capacity-profiles/...`), named-resource identity writes,
+  resource-type writes, squad plan build and **Squad Planner apply** stay available:
+  they construct the new canonical plan from explicit user inputs and do not consume
+  the discarded plan.
+- Backlog/project editing is unaffected.
+
+## Stale timeline behaviour
+
+Reset clears generated schedule output and manual overrides as part of the approved
+ownership boundary (Timeline/Planning owns both). After reset the timeline is
+intentionally empty — there is no stale schedule to misread as authoritative. A
+historical timeline viewer is out of scope for this issue.
+
+## UI
+
+- **Reset planning…** — Resource Profile page header, only for `CURRENT` projects.
+  Confirmation dialog explains: project/backlog/effort/dependencies kept, business
+  and commercial data kept, capacity profiles/plans/planned resources/schedule
+  removed, project must be replanned.
+- **Planning needs attention** banner (Resource Profile + Timeline pages) — copy:
+  "This project's resource planning is no longer current. Review the resource
+  inputs and replan from the existing backlog." Primary action **Replan project**:
+  runs the completion validation; on success the project returns to `CURRENT`; on
+  `REPLAN_INCOMPLETE` the actionable findings are shown inline with a link into
+  Resource Profile.
+- No planning option is automatically selected because of migration history; the
+  user picks the approach (As needed, fixed whole project, fixed selected weeks,
+  manually shaped, Squad Planner) in the existing surfaces.
+
+## Relationship to #411
+
+#411 (Switch a valid Squad Planner-managed role to manual management while
+PRESERVING its capacity) is a separate, non-destructive workflow. #449 Reset
+Planning deliberately discards the current planning model. They are kept as distinct
+user actions and are never merged into one "detach/reset" operation.
+
+## Production maintenance classification (#404)
+
+`server/src/scripts/classifyNeedsReplan.ts` (library logic in
+`lib/classifyNeedsReplan.ts`):
+
+```
+npx tsx src/scripts/classifyNeedsReplan.ts --manifest manifest.json            # DRY RUN (default)
+npx tsx src/scripts/classifyNeedsReplan.ts --manifest manifest.json --apply    # apply
+```
+
+- Manifest shape: `{ "projectIds": ["<id>", ...] }` — an explicitly reviewed input,
+  never invented selection rules on production.
+- Dry-run by default; `--apply` required to write.
+- Each classified project goes through the same atomic reset transaction as the
+  product action: planning state discarded, business data preserved, marked
+  `NEEDS_REPLAN`.
+- Fails closed: malformed manifest, unknown arguments, or a manifest project that no
+  longer exists abort with nothing changed.
+- No capacity inference, profile reconstruction, percentage, window or owner-kind
+  decisions. Output is sanitized (operator-supplied IDs and aggregate counts only).
+- Production execution under #404 remains owned by the production agent; the
+  restore-tested backup retained by #404 is untouched by this command.
+
+## Readiness semantics
+
+`lib/productionMigrationReadiness.ts` per-project completeness section skips
+projects whose persisted state is `NEEDS_REPLAN` — expected missing planning state
+is allowed ONLY because (a) the state is explicitly persisted, (b) planning-dependent
+execution is quarantined, and (c) the project can later be replanned through the
+normal workflow. The global ownership audit still fails on cross-project ownership,
+impossible FK/ownership relationships and duplicate owners where rows remain:
+`NEEDS_REPLAN` is never a generic "ignore this project" switch.
+
+## Snapshot implications
+
+V4 snapshots now capture `project.planningState` and restore it when present.
+Pre-feature snapshots (no field) leave the project's planning state untouched on
+rollback, so an old payload can never implicitly un-quarantine a `NEEDS_REPLAN`
+project or quarantine a `CURRENT` one. Snapshot creation and rollback remain
+available in both states (a pre-replan snapshot is a useful safety net).
+
+## Migration sequencing
+
+Once merged and proven on production (under #404's process):
+
+1. Classify the affected legacy projects as `NEEDS_REPLAN` via the reviewed
+   maintenance command.
+2. Run permanent readiness: `CURRENT` projects must pass; `NEEDS_REPLAN` projects
+   are explicitly quarantined.
+3. Prove the normal Reset/Replan workflow on a representative project and return it
+   to `CURRENT`.
+4. Create/restore a representative V4 snapshot and rerun readiness.
+5. Only then authorize #418 PR 2 legacy-column removal.
+
+The #421 2,011-write/130-decision preservation plan is superseded and must not be
+applied.

--- a/e2e/TESTS.md
+++ b/e2e/TESTS.md
@@ -362,6 +362,14 @@ import { login, createProject, createTestUser, createUserAndLogin, TEST_EMAIL, T
 
 ---
 
+### `planning-reset.spec.ts` — Planning reset & replan workflow (1 test — issue #449)
+
+| Test | Description |
+|------|-------------|
+| reset planning, replan via Resource Profile, and return to CURRENT | Creates a project, seeds a backlog via CSV, establishes an "As needed" capacity profile, runs Reset Planning with explicit confirmation, observes the "Planning needs attention" banner, verifies the backlog remains, replans through the Resource Profile capacity editor, completes replanning (project returns to CURRENT), and verifies Update Timeline works again |
+
+---
+
 ## Config Reference (`playwright.config.ts`)
 
 | Option | Value |

--- a/e2e/TESTS.md
+++ b/e2e/TESTS.md
@@ -366,7 +366,7 @@ import { login, createProject, createTestUser, createUserAndLogin, TEST_EMAIL, T
 
 | Test | Description |
 |------|-------------|
-| reset planning, replan via Resource Profile, and return to CURRENT | Creates a project, seeds a backlog via CSV, establishes an "As needed" capacity profile, runs Reset Planning with explicit confirmation, observes the "Planning needs attention" banner, verifies the backlog remains, replans through the Resource Profile capacity editor, completes replanning (project returns to CURRENT), and verifies Update Timeline works again |
+| reset planning, replan via Resource Profile, and return to CURRENT | Creates a project, seeds a backlog via CSV, establishes "As needed" capacity profiles, runs Reset Planning with explicit confirmation, observes the "Planning needs attention" banner, verifies the backlog remains, replans through the Resource Profile capacity editor — creating explicit profiles for EVERY preserved role, including zero-demand roles that Reset preserved (no role is deleted) — completes replanning (project returns to CURRENT), and verifies Update Timeline works again |
 
 ---
 

--- a/e2e/tests/planning-reset.spec.ts
+++ b/e2e/tests/planning-reset.spec.ts
@@ -1,0 +1,131 @@
+/**
+ * planning-reset.spec.ts — Targeted E2E flow for the Reset Planning /
+ * Replan project workflow (issue #449):
+ *
+ *   1. Open a valid project with backlog and an established capacity plan.
+ *   2. Reset planning (with confirmation).
+ *   3. Observe "Planning needs attention".
+ *   4. Verify the backlog remains.
+ *   5. Enter the supported replanning path (Resource Profile).
+ *   6. Establish new capacity inputs ("As needed" / demand-following).
+ *   7. Complete replanning → project returns to CURRENT.
+ *   8. Update Timeline works again.
+ */
+
+import { test, expect } from '@playwright/test'
+import { login, createProject, quickSchedule, API_BASE } from './helpers'
+import path from 'path'
+import fs from 'fs'
+import os from 'os'
+
+const CSV_CONTENT = [
+  'Type,Epic,Feature,Story,Task,Template,ResourceType,HoursEffort,DurationDays,Description,Assumptions,EpicStatus,FeatureStatus,StoryStatus',
+  'Epic,Platform Build,,,,,,,,,,,,',
+  'Feature,Platform Build,Core API,,,,,,,,,,,',
+  'Story,Platform Build,Core API,API Design,,,,,,,,,,',
+  'Task,Platform Build,Core API,API Design,Design endpoints,,Tech Lead,24,3,,,,,',
+].join('\n')
+
+async function seedBacklogViaCsv(page: import('@playwright/test').Page) {
+  await page.getByRole('button', { name: /backlog/i }).click()
+  await expect(page.getByRole('button', { name: /import csv/i })).toBeVisible({ timeout: 8_000 })
+
+  const tmpFile = path.join(os.tmpdir(), `planning-reset-seed-${Date.now()}.csv`)
+  fs.writeFileSync(tmpFile, CSV_CONTENT)
+  await page.getByRole('button', { name: /import csv/i }).click()
+  await page.locator('input[type="file"]').setInputFiles(tmpFile)
+  fs.unlinkSync(tmpFile)
+
+  await page.getByRole('button', { name: /review & confirm/i }).click({ timeout: 10_000 })
+  await page.getByRole('button', { name: /import backlog/i }).click({ timeout: 10_000 })
+  await expect(page.getByText('Platform Build')).toBeVisible({ timeout: 10_000 })
+}
+
+/**
+ * New projects are seeded with every global resource type. The canonical
+ * completion rule requires a ROLE profile per role, and the Resource Profile
+ * surface only renders roles that carry demand — so remove the roles that
+ * have no tasks (a supported planning action) and keep the role the backlog
+ * uses. This mirrors what a user shaping a replan does.
+ */
+async function keepOnlyBacklogRole(page: import('@playwright/test').Page, projectId: string, roleName: string) {
+  const token = await page.evaluate(() => localStorage.getItem('token'))
+  const auth = { Authorization: `Bearer ${token}` }
+  const res = await page.request.get(`${API_BASE}/api/projects/${projectId}/resource-types`, { headers: auth })
+  const resourceTypes: Array<{ id: string; name: string }> = await res.json()
+  for (const rt of resourceTypes) {
+    if (rt.name !== roleName) {
+      await page.request.delete(`${API_BASE}/api/projects/${projectId}/resource-types/${rt.id}`, { headers: auth })
+    }
+  }
+}
+
+/** Open the capacity profile editor for the first role row and save "As needed". */
+async function setRoleCapacityAsNeeded(page: import('@playwright/test').Page) {
+  const editButton = page.locator('button[title="Click to edit capacity profile"]').first()
+  await expect(editButton).toBeVisible({ timeout: 10_000 })
+  await editButton.click()
+  await expect(page.getByTestId('capacity-profile-editor')).toBeVisible({ timeout: 8_000 })
+  await page.locator('#cp-planning-basis').selectOption('demandFollowing')
+  await page.getByTestId('cp-save-btn').click()
+  await expect(page.getByTestId('capacity-profile-editor')).not.toBeVisible({ timeout: 10_000 })
+}
+
+test.describe('Planning reset and replan workflow', () => {
+  test('reset planning, replan via Resource Profile, and return to CURRENT', async ({ page }) => {
+    const projectName = `E2E Planning Reset ${Date.now()}`
+    await login(page)
+    await createProject(page, projectName)
+
+    // Open the project and seed the backlog.
+    await page.getByRole('heading', { name: projectName, exact: true }).first().click()
+    await page.getByRole('button', { name: /backlog/i }).waitFor({ timeout: 8_000 })
+    await seedBacklogViaCsv(page)
+    const projectId = page.url().match(/\/projects\/([^/]+)/)?.[1]!
+    expect(projectId).toBeTruthy()
+
+    // Shape the plan: keep only the role the backlog uses (see helper).
+    await keepOnlyBacklogRole(page, projectId, 'Tech Lead')
+
+    // ── Establish an initial plan so there is planning state to discard ──
+    await page.goto(`/projects/${projectId}/resource-profile`)
+    await expect(page.getByRole('heading', { name: /resource profile/i })).toBeVisible({ timeout: 10_000 })
+    await setRoleCapacityAsNeeded(page)
+
+    // ── Reset planning with explicit confirmation ─────────────────────────
+    await page.getByRole('button', { name: /reset planning…/i }).click()
+    await expect(page.getByRole('dialog')).toBeVisible()
+    await expect(page.getByText(/capacity profiles, capacity plans, planned resources and schedule output are removed/i)).toBeVisible()
+    await expect(page.getByText(/The project, backlog, effort estimates and dependencies are kept/i)).toBeVisible()
+
+    await page.getByRole('button', { name: 'Reset planning', exact: true }).click()
+    await expect(page.getByTestId('reset-feedback')).toBeVisible({ timeout: 10_000 })
+
+    // ── Observe the NEEDS_REPLAN state ────────────────────────────────────
+    await expect(page.getByTestId('planning-needs-attention')).toBeVisible()
+    await expect(page.getByRole('heading', { name: /planning needs attention/i })).toBeVisible()
+
+    // ── The backlog remains fully accessible ──────────────────────────────
+    await page.goto(`/projects/${projectId}/backlog`)
+    await expect(page.getByText('Platform Build')).toBeVisible({ timeout: 10_000 })
+
+    // ── Replan through the supported Resource Profile surface ─────────────
+    await page.goto(`/projects/${projectId}/resource-profile`)
+    await expect(page.getByTestId('planning-needs-attention')).toBeVisible({ timeout: 10_000 })
+    // Choose "As needed" / demand-following for the role — the new plan.
+    await setRoleCapacityAsNeeded(page)
+
+    // ── Complete replanning → project returns to CURRENT ──────────────────
+    await page.getByTestId('replan-project-button').click()
+    await expect(page.getByTestId('planning-needs-attention')).not.toBeVisible({ timeout: 10_000 })
+
+    // ── Timeline scheduling works again ───────────────────────────────────
+    await page.goto(`/projects/${projectId}/timeline`)
+    await expect(page.getByRole('heading', { name: /timeline planner/i })).toBeVisible({ timeout: 10_000 })
+    await expect(page.getByTestId('planning-needs-attention')).not.toBeVisible()
+    await quickSchedule(page)
+    await expect(page.getByTestId('schedule-error')).not.toBeVisible({ timeout: 10_000 })
+    // The schedule rendered feature entries (gantt/list present).
+    await expect(page.getByText('Core API').first()).toBeVisible({ timeout: 10_000 })
+  })
+})

--- a/e2e/tests/planning-reset.spec.ts
+++ b/e2e/tests/planning-reset.spec.ts
@@ -2,18 +2,21 @@
  * planning-reset.spec.ts — Targeted E2E flow for the Reset Planning /
  * Replan project workflow (issue #449):
  *
- *   1. Open a valid project with backlog and an established capacity plan.
+ *   1. Open a valid project with backlog and an established capacity plan
+ *      (the project carries both a demand-bearing role and preserved
+ *      zero-demand roles — no role is deleted anywhere in this flow).
  *   2. Reset planning (with confirmation).
  *   3. Observe "Planning needs attention".
  *   4. Verify the backlog remains.
  *   5. Enter the supported replanning path (Resource Profile).
- *   6. Establish new capacity inputs ("As needed" / demand-following).
+ *   6. Establish new capacity inputs ("As needed" / demand-following) for
+ *      EVERY preserved role, including the zero-demand ones.
  *   7. Complete replanning → project returns to CURRENT.
  *   8. Update Timeline works again.
  */
 
-import { test, expect } from '@playwright/test'
-import { login, createProject, quickSchedule, API_BASE } from './helpers'
+import { test, expect, type Page } from '@playwright/test'
+import { login, createProject, quickSchedule } from './helpers'
 import path from 'path'
 import fs from 'fs'
 import os from 'os'
@@ -26,7 +29,7 @@ const CSV_CONTENT = [
   'Task,Platform Build,Core API,API Design,Design endpoints,,Tech Lead,24,3,,,,,',
 ].join('\n')
 
-async function seedBacklogViaCsv(page: import('@playwright/test').Page) {
+async function seedBacklogViaCsv(page: Page) {
   await page.getByRole('button', { name: /backlog/i }).click()
   await expect(page.getByRole('button', { name: /import csv/i })).toBeVisible({ timeout: 8_000 })
 
@@ -42,33 +45,25 @@ async function seedBacklogViaCsv(page: import('@playwright/test').Page) {
 }
 
 /**
- * New projects are seeded with every global resource type. The canonical
- * completion rule requires a ROLE profile per role, and the Resource Profile
- * surface only renders roles that carry demand — so remove the roles that
- * have no tasks (a supported planning action) and keep the role the backlog
- * uses. This mirrors what a user shaping a replan does.
+ * Open the capacity profile editor for EVERY role row and save "As needed".
+ * While NEEDS_REPLAN the Resource Profile exposes every preserved role —
+ * including zero-demand roles — so this creates the user's chosen profile
+ * for each of them. Rows are iterated by index (the row list keeps its
+ * order across the refetch after each save; `.first()` would re-target the
+ * same row forever because every editable row shares the same button title).
  */
-async function keepOnlyBacklogRole(page: import('@playwright/test').Page, projectId: string, roleName: string) {
-  const token = await page.evaluate(() => localStorage.getItem('token'))
-  const auth = { Authorization: `Bearer ${token}` }
-  const res = await page.request.get(`${API_BASE}/api/projects/${projectId}/resource-types`, { headers: auth })
-  const resourceTypes: Array<{ id: string; name: string }> = await res.json()
-  for (const rt of resourceTypes) {
-    if (rt.name !== roleName) {
-      await page.request.delete(`${API_BASE}/api/projects/${projectId}/resource-types/${rt.id}`, { headers: auth })
-    }
+async function setAllRoleCapacitiesAsNeeded(page: Page) {
+  const rows = page.locator('tr[data-testid^="resource-profile-row-"]')
+  const rowCount = await rows.count()
+  for (let i = 0; i < rowCount; i++) {
+    const editButton = rows.nth(i).locator('button[title="Click to edit capacity profile"]')
+    await editButton.waitFor({ state: 'visible', timeout: 10_000 })
+    await editButton.click()
+    await expect(page.getByTestId('capacity-profile-editor')).toBeVisible({ timeout: 8_000 })
+    await page.locator('#cp-planning-basis').selectOption('demandFollowing')
+    await page.getByTestId('cp-save-btn').click()
+    await expect(page.getByTestId('capacity-profile-editor')).not.toBeVisible({ timeout: 10_000 })
   }
-}
-
-/** Open the capacity profile editor for the first role row and save "As needed". */
-async function setRoleCapacityAsNeeded(page: import('@playwright/test').Page) {
-  const editButton = page.locator('button[title="Click to edit capacity profile"]').first()
-  await expect(editButton).toBeVisible({ timeout: 10_000 })
-  await editButton.click()
-  await expect(page.getByTestId('capacity-profile-editor')).toBeVisible({ timeout: 8_000 })
-  await page.locator('#cp-planning-basis').selectOption('demandFollowing')
-  await page.getByTestId('cp-save-btn').click()
-  await expect(page.getByTestId('capacity-profile-editor')).not.toBeVisible({ timeout: 10_000 })
 }
 
 test.describe('Planning reset and replan workflow', () => {
@@ -84,13 +79,12 @@ test.describe('Planning reset and replan workflow', () => {
     const projectId = page.url().match(/\/projects\/([^/]+)/)?.[1]!
     expect(projectId).toBeTruthy()
 
-    // Shape the plan: keep only the role the backlog uses (see helper).
-    await keepOnlyBacklogRole(page, projectId, 'Tech Lead')
-
-    // ── Establish an initial plan so there is planning state to discard ──
+    // ── Establish canonical pre-reset planning ────────────────────────────
+    // (CURRENT Resource Profile shows demand-bearing roles only; the seeded
+    // project's roles carry pre-existing auto-created profiles.)
     await page.goto(`/projects/${projectId}/resource-profile`)
     await expect(page.getByRole('heading', { name: /resource profile/i })).toBeVisible({ timeout: 10_000 })
-    await setRoleCapacityAsNeeded(page)
+    await setAllRoleCapacitiesAsNeeded(page)
 
     // ── Reset planning with explicit confirmation ─────────────────────────
     await page.getByRole('button', { name: /reset planning…/i }).click()
@@ -112,8 +106,10 @@ test.describe('Planning reset and replan workflow', () => {
     // ── Replan through the supported Resource Profile surface ─────────────
     await page.goto(`/projects/${projectId}/resource-profile`)
     await expect(page.getByTestId('planning-needs-attention')).toBeVisible({ timeout: 10_000 })
-    // Choose "As needed" / demand-following for the role — the new plan.
-    await setRoleCapacityAsNeeded(page)
+    // Choose "As needed" / demand-following for EVERY preserved role — the
+    // zero-demand roles that Reset Planning preserved stay visible and
+    // editable here; no role is deleted (issue #449).
+    await setAllRoleCapacitiesAsNeeded(page)
 
     // ── Complete replanning → project returns to CURRENT ──────────────────
     await page.getByTestId('replan-project-button').click()

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "capacity-profiles:remediate-readiness": "npm run capacity-profiles:remediate-readiness --workspace=server --",
     "capacity-profiles:snapshot-evidence": "npm run capacity-profiles:snapshot-evidence --workspace=server --",
     "capacity-profiles:purge-pre-v4-snapshots": "npm run capacity-profiles:purge-pre-v4-snapshots --workspace=server --",
+    "capacity-profiles:classify-needs-replan": "npm run capacity-profiles:classify-needs-replan --workspace=server --",
     "capacity-profiles:backfill": "npm run capacity-profiles:backfill --workspace=server",
     "capacity-profiles:reconcile": "npm run capacity-profiles:reconcile --workspace=server"
   },

--- a/scripts/run-integration-local.mjs
+++ b/scripts/run-integration-local.mjs
@@ -22,6 +22,7 @@ try {
       'test:remediation-integration',
       'test:snapshot-evidence-integration',
       'test:purge-pre-v4-integration',
+      'test:planning-reset-integration',
     ]) {
       if (guard.triggered) break
       await runCommand('npm', ['run', script, '--workspace=server'], { cwd: root, env: environment, signal: guard.abortSignal })

--- a/server/package.json
+++ b/server/package.json
@@ -29,6 +29,7 @@
     "capacity-profiles:remediate-readiness": "tsx src/scripts/remediateProductionReadiness.ts",
     "capacity-profiles:snapshot-evidence": "tsx src/scripts/generateSnapshotEvidence.ts",
     "capacity-profiles:purge-pre-v4-snapshots": "tsx src/scripts/purgePreV4Snapshots.ts",
+    "capacity-profiles:classify-needs-replan": "tsx src/scripts/classifyNeedsReplan.ts",
     "test:ownership-invariants-integration": "vitest run --config vitest.integration.config.ts src/test/capacityProfileOwnershipInvariants.integration.test.ts",
     "test:runtime-cutover-integration": "vitest run --config vitest.integration.config.ts src/test/runtimeCutoverProfileFirst.integration.test.ts",
     "test:transfer-integration": "vitest run --config vitest.integration.config.ts src/test/capacityProfileTransfer.integration.test.ts",
@@ -36,7 +37,8 @@
     "test:legacy-alias-removal-integration": "vitest run --config vitest.integration.config.ts src/test/legacyCapacityAliasRemoval.integration.test.ts",
     "test:remediation-integration": "vitest run --config vitest.integration.config.ts src/test/productionRemediation.integration.test.ts",
     "test:snapshot-evidence-integration": "vitest run --config vitest.integration.config.ts src/test/snapshotEvidence.integration.test.ts",
-    "test:purge-pre-v4-integration": "vitest run --config vitest.integration.config.ts src/test/purgePreV4Snapshots.integration.test.ts"
+    "test:purge-pre-v4-integration": "vitest run --config vitest.integration.config.ts src/test/purgePreV4Snapshots.integration.test.ts",
+    "test:planning-reset-integration": "vitest run --config vitest.integration.config.ts src/test/planningReset.integration.test.ts"
   },
   "prisma": {
     "seed": "tsx prisma/seed.ts"

--- a/server/prisma/migrations/20260808221539_add_project_planning_state/migration.sql
+++ b/server/prisma/migrations/20260808221539_add_project_planning_state/migration.sql
@@ -1,0 +1,5 @@
+-- CreateEnum
+CREATE TYPE "ProjectPlanningState" AS ENUM ('CURRENT', 'NEEDS_REPLAN');
+
+-- AlterTable
+ALTER TABLE "Project" ADD COLUMN     "planningState" "ProjectPlanningState" NOT NULL DEFAULT 'CURRENT';

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -57,6 +57,14 @@ model Project {
   customerId String?
   customer   Customer?     @relation(fields: [customerId], references: [id])
   status      ProjectStatus @default(DRAFT)
+  /// Explicit project-level planning state (issue #449).
+  ///
+  /// CURRENT: planning is expected to be canonical — missing, malformed or
+  /// conflicting profile state remains an integrity failure.
+  /// NEEDS_REPLAN: the project deliberately discarded its planning state via
+  /// Reset Planning; planning incompleteness is expected and capacity-dependent
+  /// operations are quarantined until the user replans and completes replanning.
+  planningState ProjectPlanningState @default(CURRENT)
   hoursPerDay Float         @default(7.6)
   bufferWeeks     Int           @default(0)
   onboardingWeeks Int           @default(0)
@@ -87,6 +95,19 @@ enum ProjectStatus {
   REVIEW
   COMPLETE
   ARCHIVED
+}
+
+/// Explicit project-level planning state (issue #449).
+///
+/// CURRENT — planning is expected to be canonical; unexpected incomplete or
+/// malformed profile state fails closed as an integrity defect.
+/// NEEDS_REPLAN — the project deliberately retired its planning state through
+/// Reset Planning; planning incompleteness is expected and capacity-dependent
+/// operations return REPLAN_REQUIRED until the user replans through the normal
+/// supported planning surfaces and completes replanning.
+enum ProjectPlanningState {
+  CURRENT
+  NEEDS_REPLAN
 }
 
 model ResourceType {

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -35,6 +35,7 @@ import documentRoutes from './routes/documents.js'
 import optimiserRoutes from './routes/optimiser.js'
 import squadPlanRoutes from './routes/squadPlan.js'
 import capacityProfileRoutes from './routes/capacityProfiles.js'
+import planningRoutes from './routes/planning.js'
 
 const app = express()
 
@@ -73,6 +74,7 @@ app.use('/api/projects/:projectId/documents', documentRoutes)
 app.use('/api/projects/:projectId/optimise', optimiserRoutes)
 app.use('/api/projects/:projectId/squad-plan', squadPlanRoutes)
 app.use('/api/projects/:projectId/capacity-profiles', capacityProfileRoutes)
+app.use('/api/projects/:projectId/planning', planningRoutes)
 app.use('/api/projects/:projectId/squad-plans', squadPlanRoutes)
 app.use('/api/orgs', authenticate, orgRoutes)
 app.use('/api/customers', authenticate, customerRoutes)

--- a/server/src/lib/capacityProfileReplaceService.ts
+++ b/server/src/lib/capacityProfileReplaceService.ts
@@ -15,7 +15,8 @@
 import { projectCapacityProfileToLegacyAllocation } from './capacityProfileLegacyProjection.js'
 import { mapPersistedProfilesToDTOs } from './capacityProfileMapping.js'
 import type { CapacityProfileDTO } from './capacityProfileMapping.js'
-import { loadAndValidateOwnerProfile } from './ownerProfileLoader.js'
+import { loadAndValidateOwnerProfile, type ValidatedOwnerProfile } from './ownerProfileLoader.js'
+import { CapacityIntegrityError } from './capacityIntegrityError.js'
 import { classifyNRsForRoleUpdate } from './classifyNRsForRoleUpdate.js'
 import { isRoleDefaultClone } from './roleProfileClonePolicy.js'
 import type { PrismaClient } from '@prisma/client'
@@ -168,65 +169,79 @@ export async function replaceCapacityProfile(
   }> = []
   if (ownerKind === 'ROLE') {
     // Load and validate the authoritative pre-mutation role profile (fails
-    // closed on missing, duplicate, malformed or cross-project state).
-    const oldRoleProfile = await loadAndValidateOwnerProfile({
-      tx,
-      projectId,
-      ownerKind: 'ROLE',
-      ownerId,
-    })
-
-    // Load all named resources for this ResourceType
-    const nrs = await tx.namedResource.findMany({
-      where: { resourceTypeId: ownerId },
-      orderBy: { createdAt: 'asc' },
-    })
-
-    // Load NR capacity profiles with segments and validate exactly one per NR
-    const nrProfileRows = nrs.length > 0
-      ? await tx.capacityProfile.findMany({
-          where: { namedResourceId: { in: nrs.map((n: { id: string }) => n.id) }, projectId },
-          include: { segments: true },
-        })
-      : []
-
-    const profilesByNRId = new Map<string, any[]>()
-    for (const profile of nrProfileRows) {
-      if (!profile.namedResourceId) continue
-      const arr = profilesByNRId.get(profile.namedResourceId) ?? []
-      arr.push(profile)
-      profilesByNRId.set(profile.namedResourceId, arr)
-    }
-    for (const nr of nrs) {
-      const profiles = profilesByNRId.get(nr.id) ?? []
-      if (profiles.length === 0) {
-        throw new ServiceError(409, `Missing capacity profile for named resource ${nr.id}`)
-      }
-      if (profiles.length > 1) {
-        throw new ServiceError(409, `Multiple capacity profiles exist for named resource ${nr.id}`)
+    // closed on duplicate, malformed or cross-project state). A genuinely
+    // missing role profile is the CREATE path (the documented
+    // "replace (create or update)" contract): after Reset Planning (issue
+    // #449) every profile is gone and the user builds the new plan through
+    // this surface. With no prior role profile there is nothing for named
+    // resources to inherit, so the inherited-NR classification is skipped.
+    let oldRoleProfile: ValidatedOwnerProfile | null = null
+    try {
+      oldRoleProfile = await loadAndValidateOwnerProfile({
+        tx,
+        projectId,
+        ownerKind: 'ROLE',
+        ownerId,
+      })
+    } catch (error) {
+      if (!(error instanceof CapacityIntegrityError) || existingProfiles.length > 0) {
+        throw error
       }
     }
 
-    // Classify: which NRs inherit the role default vs. are explicitly custom
-    const classification = classifyNRsForRoleUpdate(
-      nrs as any,
-      nrProfileRows as any,
-      {
-        planningBasis: oldRoleProfile.planningBasis,
-        defaultPercent: oldRoleProfile.defaultPercent,
-        startWeek: oldRoleProfile.startWeek,
-        endWeek: oldRoleProfile.endWeek,
-        segments: oldRoleProfile.segments.map(s => ({
-          startWeek: s.startWeek,
-          endWeek: s.endWeek,
-          capacityPercent: s.capacityPercent,
-        })),
-      },
-    )
+    if (oldRoleProfile) {
+      // Load all named resources for this ResourceType
+      const nrs = await tx.namedResource.findMany({
+        where: { resourceTypeId: ownerId },
+        orderBy: { createdAt: 'asc' },
+      })
 
-    inheritedNRProfiles = classification.inheritedNRIds
-      .map(id => profilesByNRId.get(id)?.[0])
-      .filter((profile): profile is NonNullable<typeof profile> => profile != null)
+      // Load NR capacity profiles with segments and validate exactly one per NR
+      const nrProfileRows = nrs.length > 0
+        ? await tx.capacityProfile.findMany({
+            where: { namedResourceId: { in: nrs.map((n: { id: string }) => n.id) }, projectId },
+            include: { segments: true },
+          })
+        : []
+
+      const profilesByNRId = new Map<string, any[]>()
+      for (const profile of nrProfileRows) {
+        if (!profile.namedResourceId) continue
+        const arr = profilesByNRId.get(profile.namedResourceId) ?? []
+        arr.push(profile)
+        profilesByNRId.set(profile.namedResourceId, arr)
+      }
+      for (const nr of nrs) {
+        const profiles = profilesByNRId.get(nr.id) ?? []
+        if (profiles.length === 0) {
+          throw new ServiceError(409, `Missing capacity profile for named resource ${nr.id}`)
+        }
+        if (profiles.length > 1) {
+          throw new ServiceError(409, `Multiple capacity profiles exist for named resource ${nr.id}`)
+        }
+      }
+
+      // Classify: which NRs inherit the role default vs. are explicitly custom
+      const classification = classifyNRsForRoleUpdate(
+        nrs as any,
+        nrProfileRows as any,
+        {
+          planningBasis: oldRoleProfile.planningBasis,
+          defaultPercent: oldRoleProfile.defaultPercent,
+          startWeek: oldRoleProfile.startWeek,
+          endWeek: oldRoleProfile.endWeek,
+          segments: oldRoleProfile.segments.map(s => ({
+            startWeek: s.startWeek,
+            endWeek: s.endWeek,
+            capacityPercent: s.capacityPercent,
+          })),
+        },
+      )
+
+      inheritedNRProfiles = classification.inheritedNRIds
+        .map(id => profilesByNRId.get(id)?.[0])
+        .filter((profile): profile is NonNullable<typeof profile> => profile != null)
+    }
   }
 
   // ── 4. Prepare segment data with deterministic ordering ────────────────

--- a/server/src/lib/classifyNeedsReplan.ts
+++ b/server/src/lib/classifyNeedsReplan.ts
@@ -29,7 +29,7 @@
  */
 
 import { createHash } from 'node:crypto'
-import type { Prisma, PrismaClient } from '@prisma/client'
+import { Prisma, type PrismaClient } from '@prisma/client'
 
 import { resetProjectPlanningWithinTransaction } from './resetProjectPlanning.js'
 
@@ -63,6 +63,41 @@ export class ClassifyDriftError extends ClassifyAbortError {
     )
     this.name = 'ClassifyDriftError'
   }
+}
+
+/**
+ * Raised when the Serializable classification transaction is aborted by a
+ * concurrent write to reset-relevant state (PostgreSQL serialization
+ * conflict). The transaction rolled back with zero committed writes and the
+ * apply attempt is invalidated — it is NEVER retried automatically, because
+ * automatic retry could reuse the stale reviewed fingerprint after the
+ * database changed.
+ */
+export class ClassifySerializationConflictError extends ClassifyAbortError {
+  constructor() {
+    super(
+      'Classification aborted because project planning state changed concurrently. ' +
+      'Rerun the dry-run and review the new fingerprint before retrying. Nothing was changed.',
+    )
+    this.name = 'ClassifySerializationConflictError'
+  }
+}
+
+/**
+ * Detect a PostgreSQL serialization failure surfaced by Prisma/adapter-pg:
+ * Prisma P2034 ("transaction failed due to a write conflict or deadlock") or
+ * the driver error cause with originalCode 40001 (serialization_failure).
+ * Mirrors the detection used by the Squad Planner apply path.
+ */
+export function isSerializationConflict(err: unknown): boolean {
+  if (err instanceof Prisma.PrismaClientKnownRequestError && err.code === 'P2034') {
+    return true
+  }
+  if (typeof err !== 'object' || err === null) return false
+  const cause = (err as { cause?: unknown }).cause
+  return typeof cause === 'object'
+    && cause !== null
+    && (cause as { originalCode?: unknown }).originalCode === '40001'
 }
 
 export interface ClassifyManifest {
@@ -328,31 +363,56 @@ export async function classifyNeedsReplan(
     }
     const expectedFingerprint: string = options.expectedFingerprint
 
-    // One atomic transaction for the complete reviewed set.
-    return db.$transaction(async tx => {
-      const stateFingerprint = await computeClassificationFingerprint(tx, manifest)
-      if (stateFingerprint !== expectedFingerprint) {
-        throw new ClassifyDriftError(expectedFingerprint, stateFingerprint)
-      }
-
-      const plan = await planClassification(tx, manifest)
-      if (!plan.completed) {
-        throw new ClassifyAbortError(
-          `Classification aborted: ${plan.notFoundCount} manifest project(s) no longer exist. ` +
-          'Re-review the manifest before retrying; nothing was changed.',
-        )
-      }
-
-      for (const entry of plan.entries) {
-        if (entry.status !== 'to-classify') continue
-        await resetProjectPlanningWithinTransaction(tx, entry.projectId)
-        if (options.afterProjectReset) {
-          await options.afterProjectReset(tx, entry.projectId)
+    // One atomic, SERIALIZABLE transaction for the complete reviewed set.
+    //
+    // Serializable isolation closes the review→write race: the fingerprint is
+    // computed inside this transaction, so any concurrent commit that changes
+    // reset-relevant state between the fingerprint reads and the destructive
+    // writes forces a serialization conflict at the transaction boundary and
+    // rolls the WHOLE batch back. A project changed after review can never be
+    // destructively reset on stale review evidence.
+    //
+    // The destructive classification transaction is invoked on the root
+    // client (the apply path is only ever entered with one); the dry-run and
+    // fingerprint helpers accept transaction clients too, but only the root
+    // client supports an explicit isolation level.
+    const batchClient = db as PrismaClient
+    try {
+      return await batchClient.$transaction(async tx => {
+        const stateFingerprint = await computeClassificationFingerprint(tx, manifest)
+        if (stateFingerprint !== expectedFingerprint) {
+          throw new ClassifyDriftError(expectedFingerprint, stateFingerprint)
         }
-      }
 
-      return { ...plan, stateFingerprint }
-    })
+        const plan = await planClassification(tx, manifest)
+        if (!plan.completed) {
+          throw new ClassifyAbortError(
+            `Classification aborted: ${plan.notFoundCount} manifest project(s) no longer exist. ` +
+            'Re-review the manifest before retrying; nothing was changed.',
+          )
+        }
+
+        for (const entry of plan.entries) {
+          if (entry.status !== 'to-classify') continue
+          await resetProjectPlanningWithinTransaction(tx, entry.projectId)
+          if (options.afterProjectReset) {
+            await options.afterProjectReset(tx, entry.projectId)
+          }
+        }
+
+        return { ...plan, stateFingerprint }
+      }, {
+        isolationLevel: Prisma.TransactionIsolationLevel.Serializable,
+      })
+    } catch (error) {
+      // Serialization conflict: the reviewed transaction raced a concurrent
+      // write and was rolled back with zero committed writes. Invalidate the
+      // apply attempt — never retry automatically with the stale fingerprint.
+      if (isSerializationConflict(error)) {
+        throw new ClassifySerializationConflictError()
+      }
+      throw error
+    }
   }
 
   // Dry run (default): read-only plan plus the reviewed-state fingerprint.

--- a/server/src/lib/classifyNeedsReplan.ts
+++ b/server/src/lib/classifyNeedsReplan.ts
@@ -1,0 +1,186 @@
+/**
+ * classifyNeedsReplan.ts — Reviewed production maintenance path for issue #449.
+ *
+ * Classifies an explicitly supplied, reviewed set of projects as NEEDS_REPLAN
+ * using the same atomic reset transaction as the normal product action.
+ *
+ * Design constraints (issue #449):
+ *   - dry-run by default; an explicit --apply flag is required to write;
+ *   - accepts exact project identifiers from a reviewed input manifest —
+ *     never invents selection rules on production;
+ *   - reports intended projects/operations before applying;
+ *   - fails closed when the target state changed unexpectedly (a manifest
+ *     project no longer exists, or the manifest is malformed);
+ *   - performs NO capacity inference, profile reconstruction, percentage,
+ *     window or owner-kind decisions;
+ *   - supports sanitized evidence output (operator-supplied IDs only, no
+ *     project names, payloads or connection details).
+ *
+ * This is deliberately NOT a generic remediation framework: it is one focused
+ * command for the reviewed #404 migration classification step.
+ */
+
+import type { PrismaClient } from '@prisma/client'
+
+import { resetProjectPlanning } from './resetProjectPlanning.js'
+
+export class ClassifyManifestError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'ClassifyManifestError'
+  }
+}
+
+export class ClassifyAbortError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'ClassifyAbortError'
+  }
+}
+
+export interface ClassifyManifest {
+  projectIds: string[]
+}
+
+/**
+ * Parse and validate a reviewed classification manifest.
+ *
+ * Accepts `{ "projectIds": ["<id>", ...] }` with non-empty, unique string
+ * identifiers. Anything else fails closed with an actionable error.
+ */
+export function parseClassifyManifest(raw: unknown): ClassifyManifest {
+  if (typeof raw !== 'object' || raw === null || Array.isArray(raw)) {
+    throw new ClassifyManifestError('manifest must be a JSON object with a "projectIds" array')
+  }
+  const obj = raw as Record<string, unknown>
+  if (!Array.isArray(obj.projectIds)) {
+    throw new ClassifyManifestError('manifest must include a "projectIds" array')
+  }
+  const seen = new Set<string>()
+  const projectIds: string[] = []
+  for (const id of obj.projectIds) {
+    if (typeof id !== 'string' || id.trim() === '') {
+      throw new ClassifyManifestError('every manifest projectId must be a non-empty string')
+    }
+    if (seen.has(id)) {
+      throw new ClassifyManifestError(`manifest contains a duplicate projectId: ${id}`)
+    }
+    seen.add(id)
+    projectIds.push(id)
+  }
+  if (projectIds.length === 0) {
+    throw new ClassifyManifestError('manifest "projectIds" must not be empty')
+  }
+  return { projectIds }
+}
+
+export type ClassificationStatus = 'to-classify' | 'already-needs-replan' | 'not-found'
+
+export interface ClassificationEntry {
+  projectId: string
+  status: ClassificationStatus
+}
+
+export interface ClassificationReport {
+  /** True when every manifest project is classified (or already classified). */
+  completed: boolean
+  entries: ClassificationEntry[]
+  classifiedCount: number
+  alreadyCount: number
+  notFoundCount: number
+}
+
+/**
+ * Read-only classification plan. Never writes.
+ *
+ * Each manifest project is classified as:
+ *   - `to-classify`         — exists and is CURRENT (or any non-NEEDS_REPLAN value);
+ *   - `already-needs-replan`— already explicitly quarantined (idempotent skip);
+ *   - `not-found`           — missing; the apply run must abort (fail closed).
+ */
+export async function planClassification(
+  prisma: PrismaClient,
+  manifest: ClassifyManifest,
+): Promise<ClassificationReport> {
+  const projects = await prisma.project.findMany({
+    where: { id: { in: manifest.projectIds } },
+    select: { id: true, planningState: true },
+  })
+  const byId = new Map(projects.map(p => [p.id, p]))
+
+  const entries: ClassificationEntry[] = manifest.projectIds.map(projectId => {
+    const project = byId.get(projectId)
+    if (!project) return { projectId, status: 'not-found' }
+    return {
+      projectId,
+      status: project.planningState === 'NEEDS_REPLAN' ? 'already-needs-replan' : 'to-classify',
+    }
+  })
+
+  return summarizeClassification(entries)
+}
+
+function summarizeClassification(entries: ClassificationEntry[]): ClassificationReport {
+  return {
+    completed: entries.every(e => e.status !== 'not-found'),
+    entries,
+    classifiedCount: entries.filter(e => e.status === 'to-classify').length,
+    alreadyCount: entries.filter(e => e.status === 'already-needs-replan').length,
+    notFoundCount: entries.filter(e => e.status === 'not-found').length,
+  }
+}
+
+/**
+ * Classify the reviewed project set as NEEDS_REPLAN.
+ *
+ * In dry-run mode (`apply: false`, the default) this only plans and reports.
+ * In apply mode every `to-classify` project goes through the same atomic
+ * reset service transaction the product uses — planning state is discarded,
+ * business data preserved, and the project marked NEEDS_REPLAN. No capacity
+ * is inferred or reconstructed anywhere in this command.
+ *
+ * Fails closed (throws {@link ClassifyAbortError}) when any manifest project
+ * is missing, so an unexpected state change between review and apply never
+ * classifies silently.
+ */
+export async function classifyNeedsReplan(
+  prisma: PrismaClient,
+  manifest: ClassifyManifest,
+  options: { apply?: boolean } = {},
+): Promise<ClassificationReport> {
+  const plan = await planClassification(prisma, manifest)
+  if (!plan.completed) {
+    throw new ClassifyAbortError(
+      `Classification aborted: ${plan.notFoundCount} manifest project(s) no longer exist. ` +
+      'Re-review the manifest before retrying; nothing was changed.',
+    )
+  }
+  if (!options.apply) {
+    return plan
+  }
+
+  for (const entry of plan.entries) {
+    if (entry.status !== 'to-classify') continue
+    await resetProjectPlanning(prisma, entry.projectId)
+  }
+  return plan
+}
+
+/** Render the report as aggregate sanitized evidence (IDs are operator-supplied). */
+export function formatClassificationReport(report: ClassificationReport, apply: boolean): string {
+  const lines: string[] = []
+  lines.push(apply
+    ? 'Mode: APPLY — each listed project was classified NEEDS_REPLAN via the atomic reset transaction.'
+    : 'Mode: DRY RUN (default) — zero writes.')
+  lines.push(`Manifest projects: ${report.entries.length}`)
+  lines.push(`Will classify / classified: ${report.classifiedCount}`)
+  lines.push(`Already NEEDS_REPLAN (skipped): ${report.alreadyCount}`)
+  lines.push(`Not found (fail closed): ${report.notFoundCount}`)
+  if (report.classifiedCount > 0) {
+    lines.push('Project IDs:')
+    for (const entry of report.entries) {
+      if (entry.status === 'to-classify') lines.push(`  - ${entry.projectId}`)
+    }
+  }
+  return lines.join('\n')
+}

--- a/server/src/lib/classifyNeedsReplan.ts
+++ b/server/src/lib/classifyNeedsReplan.ts
@@ -2,27 +2,39 @@
  * classifyNeedsReplan.ts — Reviewed production maintenance path for issue #449.
  *
  * Classifies an explicitly supplied, reviewed set of projects as NEEDS_REPLAN
- * using the same atomic reset transaction as the normal product action.
+ * using the same atomic reset transaction body as the normal product action.
  *
- * Design constraints (issue #449):
+ * Design constraints (issue #449 + review remediation):
  *   - dry-run by default; an explicit --apply flag is required to write;
  *   - accepts exact project identifiers from a reviewed input manifest —
  *     never invents selection rules on production;
+ *   - dry-run emits a deterministic SHA-256 fingerprint over the
+ *     reset-relevant state of the exact manifest set (`stateFingerprint`);
+ *   - apply requires the reviewed fingerprint (`expectedFingerprint`) and
+ *     verifies it INSIDE the batch transaction immediately before any write;
+ *     any drift aborts with zero writes — a changed project can never be
+ *     destructively reset on stale review evidence;
+ *   - the complete manifest apply is ONE Prisma transaction: either every
+ *     to-classify project is reset or none is (no partial batch);
  *   - reports intended projects/operations before applying;
  *   - fails closed when the target state changed unexpectedly (a manifest
  *     project no longer exists, or the manifest is malformed);
  *   - performs NO capacity inference, profile reconstruction, percentage,
  *     window or owner-kind decisions;
- *   - supports sanitized evidence output (operator-supplied IDs only, no
- *     project names, payloads or connection details).
+ *   - supports sanitized evidence output (operator-supplied IDs and hashes
+ *     only, no project names, payloads or connection details).
  *
  * This is deliberately NOT a generic remediation framework: it is one focused
  * command for the reviewed #404 migration classification step.
  */
 
-import type { PrismaClient } from '@prisma/client'
+import { createHash } from 'node:crypto'
+import type { Prisma, PrismaClient } from '@prisma/client'
 
-import { resetProjectPlanning } from './resetProjectPlanning.js'
+import { resetProjectPlanningWithinTransaction } from './resetProjectPlanning.js'
+
+/** Prisma client or an already-open transaction client (both work here). */
+export type ClassifyDb = PrismaClient | Prisma.TransactionClient
 
 export class ClassifyManifestError extends Error {
   constructor(message: string) {
@@ -35,6 +47,21 @@ export class ClassifyAbortError extends Error {
   constructor(message: string) {
     super(message)
     this.name = 'ClassifyAbortError'
+  }
+}
+
+/**
+ * Raised when the recomputed reset-state fingerprint differs from the
+ * reviewed fingerprint supplied for apply. Nothing has been written.
+ */
+export class ClassifyDriftError extends ClassifyAbortError {
+  constructor(expected: string, actual: string) {
+    super(
+      'Classification aborted: reset-relevant state does not match the reviewed fingerprint ' +
+      `(expected ${expected}, actual ${actual}). Rerun the dry-run and review the new state ` +
+      'before retrying; nothing was changed.',
+    )
+    this.name = 'ClassifyDriftError'
   }
 }
 
@@ -88,21 +115,161 @@ export interface ClassificationReport {
   classifiedCount: number
   alreadyCount: number
   notFoundCount: number
+  /**
+   * Deterministic SHA-256 over the reset-relevant state of the exact
+   * manifest project set. Emitted by every dry-run; apply must reproduce it.
+   */
+  stateFingerprint: string
+}
+
+export interface ClassifyOptions {
+  apply?: boolean
+  /**
+   * The reviewed fingerprint from a dry-run on unchanged state. Required for
+   * apply; verified inside the batch transaction before any write.
+   */
+  expectedFingerprint?: string
+  /**
+   * Test-only seam: invoked inside the batch transaction after each project
+   * reset. Throwing from it rolls the whole batch back.
+   */
+  afterProjectReset?: (tx: Prisma.TransactionClient, projectId: string) => Promise<void>
+}
+
+/**
+ * Deterministic JSON stringify: object keys sorted recursively, array order
+ * preserved. PostgreSQL jsonb does not preserve key order, so sorting is
+ * required for stable fingerprints across reads.
+ */
+export function stableStringify(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map(v => stableStringify(v)).join(',')}]`
+  }
+  if (value !== null && typeof value === 'object') {
+    const obj = value as Record<string, unknown>
+    const keys = Object.keys(obj).sort()
+    return `{${keys.map(k => `${JSON.stringify(k)}:${stableStringify(obj[k])}`).join(',')}}`
+  }
+  return JSON.stringify(value)
+}
+
+/** Sort rows by id so database return order never changes the fingerprint. */
+function sortById<T extends { id: string }>(rows: readonly T[]): T[] {
+  return [...rows].sort((a, b) => a.id.localeCompare(b.id))
+}
+
+/**
+ * Compute the deterministic SHA-256 fingerprint over the reset-relevant state
+ * of the exact manifest project set.
+ *
+ * Covers exactly the state Reset Planning consumes or clears (issue #449
+ * review remediation): manifest project IDs and existence, planningState,
+ * weeklyDemandCache, CapacityProfile ownership/provenance fields,
+ * CapacitySegments, CapacityPlans/Periods/Entries, TimelineEntries,
+ * StoryTimelineEntries, and the NamedResource identity linkage that (together
+ * with profile ownerKind) determines which rows qualify as proven
+ * PLANNED_RESOURCE planner artefacts. Unrelated backlog/business fields are
+ * deliberately not included.
+ */
+export async function computeClassificationFingerprint(
+  db: ClassifyDb,
+  manifest: ClassifyManifest,
+): Promise<string> {
+  const projectIds = [...manifest.projectIds].sort()
+
+  const [
+    projects,
+    capacityProfiles,
+    capacitySegments,
+    capacityPlans,
+    capacityPlanPeriods,
+    capacityPlanEntries,
+    timelineEntries,
+    storyTimelineEntries,
+    namedResources,
+  ] = await Promise.all([
+    db.project.findMany({
+      where: { id: { in: projectIds } },
+      select: { id: true, planningState: true, weeklyDemandCache: true },
+    }),
+    db.capacityProfile.findMany({
+      where: { projectId: { in: projectIds } },
+      select: {
+        id: true,
+        projectId: true,
+        resourceTypeId: true,
+        namedResourceId: true,
+        ownerKind: true,
+        planningBasis: true,
+        source: true,
+        defaultPercent: true,
+        startWeek: true,
+        endWeek: true,
+      },
+    }),
+    db.capacitySegment.findMany({
+      where: { capacityProfile: { projectId: { in: projectIds } } },
+      select: { id: true, capacityProfileId: true, startWeek: true, endWeek: true, capacityPercent: true, source: true },
+    }),
+    db.capacityPlan.findMany({
+      where: { projectId: { in: projectIds } },
+      select: { id: true, projectId: true, name: true, targetWeeks: true, periodWeeks: true, maxDelta: true, isActive: true, totalCost: true, deliveryWeeks: true },
+    }),
+    db.capacityPlanPeriod.findMany({
+      where: { plan: { projectId: { in: projectIds } } },
+      select: { id: true, planId: true, periodIndex: true, startWeek: true, endWeek: true },
+    }),
+    db.capacityPlanEntry.findMany({
+      where: { period: { plan: { projectId: { in: projectIds } } } },
+      select: { id: true, periodId: true, resourceTypeId: true, headcount: true, demandFTE: true, utilisationPct: true },
+    }),
+    db.timelineEntry.findMany({
+      where: { projectId: { in: projectIds } },
+      select: { id: true, projectId: true, featureId: true, startWeek: true, durationWeeks: true, isManual: true },
+    }),
+    db.storyTimelineEntry.findMany({
+      where: { projectId: { in: projectIds } },
+      select: { id: true, projectId: true, storyId: true, startWeek: true, durationWeeks: true, isManual: true },
+    }),
+    db.namedResource.findMany({
+      where: { resourceType: { projectId: { in: projectIds } } },
+      select: { id: true, resourceTypeId: true },
+    }),
+  ])
+
+  const payload = {
+    manifestProjectIds: projectIds,
+    projects: sortById(projects).map(p => ({
+      id: p.id,
+      planningState: p.planningState,
+      weeklyDemandCache: p.weeklyDemandCache,
+    })),
+    capacityProfiles: sortById(capacityProfiles),
+    capacitySegments: sortById(capacitySegments),
+    capacityPlans: sortById(capacityPlans),
+    capacityPlanPeriods: sortById(capacityPlanPeriods),
+    capacityPlanEntries: sortById(capacityPlanEntries),
+    timelineEntries: sortById(timelineEntries),
+    storyTimelineEntries: sortById(storyTimelineEntries),
+    namedResources: sortById(namedResources),
+  }
+
+  return createHash('sha256').update(stableStringify(payload)).digest('hex')
 }
 
 /**
  * Read-only classification plan. Never writes.
  *
  * Each manifest project is classified as:
- *   - `to-classify`         — exists and is CURRENT (or any non-NEEDS_REPLAN value);
- *   - `already-needs-replan`— already explicitly quarantined (idempotent skip);
- *   - `not-found`           — missing; the apply run must abort (fail closed).
+ *   - `to-classify`          — exists and is CURRENT (or any non-NEEDS_REPLAN value);
+ *   - `already-needs-replan` — already explicitly quarantined (idempotent skip);
+ *   - `not-found`            — missing; the apply run must abort (fail closed).
  */
 export async function planClassification(
-  prisma: PrismaClient,
+  db: ClassifyDb,
   manifest: ClassifyManifest,
-): Promise<ClassificationReport> {
-  const projects = await prisma.project.findMany({
+): Promise<Omit<ClassificationReport, 'stateFingerprint'>> {
+  const projects = await db.project.findMany({
     where: { id: { in: manifest.projectIds } },
     select: { id: true, planningState: true },
   })
@@ -120,7 +287,7 @@ export async function planClassification(
   return summarizeClassification(entries)
 }
 
-function summarizeClassification(entries: ClassificationEntry[]): ClassificationReport {
+function summarizeClassification(entries: ClassificationEntry[]) {
   return {
     completed: entries.every(e => e.status !== 'not-found'),
     entries,
@@ -133,45 +300,80 @@ function summarizeClassification(entries: ClassificationEntry[]): Classification
 /**
  * Classify the reviewed project set as NEEDS_REPLAN.
  *
- * In dry-run mode (`apply: false`, the default) this only plans and reports.
- * In apply mode every `to-classify` project goes through the same atomic
- * reset service transaction the product uses — planning state is discarded,
- * business data preserved, and the project marked NEEDS_REPLAN. No capacity
- * is inferred or reconstructed anywhere in this command.
+ * Dry-run (default): read-only plan plus the deterministic `stateFingerprint`
+ * of the reset-relevant state the operator reviews.
  *
- * Fails closed (throws {@link ClassifyAbortError}) when any manifest project
- * is missing, so an unexpected state change between review and apply never
- * classifies silently.
+ * Apply: requires `expectedFingerprint` (the reviewed dry-run value). The
+ * whole manifest set runs in ONE Prisma transaction: the fingerprint is
+ * recomputed inside that transaction immediately before any write, the plan
+ * is re-derived, and every to-classify project goes through the same atomic
+ * reset transaction body used by the product. Any drift, missing project or
+ * failure rolls the entire batch back — no partial classification.
+ *
+ * Already-NEEDS_REPLAN projects are skipped (idempotent) only when their
+ * state is part of the reviewed fingerprint; the drift check still refuses
+ * any other unexpected change.
  */
 export async function classifyNeedsReplan(
-  prisma: PrismaClient,
+  db: ClassifyDb,
   manifest: ClassifyManifest,
-  options: { apply?: boolean } = {},
+  options: ClassifyOptions = {},
 ): Promise<ClassificationReport> {
-  const plan = await planClassification(prisma, manifest)
+  if (options.apply) {
+    if (options.expectedFingerprint == null) {
+      throw new ClassifyAbortError(
+        'Apply requires the reviewed state fingerprint: pass --expected-fingerprint <sha256> ' +
+        'from a dry-run on unchanged state. Nothing was changed.',
+      )
+    }
+    const expectedFingerprint: string = options.expectedFingerprint
+
+    // One atomic transaction for the complete reviewed set.
+    return db.$transaction(async tx => {
+      const stateFingerprint = await computeClassificationFingerprint(tx, manifest)
+      if (stateFingerprint !== expectedFingerprint) {
+        throw new ClassifyDriftError(expectedFingerprint, stateFingerprint)
+      }
+
+      const plan = await planClassification(tx, manifest)
+      if (!plan.completed) {
+        throw new ClassifyAbortError(
+          `Classification aborted: ${plan.notFoundCount} manifest project(s) no longer exist. ` +
+          'Re-review the manifest before retrying; nothing was changed.',
+        )
+      }
+
+      for (const entry of plan.entries) {
+        if (entry.status !== 'to-classify') continue
+        await resetProjectPlanningWithinTransaction(tx, entry.projectId)
+        if (options.afterProjectReset) {
+          await options.afterProjectReset(tx, entry.projectId)
+        }
+      }
+
+      return { ...plan, stateFingerprint }
+    })
+  }
+
+  // Dry run (default): read-only plan plus the reviewed-state fingerprint.
+  const plan = await planClassification(db, manifest)
   if (!plan.completed) {
     throw new ClassifyAbortError(
       `Classification aborted: ${plan.notFoundCount} manifest project(s) no longer exist. ` +
       'Re-review the manifest before retrying; nothing was changed.',
     )
   }
-  if (!options.apply) {
-    return plan
-  }
-
-  for (const entry of plan.entries) {
-    if (entry.status !== 'to-classify') continue
-    await resetProjectPlanning(prisma, entry.projectId)
-  }
-  return plan
+  const stateFingerprint = await computeClassificationFingerprint(db, manifest)
+  return { ...plan, stateFingerprint }
 }
 
 /** Render the report as aggregate sanitized evidence (IDs are operator-supplied). */
 export function formatClassificationReport(report: ClassificationReport, apply: boolean): string {
   const lines: string[] = []
   lines.push(apply
-    ? 'Mode: APPLY — each listed project was classified NEEDS_REPLAN via the atomic reset transaction.'
+    ? 'Mode: APPLY — the reviewed set was classified NEEDS_REPLAN atomically (one transaction).'
     : 'Mode: DRY RUN (default) — zero writes.')
+  lines.push(`stateFingerprint: ${report.stateFingerprint}`)
   lines.push(`Manifest projects: ${report.entries.length}`)
   lines.push(`Will classify / classified: ${report.classifiedCount}`)
   lines.push(`Already NEEDS_REPLAN (skipped): ${report.alreadyCount}`)

--- a/server/src/lib/classifyNeedsReplan.ts
+++ b/server/src/lib/classifyNeedsReplan.ts
@@ -165,6 +165,12 @@ export interface ClassifyOptions {
    */
   expectedFingerprint?: string
   /**
+   * Test-only seam: invoked inside the dry-run snapshot transaction after the
+   * classification read and before the fingerprint read. Lets tests prove
+   * that report and fingerprint come from one consistent snapshot.
+   */
+  afterPlanRead?: (tx: Prisma.TransactionClient) => Promise<void>
+  /**
    * Test-only seam: invoked inside the batch transaction after each project
    * reset. Throwing from it rolls the whole batch back.
    */
@@ -335,15 +341,18 @@ function summarizeClassification(entries: ClassificationEntry[]) {
 /**
  * Classify the reviewed project set as NEEDS_REPLAN.
  *
- * Dry-run (default): read-only plan plus the deterministic `stateFingerprint`
- * of the reset-relevant state the operator reviews.
+ * Dry-run (default): read-only plan plus the deterministic `stateFingerprint`,
+ * generated inside ONE repeatable-read transaction so the classification
+ * report and the fingerprint describe the same database snapshot.
  *
  * Apply: requires `expectedFingerprint` (the reviewed dry-run value). The
- * whole manifest set runs in ONE Prisma transaction: the fingerprint is
- * recomputed inside that transaction immediately before any write, the plan
- * is re-derived, and every to-classify project goes through the same atomic
- * reset transaction body used by the product. Any drift, missing project or
- * failure rolls the entire batch back — no partial classification.
+ * whole manifest set runs in ONE SERIALIZABLE Prisma transaction: the
+ * fingerprint is recomputed inside that transaction immediately before any
+ * write, the plan is re-derived, and every to-classify project goes through
+ * the same atomic reset transaction body used by the product. Any drift,
+ * missing project, serialization conflict or failure rolls the entire batch
+ * back — no partial classification, and a serialization conflict never
+ * auto-retries with the stale reviewed fingerprint.
  *
  * Already-NEEDS_REPLAN projects are skipped (idempotent) only when their
  * state is part of the reviewed fingerprint; the drift check still refuses
@@ -415,16 +424,29 @@ export async function classifyNeedsReplan(
     }
   }
 
-  // Dry run (default): read-only plan plus the reviewed-state fingerprint.
-  const plan = await planClassification(db, manifest)
-  if (!plan.completed) {
-    throw new ClassifyAbortError(
-      `Classification aborted: ${plan.notFoundCount} manifest project(s) no longer exist. ` +
-      'Re-review the manifest before retrying; nothing was changed.',
-    )
-  }
-  const stateFingerprint = await computeClassificationFingerprint(db, manifest)
-  return { ...plan, stateFingerprint }
+  // Dry run (default): classification entries and the reviewed fingerprint
+  // are generated inside ONE repeatable-read transaction, so the report and
+  // the fingerprint always describe the same database snapshot — the operator
+  // can never review a fingerprint that belongs to a different state than the
+  // classification they were shown. Zero writes. Concurrent changes after the
+  // dry-run are still handled by the apply fingerprint + Serializable checks.
+  const dryClient = db as PrismaClient
+  return dryClient.$transaction(async tx => {
+    const plan = await planClassification(tx, manifest)
+    if (!plan.completed) {
+      throw new ClassifyAbortError(
+        `Classification aborted: ${plan.notFoundCount} manifest project(s) no longer exist. ` +
+        'Re-review the manifest before retrying; nothing was changed.',
+      )
+    }
+    if (options.afterPlanRead) {
+      await options.afterPlanRead(tx)
+    }
+    const stateFingerprint = await computeClassificationFingerprint(tx, manifest)
+    return { ...plan, stateFingerprint }
+  }, {
+    isolationLevel: Prisma.TransactionIsolationLevel.RepeatableRead,
+  })
 }
 
 /** Render the report as aggregate sanitized evidence (IDs are operator-supplied). */

--- a/server/src/lib/completeReplanning.ts
+++ b/server/src/lib/completeReplanning.ts
@@ -1,0 +1,142 @@
+/**
+ * completeReplanning.ts — Completion validation for the Reset Planning /
+ * Replan project workflow (issue #449).
+ *
+ * NEEDS_REPLAN returns to CURRENT only when the project's persisted planning
+ * state is canonical and valid. This module reuses the existing authoritative
+ * validation (validatePersistedCapacityProfiles + checkPersistedCompleteness —
+ * the same rules the readiness check and GET /capacity-profiles enforce) so no
+ * second integrity implementation is introduced.
+ *
+ * The completion itself is atomic: the validation runs inside the same
+ * transaction that flips the state, so the project can never become CURRENT
+ * with incomplete planning state, and a concurrent mutation cannot slip in
+ * between validation and the state change.
+ */
+
+import type { Prisma, PrismaClient } from '@prisma/client'
+
+import {
+  validatePersistedCapacityProfiles,
+  checkPersistedCompleteness,
+} from './persistedCapacityProfileValidation.js'
+
+export class ReplanIncompleteError extends Error {
+  /** Stable machine-readable code for client-side handling. */
+  readonly code: string = 'REPLAN_INCOMPLETE'
+  /** HTTP status code — 422 Unprocessable (actionable validation findings). */
+  readonly status: number = 422
+  /** Actionable validation findings. */
+  readonly findings: string[]
+
+  constructor(findings: string[]) {
+    super(
+      'Replanning is incomplete: ' +
+        findings.join('; ') +
+        ' Review the resource inputs in Resource Profile and complete the plan before finishing replanning.',
+    )
+    this.name = 'ReplanIncompleteError'
+    this.findings = findings
+  }
+}
+
+/**
+ * Validate that a project's persisted planning state is canonical.
+ *
+ * Mirrors the per-project readiness section: structural profile rules plus
+ * per-owner completeness (every role covered by a ROLE profile unless all of
+ * its named resources carry explicit NAMED_PERSON profiles; every named
+ * resource has exactly one valid profile).
+ *
+ * @returns Empty array when the project is valid, otherwise actionable findings.
+ */
+export async function collectReplanningFindings(
+  db: PrismaClient | Prisma.TransactionClient,
+  projectId: string,
+): Promise<string[]> {
+  const project = await db.project.findUnique({
+    where: { id: projectId },
+    select: {
+      id: true,
+      resourceTypes: {
+        include: { namedResources: { orderBy: { createdAt: 'asc' as const } } },
+      },
+      capacityProfiles: {
+        include: {
+          segments: {
+            orderBy: [{ startWeek: 'asc' as const }, { endWeek: 'asc' as const }],
+          },
+        },
+      },
+    },
+  })
+  if (!project) return ['Project not found']
+
+  const resourceTypeIds = new Set(project.resourceTypes.map(rt => rt.id))
+  const namedResourceIds = new Set(
+    project.resourceTypes.flatMap(rt => rt.namedResources.map(nr => nr.id)),
+  )
+
+  const validation = validatePersistedCapacityProfiles(
+    project.capacityProfiles as Parameters<typeof validatePersistedCapacityProfiles>[0],
+    { projectId, resourceTypeIds, namedResourceIds },
+  )
+  const findings = [...validation.errors]
+
+  const completenessErrors = checkPersistedCompleteness({
+    resourceTypes: project.resourceTypes.map(rt => ({
+      id: rt.id,
+      name: rt.name,
+      namedResources: rt.namedResources.map(nr => ({ id: nr.id, name: nr.name })),
+    })),
+    capacityProfiles: project.capacityProfiles.map(profile => ({
+      resourceTypeId: profile.resourceTypeId,
+      namedResourceId: profile.namedResourceId,
+      ownerKind: String(profile.ownerKind),
+      source: String(profile.source),
+      planningBasis: String(profile.planningBasis),
+    })),
+  })
+  findings.push(...completenessErrors)
+  return findings
+}
+
+/**
+ * Complete replanning: atomically move the project from NEEDS_REPLAN to
+ * CURRENT, but only when canonical planning validation passes.
+ *
+ * - A CURRENT project is a no-op (returns CURRENT).
+ * - A NEEDS_REPLAN project with valid canonical state flips to CURRENT.
+ * - A NEEDS_REPLAN project with incomplete/structural findings throws
+ *   {@link ReplanIncompleteError} and leaves the state untouched — no profile
+ *   is fabricated and the flag is never cleared merely because a button was
+ *   clicked.
+ */
+export async function completeReplanning(
+  prisma: PrismaClient,
+  projectId: string,
+): Promise<'CURRENT'> {
+  return prisma.$transaction(async tx => {
+    const project = await tx.project.findUnique({
+      where: { id: projectId },
+      select: { id: true, planningState: true },
+    })
+    if (!project) {
+      const error = new Error('Project not found') as Error & { status: number }
+      error.status = 404
+      throw error
+    }
+    if (project.planningState === 'CURRENT') return 'CURRENT' as const
+
+    const findings = await collectReplanningFindings(tx, projectId)
+    if (findings.length > 0) {
+      throw new ReplanIncompleteError(findings)
+    }
+
+    await tx.project.update({
+      where: { id: projectId },
+      data: { planningState: 'CURRENT' },
+    })
+    return 'CURRENT' as const
+  })
+}

--- a/server/src/lib/productionMigrationReadiness.ts
+++ b/server/src/lib/productionMigrationReadiness.ts
@@ -80,6 +80,7 @@ async function checkProjectCompleteness(prisma: PrismaClient): Promise<Readiness
     select: {
       id: true,
       name: true,
+      planningState: true,
       resourceTypes: {
         include: { namedResources: { orderBy: { createdAt: 'asc' as const } } },
       },
@@ -94,8 +95,21 @@ async function checkProjectCompleteness(prisma: PrismaClient): Promise<Readiness
   })
 
   const blockers: string[] = []
+  let quarantinedCount = 0
   for (const project of projects) {
     const prefix = `project "${project.name}" (${project.id})`
+    if (project.planningState === 'NEEDS_REPLAN') {
+      // Issue #449: a NEEDS_REPLAN project deliberately retired its planning
+      // state (Reset Planning / the reviewed maintenance classification).
+      // Expected missing planning state is allowed here ONLY because the
+      // state is explicitly persisted and planning-dependent execution is
+      // quarantined until the project is replanned. The global ownership
+      // audit section still fails on cross-project ownership, impossible
+      // FK/ownership relationships and duplicate owners where rows remain —
+      // NEEDS_REPLAN is never a generic "ignore this project" switch.
+      quarantinedCount++
+      continue
+    }
     const resourceTypeIds = new Set(project.resourceTypes.map(rt => rt.id))
     const namedResourceIds = new Set(
       project.resourceTypes.flatMap(rt => rt.namedResources.map(nr => nr.id)),
@@ -130,6 +144,9 @@ async function checkProjectCompleteness(prisma: PrismaClient): Promise<Readiness
     name: 'per-project profile completeness and shape',
     passed: blockers.length === 0,
     blockers,
+    notes: quarantinedCount > 0
+      ? [`NEEDS_REPLAN projects (intentional planning quarantine): ${quarantinedCount}`]
+      : undefined,
   }
 }
 

--- a/server/src/lib/projectPlanningState.ts
+++ b/server/src/lib/projectPlanningState.ts
@@ -1,0 +1,74 @@
+/**
+ * projectPlanningState.ts — Shared project planning-state guard (issue #449).
+ *
+ * A project carries an explicit persisted planning state:
+ *
+ *   CURRENT     — planning is expected to be canonical. Missing, duplicate,
+ *                 malformed or conflicting profile state remains a real
+ *                 integrity failure (fail closed as today).
+ *   NEEDS_REPLAN — the project deliberately discarded its planning state via
+ *                 the Reset Planning workflow. Planning incompleteness is
+ *                 expected and must NOT trigger legacy fallback, auto-repair
+ *                 or capacity invention. Capacity-dependent operations are
+ *                 quarantined and return an actionable REPLAN_REQUIRED result
+ *                 until the user replans through the normal supported
+ *                 planning surfaces and completes replanning.
+ *
+ * This guard is deliberately NOT a generic recovery framework: it only
+ * interprets the explicit persisted state and raises the typed error used by
+ * the error handler. Existing profile/planning validation remains the source
+ * of truth for canonical completion (see completeReplanning.ts).
+ */
+
+export type ProjectPlanningState = 'CURRENT' | 'NEEDS_REPLAN'
+
+/** Minimal project shape the guard needs. */
+export interface PlanningStateProjectLike {
+  planningState?: ProjectPlanningState | string | null
+}
+
+/**
+ * Domain error raised when a capacity-dependent operation runs on a project
+ * whose planning state is NEEDS_REPLAN. The error handler maps it to HTTP 409
+ * with the stable `REPLAN_REQUIRED` code and an actionable message — never a
+ * legacy fallback, auto-repair or an opaque integrity failure.
+ */
+export class ReplanRequiredError extends Error {
+  /** Stable machine-readable code for client-side handling. */
+  readonly code: string = 'REPLAN_REQUIRED'
+  /** HTTP status code — 409 Conflict (the action conflicts with the explicit planning state). */
+  readonly status: number = 409
+  /** User-facing message safe to return in all environments. */
+  readonly userMessage: string
+
+  constructor(message?: string) {
+    super(message ?? defaultReplanRequiredMessage())
+    this.name = 'ReplanRequiredError'
+    this.userMessage = this.message
+  }
+}
+
+export function defaultReplanRequiredMessage(): string {
+  return (
+    'This project needs replanning. Its resource planning is no longer current: ' +
+    'review the resource inputs in Resource Profile and replan from the existing ' +
+    'backlog before running this action.'
+  )
+}
+
+/**
+ * Assert that a project's planning state is CURRENT.
+ *
+ * Throws {@link ReplanRequiredError} when the project is explicitly in
+ * NEEDS_REPLAN. Projects without a persisted state (or with the default
+ * CURRENT) pass — the persisted field is authoritative and intentional
+ * incompleteness is never inferred from malformed data.
+ */
+export function assertPlanningCurrent(
+  project: PlanningStateProjectLike | null | undefined,
+  message?: string,
+): void {
+  if (project?.planningState === 'NEEDS_REPLAN') {
+    throw new ReplanRequiredError(message)
+  }
+}

--- a/server/src/lib/projectSnapshotService.ts
+++ b/server/src/lib/projectSnapshotService.ts
@@ -135,7 +135,7 @@ export async function buildSnapshot(
     fetchEpics(projectId, db),
     db.project.findUnique({
       where: { id: projectId },
-      select: { startDate: true, onboardingWeeks: true, bufferWeeks: true, hoursPerDay: true, weeklyDemandCache: true },
+      select: { startDate: true, onboardingWeeks: true, bufferWeeks: true, hoursPerDay: true, weeklyDemandCache: true, planningState: true },
     }),
     db.resourceType.findMany({
       where: { projectId },
@@ -218,6 +218,7 @@ export async function buildSnapshot(
         bufferWeeks: project.bufferWeeks,
         hoursPerDay: project.hoursPerDay,
         weeklyDemandCache: parseWeeklyDemandCache(project.weeklyDemandCache),
+        planningState: project.planningState,
       }
     : null
 
@@ -379,6 +380,13 @@ export async function restoreSnapshotCommonState(
                 ? Prisma.DbNull
                 : data.project.weeklyDemandCache,
             }
+          : {}),
+        // Issue #449: restore the explicit planning state only when the
+        // snapshot carries one. Pre-feature snapshots leave it untouched so
+        // rollback can never implicitly un-quarantine a NEEDS_REPLAN project
+        // (or quarantine a CURRENT one) from an older payload.
+        ...(data.project.planningState !== undefined
+          ? { planningState: data.project.planningState }
           : {}),
       },
     })

--- a/server/src/lib/projectSnapshotTypes.ts
+++ b/server/src/lib/projectSnapshotTypes.ts
@@ -147,6 +147,13 @@ export type SnapshotProjectFields = {
   hoursPerDay: number | null
   /** Optional cache field added after v3 snapshots were introduced. */
   weeklyDemandCache?: Record<string, number> | null
+  /**
+   * Optional project planning state (issue #449). Absent on snapshots
+   * created before the field existed; those restores leave the project's
+   * planning state untouched so a pre-feature snapshot can never flip a
+   * quarantined project to CURRENT (or vice versa) implicitly.
+   */
+  planningState?: 'CURRENT' | 'NEEDS_REPLAN'
 }
 
 export type SnapshotResourceType = {

--- a/server/src/lib/resetProjectPlanning.ts
+++ b/server/src/lib/resetProjectPlanning.ts
@@ -77,48 +77,64 @@ export async function resetProjectPlanning(
   options: ResetPlanningOptions = {},
 ): Promise<ResetPlanningResult> {
   return db.$transaction(async tx => {
-    const project = await tx.project.findUnique({
-      where: { id: projectId },
-      select: { id: true, planningState: true },
-    })
-    if (!project) {
-      throw new ResetPlanningError(404, 'Project not found')
-    }
-
-    // Proven planner-generated placeholders: NamedResources that carry a
-    // PLANNED_RESOURCE profile (the provenance mark written by the Squad
-    // Planner apply path). User-authored resources always get NAMED_PERSON
-    // profiles, so they are never matched here.
-    const plannerProfiles = await tx.capacityProfile.findMany({
-      where: { projectId, ownerKind: 'PLANNED_RESOURCE' },
-      select: { namedResourceId: true },
-    })
-    const plannerNamedResourceIds = Array.from(
-      new Set(plannerProfiles.map(p => p.namedResourceId).filter((id): id is string => id != null)),
-    )
-
-    // Planning-owned state (see module doc for the evidence-based allow-list).
-    await tx.capacityProfile.deleteMany({ where: { projectId } }) // cascades segments
-    await tx.capacityPlan.deleteMany({ where: { projectId } }) // cascades periods/entries
-    await tx.timelineEntry.deleteMany({ where: { projectId } })
-    await tx.storyTimelineEntry.deleteMany({ where: { projectId } })
-    if (plannerNamedResourceIds.length > 0) {
-      await tx.namedResource.deleteMany({
-        where: { id: { in: plannerNamedResourceIds }, resourceType: { projectId } },
-      })
-    }
-    await tx.project.update({
-      where: { id: projectId },
-      data: {
-        weeklyDemandCache: Prisma.DbNull,
-        planningState: 'NEEDS_REPLAN',
-      },
-    })
-
+    const result = await resetProjectPlanningWithinTransaction(tx, projectId)
     if (options.afterWrites) {
       await options.afterWrites(tx)
     }
-
-    return { projectId, planningState: 'NEEDS_REPLAN' as const }
+    return result
   })
+}
+
+/**
+ * The reset transaction body, executed against an already-open transaction
+ * client. Shared by the product-facing single-project wrapper above and the
+ * maintenance classification batch, which runs the whole reviewed manifest
+ * set inside ONE transaction (issue #449 remediation).
+ *
+ * No writes are committed by this helper itself; the caller's transaction
+ * decides commit/rollback.
+ */
+export async function resetProjectPlanningWithinTransaction(
+  tx: Prisma.TransactionClient,
+  projectId: string,
+): Promise<ResetPlanningResult> {
+  const project = await tx.project.findUnique({
+    where: { id: projectId },
+    select: { id: true, planningState: true },
+  })
+  if (!project) {
+    throw new ResetPlanningError(404, 'Project not found')
+  }
+
+  // Proven planner-generated placeholders: NamedResources that carry a
+  // PLANNED_RESOURCE profile (the provenance mark written by the Squad
+  // Planner apply path). User-authored resources always get NAMED_PERSON
+  // profiles, so they are never matched here.
+  const plannerProfiles = await tx.capacityProfile.findMany({
+    where: { projectId, ownerKind: 'PLANNED_RESOURCE' },
+    select: { namedResourceId: true },
+  })
+  const plannerNamedResourceIds = Array.from(
+    new Set(plannerProfiles.map(p => p.namedResourceId).filter((id): id is string => id != null)),
+  )
+
+  // Planning-owned state (see module doc for the evidence-based allow-list).
+  await tx.capacityProfile.deleteMany({ where: { projectId } }) // cascades segments
+  await tx.capacityPlan.deleteMany({ where: { projectId } }) // cascades periods/entries
+  await tx.timelineEntry.deleteMany({ where: { projectId } })
+  await tx.storyTimelineEntry.deleteMany({ where: { projectId } })
+  if (plannerNamedResourceIds.length > 0) {
+    await tx.namedResource.deleteMany({
+      where: { id: { in: plannerNamedResourceIds }, resourceType: { projectId } },
+    })
+  }
+  await tx.project.update({
+    where: { id: projectId },
+    data: {
+      weeklyDemandCache: Prisma.DbNull,
+      planningState: 'NEEDS_REPLAN',
+    },
+  })
+
+  return { projectId, planningState: 'NEEDS_REPLAN' as const }
 }

--- a/server/src/lib/resetProjectPlanning.ts
+++ b/server/src/lib/resetProjectPlanning.ts
@@ -1,0 +1,124 @@
+/**
+ * resetProjectPlanning.ts — Atomic Reset Planning service (issue #449).
+ *
+ * One focused server-side operation that discards planning-owned state and
+ * marks the project NEEDS_REPLAN, preserving estimation/business inputs.
+ *
+ * ── Reset allow-list (planning-owned state cleared) ─────────────────────────
+ * Based on repository domain ownership (docs/domain/planning-resource-commercial-boundaries.md,
+ * capacity-profile-design.md) and the issue #449 boundary:
+ *
+ *   - CapacityProfile / CapacitySegment rows             (planning state being reset)
+ *   - CapacityPlan / CapacityPlanPeriod / CapacityPlanEntry rows (planning inputs/outputs)
+ *   - TimelineEntry / StoryTimelineEntry rows            (generated feature/story schedule
+ *                                                        output; Timeline/Planning owns manual
+ *                                                        overrides as planning state too)
+ *   - weeklyDemandCache                                  (derived planning cache)
+ *   - NamedResource rows proven to be planner-generated placeholders:
+ *     provenance = an existing CapacityProfile with ownerKind PLANNED_RESOURCE.
+ *     Squad Planner's findOrCreatePlannedResources creates those rows and marks
+ *     them with a PLANNED_RESOURCE profile; user-authored named resources
+ *     always carry NAMED_PERSON profiles. Ambiguous rows are preserved.
+ *   - project.planningState → NEEDS_REPLAN
+ *
+ * ── Preserved (never touched) ───────────────────────────────────────────────
+ *   Project identity/metadata (incl. hoursPerDay, onboarding/buffer weeks,
+ *   startDate, tax settings), org/customer links, backlog hierarchy, task
+ *   effort/duration/resource-type assignment, dependencies, ResourceType
+ *   identity/count/hoursPerDay/dayRate/global-type links, user-authored
+ *   NamedResource identity + pricingModel, ProjectDiscount, ProjectOverhead,
+ *   BacklogSnapshots, generated documents. The candidate legacy capacity
+ *   columns on ResourceType/NamedResource are NOT removed or rewritten here
+ *   (issue #418 PR 2 owns those columns); runtime readers are made
+ *   NEEDS_REPLAN-aware so stale legacy values are never projected as capacity.
+ *
+ * The whole operation runs in one Prisma transaction: any failure rolls back
+ * every write and leaves the previous planning state intact.
+ *
+ * The optional `afterWrites` hook runs inside the transaction after all
+ * writes and before commit; it exists solely so tests can inject a
+ * mid-transaction failure and prove full rollback.
+ */
+
+import { Prisma, type PrismaClient } from '@prisma/client'
+
+export interface ResetPlanningOptions {
+  /**
+   * Test-only seam: invoked inside the transaction after every reset write.
+   * Throwing from it rolls the whole reset back.
+   */
+  afterWrites?: (tx: Prisma.TransactionClient) => Promise<void>
+}
+
+export class ResetPlanningError extends Error {
+  readonly status: number
+  constructor(status: number, message: string) {
+    super(message)
+    this.name = 'ResetPlanningError'
+    this.status = status
+  }
+}
+
+export interface ResetPlanningResult {
+  projectId: string
+  planningState: 'NEEDS_REPLAN'
+}
+
+/**
+ * Reset a project's planning state atomically.
+ *
+ * @param db Prisma client or an already-open transaction client.
+ * @param projectId Project whose planning state is discarded.
+ * @param options Optional test seam (afterWrites).
+ */
+export async function resetProjectPlanning(
+  db: PrismaClient | Prisma.TransactionClient,
+  projectId: string,
+  options: ResetPlanningOptions = {},
+): Promise<ResetPlanningResult> {
+  return db.$transaction(async tx => {
+    const project = await tx.project.findUnique({
+      where: { id: projectId },
+      select: { id: true, planningState: true },
+    })
+    if (!project) {
+      throw new ResetPlanningError(404, 'Project not found')
+    }
+
+    // Proven planner-generated placeholders: NamedResources that carry a
+    // PLANNED_RESOURCE profile (the provenance mark written by the Squad
+    // Planner apply path). User-authored resources always get NAMED_PERSON
+    // profiles, so they are never matched here.
+    const plannerProfiles = await tx.capacityProfile.findMany({
+      where: { projectId, ownerKind: 'PLANNED_RESOURCE' },
+      select: { namedResourceId: true },
+    })
+    const plannerNamedResourceIds = Array.from(
+      new Set(plannerProfiles.map(p => p.namedResourceId).filter((id): id is string => id != null)),
+    )
+
+    // Planning-owned state (see module doc for the evidence-based allow-list).
+    await tx.capacityProfile.deleteMany({ where: { projectId } }) // cascades segments
+    await tx.capacityPlan.deleteMany({ where: { projectId } }) // cascades periods/entries
+    await tx.timelineEntry.deleteMany({ where: { projectId } })
+    await tx.storyTimelineEntry.deleteMany({ where: { projectId } })
+    if (plannerNamedResourceIds.length > 0) {
+      await tx.namedResource.deleteMany({
+        where: { id: { in: plannerNamedResourceIds }, resourceType: { projectId } },
+      })
+    }
+    await tx.project.update({
+      where: { id: projectId },
+      data: {
+        weeklyDemandCache: Prisma.DbNull,
+        planningState: 'NEEDS_REPLAN',
+      },
+    })
+
+    if (options.afterWrites) {
+      await options.afterWrites(tx)
+    }
+
+    return { projectId, planningState: 'NEEDS_REPLAN' as const }
+  })
+}

--- a/server/src/lib/resetProjectPlanning.ts
+++ b/server/src/lib/resetProjectPlanning.ts
@@ -15,10 +15,13 @@
  *                                                        overrides as planning state too)
  *   - weeklyDemandCache                                  (derived planning cache)
  *   - NamedResource rows proven to be planner-generated placeholders:
- *     provenance = an existing CapacityProfile with ownerKind PLANNED_RESOURCE.
- *     Squad Planner's findOrCreatePlannedResources creates those rows and marks
- *     them with a PLANNED_RESOURCE profile; user-authored named resources
- *     always carry NAMED_PERSON profiles. Ambiguous rows are preserved.
+ *     provenance = a CapacityProfile with ownerKind PLANNED_RESOURCE, or the
+ *     established legacy planner form NAMED_PERSON + SQUAD_PLANNER +
+ *     CAPACITY_PROFILE (isLegacyPlannerProfile — the same safe rule the Squad
+ *     Planner adoption path uses). Squad Planner's findOrCreatePlannedResources
+ *     writes the PLANNED_RESOURCE rows; user-authored named resources always
+ *     carry NAMED_PERSON profiles outside those exact markers. Ambiguous rows
+ *     are preserved.
  *   - project.planningState → NEEDS_REPLAN
  *
  * ── Preserved (never touched) ───────────────────────────────────────────────
@@ -41,6 +44,8 @@
  */
 
 import { Prisma, type PrismaClient } from '@prisma/client'
+
+import { isLegacyPlannerProfile } from './squadPlannerProfileWriter.js'
 
 export interface ResetPlanningOptions {
   /**
@@ -106,16 +111,36 @@ export async function resetProjectPlanningWithinTransaction(
     throw new ResetPlanningError(404, 'Project not found')
   }
 
-  // Proven planner-generated placeholders: NamedResources that carry a
-  // PLANNED_RESOURCE profile (the provenance mark written by the Squad
-  // Planner apply path). User-authored resources always get NAMED_PERSON
-  // profiles, so they are never matched here.
+  // Proven planner-generated placeholders: NamedResources that carry either
+  // (a) a PLANNED_RESOURCE profile (the provenance mark written by the Squad
+  // Planner apply path) or (b) the established legacy planner profile form
+  // NAMED_PERSON + SQUAD_PLANNER + CAPACITY_PROFILE (isLegacyPlannerProfile —
+  // the same safe provenance rule the Squad Planner adoption path uses).
+  // User-authored resources always get NAMED_PERSON profiles outside those
+  // exact markers, so they are never matched here. Ambiguous rows (unprofiled,
+  // or SQUAD_PLANNER markers that do not satisfy the safe rule) are preserved.
   const plannerProfiles = await tx.capacityProfile.findMany({
-    where: { projectId, ownerKind: 'PLANNED_RESOURCE' },
-    select: { namedResourceId: true },
+    where: {
+      projectId,
+      OR: [
+        { ownerKind: 'PLANNED_RESOURCE' },
+        {
+          ownerKind: 'NAMED_PERSON',
+          source: 'SQUAD_PLANNER',
+          planningBasis: 'CAPACITY_PROFILE',
+        },
+      ],
+    },
+    select: { namedResourceId: true, ownerKind: true, source: true, planningBasis: true },
   })
   const plannerNamedResourceIds = Array.from(
-    new Set(plannerProfiles.map(p => p.namedResourceId).filter((id): id is string => id != null)),
+    new Set(
+      plannerProfiles
+        .filter(p => p.namedResourceId != null && (
+          p.ownerKind === 'PLANNED_RESOURCE' || isLegacyPlannerProfile(p)
+        ))
+        .map(p => p.namedResourceId as string),
+    ),
   )
 
   // Planning-owned state (see module doc for the evidence-based allow-list).

--- a/server/src/middleware/errorHandler.ts
+++ b/server/src/middleware/errorHandler.ts
@@ -1,10 +1,20 @@
 import { CapacityIntegrityError } from '../lib/capacityIntegrityError.js'
+import { ReplanRequiredError } from '../lib/projectPlanningState.js'
 import { Request, Response, NextFunction } from 'express'
 import { logger } from '../lib/logger.js'
 export function errorHandler(err: Error, req: Request, res: Response, _next: NextFunction) {
   // Structured domain errors (e.g. CapacityIntegrityError) include a stable code and
   // actionable message safe to return in all environments.
   if (err instanceof CapacityIntegrityError) {
+    res.status(err.status).json({
+      error: err.userMessage,
+      code: err.code,
+    })
+    return
+  }
+
+  // Expected quarantine condition: the project is explicitly NEEDS_REPLAN.
+  if (err instanceof ReplanRequiredError) {
     res.status(err.status).json({
       error: err.userMessage,
       code: err.code,

--- a/server/src/routes/capacityProfiles.ts
+++ b/server/src/routes/capacityProfiles.ts
@@ -94,13 +94,17 @@ router.get('/', asyncHandler(async (req: AuthRequest, res: Response) => {
     })),
   })
 
-  if (completenessErrors.length > 0) {
+  if (completenessErrors.length > 0 && project.planningState !== 'NEEDS_REPLAN') {
     res.status(409).json({
       error: 'Persisted capacity profiles are incomplete: ' + completenessErrors.join('; '),
       code: 'CAPACITY_INTEGRITY_ERROR',
     })
     return
   }
+  // NEEDS_REPLAN (issue #449): missing profile coverage is the intentional,
+  // expected state after Reset Planning — the user is mid-replanning. The
+  // structural validation above still fails closed on genuinely malformed
+  // rows, so the quarantine never masks unrelated corruption.
 
   const resourceTypeById = new Map<string, { id: string; name: string }>()
   const namedResourceById = new Map<string, { id: string; name: string; resourceTypeId: string }>()

--- a/server/src/routes/optimiser.ts
+++ b/server/src/routes/optimiser.ts
@@ -16,6 +16,7 @@ import { prisma } from '../lib/prisma.js'
 import { asyncHandler } from '../lib/asyncHandler.js'
 import { authenticate, AuthRequest } from '../middleware/auth.js'
 import { ownedProject } from '../lib/ownership.js'
+import { assertPlanningCurrent } from '../lib/projectPlanningState.js'
 import {
   type SchedulerInput,
   type SchedulerResourceType,
@@ -158,6 +159,8 @@ router.post('/apply', asyncHandler(async (req: AuthRequest, res: Response) => {
   const projectId = req.params.projectId as string
   const project = await ownedProject(projectId, req.userId!)
   if (!project) { res.status(404).json({ error: 'Project not found' }); return }
+  // Planning-dependent: the optimiser consumes the current capacity model.
+  assertPlanningCurrent(project)
 
   const { resourceTypes: candidateRTs, optimiserScopeResourceTypeIds, staggerEpics } = req.body as {
     resourceTypes: ApplyCandidateResourceType[]
@@ -234,6 +237,8 @@ router.post('/', asyncHandler(async (req: AuthRequest, res: Response) => {
   const projectId = req.params.projectId as string
   const project = await ownedProject(projectId, req.userId!)
   if (!project) { res.status(404).json({ error: 'Project not found' }); return }
+  // Planning-dependent: the optimiser consumes the current capacity model.
+  assertPlanningCurrent(project)
 
   // ── 1. Parse request body ─────────────────────────────────────────────────
   const body = req.body as {

--- a/server/src/routes/planning.ts
+++ b/server/src/routes/planning.ts
@@ -1,0 +1,82 @@
+/**
+ * planning.ts — Project planning-state routes (issue #449).
+ *
+ * POST /api/projects/:projectId/planning/reset    — Reset Planning (discard)
+ * POST /api/projects/:projectId/planning/complete — Complete replanning
+ *
+ * Reset discards planning state and marks the project NEEDS_REPLAN; it never
+ * creates replacement capacity. Replanning is built through the existing
+ * planning surfaces (Resource Profile profiles, Squad Planner), and
+ * completion only flips the state back to CURRENT when canonical validation
+ * passes. The two operations are deliberately NOT merged into one endpoint.
+ */
+
+import { Router, Response } from 'express'
+
+import { prisma } from '../lib/prisma.js'
+import { asyncHandler } from '../lib/asyncHandler.js'
+import { authenticate, AuthRequest } from '../middleware/auth.js'
+import { ownedProject } from '../lib/ownership.js'
+import { resetProjectPlanning } from '../lib/resetProjectPlanning.js'
+import { completeReplanning, ReplanIncompleteError } from '../lib/completeReplanning.js'
+
+const router = Router({ mergeParams: true })
+router.use(authenticate)
+
+/**
+ * POST /api/projects/:projectId/planning/reset
+ *
+ * Explicit destructive intent is required: the request body must carry
+ * `{ confirm: true }`. The response returns the resulting planning state
+ * (NEEDS_REPLAN); no replacement capacity profile is ever created here.
+ */
+router.post('/reset', asyncHandler(async (req: AuthRequest, res: Response) => {
+  const projectId = req.params.projectId as string
+  const project = await ownedProject(projectId, req.userId!)
+  if (!project) {
+    res.status(404).json({ error: 'Project not found' })
+    return
+  }
+  if (req.body?.confirm !== true) {
+    res.status(400).json({
+      error: 'Reset planning requires explicit confirmation: send { confirm: true }.',
+    })
+    return
+  }
+
+  const result = await resetProjectPlanning(prisma, projectId)
+  res.json(result)
+}))
+
+/**
+ * POST /api/projects/:projectId/planning/complete
+ *
+ * Validates canonical project planning state and atomically marks the
+ * project CURRENT only when valid. Incomplete plans fail with actionable
+ * validation findings (422 REPLAN_INCOMPLETE) and leave NEEDS_REPLAN intact.
+ */
+router.post('/complete', asyncHandler(async (req: AuthRequest, res: Response) => {
+  const projectId = req.params.projectId as string
+  const project = await ownedProject(projectId, req.userId!)
+  if (!project) {
+    res.status(404).json({ error: 'Project not found' })
+    return
+  }
+
+  try {
+    const planningState = await completeReplanning(prisma, projectId)
+    res.json({ projectId, planningState })
+  } catch (error) {
+    if (error instanceof ReplanIncompleteError) {
+      res.status(error.status).json({
+        error: error.message,
+        code: error.code,
+        findings: error.findings,
+      })
+      return
+    }
+    throw error
+  }
+}))
+
+export default router

--- a/server/src/routes/projects.ts
+++ b/server/src/routes/projects.ts
@@ -136,6 +136,10 @@ router.post('/:id/clone', asyncHandler(async (req: AuthRequest, res: Response) =
         customerId: source.customerId,
         orgId: source.orgId,
         status: 'DRAFT',
+        // A clone of a NEEDS_REPLAN project must stay quarantined: its
+        // planning state is copied verbatim so the copy never presents an
+        // absent capacity model as CURRENT (issue #449).
+        planningState: source.planningState,
         onboardingWeeks: source.onboardingWeeks,
         bufferWeeks: source.bufferWeeks,
         startDate: source.startDate,

--- a/server/src/routes/resourceProfile.ts
+++ b/server/src/routes/resourceProfile.ts
@@ -267,7 +267,62 @@ router.get('/', asyncHandler(async (req: AuthRequest, res: Response) => {
           })),
         }
       })
-      .sort((a, b) => {
+
+    // Preserved zero-demand roles: Reset Planning keeps every ResourceType,
+    // and canonical completion requires a profile for each role without
+    // named-resource coverage. While NEEDS_REPLAN, every preserved role must
+    // therefore be visible in the replanning surface — including roles with
+    // no active task demand — so the user can create their chosen profile
+    // through the normal capacity editor. Identity and non-planning metadata
+    // are kept; effort/demand are zero and no capacity is fabricated.
+    for (const resourceType of project.resourceTypes) {
+      if (resourceAgg.has(resourceType.id)) continue
+      resourceRows.push({
+        resourceTypeId: resourceType.id,
+        name: resourceType.name,
+        category: resourceType.category,
+        count: resourceType.count,
+        hoursPerDay: resourceType.hoursPerDay ?? fallbackHoursPerDay,
+        dayRate: resourceType.dayRate ?? resourceType.globalType?.defaultDayRate ?? null,
+        totalHours: 0,
+        effortDays: 0,
+        totalDays: 0,
+        allocatedDays: 0,
+        allocationMode: 'EFFORT',
+        allocationPercent: 100,
+        allocationStartWeek: null,
+        allocationEndWeek: null,
+        derivedStartWeek: null,
+        derivedEndWeek: null,
+        estimatedCost: null,
+        epics: [],
+        namedResources: resourceType.namedResources.map(nr => ({
+          id: nr.id,
+          name: nr.name,
+          resourceTypeId: nr.resourceTypeId,
+          pricingModel: nr.pricingModel === 'PRO_RATA' ? 'PRO_RATA' : 'ACTUAL_DAYS',
+          allocationMode: 'EFFORT',
+          allocationPercent: 100,
+          allocationPct: 100,
+          allocationStartWeek: null,
+          allocationEndWeek: null,
+          startWeek: null,
+          endWeek: null,
+          allocatedDays: 0,
+          derivedStartWeek: null,
+          derivedEndWeek: null,
+          actualAllocatedDays: 0,
+          actualAllocationStartWeek: null,
+          actualAllocationEndWeek: null,
+          actualAllocatedWeeks: [],
+          actualAllocationSegments: [],
+          synthetic: false,
+          resourceIdentity: 'NAMED_PERSON' as const,
+        })),
+      })
+    }
+
+    resourceRows.sort((a, b) => {
         const indexOf = (cat: string) => {
           const idx = CATEGORY_ORDER.indexOf(cat as ResourceCategory)
           return idx === -1 ? CATEGORY_ORDER.length : idx

--- a/server/src/routes/resourceProfile.ts
+++ b/server/src/routes/resourceProfile.ts
@@ -81,27 +81,10 @@ router.get('/', asyncHandler(async (req: AuthRequest, res: Response) => {
 
   const fallbackHoursPerDay = project.hoursPerDay
   const resourceTypeById = new Map(project.resourceTypes.map(rt => [rt.id, rt]))
-  // Materialize capacity plan for shared model consumption
-  const capacityPlanByRt = materializeCapacityPlanResources(
-    (project.capacityPlans?.[0] ?? null)?.periods ?? [],
-  )
-  // Build capacity-profile enrichment map (profile-first, fail-closed)
-  const { roleProfiles, namedResourceProfiles } = buildResourceCapacityProfileMap(
-    project as unknown as Parameters<typeof buildResourceCapacityProfileMap>[0],
-  )
-  // Resolve profile-first scheduler capacity — the single source for
-  // per-resource availability (legacy-shaped display fields are projected
-  // from authoritative profiles, never read from candidate columns).
-  const resolvedCapacity = await resolveSchedulerCapacity(prisma, projectId)
 
-  // Project duration in weeks
-  const planningWindow = computePlanningWindow(
-    project.timelineEntries,
-    project.startDate,
-    project.bufferWeeks ?? 0,
-    project.onboardingWeeks ?? 0,
-  )
-  const projectDurationWeeks = planningWindow.maxWeek ?? 0
+  // ── Effort aggregation (backlog-owned; runs before any planning-derived
+  // computation so the NEEDS_REPLAN branch below can serve effort/inputs
+  // without touching the capacity model). ──────────────────────────────────
 
   // Build lookup maps for timeline entries
   const featureEntryMap = new Map(project.timelineEntries.map(e => [e.featureId, e]))
@@ -222,6 +205,132 @@ router.get('/', asyncHandler(async (req: AuthRequest, res: Response) => {
       }
     }
   }
+
+  if (project.planningState === 'NEEDS_REPLAN') {
+    // Reset Planning discarded the capacity model. Serve the estimation and
+    // business inputs the user needs to replan — roles, counts, rates, effort
+    // rollups, named-resource identity — with NO planning-derived values:
+    // no capacity-plan materialisation, no profile/legacy projection, no
+    // scheduler resolution, no assignments, no commercial totals. The client
+    // shows the explicit "Planning needs attention" state instead of treating
+    // any of this as current planning.
+    const resourceRows = Array.from(resourceAgg.values())
+      .map(agg => {
+        const resourceType = resourceTypeById.get(agg.resourceTypeId)!
+        const dayRate = resourceType.dayRate ?? resourceType.globalType?.defaultDayRate ?? null
+        return {
+          resourceTypeId: resourceType.id,
+          name: resourceType.name,
+          category: resourceType.category,
+          count: resourceType.count,
+          hoursPerDay: agg.hoursPerDay,
+          dayRate,
+          totalHours: round2(agg.totalHours),
+          effortDays: round2(agg.totalDays),
+          totalDays: 0,
+          allocatedDays: 0,
+          // Display-only default matching the pre-existing no-profile row
+          // shape, so the capacity editor opens with the same 100% "As
+          // needed" draft a normal project gets. Nothing is persisted or
+          // fabricated: allocatedDays/totalDays/cost stay zero and the
+          // explicit planningState marker keeps the UI in quarantine.
+          allocationMode: 'EFFORT',
+          allocationPercent: 100,
+          allocationStartWeek: null,
+          allocationEndWeek: null,
+          derivedStartWeek: null,
+          derivedEndWeek: null,
+          estimatedCost: null,
+          epics: [],
+          namedResources: resourceType.namedResources.map(nr => ({
+            id: nr.id,
+            name: nr.name,
+            resourceTypeId: nr.resourceTypeId,
+            pricingModel: nr.pricingModel === 'PRO_RATA' ? 'PRO_RATA' : 'ACTUAL_DAYS',
+            allocationMode: 'EFFORT',
+            allocationPercent: 100,
+            allocationPct: 100,
+            allocationStartWeek: null,
+            allocationEndWeek: null,
+            startWeek: null,
+            endWeek: null,
+            allocatedDays: 0,
+            derivedStartWeek: null,
+            derivedEndWeek: null,
+            actualAllocatedDays: 0,
+            actualAllocationStartWeek: null,
+            actualAllocationEndWeek: null,
+            actualAllocatedWeeks: [],
+            actualAllocationSegments: [],
+            synthetic: false,
+            resourceIdentity: 'NAMED_PERSON' as const,
+          })),
+        }
+      })
+      .sort((a, b) => {
+        const indexOf = (cat: string) => {
+          const idx = CATEGORY_ORDER.indexOf(cat as ResourceCategory)
+          return idx === -1 ? CATEGORY_ORDER.length : idx
+        }
+        const catDiff = indexOf(a.category) - indexOf(b.category)
+        if (catDiff !== 0) return catDiff
+        return a.name.localeCompare(b.name)
+      })
+
+    const totalResourceHours = round2(resourceRows.reduce((sum, row) => sum + row.totalHours, 0))
+
+    res.json({
+      projectId,
+      planningState: 'NEEDS_REPLAN',
+      hoursPerDay: fallbackHoursPerDay,
+      projectDurationWeeks: 0,
+      bufferWeeks: project.bufferWeeks ?? 0,
+      onboardingWeeks: project.onboardingWeeks ?? 0,
+      resourceRows,
+      overheadRows: project.overheads.map(overhead => ({
+        overheadId: overhead.id,
+        name: overhead.name,
+        resourceTypeId: overhead.resourceTypeId,
+        resourceTypeName: overhead.resourceType?.name ?? null,
+        dayRate: overhead.resourceType?.dayRate ?? overhead.resourceType?.globalType?.defaultDayRate ?? null,
+        type: overhead.type,
+        value: overhead.value,
+        computedDays: 0,
+        estimatedCost: null,
+        requiredFTE: 0,
+        currentCount: overhead.resourceType?.count ?? null,
+      })),
+      summary: {
+        totalHours: totalResourceHours,
+        totalDays: 0,
+        totalCost: null,
+        hasCost: false,
+      },
+    })
+    return
+  }
+
+  // Materialize capacity plan for shared model consumption
+  const capacityPlanByRt = materializeCapacityPlanResources(
+    (project.capacityPlans?.[0] ?? null)?.periods ?? [],
+  )
+  // Build capacity-profile enrichment map (profile-first, fail-closed)
+  const { roleProfiles, namedResourceProfiles } = buildResourceCapacityProfileMap(
+    project as unknown as Parameters<typeof buildResourceCapacityProfileMap>[0],
+  )
+  // Resolve profile-first scheduler capacity — the single source for
+  // per-resource availability (legacy-shaped display fields are projected
+  // from authoritative profiles, never read from candidate columns).
+  const resolvedCapacity = await resolveSchedulerCapacity(prisma, projectId)
+
+  // Project duration in weeks
+  const planningWindow = computePlanningWindow(
+    project.timelineEntries,
+    project.startDate,
+    project.bufferWeeks ?? 0,
+    project.onboardingWeeks ?? 0,
+  )
+  const projectDurationWeeks = planningWindow.maxWeek ?? 0
 
   // ── Fallback weekly demand from shared model ──────────────────────
   // Build entries at story-level granularity to preserve story-level scheduling semantics.

--- a/server/src/routes/timeline.ts
+++ b/server/src/routes/timeline.ts
@@ -22,6 +22,7 @@ import { buildProjectPlanningModel, convertWeeklyDemandCache } from '../lib/proj
 import { runSAPlanner } from '../lib/sa-planner.js'
 import { buildSnapshot } from './snapshots.js'
 import { pruneSnapshots } from '../lib/snapshotUtils.js'
+import { assertPlanningCurrent } from '../lib/projectPlanningState.js'
 const router = Router({ mergeParams: true })
 router.use(authenticate)
 
@@ -370,6 +371,32 @@ function buildResponse(
 
 // GET /api/projects/:projectId/timeline
 router.get('/', asyncHandler(async (req: AuthRequest, res: Response) => {
+  const project = await ownedProject(req.params.projectId as string, req.userId!)
+  if (!project) { res.status(404).json({ error: 'Project not found' }); return }
+  if (project.planningState === 'NEEDS_REPLAN') {
+    // Reset Planning clears generated schedule output and manual overrides.
+    // The timeline is intentionally empty (never derived from stale state)
+    // until the user replans and the project returns to CURRENT.
+    res.json({
+      projectId: project.id,
+      startDate: project.startDate,
+      hoursPerDay: project.hoursPerDay,
+      projectedEndDate: null,
+      bufferWeeks: project.bufferWeeks ?? 0,
+      onboardingWeeks: project.onboardingWeeks ?? 0,
+      parallelWarnings: [],
+      entries: [],
+      storyEntries: [],
+      featureDependencies: [],
+      storyDependencies: [],
+      epicDependencies: [],
+      weeklyDemand: [],
+      weeklyCapacity: [],
+      namedResources: [],
+      planningState: 'NEEDS_REPLAN',
+    })
+    return
+  }
   const model = await buildProjectPlanningModel(req.params.projectId as string, req.userId!)
     .catch(() => { res.status(404).json({ error: 'Project not found' }); return null })
   if (!model) return
@@ -481,6 +508,8 @@ router.get('/', asyncHandler(async (req: AuthRequest, res: Response) => {
 router.post('/schedule', asyncHandler(async (req: AuthRequest, res: Response) => {
   let project = await ownedProject(req.params.projectId as string, req.userId!)
   if (!project) { res.status(404).json({ error: 'Project not found' }); return }
+  // Planning-dependent: the scheduler consumes the current capacity model.
+  assertPlanningCurrent(project)
 
   const { startDate } = req.body
   const resourceLevel: boolean = req.body.resourceLevel === true
@@ -638,6 +667,8 @@ router.post('/schedule', asyncHandler(async (req: AuthRequest, res: Response) =>
 router.put('/stories/:storyId', asyncHandler(async (req: AuthRequest, res: Response) => {
   const project = await ownedProject(req.params.projectId as string, req.userId!)
   if (!project) { res.status(404).json({ error: 'Project not found' }); return }
+  // Manual overrides are planning-owned state (Timeline/Planning boundary).
+  assertPlanningCurrent(project)
 
   const { startWeek, durationWeeks } = req.body
   if (startWeek == null || durationWeeks == null) {
@@ -680,6 +711,8 @@ router.put('/stories/:storyId', asyncHandler(async (req: AuthRequest, res: Respo
 router.delete('/', asyncHandler(async (req: AuthRequest, res: Response) => {
   const project = await ownedProject(req.params.projectId as string, req.userId!)
   if (!project) { res.status(404).json({ error: 'Project not found' }); return }
+  // Manual overrides are planning-owned state (Timeline/Planning boundary).
+  assertPlanningCurrent(project)
 
   await Promise.all([
     prisma.timelineEntry.deleteMany({ where: { projectId: project.id, isManual: true } }),
@@ -699,6 +732,8 @@ router.delete('/', asyncHandler(async (req: AuthRequest, res: Response) => {
 router.delete('/stories/:storyId', asyncHandler(async (req: AuthRequest, res: Response) => {
   const project = await ownedProject(req.params.projectId as string, req.userId!)
   if (!project) { res.status(404).json({ error: 'Project not found' }); return }
+  // Manual overrides are planning-owned state (Timeline/Planning boundary).
+  assertPlanningCurrent(project)
 
   await prisma.storyTimelineEntry.deleteMany({
     where: { storyId: req.params.storyId as string, projectId: project.id },
@@ -723,6 +758,8 @@ router.get('/export/csv', asyncHandler(async (req: AuthRequest, res: Response) =
     },
   })
   if (!project) { res.status(404).json({ error: 'Project not found' }); return }
+  // Planning-dependent export: the schedule/capacity CSV is a planning output.
+  assertPlanningCurrent(project)
 
   const projectId = project.id
   const hpd = project.hoursPerDay
@@ -884,6 +921,8 @@ router.post('/level', asyncHandler(async (req: AuthRequest, res: Response) => {
   const projectId = req.params.projectId as string
   const project = await ownedProject(projectId, req.userId!)
   if (!project) { res.status(404).json({ error: 'Project not found' }); return }
+  // Planning-dependent: levelling consumes the current capacity model.
+  assertPlanningCurrent(project)
 
   const { dryRun } = req.body as { dryRun?: boolean }
 
@@ -1053,6 +1092,8 @@ router.post('/level', asyncHandler(async (req: AuthRequest, res: Response) => {
 router.put('/:featureId', asyncHandler(async (req: AuthRequest, res: Response) => {
   const project = await ownedProject(req.params.projectId as string, req.userId!)
   if (!project) { res.status(404).json({ error: 'Project not found' }); return }
+  // Manual overrides are planning-owned state (Timeline/Planning boundary).
+  assertPlanningCurrent(project)
 
   const { startWeek, durationWeeks } = req.body
   if (startWeek == null || durationWeeks == null) {
@@ -1097,6 +1138,8 @@ router.put('/:featureId', asyncHandler(async (req: AuthRequest, res: Response) =
 router.delete('/:featureId', asyncHandler(async (req: AuthRequest, res: Response) => {
   const project = await ownedProject(req.params.projectId as string, req.userId!)
   if (!project) { res.status(404).json({ error: 'Project not found' }); return }
+  // Manual overrides are planning-owned state (Timeline/Planning boundary).
+  assertPlanningCurrent(project)
 
   await prisma.timelineEntry.deleteMany({
     where: { featureId: req.params.featureId as string, projectId: project.id },

--- a/server/src/scripts/classifyNeedsReplan.ts
+++ b/server/src/scripts/classifyNeedsReplan.ts
@@ -7,25 +7,33 @@
  * startup or from an HTTP request, exposes no API or UI, and performs no
  * capacity inference, profile reconstruction, percentage, window or
  * owner-kind decisions. Each classified project goes through the same atomic
- * reset transaction as the normal Reset Planning product action, preserving
- * estimation/business data.
+ * reset transaction body as the normal Reset Planning product action,
+ * preserving estimation/business data.
  *
  * Usage:
- *   npx tsx src/scripts/classifyNeedsReplan.ts --manifest manifest.json        # DRY RUN (default)
- *   npx tsx src/scripts/classifyNeedsReplan.ts --manifest manifest.json --apply # destructive apply
+ *   npx tsx src/scripts/classifyNeedsReplan.ts --manifest manifest.json                      # DRY RUN (default)
+ *   npx tsx src/scripts/classifyNeedsReplan.ts --manifest manifest.json --apply \
+ *        --expected-fingerprint <sha256>                                                      # apply
  *
  * Manifest shape (reviewed input only — never invented selection rules):
  *   { "projectIds": ["<projectId>", ...] }
  *
+ * Dry-run prints `stateFingerprint: <sha256>` — a deterministic fingerprint
+ * over the reset-relevant state of the exact manifest set. Apply REQUIRES
+ * that reviewed fingerprint via --expected-fingerprint and aborts with zero
+ * writes on any drift. The whole apply is one transaction: either every
+ * to-classify project is reset or none is.
+ *
  * Exit contract:
  *   0 — dry run completed, or apply completed (every manifest project is now
  *       NEEDS_REPLAN or was already NEEDS_REPLAN);
- *   1 — manifest missing/invalid, unknown arguments, any manifest project no
- *       longer exists (fail closed), or the command failed.
+ *   1 — manifest missing/invalid, unknown arguments, missing/malformed
+ *       --expected-fingerprint for apply, fingerprint drift, any manifest
+ *       project no longer exists (fail closed), or the command failed.
  *
- * Output is sanitized: only operator-supplied project IDs and aggregate
- * counts are printed — no project names, payloads, user data or database
- * connection details.
+ * Output is sanitized: only operator-supplied project IDs, the reviewed
+ * fingerprint hash and aggregate counts are printed — no project names,
+ * payloads, user data or database connection details.
  */
 
 import { readFileSync } from 'node:fs'
@@ -41,22 +49,63 @@ import {
   type ClassifyManifest,
 } from '../lib/classifyNeedsReplan.js'
 
-export async function main(argv: string[]): Promise<number> {
+const FINGERPRINT_RE = /^[0-9a-f]{64}$/i
+
+export interface ClassifyCliArgs {
+  apply: boolean
+  manifestPath: string | null
+  expectedFingerprint: string | null
+  /** Human-readable usage error; null when the arguments are valid. */
+  error: string | null
+}
+
+/** Pure argument parsing (unit-testable without a database). */
+export function parseClassifyCliArgs(argv: string[]): ClassifyCliArgs {
   const apply = argv.includes('--apply')
   const manifestIndex = argv.indexOf('--manifest')
   const manifestPath = manifestIndex >= 0 ? argv[manifestIndex + 1] : null
-  const unknownArgs = argv.filter(arg => arg !== '--apply' && arg !== '--manifest' && arg !== manifestPath)
+  const fingerprintIndex = argv.indexOf('--expected-fingerprint')
+  const expectedFingerprint = fingerprintIndex >= 0 ? argv[fingerprintIndex + 1] : null
+  const known = new Set(['--apply', '--manifest', manifestPath, '--expected-fingerprint', expectedFingerprint])
+  const unknownArgs = argv.filter(arg => !known.has(arg))
+
   if (manifestPath == null || manifestPath === '--apply' || unknownArgs.length > 0) {
-    console.log('❌ usage: classifyNeedsReplan.ts --manifest <manifest.json> [--apply]')
-    console.log('')
-    console.log('  --manifest <path>  reviewed JSON manifest: { "projectIds": ["<id>", ...] }')
-    console.log('  --apply            destructive apply (default is DRY RUN, zero writes)')
+    return {
+      apply,
+      manifestPath: null,
+      expectedFingerprint: null,
+      error: 'usage: classifyNeedsReplan.ts --manifest <manifest.json> [--apply --expected-fingerprint <sha256>]',
+    }
+  }
+  if (apply && expectedFingerprint == null) {
+    return {
+      apply,
+      manifestPath,
+      expectedFingerprint: null,
+      error: 'apply requires --expected-fingerprint <sha256> from a dry-run on unchanged state',
+    }
+  }
+  if (expectedFingerprint != null && !FINGERPRINT_RE.test(expectedFingerprint)) {
+    return {
+      apply,
+      manifestPath,
+      expectedFingerprint: null,
+      error: '--expected-fingerprint must be a 64-character SHA-256 hex digest',
+    }
+  }
+  return { apply, manifestPath, expectedFingerprint, error: null }
+}
+
+export async function main(argv: string[]): Promise<number> {
+  const args = parseClassifyCliArgs(argv)
+  if (args.error) {
+    console.log(`❌ ${args.error}`)
     return 1
   }
 
   let manifest: ClassifyManifest
   try {
-    manifest = parseClassifyManifest(JSON.parse(readFileSync(manifestPath, 'utf8')))
+    manifest = parseClassifyManifest(JSON.parse(readFileSync(args.manifestPath!, 'utf8')))
   } catch (error) {
     console.log('❌ manifest invalid:', error instanceof Error ? error.message : String(error))
     return 1
@@ -64,8 +113,8 @@ export async function main(argv: string[]): Promise<number> {
 
   console.log('🔍 Classify projects as NEEDS_REPLAN')
   console.log('====================================')
-  console.log(apply
-    ? 'Mode: APPLY — each listed project is classified via the atomic reset transaction.'
+  console.log(args.apply
+    ? 'Mode: APPLY — the reviewed set is classified atomically (one transaction).'
     : 'Mode: DRY RUN (default) — zero writes.')
   console.log('')
 
@@ -73,8 +122,11 @@ export async function main(argv: string[]): Promise<number> {
   const prisma = new PrismaClient({ adapter })
 
   try {
-    const report = await classifyNeedsReplan(prisma, manifest, { apply })
-    console.log(formatClassificationReport(report, apply))
+    const report = await classifyNeedsReplan(prisma, manifest, {
+      apply: args.apply,
+      expectedFingerprint: args.expectedFingerprint ?? undefined,
+    })
+    console.log(formatClassificationReport(report, args.apply))
     return report.notFoundCount > 0 ? 1 : 0
   } catch (error) {
     console.log('')

--- a/server/src/scripts/classifyNeedsReplan.ts
+++ b/server/src/scripts/classifyNeedsReplan.ts
@@ -1,0 +1,96 @@
+/**
+ * classifyNeedsReplan.ts — Standalone maintenance command that classifies an
+ * explicitly supplied, reviewed project set as NEEDS_REPLAN (issue #449).
+ *
+ * Intended for explicit invocation by the production-machine agent under
+ * issue #404 inside a maintenance window. It NEVER runs during application
+ * startup or from an HTTP request, exposes no API or UI, and performs no
+ * capacity inference, profile reconstruction, percentage, window or
+ * owner-kind decisions. Each classified project goes through the same atomic
+ * reset transaction as the normal Reset Planning product action, preserving
+ * estimation/business data.
+ *
+ * Usage:
+ *   npx tsx src/scripts/classifyNeedsReplan.ts --manifest manifest.json        # DRY RUN (default)
+ *   npx tsx src/scripts/classifyNeedsReplan.ts --manifest manifest.json --apply # destructive apply
+ *
+ * Manifest shape (reviewed input only — never invented selection rules):
+ *   { "projectIds": ["<projectId>", ...] }
+ *
+ * Exit contract:
+ *   0 — dry run completed, or apply completed (every manifest project is now
+ *       NEEDS_REPLAN or was already NEEDS_REPLAN);
+ *   1 — manifest missing/invalid, unknown arguments, any manifest project no
+ *       longer exists (fail closed), or the command failed.
+ *
+ * Output is sanitized: only operator-supplied project IDs and aggregate
+ * counts are printed — no project names, payloads, user data or database
+ * connection details.
+ */
+
+import { readFileSync } from 'node:fs'
+import { pathToFileURL } from 'node:url'
+import { PrismaPg } from '@prisma/adapter-pg'
+import { PrismaClient } from '@prisma/client'
+import 'dotenv/config'
+
+import {
+  classifyNeedsReplan,
+  formatClassificationReport,
+  parseClassifyManifest,
+  type ClassifyManifest,
+} from '../lib/classifyNeedsReplan.js'
+
+export async function main(argv: string[]): Promise<number> {
+  const apply = argv.includes('--apply')
+  const manifestIndex = argv.indexOf('--manifest')
+  const manifestPath = manifestIndex >= 0 ? argv[manifestIndex + 1] : null
+  const unknownArgs = argv.filter(arg => arg !== '--apply' && arg !== '--manifest' && arg !== manifestPath)
+  if (manifestPath == null || manifestPath === '--apply' || unknownArgs.length > 0) {
+    console.log('❌ usage: classifyNeedsReplan.ts --manifest <manifest.json> [--apply]')
+    console.log('')
+    console.log('  --manifest <path>  reviewed JSON manifest: { "projectIds": ["<id>", ...] }')
+    console.log('  --apply            destructive apply (default is DRY RUN, zero writes)')
+    return 1
+  }
+
+  let manifest: ClassifyManifest
+  try {
+    manifest = parseClassifyManifest(JSON.parse(readFileSync(manifestPath, 'utf8')))
+  } catch (error) {
+    console.log('❌ manifest invalid:', error instanceof Error ? error.message : String(error))
+    return 1
+  }
+
+  console.log('🔍 Classify projects as NEEDS_REPLAN')
+  console.log('====================================')
+  console.log(apply
+    ? 'Mode: APPLY — each listed project is classified via the atomic reset transaction.'
+    : 'Mode: DRY RUN (default) — zero writes.')
+  console.log('')
+
+  const adapter = new PrismaPg({ connectionString: process.env.DATABASE_URL })
+  const prisma = new PrismaClient({ adapter })
+
+  try {
+    const report = await classifyNeedsReplan(prisma, manifest, { apply })
+    console.log(formatClassificationReport(report, apply))
+    return report.notFoundCount > 0 ? 1 : 0
+  } catch (error) {
+    console.log('')
+    console.log('❌ Classification failed:', error instanceof Error ? error.message : String(error))
+    return 1
+  } finally {
+    await prisma.$disconnect()
+  }
+}
+
+// Execute only when run directly as a script; importing `main` for tests
+// must not trigger process.exit.
+const isMain = Boolean(
+  process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href,
+)
+if (isMain) {
+  const exitCode = await main(process.argv.slice(2))
+  process.exit(exitCode)
+}

--- a/server/src/test/canonical-consistency.test.ts
+++ b/server/src/test/canonical-consistency.test.ts
@@ -193,6 +193,8 @@ beforeEach(() => vi.clearAllMocks())
 describe('canonical cross-surface consistency', () => {
   it('Timeline reports correct named-resource labels, allocation days, and onboarding-shifted dates', async () => {
     vi.mocked(prisma.project.findFirst).mockResolvedValueOnce(baseProjectFixture() as never)
+    // The route's planning-state lookup consumes a findFirst before the model loads.
+    vi.mocked(prisma.project.findFirst).mockResolvedValueOnce(baseProjectFixture() as never)
     vi.mocked(prisma.resourceType.findMany).mockResolvedValueOnce(resourceTypeWithNamedResources() as never)
     vi.mocked(prisma.timelineEntry.findMany).mockResolvedValueOnce(timelineEntryFixture() as never)
     vi.mocked(prisma.storyTimelineEntry.findMany).mockResolvedValueOnce([] as never)
@@ -319,6 +321,8 @@ describe('canonical cross-surface consistency', () => {
     expect(res.body.summary.totalCost).toBe(rowCostSum + overheadCostSum)
   })
   it('Timeline and Resource Profile agree on actualAllocatedDays for the same NR', async () => {
+    vi.mocked(prisma.project.findFirst).mockResolvedValueOnce(baseProjectFixture() as never)
+    // The route's planning-state lookup consumes a findFirst before the model loads.
     vi.mocked(prisma.project.findFirst).mockResolvedValueOnce(baseProjectFixture() as never)
     vi.mocked(prisma.resourceType.findMany).mockResolvedValueOnce(resourceTypeWithNamedResources() as never)
     vi.mocked(prisma.timelineEntry.findMany).mockResolvedValueOnce(timelineEntryFixture() as never)

--- a/server/src/test/classifyNeedsReplan.test.ts
+++ b/server/src/test/classifyNeedsReplan.test.ts
@@ -286,16 +286,51 @@ describe('planClassification', () => {
 // ─── classifyNeedsReplan ────────────────────────────────────────────────────
 
 describe('classifyNeedsReplan', () => {
-  it('is a read-only dry run by default and emits the reviewed-state fingerprint', async () => {
+  it('is a zero-write dry run by default: one repeatable-read snapshot for report + fingerprint', async () => {
     const { db } = makeDb(defaultState)
     const report = await classifyNeedsReplan(db, manifest)
 
     expect(report.classifiedCount).toBe(2)
     expect(report.stateFingerprint).toMatch(/^[0-9a-f]{64}$/)
     expect(report.stateFingerprint).toBe(await computeClassificationFingerprint(db, manifest))
-    // Dry-run never opens a (Serializable or any other) transaction.
-    expect(db.$transaction).not.toHaveBeenCalled()
+    // Dry-run report and fingerprint are generated inside ONE transaction
+    // with repeatable-read isolation — one consistent snapshot.
+    expect(db.$transaction).toHaveBeenCalledTimes(1)
+    expect(db.$transaction).toHaveBeenCalledWith(
+      expect.any(Function),
+      { isolationLevel: 'RepeatableRead' },
+    )
     expect(resetProjectPlanningWithinTransaction).not.toHaveBeenCalled()
+  })
+
+  it('runs classification and fingerprint reads through one transaction body', async () => {
+    const { db } = makeDb(defaultState)
+    await classifyNeedsReplan(db, manifest)
+
+    // The report path is fully enclosed in the repeatable-read transaction
+    // body — the root client is never used for the review reads. In the fake
+    // the transaction client and root client share query objects, so the
+    // ordering of classification → fingerprint inside ONE body is what this
+    // asserts.
+    const txBody = vi.mocked(db.$transaction).mock.calls[0][0] as (
+      tx: unknown,
+    ) => Promise<unknown>
+    const result = await txBody(db)
+    expect(result).toHaveProperty('stateFingerprint')
+  })
+
+  it('invokes the afterPlanRead seam inside the snapshot before the fingerprint read', async () => {
+    const { db } = makeDb(defaultState)
+    const afterPlanRead = vi.fn(async () => { /* test seam */ })
+    await classifyNeedsReplan(db, manifest, { afterPlanRead })
+
+    expect(afterPlanRead).toHaveBeenCalledTimes(1)
+    const txBody = vi.mocked(db.$transaction).mock.calls[0][0] as (
+      tx: unknown,
+    ) => Promise<unknown>
+    const result = await txBody(db)
+    expect(afterPlanRead).toHaveBeenCalledTimes(2)
+    expect(result).toHaveProperty('stateFingerprint')
   })
 
   it('refuses apply without the reviewed fingerprint, with zero writes', async () => {

--- a/server/src/test/classifyNeedsReplan.test.ts
+++ b/server/src/test/classifyNeedsReplan.test.ts
@@ -1,10 +1,13 @@
 /**
  * classifyNeedsReplan.test.ts — Unit tests for the reviewed production
  * maintenance path (issue #449 / #404): classifying an explicitly supplied
- * project set as NEEDS_REPLAN via the same atomic reset transaction.
+ * project set as NEEDS_REPLAN via the same atomic reset transaction body.
  *
- * Covers manifest parsing (fail closed), dry-run planning, apply, idempotent
- * already-NEEDS_REPLAN skipping, and abort-on-missing-project.
+ * Covers manifest parsing (fail closed), the deterministic reset-state
+ * fingerprint (stability, ordering, per-state-change sensitivity, exclusion
+ * of unrelated backlog state), the dry-run/apply fingerprint contract
+ * (refusal without/with wrong fingerprint, zero writes), the atomic batch
+ * apply, and the CLI argument contract.
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest'
@@ -13,17 +16,108 @@ import {
   parseClassifyManifest,
   planClassification,
   classifyNeedsReplan,
+  computeClassificationFingerprint,
   ClassifyManifestError,
   ClassifyAbortError,
+  ClassifyDriftError,
   type ClassifyManifest,
+  type ClassifyDb,
 } from '../lib/classifyNeedsReplan.js'
-import { resetProjectPlanning } from '../lib/resetProjectPlanning.js'
+import { parseClassifyCliArgs } from '../scripts/classifyNeedsReplan.js'
+import { resetProjectPlanningWithinTransaction } from '../lib/resetProjectPlanning.js'
 
 vi.mock('../lib/resetProjectPlanning.js', () => ({
-  resetProjectPlanning: vi.fn().mockResolvedValue({ projectId: 'x', planningState: 'NEEDS_REPLAN' }),
+  resetProjectPlanningWithinTransaction: vi.fn().mockResolvedValue({ projectId: 'x', planningState: 'NEEDS_REPLAN' }),
 }))
 
 beforeEach(() => vi.clearAllMocks())
+
+// ─── Fake database ──────────────────────────────────────────────────────────
+
+interface FakeState {
+  projects?: Array<{ id: string; planningState: string; weeklyDemandCache?: unknown }>
+  capacityProfiles?: Array<Record<string, unknown>>
+  capacitySegments?: Array<Record<string, unknown>>
+  capacityPlans?: Array<Record<string, unknown>>
+  capacityPlanPeriods?: Array<Record<string, unknown>>
+  capacityPlanEntries?: Array<Record<string, unknown>>
+  timelineEntries?: Array<Record<string, unknown>>
+  storyTimelineEntries?: Array<Record<string, unknown>>
+  namedResources?: Array<Record<string, unknown>>
+}
+
+/**
+ * Build a fake db/tx whose query methods serve the given state. The same
+ * object serves as both the outer client and the transaction client.
+ */
+function makeDb(state: FakeState) {
+  const queries = {
+    project: {
+      findMany: vi.fn().mockResolvedValue(state.projects ?? []),
+      findUnique: vi.fn().mockImplementation(async ({ where }: { where: { id: string } }) =>
+        (state.projects ?? []).find(p => p.id === where.id) ?? null),
+      update: vi.fn(),
+    },
+    capacityProfile: {
+      findMany: vi.fn().mockResolvedValue(state.capacityProfiles ?? []),
+      deleteMany: vi.fn(),
+    },
+    capacitySegment: { findMany: vi.fn().mockResolvedValue(state.capacitySegments ?? []) },
+    capacityPlan: { findMany: vi.fn().mockResolvedValue(state.capacityPlans ?? []), deleteMany: vi.fn() },
+    capacityPlanPeriod: { findMany: vi.fn().mockResolvedValue(state.capacityPlanPeriods ?? []) },
+    capacityPlanEntry: { findMany: vi.fn().mockResolvedValue(state.capacityPlanEntries ?? []) },
+    timelineEntry: { findMany: vi.fn().mockResolvedValue(state.timelineEntries ?? []), deleteMany: vi.fn() },
+    storyTimelineEntry: { findMany: vi.fn().mockResolvedValue(state.storyTimelineEntries ?? []), deleteMany: vi.fn() },
+    namedResource: { findMany: vi.fn().mockResolvedValue(state.namedResources ?? []), deleteMany: vi.fn() },
+    epic: { findMany: vi.fn().mockResolvedValue([]) },
+    task: { findMany: vi.fn().mockResolvedValue([]) },
+  }
+  const db = {
+    ...queries,
+    $transaction: vi.fn(async (fn: (tx: unknown) => Promise<unknown>) => fn(queries)),
+  } as unknown as ClassifyDb
+  return { db, queries }
+}
+
+const manifest: ClassifyManifest = { projectIds: ['p1', 'p2'] }
+
+const defaultState: FakeState = {
+  projects: [
+    { id: 'p1', planningState: 'CURRENT', weeklyDemandCache: { 'rt-1|1': 5 } },
+    { id: 'p2', planningState: 'CURRENT', weeklyDemandCache: null },
+  ],
+  capacityProfiles: [
+    { id: 'cp-1', projectId: 'p1', resourceTypeId: 'rt-1', namedResourceId: null, ownerKind: 'ROLE', planningBasis: 'DEMAND_FOLLOWING', source: 'MANUAL', defaultPercent: 100, startWeek: null, endWeek: null },
+  ],
+  capacitySegments: [
+    { id: 'seg-1', capacityProfileId: 'cp-1', startWeek: 0, endWeek: 4, capacityPercent: 100, source: 'MANUAL' },
+  ],
+  capacityPlans: [
+    { id: 'plan-1', projectId: 'p1', name: 'Plan A', targetWeeks: 8, periodWeeks: 4, maxDelta: 1, isActive: true, totalCost: 1000, deliveryWeeks: 8 },
+  ],
+  capacityPlanPeriods: [
+    { id: 'per-1', planId: 'plan-1', periodIndex: 0, startWeek: 0, endWeek: 4 },
+  ],
+  capacityPlanEntries: [
+    { id: 'ent-1', periodId: 'per-1', resourceTypeId: 'rt-1', headcount: 2, demandFTE: 1.5, utilisationPct: 75 },
+  ],
+  timelineEntries: [
+    { id: 'tl-1', projectId: 'p1', featureId: 'f-1', startWeek: 0, durationWeeks: 6, isManual: false },
+  ],
+  storyTimelineEntries: [
+    { id: 'stl-1', projectId: 'p1', storyId: 's-1', startWeek: 0, durationWeeks: 6, isManual: false },
+  ],
+  namedResources: [
+    { id: 'nr-1', resourceTypeId: 'rt-1' },
+  ],
+}
+
+async function fingerprintFor(state: FakeState): Promise<string> {
+  const { db } = makeDb(state)
+  return computeClassificationFingerprint(db, manifest)
+}
+
+// ─── Manifest parsing ───────────────────────────────────────────────────────
 
 describe('parseClassifyManifest', () => {
   it('accepts a valid reviewed manifest', () => {
@@ -44,20 +138,124 @@ describe('parseClassifyManifest', () => {
   })
 })
 
-function mockPrisma(projects: Array<{ id: string; planningState: string }>) {
-  return {
-    project: {
-      findMany: vi.fn().mockResolvedValue(projects),
-    },
-  } as never
-}
+// ─── Fingerprint ────────────────────────────────────────────────────────────
+
+describe('computeClassificationFingerprint', () => {
+  it('is identical across repeated dry-runs on unchanged state', async () => {
+    const a = await fingerprintFor(defaultState)
+    const b = await fingerprintFor(defaultState)
+    expect(a).toMatch(/^[0-9a-f]{64}$/)
+    expect(a).toBe(b)
+  })
+
+  it('is independent of database return order', async () => {
+    const reversed: FakeState = {
+      ...defaultState,
+      projects: [...defaultState.projects!].reverse(),
+      capacityProfiles: [...defaultState.capacityProfiles!].reverse(),
+      capacitySegments: [...defaultState.capacitySegments!].reverse(),
+      capacityPlans: [...defaultState.capacityPlans!].reverse(),
+      capacityPlanPeriods: [...defaultState.capacityPlanPeriods!].reverse(),
+      capacityPlanEntries: [...defaultState.capacityPlanEntries!].reverse(),
+      timelineEntries: [...defaultState.timelineEntries!].reverse(),
+      storyTimelineEntries: [...defaultState.storyTimelineEntries!].reverse(),
+      namedResources: [...defaultState.namedResources!].reverse(),
+    }
+    expect(await fingerprintFor(reversed)).toBe(await fingerprintFor(defaultState))
+  })
+
+  it('changes when a manifest project is missing (existence drift)', async () => {
+    const missing: FakeState = { ...defaultState, projects: [defaultState.projects![0]] }
+    expect(await fingerprintFor(missing)).not.toBe(await fingerprintFor(defaultState))
+  })
+
+  it('changes when project planningState or weeklyDemandCache changes', async () => {
+    const stateChanged: FakeState = {
+      ...defaultState,
+      projects: [{ ...defaultState.projects![0], planningState: 'NEEDS_REPLAN' }, defaultState.projects![1]],
+    }
+    expect(await fingerprintFor(stateChanged)).not.toBe(await fingerprintFor(defaultState))
+
+    const cacheChanged: FakeState = {
+      ...defaultState,
+      projects: [{ ...defaultState.projects![0], weeklyDemandCache: { 'rt-1|2': 9 } }, defaultState.projects![1]],
+    }
+    expect(await fingerprintFor(cacheChanged)).not.toBe(await fingerprintFor(defaultState))
+  })
+
+  it('changes when any reset-relevant CapacityProfile field changes', async () => {
+    const changed: FakeState = {
+      ...defaultState,
+      capacityProfiles: [{ ...defaultState.capacityProfiles![0], ownerKind: 'NAMED_PERSON' }],
+    }
+    expect(await fingerprintFor(changed)).not.toBe(await fingerprintFor(defaultState))
+  })
+
+  it('changes when a CapacitySegment changes', async () => {
+    const changed: FakeState = {
+      ...defaultState,
+      capacitySegments: [{ ...defaultState.capacitySegments![0], capacityPercent: 50 }],
+    }
+    expect(await fingerprintFor(changed)).not.toBe(await fingerprintFor(defaultState))
+  })
+
+  it('changes when CapacityPlan/period/entry state changes', async () => {
+    const planChanged: FakeState = { ...defaultState, capacityPlans: [{ ...defaultState.capacityPlans![0], isActive: false }] }
+    expect(await fingerprintFor(planChanged)).not.toBe(await fingerprintFor(defaultState))
+
+    const periodChanged: FakeState = { ...defaultState, capacityPlanPeriods: [{ ...defaultState.capacityPlanPeriods![0], endWeek: 5 }] }
+    expect(await fingerprintFor(periodChanged)).not.toBe(await fingerprintFor(defaultState))
+
+    const entryChanged: FakeState = { ...defaultState, capacityPlanEntries: [{ ...defaultState.capacityPlanEntries![0], headcount: 3 }] }
+    expect(await fingerprintFor(entryChanged)).not.toBe(await fingerprintFor(defaultState))
+  })
+
+  it('changes when Timeline or StoryTimeline state changes', async () => {
+    const tlChanged: FakeState = { ...defaultState, timelineEntries: [{ ...defaultState.timelineEntries![0], durationWeeks: 8 }] }
+    expect(await fingerprintFor(tlChanged)).not.toBe(await fingerprintFor(defaultState))
+
+    const stlChanged: FakeState = { ...defaultState, storyTimelineEntries: [{ ...defaultState.storyTimelineEntries![0], startWeek: 2 }] }
+    expect(await fingerprintFor(stlChanged)).not.toBe(await fingerprintFor(defaultState))
+  })
+
+  it('changes when planner provenance (profile ownerKind) changes', async () => {
+    // A named resource becomes a proven PLANNED_RESOURCE planner artefact only
+    // via its profile ownerKind — that change must alter the fingerprint.
+    const changed: FakeState = {
+      ...defaultState,
+      capacityProfiles: [{
+        ...defaultState.capacityProfiles![0],
+        namedResourceId: 'nr-1',
+        resourceTypeId: null,
+        ownerKind: 'PLANNED_RESOURCE',
+        source: 'SQUAD_PLANNER',
+        planningBasis: 'CAPACITY_PROFILE',
+      }],
+    }
+    expect(await fingerprintFor(changed)).not.toBe(await fingerprintFor(defaultState))
+  })
+
+  it('does not read unrelated backlog/business state', async () => {
+    const { db, queries } = makeDb(defaultState)
+    await computeClassificationFingerprint(db, manifest)
+    // Fingerprint input is exactly the reset-relevant state: epic/task queries
+    // are never issued, so backlog changes cannot invalidate the fingerprint.
+    expect(queries.epic.findMany).not.toHaveBeenCalled()
+    expect(queries.task.findMany).not.toHaveBeenCalled()
+  })
+})
+
+// ─── Plan classification ────────────────────────────────────────────────────
 
 describe('planClassification', () => {
   it('classifies CURRENT projects as to-classify and NEEDS_REPLAN ones as already', async () => {
-    const report = await planClassification(mockPrisma([
-      { id: 'p1', planningState: 'CURRENT' },
-      { id: 'p2', planningState: 'NEEDS_REPLAN' },
-    ]), { projectIds: ['p1', 'p2'] })
+    const { db } = makeDb({
+      projects: [
+        { id: 'p1', planningState: 'CURRENT' },
+        { id: 'p2', planningState: 'NEEDS_REPLAN' },
+      ],
+    })
+    const report = await planClassification(db, { projectIds: ['p1', 'p2'] })
 
     expect(report.completed).toBe(true)
     expect(report.classifiedCount).toBe(1)
@@ -69,9 +267,8 @@ describe('planClassification', () => {
   })
 
   it('reports not-found projects (fail closed)', async () => {
-    const report = await planClassification(mockPrisma([{ id: 'p1', planningState: 'CURRENT' }]), {
-      projectIds: ['p1', 'p-missing'],
-    })
+    const { db } = makeDb({ projects: [{ id: 'p1', planningState: 'CURRENT' }] })
+    const report = await planClassification(db, { projectIds: ['p1', 'p-missing'] })
 
     expect(report.completed).toBe(false)
     expect(report.notFoundCount).toBe(1)
@@ -79,43 +276,130 @@ describe('planClassification', () => {
   })
 })
 
-describe('classifyNeedsReplan', () => {
-  const manifest: ClassifyManifest = { projectIds: ['p1', 'p2'] }
+// ─── classifyNeedsReplan ────────────────────────────────────────────────────
 
-  it('is a read-only dry run by default', async () => {
-    const report = await classifyNeedsReplan(mockPrisma([
-      { id: 'p1', planningState: 'CURRENT' },
-      { id: 'p2', planningState: 'CURRENT' },
-    ]), manifest)
+describe('classifyNeedsReplan', () => {
+  it('is a read-only dry run by default and emits the reviewed-state fingerprint', async () => {
+    const { db } = makeDb(defaultState)
+    const report = await classifyNeedsReplan(db, manifest)
 
     expect(report.classifiedCount).toBe(2)
-    expect(resetProjectPlanning).not.toHaveBeenCalled()
+    expect(report.stateFingerprint).toMatch(/^[0-9a-f]{64}$/)
+    expect(report.stateFingerprint).toBe(await computeClassificationFingerprint(db, manifest))
+    expect(resetProjectPlanningWithinTransaction).not.toHaveBeenCalled()
   })
 
-  it('applies the atomic reset transaction for each to-classify project', async () => {
-    const report = await classifyNeedsReplan(mockPrisma([
-      { id: 'p1', planningState: 'CURRENT' },
-      { id: 'p2', planningState: 'NEEDS_REPLAN' },
-    ]), manifest, { apply: true })
+  it('refuses apply without the reviewed fingerprint, with zero writes', async () => {
+    const { db, queries } = makeDb(defaultState)
+    await expect(
+      classifyNeedsReplan(db, manifest, { apply: true }),
+    ).rejects.toThrow(ClassifyAbortError)
+    expect(resetProjectPlanningWithinTransaction).not.toHaveBeenCalled()
+    expect(queries.project.update).not.toHaveBeenCalled()
+  })
+
+  it('refuses apply on fingerprint drift, with zero reset calls', async () => {
+    const { db } = makeDb(defaultState)
+    const reviewed = await computeClassificationFingerprint(db, manifest)
+
+    // One reset-relevant field changes after review.
+    const drifted = makeDb({
+      ...defaultState,
+      capacityProfiles: [{ ...defaultState.capacityProfiles![0], defaultPercent: 80 }],
+    })
+
+    await expect(
+      classifyNeedsReplan(drifted.db, manifest, { apply: true, expectedFingerprint: reviewed }),
+    ).rejects.toThrow(ClassifyDriftError)
+    expect(resetProjectPlanningWithinTransaction).not.toHaveBeenCalled()
+    expect(drifted.queries.project.update).not.toHaveBeenCalled()
+    expect(drifted.queries.capacityProfile.deleteMany).not.toHaveBeenCalled()
+  })
+
+  it('applies the reviewed set atomically in one transaction via the reset body', async () => {
+    const { db } = makeDb(defaultState)
+    const reviewed = await computeClassificationFingerprint(db, manifest)
+
+    const report = await classifyNeedsReplan(db, manifest, {
+      apply: true,
+      expectedFingerprint: reviewed,
+    })
+
+    expect(report.classifiedCount).toBe(2)
+    expect(report.stateFingerprint).toBe(reviewed)
+    expect(db.$transaction).toHaveBeenCalledTimes(1)
+    // Every to-classify project goes through the same reset body.
+    expect(resetProjectPlanningWithinTransaction).toHaveBeenCalledTimes(2)
+    expect(vi.mocked(resetProjectPlanningWithinTransaction).mock.calls.map(c => c[1])).toEqual(['p1', 'p2'])
+  })
+
+  it('skips already-NEEDS_REPLAN projects and still runs in one transaction', async () => {
+    const state: FakeState = {
+      ...defaultState,
+      projects: [
+        { id: 'p1', planningState: 'CURRENT' },
+        { id: 'p2', planningState: 'NEEDS_REPLAN' },
+      ],
+    }
+    const { db } = makeDb(state)
+    const reviewed = await computeClassificationFingerprint(db, manifest)
+
+    const report = await classifyNeedsReplan(db, manifest, {
+      apply: true,
+      expectedFingerprint: reviewed,
+    })
 
     expect(report.classifiedCount).toBe(1)
-    expect(resetProjectPlanning).toHaveBeenCalledTimes(1)
-    // Only p1 was reset; p2 was already quarantined (idempotent skip).
-    expect(vi.mocked(resetProjectPlanning).mock.calls[0][1]).toBe('p1')
+    expect(report.alreadyCount).toBe(1)
+    expect(db.$transaction).toHaveBeenCalledTimes(1)
+    expect(resetProjectPlanningWithinTransaction).toHaveBeenCalledTimes(1)
+    expect(vi.mocked(resetProjectPlanningWithinTransaction).mock.calls[0][1]).toBe('p1')
   })
 
-  it('aborts apply when a manifest project no longer exists', async () => {
+  it('aborts when a manifest project no longer exists', async () => {
+    const { db } = makeDb({ projects: [{ id: 'p1', planningState: 'CURRENT' }] })
     await expect(
-      classifyNeedsReplan(mockPrisma([{ id: 'p1', planningState: 'CURRENT' }]), {
-        projectIds: ['p1', 'p-gone'],
-      }, { apply: true }),
+      classifyNeedsReplan(db, { projectIds: ['p1', 'p-gone'] }),
     ).rejects.toThrow(ClassifyAbortError)
-    expect(resetProjectPlanning).not.toHaveBeenCalled()
+
+    await expect(
+      classifyNeedsReplan(db, { projectIds: ['p1', 'p-gone'] }, { apply: true, expectedFingerprint: '0'.repeat(64) }),
+    ).rejects.toThrow(ClassifyAbortError)
+  })
+})
+
+// ─── CLI argument contract ──────────────────────────────────────────────────
+
+describe('parseClassifyCliArgs', () => {
+  it('parses a valid dry-run invocation', () => {
+    expect(parseClassifyCliArgs(['--manifest', 'm.json'])).toEqual({
+      apply: false,
+      manifestPath: 'm.json',
+      expectedFingerprint: null,
+      error: null,
+    })
   })
 
-  it('aborts dry run planning when a manifest project no longer exists', async () => {
-    await expect(
-      classifyNeedsReplan(mockPrisma([]), { projectIds: ['p-gone'] }),
-    ).rejects.toThrow(ClassifyAbortError)
+  it('parses a valid apply invocation with the reviewed fingerprint', () => {
+    const args = parseClassifyCliArgs(['--manifest', 'm.json', '--apply', '--expected-fingerprint', 'a'.repeat(64)])
+    expect(args.error).toBeNull()
+    expect(args.apply).toBe(true)
+    expect(args.expectedFingerprint).toBe('a'.repeat(64))
+  })
+
+  it('rejects apply without the reviewed fingerprint', () => {
+    const args = parseClassifyCliArgs(['--manifest', 'm.json', '--apply'])
+    expect(args.error).toContain('--expected-fingerprint')
+  })
+
+  it('rejects a malformed fingerprint', () => {
+    const args = parseClassifyCliArgs(['--manifest', 'm.json', '--apply', '--expected-fingerprint', 'not-a-hash'])
+    expect(args.error).toContain('SHA-256')
+  })
+
+  it('rejects missing manifest and unknown arguments', () => {
+    expect(parseClassifyCliArgs([]).error).toContain('usage')
+    expect(parseClassifyCliArgs(['--bogus']).error).toContain('usage')
+    expect(parseClassifyCliArgs(['--manifest']).error).toContain('usage')
   })
 })

--- a/server/src/test/classifyNeedsReplan.test.ts
+++ b/server/src/test/classifyNeedsReplan.test.ts
@@ -1,0 +1,121 @@
+/**
+ * classifyNeedsReplan.test.ts — Unit tests for the reviewed production
+ * maintenance path (issue #449 / #404): classifying an explicitly supplied
+ * project set as NEEDS_REPLAN via the same atomic reset transaction.
+ *
+ * Covers manifest parsing (fail closed), dry-run planning, apply, idempotent
+ * already-NEEDS_REPLAN skipping, and abort-on-missing-project.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+import {
+  parseClassifyManifest,
+  planClassification,
+  classifyNeedsReplan,
+  ClassifyManifestError,
+  ClassifyAbortError,
+  type ClassifyManifest,
+} from '../lib/classifyNeedsReplan.js'
+import { resetProjectPlanning } from '../lib/resetProjectPlanning.js'
+
+vi.mock('../lib/resetProjectPlanning.js', () => ({
+  resetProjectPlanning: vi.fn().mockResolvedValue({ projectId: 'x', planningState: 'NEEDS_REPLAN' }),
+}))
+
+beforeEach(() => vi.clearAllMocks())
+
+describe('parseClassifyManifest', () => {
+  it('accepts a valid reviewed manifest', () => {
+    expect(parseClassifyManifest({ projectIds: ['p1', 'p2'] })).toEqual({ projectIds: ['p1', 'p2'] })
+  })
+
+  it.each([
+    [null, 'object'],
+    ['nope', 'object'],
+    [{}, 'projectIds'],
+    [{ projectIds: 'p1' }, 'projectIds'],
+    [{ projectIds: [] }, 'not be empty'],
+    [{ projectIds: ['p1', 42] }, 'non-empty string'],
+    [{ projectIds: ['p1', 'p1'] }, 'duplicate'],
+  ])('fails closed on malformed manifest %#', (raw, expected) => {
+    expect(() => parseClassifyManifest(raw)).toThrow(ClassifyManifestError)
+    expect(() => parseClassifyManifest(raw)).toThrow(expected)
+  })
+})
+
+function mockPrisma(projects: Array<{ id: string; planningState: string }>) {
+  return {
+    project: {
+      findMany: vi.fn().mockResolvedValue(projects),
+    },
+  } as never
+}
+
+describe('planClassification', () => {
+  it('classifies CURRENT projects as to-classify and NEEDS_REPLAN ones as already', async () => {
+    const report = await planClassification(mockPrisma([
+      { id: 'p1', planningState: 'CURRENT' },
+      { id: 'p2', planningState: 'NEEDS_REPLAN' },
+    ]), { projectIds: ['p1', 'p2'] })
+
+    expect(report.completed).toBe(true)
+    expect(report.classifiedCount).toBe(1)
+    expect(report.alreadyCount).toBe(1)
+    expect(report.entries).toEqual([
+      { projectId: 'p1', status: 'to-classify' },
+      { projectId: 'p2', status: 'already-needs-replan' },
+    ])
+  })
+
+  it('reports not-found projects (fail closed)', async () => {
+    const report = await planClassification(mockPrisma([{ id: 'p1', planningState: 'CURRENT' }]), {
+      projectIds: ['p1', 'p-missing'],
+    })
+
+    expect(report.completed).toBe(false)
+    expect(report.notFoundCount).toBe(1)
+    expect(report.entries.find(e => e.projectId === 'p-missing')?.status).toBe('not-found')
+  })
+})
+
+describe('classifyNeedsReplan', () => {
+  const manifest: ClassifyManifest = { projectIds: ['p1', 'p2'] }
+
+  it('is a read-only dry run by default', async () => {
+    const report = await classifyNeedsReplan(mockPrisma([
+      { id: 'p1', planningState: 'CURRENT' },
+      { id: 'p2', planningState: 'CURRENT' },
+    ]), manifest)
+
+    expect(report.classifiedCount).toBe(2)
+    expect(resetProjectPlanning).not.toHaveBeenCalled()
+  })
+
+  it('applies the atomic reset transaction for each to-classify project', async () => {
+    const report = await classifyNeedsReplan(mockPrisma([
+      { id: 'p1', planningState: 'CURRENT' },
+      { id: 'p2', planningState: 'NEEDS_REPLAN' },
+    ]), manifest, { apply: true })
+
+    expect(report.classifiedCount).toBe(1)
+    expect(resetProjectPlanning).toHaveBeenCalledTimes(1)
+    // Only p1 was reset; p2 was already quarantined (idempotent skip).
+    expect(vi.mocked(resetProjectPlanning).mock.calls[0][1]).toBe('p1')
+  })
+
+  it('aborts apply when a manifest project no longer exists', async () => {
+    await expect(
+      classifyNeedsReplan(mockPrisma([{ id: 'p1', planningState: 'CURRENT' }]), {
+        projectIds: ['p1', 'p-gone'],
+      }, { apply: true }),
+    ).rejects.toThrow(ClassifyAbortError)
+    expect(resetProjectPlanning).not.toHaveBeenCalled()
+  })
+
+  it('aborts dry run planning when a manifest project no longer exists', async () => {
+    await expect(
+      classifyNeedsReplan(mockPrisma([]), { projectIds: ['p-gone'] }),
+    ).rejects.toThrow(ClassifyAbortError)
+  })
+})

--- a/server/src/test/classifyNeedsReplan.test.ts
+++ b/server/src/test/classifyNeedsReplan.test.ts
@@ -11,6 +11,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { Prisma } from '@prisma/client'
 
 import {
   parseClassifyManifest,
@@ -20,6 +21,7 @@ import {
   ClassifyManifestError,
   ClassifyAbortError,
   ClassifyDriftError,
+  ClassifySerializationConflictError,
   type ClassifyManifest,
   type ClassifyDb,
 } from '../lib/classifyNeedsReplan.js'
@@ -50,7 +52,7 @@ interface FakeState {
  * Build a fake db/tx whose query methods serve the given state. The same
  * object serves as both the outer client and the transaction client.
  */
-function makeDb(state: FakeState) {
+function makeDb(state: FakeState, opts: { transactionError?: unknown } = {}) {
   const queries = {
     project: {
       findMany: vi.fn().mockResolvedValue(state.projects ?? []),
@@ -74,7 +76,12 @@ function makeDb(state: FakeState) {
   }
   const db = {
     ...queries,
-    $transaction: vi.fn(async (fn: (tx: unknown) => Promise<unknown>) => fn(queries)),
+    $transaction: vi.fn(async (fn: (tx: unknown) => Promise<unknown>) => {
+      const result = await fn(queries)
+      // Simulated commit-time failure (e.g. a serialization conflict).
+      if (opts.transactionError) throw opts.transactionError
+      return result
+    }),
   } as unknown as ClassifyDb
   return { db, queries }
 }
@@ -286,6 +293,8 @@ describe('classifyNeedsReplan', () => {
     expect(report.classifiedCount).toBe(2)
     expect(report.stateFingerprint).toMatch(/^[0-9a-f]{64}$/)
     expect(report.stateFingerprint).toBe(await computeClassificationFingerprint(db, manifest))
+    // Dry-run never opens a (Serializable or any other) transaction.
+    expect(db.$transaction).not.toHaveBeenCalled()
     expect(resetProjectPlanningWithinTransaction).not.toHaveBeenCalled()
   })
 
@@ -331,6 +340,60 @@ describe('classifyNeedsReplan', () => {
     // Every to-classify project goes through the same reset body.
     expect(resetProjectPlanningWithinTransaction).toHaveBeenCalledTimes(2)
     expect(vi.mocked(resetProjectPlanningWithinTransaction).mock.calls.map(c => c[1])).toEqual(['p1', 'p2'])
+  })
+
+  it('requests Serializable isolation for the destructive apply transaction', async () => {
+    const { db } = makeDb(defaultState)
+    const reviewed = await computeClassificationFingerprint(db, manifest)
+
+    await classifyNeedsReplan(db, manifest, {
+      apply: true,
+      expectedFingerprint: reviewed,
+    })
+
+    expect(db.$transaction).toHaveBeenCalledWith(
+      expect.any(Function),
+      { isolationLevel: 'Serializable' },
+    )
+  })
+
+  it('maps a Prisma P2034 serialization conflict to the actionable fail-closed error without retry', async () => {
+    const conflict = new Prisma.PrismaClientKnownRequestError('Transaction failed', {
+      code: 'P2034',
+      clientVersion: '7.8.0',
+    })
+    const { db, queries } = makeDb(defaultState, { transactionError: conflict })
+    const reviewed = await computeClassificationFingerprint(db, manifest)
+
+    const attempt = classifyNeedsReplan(db, manifest, { apply: true, expectedFingerprint: reviewed })
+    await expect(attempt).rejects.toThrow(ClassifySerializationConflictError)
+    await expect(attempt).rejects.toThrow(/changed concurrently/)
+    // The apply attempt is invalidated — the destructive transaction is NEVER
+    // retried automatically with the stale reviewed fingerprint.
+    expect(db.$transaction).toHaveBeenCalledTimes(1)
+    expect(queries.project.update).not.toHaveBeenCalled()
+  })
+
+  it('maps a driver-level 40001 serialization conflict to the actionable fail-closed error', async () => {
+    const conflict = new Error('serialization_failure') as Error & { cause?: unknown }
+    conflict.cause = { originalCode: '40001' }
+    const { db } = makeDb(defaultState, { transactionError: conflict })
+    const reviewed = await computeClassificationFingerprint(db, manifest)
+
+    await expect(
+      classifyNeedsReplan(db, manifest, { apply: true, expectedFingerprint: reviewed }),
+    ).rejects.toThrow(ClassifySerializationConflictError)
+    expect(db.$transaction).toHaveBeenCalledTimes(1)
+  })
+
+  it('leaves unrelated transaction failures unmodified (no retry, no masking)', async () => {
+    const { db } = makeDb(defaultState, { transactionError: new Error('disk full') })
+    const reviewed = await computeClassificationFingerprint(db, manifest)
+
+    await expect(
+      classifyNeedsReplan(db, manifest, { apply: true, expectedFingerprint: reviewed }),
+    ).rejects.toThrow('disk full')
+    expect(db.$transaction).toHaveBeenCalledTimes(1)
   })
 
   it('skips already-NEEDS_REPLAN projects and still runs in one transaction', async () => {

--- a/server/src/test/migrationSequencing.test.ts
+++ b/server/src/test/migrationSequencing.test.ts
@@ -1,0 +1,54 @@
+/**
+ * migrationSequencing.test.ts — Deployment-ordering protection for issue #449
+ * review finding 1.
+ *
+ * The #450 planning-state migration
+ * (`20260808221539_add_project_planning_state`) sits after the staged
+ * ownership-invariants migration
+ * (`20260721000001_enforce_capacity_profile_ownership_invariants`) in Prisma
+ * migration order. Production evidence records the older migration as still
+ * pending, so `prisma migrate deploy` applies it before the #450 migration.
+ *
+ * These assertions protect the documented deployment contract:
+ *   - the ownership-invariants migration still exists, is ordered BEFORE the
+ *     planning-state migration, and still contains its invariant enforcement
+ *     (it is never emptied, modified or silently bundled by #450);
+ *   - the planning-state migration exists and adds the planningState column.
+ */
+
+import { readFileSync, readdirSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+const migrationsDir = join(dirname(fileURLToPath(import.meta.url)), '..', '..', 'prisma', 'migrations')
+
+const OWNERSHIP_MIGRATION = '20260721000001_enforce_capacity_profile_ownership_invariants'
+const PLANNING_STATE_MIGRATION = '20260808221539_add_project_planning_state'
+
+describe('migration deployment sequencing (issue #449 review)', () => {
+  it('the ownership-invariants migration is ordered before the planning-state migration', () => {
+    const names = readdirSync(migrationsDir).filter(name => name.endsWith('.sql') === false)
+    expect(names).toContain(OWNERSHIP_MIGRATION)
+    expect(names).toContain(PLANNING_STATE_MIGRATION)
+    // Prisma applies migrations in lexicographic folder order; deploy therefore
+    // applies the ownership-invariants migration first.
+    expect(OWNERSHIP_MIGRATION.localeCompare(PLANNING_STATE_MIGRATION)).toBeLessThan(0)
+  })
+
+  it('the ownership-invariants migration is unchanged and still enforces its invariants', () => {
+    const sql = readFileSync(join(migrationsDir, OWNERSHIP_MIGRATION, 'migration.sql'), 'utf8')
+    // Core enforcement content — guards against accidental emptying/modification.
+    expect(sql).toContain('chk_CapacityProfile_exactly_one_owner')
+    expect(sql).toContain('chk_CapacityProfile_owner_kind_fk')
+    expect(sql).toContain('CREATE UNIQUE INDEX "CapacityProfile_resourceTypeId_key"')
+    expect(sql).toContain('CREATE UNIQUE INDEX "CapacityProfile_namedResourceId_key"')
+    expect(sql).toContain('Preflight FAILED')
+  })
+
+  it('the planning-state migration adds the Project.planningState column', () => {
+    const sql = readFileSync(join(migrationsDir, PLANNING_STATE_MIGRATION, 'migration.sql'), 'utf8')
+    expect(sql).toContain('ProjectPlanningState')
+    expect(sql).toContain('ADD COLUMN     "planningState"')
+  })
+})

--- a/server/src/test/planningGuards.test.ts
+++ b/server/src/test/planningGuards.test.ts
@@ -235,4 +235,96 @@ describe('accessible surfaces while NEEDS_REPLAN', () => {
     expect(res.body.summary.hasCost).toBe(false)
     expect(res.body.summary.totalDays).toBe(0)
   })
+
+  it('GET /resource-profile exposes preserved zero-demand roles while NEEDS_REPLAN', async () => {
+    vi.mocked(prisma.project.findFirst).mockResolvedValue({
+      ...NEEDS_REPLAN_PROJECT,
+      resourceTypes: [{
+        id: 'rt-1',
+        name: 'Engineer',
+        category: 'ENGINEERING',
+        count: 2,
+        hoursPerDay: 7.6,
+        dayRate: 500,
+        globalType: null,
+        namedResources: [{
+          id: 'nr-1',
+          resourceTypeId: 'rt-1',
+          name: 'Alice',
+          pricingModel: 'ACTUAL_DAYS',
+        }],
+      }, {
+        // Preserved role with NO task demand (no tasks reference it).
+        id: 'rt-2',
+        name: 'Designer',
+        category: 'DESIGN',
+        count: 1,
+        hoursPerDay: 7.6,
+        dayRate: 400,
+        globalType: null,
+        namedResources: [],
+      }],
+      epics: [{
+        id: 'epic-1',
+        name: 'Epic 1',
+        order: 0,
+        isActive: true,
+        features: [{
+          id: 'feat-1',
+          name: 'Feature 1',
+          order: 0,
+          isActive: true,
+          userStories: [{
+            id: 'story-1',
+            name: 'Story 1',
+            order: 0,
+            isActive: true,
+            tasks: [{
+              id: 'task-1',
+              name: 'Task 1',
+              hoursEffort: 10,
+              durationDays: null,
+              resourceTypeId: 'rt-1',
+              resourceType: { id: 'rt-1', name: 'Engineer', hoursPerDay: 7.6 },
+            }],
+          }],
+        }],
+      }],
+      overheads: [],
+      timelineEntries: [],
+      storyTimelineEntries: [],
+      capacityPlans: [],
+      capacityProfiles: [],
+    } as never)
+
+    const res = await request(app)
+      .get('/api/projects/proj-1/resource-profile')
+      .set('Authorization', authHeader)
+
+    expect(res.status).toBe(200)
+    expect(res.body.planningState).toBe('NEEDS_REPLAN')
+    // Every preserved role is visible — including the zero-demand one — so
+    // the user can create its profile before completing replanning.
+    expect(res.body.resourceRows).toHaveLength(2)
+    const zeroRow = res.body.resourceRows.find((r: { resourceTypeId: string }) => r.resourceTypeId === 'rt-2')
+    expect(zeroRow).toBeDefined()
+    // Real identity and non-planning metadata…
+    expect(zeroRow.name).toBe('Designer')
+    expect(zeroRow.count).toBe(1)
+    expect(zeroRow.hoursPerDay).toBe(7.6)
+    expect(zeroRow.dayRate).toBe(400)
+    // …zero effort/demand and NO fabricated capacity.
+    expect(zeroRow.totalHours).toBe(0)
+    expect(zeroRow.effortDays).toBe(0)
+    expect(zeroRow.totalDays).toBe(0)
+    expect(zeroRow.allocatedDays).toBe(0)
+    expect(zeroRow.estimatedCost).toBeNull()
+    // Editor-usable default shape (same draft a normal project gets).
+    expect(zeroRow.allocationMode).toBe('EFFORT')
+    expect(zeroRow.allocationPercent).toBe(100)
+    expect(zeroRow.capacityProfile).toBeUndefined()
+    // A named resource on the zero-demand role keeps its identity.
+    const rt2Named = res.body.resourceRows.find((r: { resourceTypeId: string }) => r.resourceTypeId === 'rt-2')
+    expect(rt2Named.namedResources).toEqual([])
+  })
 })

--- a/server/src/test/planningGuards.test.ts
+++ b/server/src/test/planningGuards.test.ts
@@ -1,0 +1,238 @@
+/**
+ * planningGuards.test.ts — NEEDS_REPLAN quarantine behaviour (issue #449).
+ *
+ * Capacity-dependent operations return an actionable 409 REPLAN_REQUIRED
+ * instead of running legacy fallback or surfacing opaque integrity errors,
+ * while the surfaces the user needs to replan (project shell, backlog,
+ * resource inputs, profile writes) stay accessible with an explicit
+ * NEEDS_REPLAN marker.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import request from 'supertest'
+import jwt from 'jsonwebtoken'
+
+import { app } from '../index.js'
+import { prisma } from '../lib/prisma.js'
+
+const userId = 'user-1'
+process.env.JWT_SECRET = 'test-secret'
+const token = jwt.sign({ userId }, 'test-secret')
+const authHeader = `Bearer ${token}`
+
+const NEEDS_REPLAN_PROJECT = {
+  id: 'proj-1',
+  ownerId: userId,
+  planningState: 'NEEDS_REPLAN',
+  hoursPerDay: 7.6,
+  startDate: null,
+  bufferWeeks: 0,
+  onboardingWeeks: 0,
+}
+
+beforeEach(() => vi.clearAllMocks())
+
+describe('planning-dependent guards while NEEDS_REPLAN', () => {
+  it('POST /timeline/schedule returns 409 REPLAN_REQUIRED without scheduling', async () => {
+    vi.mocked(prisma.project.findFirst).mockResolvedValue(NEEDS_REPLAN_PROJECT as never)
+
+    const res = await request(app)
+      .post('/api/projects/proj-1/timeline/schedule')
+      .set('Authorization', authHeader)
+      .send({})
+
+    expect(res.status).toBe(409)
+    expect(res.body.code).toBe('REPLAN_REQUIRED')
+    expect(res.body.error).toContain('needs replanning')
+    // No scheduler/data loads ran.
+    expect(prisma.epic.findMany).not.toHaveBeenCalled()
+  })
+
+  it('POST /timeline/level returns 409 REPLAN_REQUIRED', async () => {
+    vi.mocked(prisma.project.findFirst).mockResolvedValue(NEEDS_REPLAN_PROJECT as never)
+
+    const res = await request(app)
+      .post('/api/projects/proj-1/timeline/level')
+      .set('Authorization', authHeader)
+      .send({})
+
+    expect(res.status).toBe(409)
+    expect(res.body.code).toBe('REPLAN_REQUIRED')
+  })
+
+  it('GET /timeline/export/csv returns 409 REPLAN_REQUIRED', async () => {
+    vi.mocked(prisma.project.findFirst).mockResolvedValue(NEEDS_REPLAN_PROJECT as never)
+
+    const res = await request(app)
+      .get('/api/projects/proj-1/timeline/export/csv')
+      .set('Authorization', authHeader)
+
+    expect(res.status).toBe(409)
+    expect(res.body.code).toBe('REPLAN_REQUIRED')
+  })
+
+  it('manual timeline override PUT returns 409 REPLAN_REQUIRED', async () => {
+    vi.mocked(prisma.project.findFirst).mockResolvedValue(NEEDS_REPLAN_PROJECT as never)
+
+    const res = await request(app)
+      .put('/api/projects/proj-1/timeline/feature-1')
+      .set('Authorization', authHeader)
+      .send({ startWeek: 1, durationWeeks: 2 })
+
+    expect(res.status).toBe(409)
+    expect(res.body.code).toBe('REPLAN_REQUIRED')
+  })
+
+  it('POST /optimise returns 409 REPLAN_REQUIRED', async () => {
+    vi.mocked(prisma.project.findFirst).mockResolvedValue(NEEDS_REPLAN_PROJECT as never)
+
+    const res = await request(app)
+      .post('/api/projects/proj-1/optimise')
+      .set('Authorization', authHeader)
+      .send({})
+
+    expect(res.status).toBe(409)
+    expect(res.body.code).toBe('REPLAN_REQUIRED')
+  })
+})
+
+describe('accessible surfaces while NEEDS_REPLAN', () => {
+  it('GET /timeline returns an explicit neutral empty payload (no stale schedule)', async () => {
+    vi.mocked(prisma.project.findFirst).mockResolvedValue(NEEDS_REPLAN_PROJECT as never)
+
+    const res = await request(app)
+      .get('/api/projects/proj-1/timeline')
+      .set('Authorization', authHeader)
+
+    expect(res.status).toBe(200)
+    expect(res.body.planningState).toBe('NEEDS_REPLAN')
+    expect(res.body.entries).toEqual([])
+    expect(res.body.weeklyDemand).toEqual([])
+    expect(res.body.weeklyCapacity).toEqual([])
+    expect(res.body.namedResources).toEqual([])
+  })
+
+  it('GET /capacity-profiles serves the persisted (empty) set instead of failing completeness', async () => {
+    vi.mocked(prisma.project.findFirst).mockResolvedValue({
+      ...NEEDS_REPLAN_PROJECT,
+      resourceTypes: [{ id: 'rt-1', name: 'Engineer', namedResources: [] }],
+      capacityPlans: [],
+      capacityProfiles: [],
+    } as never)
+
+    const res = await request(app)
+      .get('/api/projects/proj-1/capacity-profiles')
+      .set('Authorization', authHeader)
+
+    expect(res.status).toBe(200)
+    expect(res.body.capacityProfiles).toEqual([])
+  })
+
+  it('GET /capacity-profiles still fails closed on genuinely malformed rows while NEEDS_REPLAN', async () => {
+    vi.mocked(prisma.project.findFirst).mockResolvedValue({
+      ...NEEDS_REPLAN_PROJECT,
+      resourceTypes: [{ id: 'rt-1', name: 'Engineer', namedResources: [] }],
+      capacityPlans: [],
+      capacityProfiles: [{
+        id: 'cp-bad',
+        projectId: 'proj-1',
+        resourceTypeId: 'rt-1',
+        namedResourceId: null,
+        ownerKind: 'ROLE',
+        source: 'MANUAL',
+        planningBasis: 'DEMAND_FOLLOWING',
+        defaultPercent: 100,
+        startWeek: 8,
+        endWeek: 3,
+        segments: [],
+      }],
+    } as never)
+
+    const res = await request(app)
+      .get('/api/projects/proj-1/capacity-profiles')
+      .set('Authorization', authHeader)
+
+    expect(res.status).toBe(409)
+    expect(res.body.code).toBe('CAPACITY_INTEGRITY_ERROR')
+  })
+
+  it('GET /resource-profile returns effort/inputs with neutral planning values and the marker', async () => {
+    vi.mocked(prisma.project.findFirst).mockResolvedValue({
+      ...NEEDS_REPLAN_PROJECT,
+      resourceTypes: [{
+        id: 'rt-1',
+        name: 'Engineer',
+        category: 'ENGINEERING',
+        count: 2,
+        hoursPerDay: 7.6,
+        dayRate: 500,
+        globalType: null,
+        namedResources: [{
+          id: 'nr-1',
+          resourceTypeId: 'rt-1',
+          name: 'Alice',
+          pricingModel: 'ACTUAL_DAYS',
+        }],
+      }],
+      epics: [{
+        id: 'epic-1',
+        name: 'Epic 1',
+        order: 0,
+        isActive: true,
+        features: [{
+          id: 'feat-1',
+          name: 'Feature 1',
+          order: 0,
+          isActive: true,
+          userStories: [{
+            id: 'story-1',
+            name: 'Story 1',
+            order: 0,
+            isActive: true,
+            tasks: [{
+              id: 'task-1',
+              name: 'Task 1',
+              hoursEffort: 10,
+              durationDays: null,
+              resourceTypeId: 'rt-1',
+              resourceType: { id: 'rt-1', name: 'Engineer', hoursPerDay: 7.6 },
+            }],
+          }],
+        }],
+      }],
+      overheads: [],
+      timelineEntries: [],
+      storyTimelineEntries: [],
+      capacityPlans: [],
+      capacityProfiles: [],
+    } as never)
+
+    const res = await request(app)
+      .get('/api/projects/proj-1/resource-profile')
+      .set('Authorization', authHeader)
+
+    expect(res.status).toBe(200)
+    expect(res.body.planningState).toBe('NEEDS_REPLAN')
+    expect(res.body.resourceRows).toHaveLength(1)
+    const row = res.body.resourceRows[0]
+    // Effort and identity survive…
+    expect(row.totalHours).toBe(10)
+    expect(row.effortDays).toBeGreaterThan(0)
+    expect(row.name).toBe('Engineer')
+    expect(row.count).toBe(2)
+    expect(row.dayRate).toBe(500)
+    // …but no planning/commercial values are fabricated.
+    expect(row.allocatedDays).toBe(0)
+    expect(row.totalDays).toBe(0)
+    expect(row.estimatedCost).toBeNull()
+    expect(row.capacityProfile).toBeUndefined()
+    // User-authored named resource identity is preserved.
+    expect(row.namedResources).toHaveLength(1)
+    expect(row.namedResources[0].name).toBe('Alice')
+    expect(row.namedResources[0].pricingModel).toBe('ACTUAL_DAYS')
+    // Summary carries no invented totals.
+    expect(res.body.summary.totalCost).toBeNull()
+    expect(res.body.summary.hasCost).toBe(false)
+    expect(res.body.summary.totalDays).toBe(0)
+  })
+})

--- a/server/src/test/planningReset.integration.test.ts
+++ b/server/src/test/planningReset.integration.test.ts
@@ -34,7 +34,7 @@ import { PrismaClient } from '@prisma/client'
 import { app } from '../app.js'
 import { resetProjectPlanning } from '../lib/resetProjectPlanning.js'
 import { runProductionMigrationReadiness, formatReadinessReport } from '../lib/productionMigrationReadiness.js'
-import { classifyNeedsReplan, parseClassifyManifest, ClassifyAbortError, type ClassificationReport } from '../lib/classifyNeedsReplan.js'
+import { classifyNeedsReplan, parseClassifyManifest, computeClassificationFingerprint, ClassifyAbortError, type ClassificationReport } from '../lib/classifyNeedsReplan.js'
 // Override the global prisma mock so route handlers use real PostgreSQL.
 vi.mock('../lib/prisma.js', async importOriginal => await importOriginal())
 
@@ -423,6 +423,94 @@ describeIf('Reset Planning — full boundary (issue #449)', () => {
     expect(after.nr.length).toBe(before.nr.length)
     expect(after.project!.weeklyDemandCache).toEqual(before.project!.weeklyDemandCache)
   })
+
+  it('removes proven legacy Squad Planner placeholders and preserves ambiguous ones', async () => {
+    const f = await createFullyPlannedProject()
+
+    // A proven legacy planner placeholder: NAMED_PERSON profile with the
+    // SQUAD_PLANNER + CAPACITY_PROFILE markers (isLegacyPlannerProfile).
+    const legacyRt = await prisma.resourceType.create({
+      data: {
+        projectId: f.projectId,
+        name: 'Legacy Planner Role',
+        category: 'ENGINEERING',
+        count: 1,
+        hoursPerDay: 7.6,
+      },
+    })
+    const legacyNr = await prisma.namedResource.create({
+      data: { resourceTypeId: legacyRt.id, name: 'Legacy Planner Person', pricingModel: 'ACTUAL_DAYS' },
+    })
+    const legacyProfile = await prisma.capacityProfile.create({
+      data: {
+        projectId: f.projectId,
+        resourceTypeId: null,
+        namedResourceId: legacyNr.id,
+        ownerKind: 'NAMED_PERSON',
+        source: 'SQUAD_PLANNER',
+        planningBasis: 'CAPACITY_PROFILE',
+        defaultPercent: 100,
+        startWeek: 0,
+        endWeek: 10,
+      },
+    })
+    await prisma.capacitySegment.create({
+      data: {
+        capacityProfileId: legacyProfile.id,
+        startWeek: 0,
+        endWeek: 10,
+        capacityPercent: 100,
+        source: 'SQUAD_PLANNER',
+      },
+    })
+
+    // An ambiguous row that must be preserved: a NAMED_PERSON profile that
+    // does NOT satisfy the safe planner-provenance rule (MANUAL source), i.e.
+    // a real user-authored resource.
+    const ambiguousRt = await prisma.resourceType.create({
+      data: {
+        projectId: f.projectId,
+        name: 'Ambiguous Role',
+        category: 'ENGINEERING',
+        count: 1,
+        hoursPerDay: 7.6,
+      },
+    })
+    const ambiguousNr = await prisma.namedResource.create({
+      data: { resourceTypeId: ambiguousRt.id, name: 'Bob', pricingModel: 'PRO_RATA' },
+    })
+    await prisma.capacityProfile.create({
+      data: {
+        projectId: f.projectId,
+        namedResourceId: ambiguousNr.id,
+        ownerKind: 'NAMED_PERSON',
+        source: 'MANUAL',
+        planningBasis: 'WHOLE_PROJECT_ALLOCATION',
+        defaultPercent: 100,
+      },
+    })
+
+    await resetProjectPlanning(prisma, f.projectId)
+
+    const nr = await prisma.namedResource.findMany({ where: { resourceType: { projectId: f.projectId } } })
+    const nrIds = nr.map(n => n.id)
+    // PLANNED_RESOURCE placeholder removed (existing behaviour)…
+    expect(nrIds).not.toContain(f.plannedNrId)
+    // …and the proven LEGACY planner placeholder is removed too.
+    expect(nrIds).not.toContain(legacyNr.id)
+    // Real user-authored NAMED_PERSON resources survive with identity intact,
+    // including the ambiguous row and the fixture's ordinary resource.
+    const preserved = [f.userNrId, ambiguousNr.id]
+    for (const id of preserved) {
+      const row = nr.find(n => n.id === id)
+      expect(row).toBeDefined()
+    }
+    const alice = nr.find(n => n.id === f.userNrId)!
+    expect(alice.pricingModel).toBe('PRO_RATA')
+    const bob = nr.find(n => n.id === ambiguousNr.id)!
+    expect(bob.pricingModel).toBe('PRO_RATA')
+    expect(bob.resourceTypeId).toBe(ambiguousRt.id)
+  })
 })
 
 describeIf('NEEDS_REPLAN quarantine (issue #449)', () => {
@@ -447,6 +535,18 @@ describeIf('NEEDS_REPLAN quarantine (issue #449)', () => {
 
   it('NEEDS_REPLAN projects stay accessible with expected missing planning state', async () => {
     const f = await createFullyPlannedProject()
+    // A preserved role with NO task demand: the replanning surface must still
+    // expose it so its profile can be created before completion.
+    const zeroDemandRt = await prisma.resourceType.create({
+      data: {
+        projectId: f.projectId,
+        name: 'Designer',
+        category: 'ENGINEERING',
+        count: 1,
+        hoursPerDay: 7.6,
+        dayRate: 400,
+      },
+    })
     await request(app)
       .post(`/api/projects/${f.projectId}/planning/reset`)
       .set('Authorization', authHeader)
@@ -465,9 +565,25 @@ describeIf('NEEDS_REPLAN quarantine (issue #449)', () => {
       .set('Authorization', authHeader)
     expect(rp.status).toBe(200)
     expect(rp.body.planningState).toBe('NEEDS_REPLAN')
-    expect(rp.body.resourceRows[0].totalHours).toBe(16)
+    const demandRow = rp.body.resourceRows.find((r: { resourceTypeId: string }) => r.resourceTypeId === f.rtId)
+    expect(demandRow.totalHours).toBe(16)
     expect(rp.body.summary.totalCost).toBeNull()
-    expect(rp.body.resourceRows[0].namedResources).toHaveLength(1) // Alice preserved
+    expect(demandRow.namedResources).toHaveLength(1) // Alice preserved
+
+    // Every preserved role is visible, including the zero-demand one.
+    const rowIds = rp.body.resourceRows.map((r: { resourceTypeId: string }) => r.resourceTypeId)
+    expect(rowIds).toContain(f.rtId)
+    expect(rowIds).toContain(zeroDemandRt.id)
+    const zeroRow = rp.body.resourceRows.find((r: { resourceTypeId: string }) => r.resourceTypeId === zeroDemandRt.id)
+    // Real identity, zero demand, no fabricated capacity.
+    expect(zeroRow.name).toBe('Designer')
+    expect(zeroRow.count).toBe(1)
+    expect(zeroRow.dayRate).toBe(400)
+    expect(zeroRow.totalHours).toBe(0)
+    expect(zeroRow.effortDays).toBe(0)
+    expect(zeroRow.totalDays).toBe(0)
+    expect(zeroRow.allocatedDays).toBe(0)
+    expect(zeroRow.estimatedCost).toBeNull()
 
     // Timeline is explicitly empty, never derived from stale state.
     const tl = await request(app)
@@ -804,6 +920,70 @@ describeIf('Reviewed production maintenance classification (issue #449 / #404)',
       expect(await prisma.task.count({ where: { userStory: { feature: { epic: { projectId: f.projectId } } } } })).toBeGreaterThan(0)
       expect(await prisma.projectDiscount.count({ where: { projectId: f.projectId } })).toBe(1)
     }
+  })
+
+  it('dry-run report and fingerprint come from one consistent snapshot', async () => {
+    const f = await createFullyPlannedProject()
+    const manifest = parseClassifyManifest({ projectIds: [f.projectId] })
+
+    // The project is already NEEDS_REPLAN: the dry run's classification must
+    // describe that state.
+    await prisma.project.update({
+      where: { id: f.projectId },
+      data: { planningState: 'NEEDS_REPLAN' },
+    })
+
+    // A second real connection flips reset-relevant state to CURRENT while
+    // the dry-run transaction is open, between the classification read and
+    // the fingerprint read. Without one consistent snapshot the fingerprint
+    // would describe the NEW state while the report describes the OLD one.
+    const prisma2 = new PrismaClient({
+      adapter: new PrismaPg({ connectionString: process.env.DATABASE_URL }),
+    })
+    await prisma2.$connect()
+
+    let seamReached: () => void = () => {}
+    const seamReachedPromise = new Promise<void>(resolve => { seamReached = resolve })
+    let release: () => void = () => {}
+    const gate = new Promise<void>(resolve => { release = resolve })
+
+    const promise = classifyNeedsReplan(prisma, manifest, {
+      afterPlanRead: async () => {
+        seamReached()
+        await gate
+      },
+    })
+    await seamReachedPromise
+    await prisma2.project.update({
+      where: { id: f.projectId },
+      data: { planningState: 'CURRENT' },
+    })
+    release()
+
+    let report: ClassificationReport
+    try {
+      report = await promise
+    } finally {
+      await prisma2.$disconnect()
+    }
+
+    // The report saw NEEDS_REPLAN (snapshot taken before the concurrent flip).
+    expect(report.alreadyCount).toBe(1)
+    expect(report.stateFingerprint).toMatch(/^[0-9a-f]{64}$/)
+    // Zero writes: the flip is the ONLY state change.
+    expect((await prisma.project.findUnique({ where: { id: f.projectId } }))!.planningState).toBe('CURRENT')
+
+    // The fingerprint describes the SAME snapshot as the report: it matches a
+    // fingerprint over the state as read (NEEDS_REPLAN), and differs from the
+    // post-commit state (CURRENT).
+    const freshNow = await computeClassificationFingerprint(prisma, manifest)
+    expect(report.stateFingerprint).not.toBe(freshNow)
+    await prisma.project.update({
+      where: { id: f.projectId },
+      data: { planningState: 'NEEDS_REPLAN' },
+    })
+    const snapshotStateFingerprint = await computeClassificationFingerprint(prisma, manifest)
+    expect(report.stateFingerprint).toBe(snapshotStateFingerprint)
   })
 
   it('Serializable isolation rolls the whole batch back when reset-relevant state changes concurrently', async () => {

--- a/server/src/test/planningReset.integration.test.ts
+++ b/server/src/test/planningReset.integration.test.ts
@@ -34,7 +34,7 @@ import { PrismaClient } from '@prisma/client'
 import { app } from '../app.js'
 import { resetProjectPlanning } from '../lib/resetProjectPlanning.js'
 import { runProductionMigrationReadiness, formatReadinessReport } from '../lib/productionMigrationReadiness.js'
-import { classifyNeedsReplan, parseClassifyManifest } from '../lib/classifyNeedsReplan.js'
+import { classifyNeedsReplan, parseClassifyManifest, ClassifyAbortError } from '../lib/classifyNeedsReplan.js'
 // Override the global prisma mock so route handlers use real PostgreSQL.
 vi.mock('../lib/prisma.js', async importOriginal => await importOriginal())
 
@@ -672,32 +672,137 @@ describeIf('Readiness with NEEDS_REPLAN (issue #449)', () => {
   })
 })
 
-describeIf('Reviewed production maintenance classification (issue #449 / #404)', () => {  it('dry-run reports, apply classifies via the same reset transaction', async () => {
+describeIf('Reviewed production maintenance classification (issue #449 / #404)', () => {
+  it('dry-run emits the reviewed fingerprint; apply with it classifies via the reset body', async () => {
     const f = await createFullyPlannedProject()
     const manifest = parseClassifyManifest({ projectIds: [f.projectId] })
 
-    // Dry run: zero writes.
+    // Dry run: zero writes, emits the deterministic reviewed-state fingerprint.
     const dry = await classifyNeedsReplan(prisma, manifest)
     expect(dry.classifiedCount).toBe(1)
+    expect(dry.stateFingerprint).toMatch(/^[0-9a-f]{64}$/)
     const afterDry = await prisma.project.findUnique({ where: { id: f.projectId } })
     expect(afterDry!.planningState).toBe('CURRENT')
     expect(await prisma.capacityProfile.count({ where: { projectId: f.projectId } })).toBeGreaterThan(0)
 
-    // Apply: classifies via the atomic reset (planning cleared, business kept).
-    const applied = await classifyNeedsReplan(prisma, manifest, { apply: true })
+    // Apply with the exact reviewed fingerprint: atomic classification
+    // (planning cleared, business kept).
+    const applied = await classifyNeedsReplan(prisma, manifest, {
+      apply: true,
+      expectedFingerprint: dry.stateFingerprint,
+    })
     expect(applied.classifiedCount).toBe(1)
+    expect(applied.stateFingerprint).toBe(dry.stateFingerprint)
     const afterApply = await prisma.project.findUnique({ where: { id: f.projectId } })
     expect(afterApply!.planningState).toBe('NEEDS_REPLAN')
     expect(await prisma.capacityProfile.count({ where: { projectId: f.projectId } })).toBe(0)
     expect(await prisma.task.count({ where: { userStory: { feature: { epic: { projectId: f.projectId } } } } })).toBeGreaterThan(0)
 
-    // Idempotent re-run: already NEEDS_REPLAN is skipped.
-    const again = await classifyNeedsReplan(prisma, manifest, { apply: true })
+    // Idempotent re-run with the NEW reviewed state: already NEEDS_REPLAN is
+    // skipped — but only with a fingerprint matching the new state.
+    const freshDry = await classifyNeedsReplan(prisma, manifest)
+    expect(freshDry.stateFingerprint).not.toBe(dry.stateFingerprint)
+    const again = await classifyNeedsReplan(prisma, manifest, {
+      apply: true,
+      expectedFingerprint: freshDry.stateFingerprint,
+    })
     expect(again.alreadyCount).toBe(1)
     expect(again.classifiedCount).toBe(0)
 
-    // Fails closed for a missing project.
+    // The stale (pre-apply) fingerprint now REFUSES — idempotence never
+    // weakens drift detection.
+    await expect(
+      classifyNeedsReplan(prisma, manifest, { apply: true, expectedFingerprint: dry.stateFingerprint }),
+    ).rejects.toThrow(/does not match the reviewed fingerprint/)
+
+    // Fails closed for a missing project: the stale reviewed fingerprint no
+    // longer matches (existence drift) and nothing is written.
     const badManifest = parseClassifyManifest({ projectIds: [f.projectId, 'does-not-exist'] })
-    await expect(classifyNeedsReplan(prisma, badManifest, { apply: true })).rejects.toThrow('no longer exist')
+    await expect(
+      classifyNeedsReplan(prisma, badManifest, { apply: true, expectedFingerprint: dry.stateFingerprint }),
+    ).rejects.toThrow(ClassifyAbortError)
+  })
+
+  it('refuses apply on reset-relevant drift with zero changes to any project', async () => {
+    const f = await createFullyPlannedProject()
+    const manifest = parseClassifyManifest({ projectIds: [f.projectId] })
+
+    const dry = await classifyNeedsReplan(prisma, manifest)
+
+    // One reset-relevant field changes after review: the weekly demand cache.
+    await prisma.project.update({
+      where: { id: f.projectId },
+      data: { weeklyDemandCache: { 'rt-changed|3': 7 } },
+    })
+
+    await expect(
+      classifyNeedsReplan(prisma, manifest, { apply: true, expectedFingerprint: dry.stateFingerprint }),
+    ).rejects.toThrow(/does not match the reviewed fingerprint/)
+
+    // Zero writes: the project and all planning state remain untouched.
+    const state = await prisma.project.findUnique({ where: { id: f.projectId } })
+    expect(state!.planningState).toBe('CURRENT')
+    expect(state!.weeklyDemandCache).toEqual({ 'rt-changed|3': 7 })
+    expect(await prisma.capacityProfile.count({ where: { projectId: f.projectId } })).toBe(3)
+    expect(await prisma.capacityPlan.count({ where: { projectId: f.projectId } })).toBe(1)
+    expect(await prisma.timelineEntry.count({ where: { projectId: f.projectId } })).toBe(1)
+  })
+
+  it('rolls the whole batch back when a later project fails (no partial classification)', async () => {
+    const f1 = await createFullyPlannedProject()
+    const f2 = await createFullyPlannedProject()
+    const manifest = parseClassifyManifest({ projectIds: [f1.projectId, f2.projectId] })
+
+    const dry = await classifyNeedsReplan(prisma, manifest)
+    expect(dry.classifiedCount).toBe(2)
+
+    // Inject a failure while resetting the SECOND project.
+    let resets = 0
+    await expect(
+      classifyNeedsReplan(prisma, manifest, {
+        apply: true,
+        expectedFingerprint: dry.stateFingerprint,
+        afterProjectReset: async (_tx, projectId) => {
+          resets++
+          if (projectId === f2.projectId) {
+            throw new Error('injected batch failure')
+          }
+        },
+      }),
+    ).rejects.toThrow('injected batch failure')
+    expect(resets).toBe(2)
+
+    // The whole batch rolled back: the FIRST project was not left quarantined
+    // and its planning data is intact.
+    const state1 = await prisma.project.findUnique({ where: { id: f1.projectId } })
+    expect(state1!.planningState).toBe('CURRENT')
+    expect(await prisma.capacityProfile.count({ where: { projectId: f1.projectId } })).toBe(3)
+    expect(await prisma.capacityPlan.count({ where: { projectId: f1.projectId } })).toBe(1)
+    expect(await prisma.timelineEntry.count({ where: { projectId: f1.projectId } })).toBe(1)
+
+    const state2 = await prisma.project.findUnique({ where: { id: f2.projectId } })
+    expect(state2!.planningState).toBe('CURRENT')
+  })
+
+  it('applies a multi-project manifest atomically on unchanged state', async () => {
+    const f1 = await createFullyPlannedProject()
+    const f2 = await createFullyPlannedProject()
+    const manifest = parseClassifyManifest({ projectIds: [f1.projectId, f2.projectId] })
+
+    const dry = await classifyNeedsReplan(prisma, manifest)
+    const applied = await classifyNeedsReplan(prisma, manifest, {
+      apply: true,
+      expectedFingerprint: dry.stateFingerprint,
+    })
+
+    expect(applied.classifiedCount).toBe(2)
+    for (const f of [f1, f2]) {
+      const state = await prisma.project.findUnique({ where: { id: f.projectId } })
+      expect(state!.planningState).toBe('NEEDS_REPLAN')
+      expect(await prisma.capacityProfile.count({ where: { projectId: f.projectId } })).toBe(0)
+      // Preserved business data remains intact.
+      expect(await prisma.task.count({ where: { userStory: { feature: { epic: { projectId: f.projectId } } } } })).toBeGreaterThan(0)
+      expect(await prisma.projectDiscount.count({ where: { projectId: f.projectId } })).toBe(1)
+    }
   })
 })

--- a/server/src/test/planningReset.integration.test.ts
+++ b/server/src/test/planningReset.integration.test.ts
@@ -34,7 +34,7 @@ import { PrismaClient } from '@prisma/client'
 import { app } from '../app.js'
 import { resetProjectPlanning } from '../lib/resetProjectPlanning.js'
 import { runProductionMigrationReadiness, formatReadinessReport } from '../lib/productionMigrationReadiness.js'
-import { classifyNeedsReplan, parseClassifyManifest, ClassifyAbortError } from '../lib/classifyNeedsReplan.js'
+import { classifyNeedsReplan, parseClassifyManifest, ClassifyAbortError, type ClassificationReport } from '../lib/classifyNeedsReplan.js'
 // Override the global prisma mock so route handlers use real PostgreSQL.
 vi.mock('../lib/prisma.js', async importOriginal => await importOriginal())
 
@@ -804,5 +804,80 @@ describeIf('Reviewed production maintenance classification (issue #449 / #404)',
       expect(await prisma.task.count({ where: { userStory: { feature: { epic: { projectId: f.projectId } } } } })).toBeGreaterThan(0)
       expect(await prisma.projectDiscount.count({ where: { projectId: f.projectId } })).toBe(1)
     }
+  })
+
+  it('Serializable isolation rolls the whole batch back when reset-relevant state changes concurrently', async () => {
+    const f1 = await createFullyPlannedProject()
+    const f2 = await createFullyPlannedProject()
+    const manifest = parseClassifyManifest({ projectIds: [f1.projectId, f2.projectId] })
+
+    const dry = await classifyNeedsReplan(prisma, manifest)
+
+    // A second real connection mutates state while the apply is in flight.
+    const prisma2 = new PrismaClient({
+      adapter: new PrismaPg({ connectionString: process.env.DATABASE_URL }),
+    })
+    await prisma2.$connect()
+
+    // Narrow test seam: hold the batch AFTER the fingerprint reads and the
+    // FIRST project's (uncommitted) reset, BEFORE the second project's
+    // destructive writes. No production synchronization code is involved.
+    let seamReached: () => void = () => {}
+    const seamReachedPromise = new Promise<void>(resolve => { seamReached = resolve })
+    let release: () => void = () => {}
+    const gate = new Promise<void>(resolve => { release = resolve })
+
+    let applyPromise: Promise<ClassificationReport> | null = null
+    try {
+      applyPromise = classifyNeedsReplan(prisma, manifest, {
+        apply: true,
+        expectedFingerprint: dry.stateFingerprint,
+        afterProjectReset: async (_tx, projectId) => {
+          if (projectId === f1.projectId) {
+            seamReached()
+            await gate
+          }
+        },
+      })
+
+      // Wait for the apply to be paused at the seam, then commit a concurrent
+      // change to reset-relevant state of the SECOND project (a segment row
+      // the reviewed fingerprint covered).
+      await seamReachedPromise
+      const seg = await prisma2.capacitySegment.findFirst({
+        where: { capacityProfile: { projectId: f2.projectId } },
+      })
+      expect(seg).not.toBeNull()
+      await prisma2.capacitySegment.update({
+        where: { id: seg!.id },
+        data: { capacityPercent: 77 },
+      })
+    } finally {
+      release()
+      if (applyPromise) {
+        // The apply must fail with the serialization-conflict mapping, not
+        // commit the stale review: the concurrent write was never part of the
+        // reviewed fingerprint and must not be destroyed.
+        await expect(applyPromise).rejects.toThrow(/changed concurrently/)
+      }
+      await prisma2.$disconnect()
+    }
+
+    // Whole batch rolled back: neither project became NEEDS_REPLAN…
+    const state1 = await prisma.project.findUnique({ where: { id: f1.projectId } })
+    expect(state1!.planningState).toBe('CURRENT')
+    const state2 = await prisma.project.findUnique({ where: { id: f2.projectId } })
+    expect(state2!.planningState).toBe('CURRENT')
+
+    // …no partial deletion of prior planning state…
+    expect(await prisma.capacityProfile.count({ where: { projectId: f1.projectId } })).toBe(3)
+    expect(await prisma.capacityPlan.count({ where: { projectId: f1.projectId } })).toBe(1)
+    expect(await prisma.capacityProfile.count({ where: { projectId: f2.projectId } })).toBe(3)
+
+    // …and the concurrently committed mutation survived.
+    const segAfter = await prisma.capacitySegment.findFirst({
+      where: { capacityProfile: { projectId: f2.projectId } },
+    })
+    expect(segAfter!.capacityPercent).toBe(77)
   })
 })

--- a/server/src/test/planningReset.integration.test.ts
+++ b/server/src/test/planningReset.integration.test.ts
@@ -1,0 +1,703 @@
+/**
+ * planningReset.integration.test.ts — Real PostgreSQL integration tests for
+ * the Reset Planning / Replan project workflow (issue #449).
+ *
+ * Proves against the actual schema:
+ *
+ *   - The atomic reset clears exactly the planning allow-list (profiles,
+ *     segments, capacity plans, timeline output, caches, proven planner
+ *     placeholders) and preserves every estimation/business input.
+ *   - An injected mid-transaction failure rolls the entire reset back.
+ *   - A CURRENT project with intentionally absent planning state still fails
+ *     closed; a NEEDS_REPLAN project does not fail for that same absence.
+ *   - Planning-dependent operations return 409 REPLAN_REQUIRED while
+ *     quarantined; Squad Planner apply stays available as a replanning path.
+ *   - Unrelated ownership corruption still fails even when NEEDS_REPLAN.
+ *   - Replanning through the normal profile surface, and through Squad
+ *     Planner, returns the project to CURRENT only via canonical validation;
+ *     Timeline scheduling then works.
+ *   - Readiness treats NEEDS_REPLAN as an explicit quarantine without masking
+ *     ownership defects.
+ *   - The reviewed production maintenance command (dry-run then apply)
+ *     classifies an explicit project set via the same reset transaction.
+ *
+ * All tests are skipped unless INTEGRATION_TEST=true. Follows the isolation
+ * and cleanup pattern of squadPlanProfileFirst.integration.test.ts.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest'
+import request from 'supertest'
+import jwt from 'jsonwebtoken'
+import { PrismaPg } from '@prisma/adapter-pg'
+import { PrismaClient } from '@prisma/client'
+
+import { app } from '../app.js'
+import { resetProjectPlanning } from '../lib/resetProjectPlanning.js'
+import { runProductionMigrationReadiness, formatReadinessReport } from '../lib/productionMigrationReadiness.js'
+import { classifyNeedsReplan, parseClassifyManifest } from '../lib/classifyNeedsReplan.js'
+// Override the global prisma mock so route handlers use real PostgreSQL.
+vi.mock('../lib/prisma.js', async importOriginal => await importOriginal())
+
+// ─── Guard ──────────────────────────────────────────────────────────────────
+
+const runIntegration = process.env.INTEGRATION_TEST === 'true'
+const describeIf = runIntegration ? describe : describe.skip
+
+// ─── Shared state ───────────────────────────────────────────────────────────
+
+let prisma: PrismaClient
+let userId: string
+let token: string
+let authHeader: string
+
+beforeAll(async () => {
+  if (!runIntegration) return
+  prisma = new PrismaClient({
+    adapter: new PrismaPg({ connectionString: process.env.DATABASE_URL }),
+  })
+  await prisma.$connect()
+
+  const user = await prisma.user.create({
+    data: {
+      email: `planning-reset-${Date.now()}@example.com`,
+      name: 'Planning Reset Integration Test',
+      password: '$2b$10$placeholder',
+    },
+  })
+  userId = user.id
+  token = jwt.sign({ userId, role: 'USER' }, process.env.JWT_SECRET!)
+  authHeader = `Bearer ${token}`
+})
+
+afterAll(async () => {
+  if (!runIntegration) return
+  await prisma.backlogSnapshot.deleteMany({ where: { project: { ownerId: userId } } })
+  await prisma.capacitySegment.deleteMany({ where: { capacityProfile: { project: { ownerId: userId } } } })
+  await prisma.capacityProfile.deleteMany({ where: { project: { ownerId: userId } } })
+  await prisma.capacityPlanEntry.deleteMany({ where: { period: { plan: { project: { ownerId: userId } } } } })
+  await prisma.capacityPlanPeriod.deleteMany({ where: { plan: { project: { ownerId: userId } } } })
+  await prisma.capacityPlan.deleteMany({ where: { project: { ownerId: userId } } })
+  await prisma.projectDiscount.deleteMany({ where: { project: { ownerId: userId } } })
+  await prisma.projectOverhead.deleteMany({ where: { project: { ownerId: userId } } })
+  await prisma.storyTimelineEntry.deleteMany({ where: { project: { ownerId: userId } } })
+  await prisma.timelineEntry.deleteMany({ where: { project: { ownerId: userId } } })
+  await prisma.storyDependency.deleteMany({ where: { story: { feature: { epic: { project: { ownerId: userId } } } } } })
+  await prisma.featureDependency.deleteMany({ where: { feature: { epic: { project: { ownerId: userId } } } } })
+  await prisma.epicDependency.deleteMany({ where: { epic: { project: { ownerId: userId } } } })
+  await prisma.task.deleteMany({ where: { userStory: { feature: { epic: { project: { ownerId: userId } } } } } })
+  await prisma.userStory.deleteMany({ where: { feature: { epic: { project: { ownerId: userId } } } } })
+  await prisma.feature.deleteMany({ where: { epic: { project: { ownerId: userId } } } })
+  await prisma.epic.deleteMany({ where: { project: { ownerId: userId } } })
+  await prisma.namedResource.deleteMany({ where: { resourceType: { project: { ownerId: userId } } } })
+  await prisma.resourceType.deleteMany({ where: { project: { ownerId: userId } } })
+  await prisma.project.deleteMany({ where: { ownerId: userId } })
+  await prisma.$disconnect()
+})
+
+// ─── Fixture builder ────────────────────────────────────────────────────────
+
+interface PlannedProject {
+  projectId: string
+  rtId: string
+  userNrId: string
+  plannedNrId: string
+  epicId: string
+  featureId: string
+  storyId: string
+  taskId: string
+  planId: string
+}
+
+/**
+ * Create a fully planned project: backlog + dependency + roles + genuine
+ * user-authored named resource + Commercial metadata + CapacityPlan +
+ * ROLE/NAMED_PERSON/PLANNED_RESOURCE profiles + timeline output + cache.
+ */
+async function createFullyPlannedProject(): Promise<PlannedProject> {
+  const project = await prisma.project.create({
+    data: {
+      name: `Reset fixture ${Date.now()}`,
+      description: 'boundary fixture',
+      status: 'ACTIVE',
+      hoursPerDay: 7.6,
+      bufferWeeks: 2,
+      onboardingWeeks: 1,
+      startDate: new Date('2026-09-01'),
+      taxRate: 10,
+      taxLabel: 'GST',
+      ownerId: userId,
+      weeklyDemandCache: { 'rt-1|1': 5 },
+      resourceTypes: {
+        create: [{
+          name: 'Engineer',
+          category: 'ENGINEERING',
+          count: 2,
+          hoursPerDay: 7.6,
+          dayRate: 500,
+        }],
+      },
+      epics: {
+        create: [{
+          name: 'Epic 1',
+          features: {
+            create: [{
+              name: 'Feature 1',
+              userStories: {
+                create: [{
+                  name: 'Story 1',
+                  tasks: {
+                    create: [{
+                      name: 'Task 1',
+                      hoursEffort: 16,
+                      durationDays: 2,
+                    }],
+                  },
+                }],
+              },
+            }],
+          },
+        }],
+      },
+      overheads: { create: [{ name: 'Travel', type: 'FIXED_DAYS', value: 3, order: 0 }] },
+      discounts: { create: [{ type: 'PERCENTAGE', value: 5, label: 'Loyalty', order: 0 }] },
+    },
+    include: {
+      resourceTypes: { include: { namedResources: true } },
+      epics: { include: { features: { include: { userStories: { include: { tasks: true } } } } } },
+    },
+  })
+
+  const rt = project.resourceTypes[0]!
+  const epic = project.epics[0]!
+  const feature = epic.features[0]!
+  const story = feature.userStories[0]!
+  const task = story.tasks[0]!
+  await prisma.task.update({ where: { id: task.id }, data: { resourceTypeId: rt.id } })
+
+  // User-authored named resource (NAMED_PERSON provenance).
+  const userNr = await prisma.namedResource.create({
+    data: { resourceTypeId: rt.id, name: 'Alice', pricingModel: 'PRO_RATA' },
+  })
+  await prisma.capacityProfile.create({
+    data: {
+      projectId: project.id,
+      namedResourceId: userNr.id,
+      ownerKind: 'NAMED_PERSON',
+      planningBasis: 'WHOLE_PROJECT_ALLOCATION',
+      source: 'MANUAL',
+      defaultPercent: 100,
+    },
+  })
+
+  // Planner-generated placeholder (PLANNED_RESOURCE provenance, as the Squad
+  // Planner apply path writes them).
+  const plannedNr = await prisma.namedResource.create({
+    data: { resourceTypeId: rt.id, name: 'Engineer 2' },
+  })
+  const plannedProfile = await prisma.capacityProfile.create({
+    data: {
+      projectId: project.id,
+      namedResourceId: plannedNr.id,
+      ownerKind: 'PLANNED_RESOURCE',
+      planningBasis: 'CAPACITY_PROFILE',
+      source: 'SQUAD_PLANNER',
+      defaultPercent: 100,
+      startWeek: 0,
+      endWeek: 10,
+    },
+  })
+  await prisma.capacitySegment.create({
+    data: {
+      capacityProfileId: plannedProfile.id,
+      startWeek: 0,
+      endWeek: 10,
+      capacityPercent: 100,
+      source: 'SQUAD_PLANNER',
+    },
+  })
+
+  // Role profile with segments.
+  const roleProfile = await prisma.capacityProfile.create({
+    data: {
+      projectId: project.id,
+      resourceTypeId: rt.id,
+      ownerKind: 'ROLE',
+      planningBasis: 'CAPACITY_PROFILE',
+      source: 'MANUAL',
+      defaultPercent: 100,
+    },
+  })
+  await prisma.capacitySegment.createMany({
+    data: [
+      { capacityProfileId: roleProfile.id, startWeek: 0, endWeek: 4, capacityPercent: 100, source: 'MANUAL' },
+      { capacityProfileId: roleProfile.id, startWeek: 5, endWeek: 10, capacityPercent: 80, source: 'MANUAL' },
+    ],
+  })
+
+  // Capacity plan with periods/entries.
+  const plan = await prisma.capacityPlan.create({
+    data: {
+      projectId: project.id,
+      name: 'Plan 1',
+      targetWeeks: 12,
+      periodWeeks: 4,
+      isActive: true,
+      totalCost: 12000,
+      deliveryWeeks: 12,
+      periods: {
+        create: [{
+          periodIndex: 0,
+          startWeek: 0,
+          endWeek: 4,
+          entries: { create: [{ resourceTypeId: rt.id, headcount: 2, demandFTE: 1.5, utilisationPct: 75 }] },
+        }],
+      },
+    },
+  })
+
+  // Generated schedule output (feature + story) with a manual override.
+  await prisma.timelineEntry.create({ data: { projectId: project.id, featureId: feature.id, startWeek: 0, durationWeeks: 6, isManual: true } })
+  await prisma.storyTimelineEntry.create({ data: { projectId: project.id, storyId: story.id, startWeek: 0, durationWeeks: 6, isManual: false } })
+
+  // Dependency.
+  await prisma.featureDependency.create({ data: { featureId: feature.id, dependsOnId: feature.id } })
+
+  return {
+    projectId: project.id,
+    rtId: rt.id,
+    userNrId: userNr.id,
+    plannedNrId: plannedNr.id,
+    epicId: epic.id,
+    featureId: feature.id,
+    storyId: story.id,
+    taskId: task.id,
+    planId: plan.id,
+  }
+}
+
+/** Snapshot a project's full planning + business state for byte-level comparison. */
+async function captureProjectState(projectId: string) {
+  const [project, profiles, segments, plans, periods, entries, timeline, storyTimeline, nr, rt, epicCount, taskCount, deps, discounts, overheads] = await Promise.all([
+    prisma.project.findUnique({ where: { id: projectId } }),
+    prisma.capacityProfile.findMany({ where: { projectId } }),
+    prisma.capacitySegment.findMany({ where: { capacityProfile: { projectId } } }),
+    prisma.capacityPlan.findMany({ where: { projectId } }),
+    prisma.capacityPlanPeriod.findMany({ where: { plan: { projectId } } }),
+    prisma.capacityPlanEntry.findMany({ where: { period: { plan: { projectId } } } }),
+    prisma.timelineEntry.findMany({ where: { projectId } }),
+    prisma.storyTimelineEntry.findMany({ where: { projectId } }),
+    prisma.namedResource.findMany({ where: { resourceType: { projectId } } }),
+    prisma.resourceType.findMany({ where: { projectId } }),
+    prisma.epic.count({ where: { projectId } }),
+    prisma.task.count({ where: { userStory: { feature: { epic: { projectId } } } } }),
+    prisma.featureDependency.count({ where: { feature: { epic: { projectId } } } }),
+    prisma.projectDiscount.findMany({ where: { projectId } }),
+    prisma.projectOverhead.findMany({ where: { projectId } }),
+  ])
+  return { project, profiles, segments, plans, periods, entries, timeline, storyTimeline, nr, rt, epicCount, taskCount, deps, discounts, overheads }
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describeIf('Reset Planning — full boundary (issue #449)', () => {
+  it('clears the planning allow-list and preserves every business input', async () => {
+    const f = await createFullyPlannedProject()
+    const before = await captureProjectState(f.projectId)
+
+    // Pre-conditions: everything exists.
+    expect(before.profiles.length).toBe(3)
+    expect(before.segments.length).toBe(3)
+    expect(before.plans.length).toBe(1)
+    expect(before.periods.length).toBe(1)
+    expect(before.entries.length).toBe(1)
+    expect(before.timeline.length).toBe(1)
+    expect(before.storyTimeline.length).toBe(1)
+    expect(before.nr.some(n => n.id === f.userNrId)).toBe(true)
+    expect(before.nr.some(n => n.id === f.plannedNrId)).toBe(true)
+    expect(before.project!.weeklyDemandCache).not.toBeNull()
+    expect(before.project!.planningState).toBe('CURRENT')
+
+    const res = await request(app)
+      .post(`/api/projects/${f.projectId}/planning/reset`)
+      .set('Authorization', authHeader)
+      .send({ confirm: true })
+
+    expect(res.status).toBe(200)
+    expect(res.body).toEqual({ projectId: f.projectId, planningState: 'NEEDS_REPLAN' })
+
+    const after = await captureProjectState(f.projectId)
+
+    // ── Cleared: planning-owned state ──
+    expect(after.profiles).toHaveLength(0)
+    expect(after.segments).toHaveLength(0)
+    expect(after.plans).toHaveLength(0)
+    expect(after.periods).toHaveLength(0)
+    expect(after.entries).toHaveLength(0)
+    expect(after.timeline).toHaveLength(0)
+    expect(after.storyTimeline).toHaveLength(0)
+    expect(after.project!.weeklyDemandCache).toBeNull()
+    expect(after.project!.planningState).toBe('NEEDS_REPLAN')
+    // Proven planner-generated placeholder removed…
+    expect(after.nr.some(n => n.id === f.plannedNrId)).toBe(false)
+
+    // ── Preserved: estimation/business state, byte/value-equivalent ──
+    expect(after.nr.some(n => n.id === f.userNrId)).toBe(true)
+    const preservedUserNr = after.nr.find(n => n.id === f.userNrId)!
+    const beforeUserNr = before.nr.find(n => n.id === f.userNrId)!
+    expect(preservedUserNr.name).toBe(beforeUserNr.name)
+    expect(preservedUserNr.pricingModel).toBe(beforeUserNr.pricingModel)
+    expect(preservedUserNr.resourceTypeId).toBe(beforeUserNr.resourceTypeId)
+
+    const rtAfter = after.rt[0]!
+    const rtBefore = before.rt[0]!
+    expect(rtAfter.name).toBe(rtBefore.name)
+    expect(rtAfter.count).toBe(rtBefore.count)
+    expect(rtAfter.hoursPerDay).toBe(rtBefore.hoursPerDay)
+    expect(rtAfter.dayRate).toBe(rtBefore.dayRate)
+    expect(rtAfter.category).toBe(rtBefore.category)
+
+    expect(after.epicCount).toBe(before.epicCount)
+    expect(after.taskCount).toBe(before.taskCount)
+    expect(after.deps).toBe(before.deps)
+    expect(after.discounts).toHaveLength(1)
+    expect(after.overheads).toHaveLength(1)
+
+    const p = after.project!
+    expect(p.name).toBe(before.project!.name)
+    expect(p.description).toBe(before.project!.description)
+    expect(p.status).toBe(before.project!.status)
+    expect(p.hoursPerDay).toBe(before.project!.hoursPerDay)
+    expect(p.bufferWeeks).toBe(before.project!.bufferWeeks)
+    expect(p.onboardingWeeks).toBe(before.project!.onboardingWeeks)
+    expect(p.startDate?.toISOString()).toBe(before.project!.startDate?.toISOString())
+    expect(p.taxRate).toBe(before.project!.taxRate)
+    expect(p.taxLabel).toBe(before.project!.taxLabel)
+  })
+
+  it('requires explicit confirmation and rejects foreign projects', async () => {
+    const f = await createFullyPlannedProject()
+
+    // Missing confirmation → 400, nothing changes.
+    const res400 = await request(app)
+      .post(`/api/projects/${f.projectId}/planning/reset`)
+      .set('Authorization', authHeader)
+      .send({})
+    expect(res400.status).toBe(400)
+
+    // Another user's project → 404.
+    const other = await prisma.user.create({
+      data: { email: `other-${Date.now()}@example.com`, name: 'Other', password: 'x' },
+    })
+    const foreignProject = await prisma.project.create({
+      data: { name: 'Foreign', ownerId: other.id },
+    })
+    const resForeign = await request(app)
+      .post(`/api/projects/${foreignProject.id}/planning/reset`)
+      .set('Authorization', authHeader)
+      .send({ confirm: true })
+    expect(resForeign.status).toBe(404)
+
+    const state = await captureProjectState(f.projectId)
+    expect(state.project!.planningState).toBe('CURRENT')
+    expect(state.profiles.length).toBeGreaterThan(0)
+  })
+
+  it('rolls the entire reset back when a mid-transaction failure is injected', async () => {
+    const f = await createFullyPlannedProject()
+    const before = await captureProjectState(f.projectId)
+
+    await expect(
+      resetProjectPlanning(prisma, f.projectId, {
+        afterWrites: async () => { throw new Error('injected mid-transaction failure') },
+      }),
+    ).rejects.toThrow('injected mid-transaction failure')
+
+    const after = await captureProjectState(f.projectId)
+    // Zero partial reset: every planning row and the state flag are intact.
+    expect(after.project!.planningState).toBe('CURRENT')
+    expect(after.profiles.length).toBe(before.profiles.length)
+    expect(after.segments.length).toBe(before.segments.length)
+    expect(after.plans.length).toBe(before.plans.length)
+    expect(after.timeline.length).toBe(before.timeline.length)
+    expect(after.storyTimeline.length).toBe(before.storyTimeline.length)
+    expect(after.nr.length).toBe(before.nr.length)
+    expect(after.project!.weeklyDemandCache).toEqual(before.project!.weeklyDemandCache)
+  })
+})
+
+describeIf('NEEDS_REPLAN quarantine (issue #449)', () => {
+  it('a CURRENT project still fails closed on absent planning state', async () => {
+    const f = await createFullyPlannedProject()
+    // Simulate a CURRENT project with missing profiles: delete only profiles.
+    await prisma.capacityProfile.deleteMany({ where: { projectId: f.projectId } })
+
+    const res = await request(app)
+      .get(`/api/projects/${f.projectId}/capacity-profiles`)
+      .set('Authorization', authHeader)
+    expect(res.status).toBe(409)
+    expect(res.body.code).toBe('CAPACITY_INTEGRITY_ERROR')
+
+    // Quarantine the intentionally-broken project so later global readiness
+    // assertions are stable (the quarantine is exactly what reset is for).
+    await request(app)
+      .post(`/api/projects/${f.projectId}/planning/reset`)
+      .set('Authorization', authHeader)
+      .send({ confirm: true })
+  })
+
+  it('NEEDS_REPLAN projects stay accessible with expected missing planning state', async () => {
+    const f = await createFullyPlannedProject()
+    await request(app)
+      .post(`/api/projects/${f.projectId}/planning/reset`)
+      .set('Authorization', authHeader)
+      .send({ confirm: true })
+
+    // Profile surface serves the empty persisted set (expected absence).
+    const cp = await request(app)
+      .get(`/api/projects/${f.projectId}/capacity-profiles`)
+      .set('Authorization', authHeader)
+    expect(cp.status).toBe(200)
+    expect(cp.body.capacityProfiles).toEqual([])
+
+    // Resource Profile serves effort/inputs with the explicit marker.
+    const rp = await request(app)
+      .get(`/api/projects/${f.projectId}/resource-profile`)
+      .set('Authorization', authHeader)
+    expect(rp.status).toBe(200)
+    expect(rp.body.planningState).toBe('NEEDS_REPLAN')
+    expect(rp.body.resourceRows[0].totalHours).toBe(16)
+    expect(rp.body.summary.totalCost).toBeNull()
+    expect(rp.body.resourceRows[0].namedResources).toHaveLength(1) // Alice preserved
+
+    // Timeline is explicitly empty, never derived from stale state.
+    const tl = await request(app)
+      .get(`/api/projects/${f.projectId}/timeline`)
+      .set('Authorization', authHeader)
+    expect(tl.status).toBe(200)
+    expect(tl.body.planningState).toBe('NEEDS_REPLAN')
+    expect(tl.body.entries).toEqual([])
+  })
+
+  it('planning-dependent operations return actionable REPLAN_REQUIRED', async () => {
+    const f = await createFullyPlannedProject()
+    await request(app)
+      .post(`/api/projects/${f.projectId}/planning/reset`)
+      .set('Authorization', authHeader)
+      .send({ confirm: true })
+
+    const schedule = await request(app)
+      .post(`/api/projects/${f.projectId}/timeline/schedule`)
+      .set('Authorization', authHeader)
+      .send({})
+    expect(schedule.status).toBe(409)
+    expect(schedule.body.code).toBe('REPLAN_REQUIRED')
+    expect(schedule.body.error).toContain('needs replanning')
+
+    const optimise = await request(app)
+      .post(`/api/projects/${f.projectId}/optimise`)
+      .set('Authorization', authHeader)
+      .send({})
+    expect(optimise.status).toBe(409)
+    expect(optimise.body.code).toBe('REPLAN_REQUIRED')
+
+    // Backlog editing stays available.
+    const epics = await request(app)
+      .get(`/api/projects/${f.projectId}/epics`)
+      .set('Authorization', authHeader)
+    expect(epics.status).toBe(200)
+  })
+
+  it('unrelated ownership corruption still fails even when NEEDS_REPLAN', async () => {
+    const f = await createFullyPlannedProject()
+    await request(app)
+      .post(`/api/projects/${f.projectId}/planning/reset`)
+      .set('Authorization', authHeader)
+      .send({ confirm: true })
+
+    // Corrupt the quarantined project with a cross-project profile row.
+    const otherProject = await prisma.project.create({
+      data: { name: 'Corruption host', ownerId: userId },
+    })
+    const foreignRt = await prisma.resourceType.create({
+      data: { name: 'Foreign', category: 'ENGINEERING', projectId: otherProject.id },
+    })
+    await prisma.capacityProfile.create({
+      data: {
+        projectId: f.projectId,
+        resourceTypeId: foreignRt.id,
+        ownerKind: 'ROLE',
+        planningBasis: 'DEMAND_FOLLOWING',
+        source: 'MANUAL',
+      },
+    })
+
+    // Structural validation still rejects the cross-project owner.
+    const cp = await request(app)
+      .get(`/api/projects/${f.projectId}/capacity-profiles`)
+      .set('Authorization', authHeader)
+    expect(cp.status).toBe(409)
+    expect(cp.body.code).toBe('CAPACITY_INTEGRITY_ERROR')
+
+    // Readiness still fails on the unrelated ownership defect.
+    const readiness = await runProductionMigrationReadiness(prisma)
+    expect(readiness.passed).toBe(false)
+
+    // Clean up the corruption so later global readiness assertions are stable.
+    await prisma.capacityProfile.deleteMany({ where: { projectId: f.projectId, resourceTypeId: foreignRt.id } })
+    await prisma.resourceType.deleteMany({ where: { id: foreignRt.id } })
+    await prisma.project.deleteMany({ where: { id: otherProject.id } })
+  })
+})
+
+describeIf('Replanning completion (issue #449)', () => {
+  it('cannot complete while canonical planning state is missing, and replanning restores CURRENT', async () => {
+    const f = await createFullyPlannedProject()
+    await request(app)
+      .post(`/api/projects/${f.projectId}/planning/reset`)
+      .set('Authorization', authHeader)
+      .send({ confirm: true })
+
+    // Completion without any plan → actionable findings, state unchanged.
+    const incomplete = await request(app)
+      .post(`/api/projects/${f.projectId}/planning/complete`)
+      .set('Authorization', authHeader)
+    expect(incomplete.status).toBe(422)
+    expect(incomplete.body.code).toBe('REPLAN_INCOMPLETE')
+    expect(incomplete.body.findings.length).toBeGreaterThan(0)
+    const still = await prisma.project.findUnique({ where: { id: f.projectId } })
+    expect(still!.planningState).toBe('NEEDS_REPLAN')
+
+    // Build the new plan through the normal supported surface: "As needed /
+    // demand-following" ROLE profile for the role…
+    const roleProfile = await request(app)
+      .put(`/api/projects/${f.projectId}/capacity-profiles/ROLE/${f.rtId}`)
+      .set('Authorization', authHeader)
+      .send({ planningBasis: 'DEMAND_FOLLOWING', defaultPercent: 100 })
+    expect(roleProfile.status).toBe(200)
+
+    // …and a NAMED_PERSON profile for the preserved user-authored resource.
+    const namedProfile = await request(app)
+      .put(`/api/projects/${f.projectId}/capacity-profiles/NAMED_PERSON/${f.userNrId}`)
+      .set('Authorization', authHeader)
+      .send({ planningBasis: 'DEMAND_FOLLOWING', defaultPercent: 100 })
+    expect(namedProfile.status).toBe(200)
+
+    // Still not complete: the planner placeholder was removed, but the role
+    // profile exists → completeness passes now. Completion flips to CURRENT.
+    const complete = await request(app)
+      .post(`/api/projects/${f.projectId}/planning/complete`)
+      .set('Authorization', authHeader)
+    expect(complete.status).toBe(200)
+    expect(complete.body.planningState).toBe('CURRENT')
+
+    // Timeline scheduling now works against the new plan.
+    const schedule = await request(app)
+      .post(`/api/projects/${f.projectId}/timeline/schedule`)
+      .set('Authorization', authHeader)
+      .send({})
+    expect(schedule.status).toBe(200)
+    expect(schedule.body.entries.length).toBeGreaterThan(0)
+
+    const timeline = await request(app)
+      .get(`/api/projects/${f.projectId}/timeline`)
+      .set('Authorization', authHeader)
+    expect(timeline.status).toBe(200)
+    expect(timeline.body.entries.length).toBeGreaterThan(0)
+  })
+
+  it('Squad Planner apply works after reset as a replanning path, then completes', async () => {
+    // Squad Planner replanning: roles only, no user-authored named resources.
+    const project = await prisma.project.create({
+      data: {
+        name: `Squad replan ${Date.now()}`,
+        status: 'ACTIVE',
+        ownerId: userId,
+        resourceTypes: { create: [{ name: 'Engineer', category: 'ENGINEERING', count: 2 }] },
+      },
+      include: { resourceTypes: true },
+    })
+    const rtId = project.resourceTypes[0]!.id
+
+    await request(app)
+      .post(`/api/projects/${project.id}/planning/reset`)
+      .set('Authorization', authHeader)
+      .send({ confirm: true })
+
+    // Apply a squad plan (the supported Squad Planner replanning path).
+    const apply = await request(app)
+      .post(`/api/projects/${project.id}/squad-plan/apply`)
+      .set('Authorization', authHeader)
+      .send({
+        name: 'Squad plan',
+        targetWeeks: 8,
+        periodWeeks: 4,
+        maxDelta: 1,
+        periods: [{
+          periodIndex: 0,
+          startWeek: 0,
+          endWeek: 4,
+          entries: [{ resourceTypeId: rtId, headcount: 2, demandFTE: 1, utilisationPct: 50 }],
+        }],
+      })
+    expect(apply.status).toBe(201)
+
+    // Canonical validation passes after apply → completion returns CURRENT.
+    const complete = await request(app)
+      .post(`/api/projects/${project.id}/planning/complete`)
+      .set('Authorization', authHeader)
+    expect(complete.status).toBe(200)
+    expect(complete.body.planningState).toBe('CURRENT')
+
+    const state = await prisma.project.findUnique({ where: { id: project.id } })
+    expect(state!.planningState).toBe('CURRENT')
+  })
+})
+
+describeIf('Readiness with NEEDS_REPLAN (issue #449)', () => {
+  it('allows expected quarantine while still requiring canonical CURRENT projects', async () => {
+    // CURRENT project with missing profiles → readiness fails.
+    const broken = await createFullyPlannedProject()
+    await prisma.capacityProfile.deleteMany({ where: { projectId: broken.projectId } })
+    const before = await runProductionMigrationReadiness(prisma)
+    expect(before.passed).toBe(false)
+
+    // Same project quarantined via the product reset → per-project section passes.
+    await request(app)
+      .post(`/api/projects/${broken.projectId}/planning/reset`)
+      .set('Authorization', authHeader)
+      .send({ confirm: true })
+    const after = await runProductionMigrationReadiness(prisma)
+    expect(after.passed).toBe(true)
+    expect(formatReadinessReport(after)).toContain('NEEDS_REPLAN')
+  })
+})
+
+describeIf('Reviewed production maintenance classification (issue #449 / #404)', () => {  it('dry-run reports, apply classifies via the same reset transaction', async () => {
+    const f = await createFullyPlannedProject()
+    const manifest = parseClassifyManifest({ projectIds: [f.projectId] })
+
+    // Dry run: zero writes.
+    const dry = await classifyNeedsReplan(prisma, manifest)
+    expect(dry.classifiedCount).toBe(1)
+    const afterDry = await prisma.project.findUnique({ where: { id: f.projectId } })
+    expect(afterDry!.planningState).toBe('CURRENT')
+    expect(await prisma.capacityProfile.count({ where: { projectId: f.projectId } })).toBeGreaterThan(0)
+
+    // Apply: classifies via the atomic reset (planning cleared, business kept).
+    const applied = await classifyNeedsReplan(prisma, manifest, { apply: true })
+    expect(applied.classifiedCount).toBe(1)
+    const afterApply = await prisma.project.findUnique({ where: { id: f.projectId } })
+    expect(afterApply!.planningState).toBe('NEEDS_REPLAN')
+    expect(await prisma.capacityProfile.count({ where: { projectId: f.projectId } })).toBe(0)
+    expect(await prisma.task.count({ where: { userStory: { feature: { epic: { projectId: f.projectId } } } } })).toBeGreaterThan(0)
+
+    // Idempotent re-run: already NEEDS_REPLAN is skipped.
+    const again = await classifyNeedsReplan(prisma, manifest, { apply: true })
+    expect(again.alreadyCount).toBe(1)
+    expect(again.classifiedCount).toBe(0)
+
+    // Fails closed for a missing project.
+    const badManifest = parseClassifyManifest({ projectIds: [f.projectId, 'does-not-exist'] })
+    await expect(classifyNeedsReplan(prisma, badManifest, { apply: true })).rejects.toThrow('no longer exist')
+  })
+})

--- a/server/src/test/planningRoutes.test.ts
+++ b/server/src/test/planningRoutes.test.ts
@@ -1,0 +1,181 @@
+/**
+ * planningRoutes.test.ts — Route tests for the project planning-state API
+ * (issue #449): POST /planning/reset and POST /planning/complete.
+ *
+ * Covers authentication/ownership, explicit destructive confirmation,
+ * CURRENT → NEEDS_REPLAN, and the canonical-validation-gated completion
+ * (422 REPLAN_INCOMPLETE with actionable findings).
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import request from 'supertest'
+import jwt from 'jsonwebtoken'
+
+import { app } from '../index.js'
+import { prisma } from '../lib/prisma.js'
+
+const userId = 'user-1'
+process.env.JWT_SECRET = 'test-secret'
+const token = jwt.sign({ userId }, 'test-secret')
+const authHeader = `Bearer ${token}`
+
+beforeEach(() => vi.clearAllMocks())
+
+describe('POST /api/projects/:projectId/planning/reset', () => {
+  it('rejects unauthenticated request', async () => {
+    const res = await request(app).post('/api/projects/proj-1/planning/reset').send({ confirm: true })
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 404 for missing or inaccessible project', async () => {
+    vi.mocked(prisma.project.findFirst).mockResolvedValue(null)
+    const res = await request(app)
+      .post('/api/projects/proj-missing/planning/reset')
+      .set('Authorization', authHeader)
+      .send({ confirm: true })
+    expect(res.status).toBe(404)
+    expect(prisma.$transaction).not.toHaveBeenCalled()
+  })
+
+  it('requires explicit confirmation', async () => {
+    vi.mocked(prisma.project.findFirst).mockResolvedValue({ id: 'proj-1', ownerId: userId } as never)
+    const res = await request(app)
+      .post('/api/projects/proj-1/planning/reset')
+      .set('Authorization', authHeader)
+      .send({})
+    expect(res.status).toBe(400)
+    expect(res.body.error).toContain('explicit confirmation')
+    expect(prisma.$transaction).not.toHaveBeenCalled()
+  })
+
+  it('resets planning and returns the NEEDS_REPLAN state', async () => {
+    vi.mocked(prisma.project.findFirst).mockResolvedValue({ id: 'proj-1', ownerId: userId } as never)
+    vi.mocked(prisma.$transaction).mockImplementation(async (fn: any) => {
+      const tx = {
+        project: {
+          findUnique: vi.fn().mockResolvedValue({ id: 'proj-1', planningState: 'CURRENT' }),
+          update: vi.fn(),
+        },
+        capacityProfile: { findMany: vi.fn().mockResolvedValue([]), deleteMany: vi.fn() },
+        capacityPlan: { deleteMany: vi.fn() },
+        timelineEntry: { deleteMany: vi.fn() },
+        storyTimelineEntry: { deleteMany: vi.fn() },
+        namedResource: { deleteMany: vi.fn() },
+      }
+      return fn(tx)
+    })
+
+    const res = await request(app)
+      .post('/api/projects/proj-1/planning/reset')
+      .set('Authorization', authHeader)
+      .send({ confirm: true })
+
+    expect(res.status).toBe(200)
+    expect(res.body).toEqual({ projectId: 'proj-1', planningState: 'NEEDS_REPLAN' })
+  })
+})
+
+describe('POST /api/projects/:projectId/planning/complete', () => {
+  it('rejects unauthenticated request', async () => {
+    const res = await request(app).post('/api/projects/proj-1/planning/complete')
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 404 for missing or inaccessible project', async () => {
+    vi.mocked(prisma.project.findFirst).mockResolvedValue(null)
+    const res = await request(app)
+      .post('/api/projects/proj-missing/planning/complete')
+      .set('Authorization', authHeader)
+    expect(res.status).toBe(404)
+  })
+
+  it('fails with actionable findings when planning is incomplete (no profiles)', async () => {
+    vi.mocked(prisma.project.findFirst).mockResolvedValue({ id: 'proj-1', ownerId: userId } as never)
+    const txUpdate = vi.fn()
+    vi.mocked(prisma.$transaction).mockImplementation(async (fn: any) => {
+      const tx = {
+        project: {
+          findUnique: vi.fn()
+            .mockResolvedValueOnce({ id: 'proj-1', planningState: 'NEEDS_REPLAN' })
+            .mockResolvedValueOnce({
+              id: 'proj-1',
+              resourceTypes: [{ id: 'rt-1', name: 'Engineer', namedResources: [] }],
+              capacityProfiles: [],
+            }),
+          update: txUpdate,
+        },
+      }
+      return fn(tx)
+    })
+
+    const res = await request(app)
+      .post('/api/projects/proj-1/planning/complete')
+      .set('Authorization', authHeader)
+
+    expect(res.status).toBe(422)
+    expect(res.body.code).toBe('REPLAN_INCOMPLETE')
+    expect(res.body.findings.length).toBeGreaterThan(0)
+    expect(res.body.error).toContain('Replanning is incomplete')
+    // The state must NOT have been flipped.
+    expect(txUpdate).not.toHaveBeenCalled()
+  })
+
+  it('atomically flips NEEDS_REPLAN to CURRENT when canonical validation passes', async () => {
+    vi.mocked(prisma.project.findFirst).mockResolvedValue({ id: 'proj-1', ownerId: userId } as never)
+    let updated = false
+    vi.mocked(prisma.$transaction).mockImplementation(async (fn: any) => {
+      const tx = {
+        project: {
+          findUnique: vi.fn()
+            .mockResolvedValueOnce({ id: 'proj-1', planningState: 'NEEDS_REPLAN' })
+            .mockResolvedValueOnce({
+              id: 'proj-1',
+              resourceTypes: [{ id: 'rt-1', name: 'Engineer', namedResources: [] }],
+              capacityProfiles: [{
+                id: 'cp-1',
+                projectId: 'proj-1',
+                resourceTypeId: 'rt-1',
+                namedResourceId: null,
+                ownerKind: 'ROLE',
+                source: 'MANUAL',
+                planningBasis: 'DEMAND_FOLLOWING',
+                defaultPercent: 100,
+                startWeek: null,
+                endWeek: null,
+                segments: [],
+              }],
+            }),
+          update: vi.fn(async args => { updated = true; return args }),
+        },
+      }
+      return fn(tx)
+    })
+
+    const res = await request(app)
+      .post('/api/projects/proj-1/planning/complete')
+      .set('Authorization', authHeader)
+
+    expect(res.status).toBe(200)
+    expect(res.body).toEqual({ projectId: 'proj-1', planningState: 'CURRENT' })
+    expect(updated).toBe(true)
+  })
+
+  it('is a no-op success for an already CURRENT project', async () => {
+    vi.mocked(prisma.project.findFirst).mockResolvedValue({ id: 'proj-1', ownerId: userId } as never)
+    const txUpdate = vi.fn()
+    vi.mocked(prisma.$transaction).mockImplementation(async (fn: any) => {
+      const tx = {
+        project: { findUnique: vi.fn().mockResolvedValue({ id: 'proj-1', planningState: 'CURRENT' }), update: txUpdate },
+      }
+      return fn(tx)
+    })
+
+    const res = await request(app)
+      .post('/api/projects/proj-1/planning/complete')
+      .set('Authorization', authHeader)
+
+    expect(res.status).toBe(200)
+    expect(res.body.planningState).toBe('CURRENT')
+    expect(txUpdate).not.toHaveBeenCalled()
+  })
+})

--- a/server/src/test/resetProjectPlanning.test.ts
+++ b/server/src/test/resetProjectPlanning.test.ts
@@ -1,0 +1,169 @@
+/**
+ * resetProjectPlanning.test.ts — Unit tests for the atomic Reset Planning
+ * service (issue #449).
+ *
+ * Covers the reset allow-list (cleared vs preserved), the PLANNED_RESOURCE
+ * provenance rule for planner-generated placeholder NamedResources,
+ * CURRENT → NEEDS_REPLAN, 404 behaviour, and injected mid-transaction
+ * failure rollback.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { Prisma } from '@prisma/client'
+
+import { resetProjectPlanning, ResetPlanningError } from '../lib/resetProjectPlanning.js'
+
+/** Build a minimal fake transaction recording every call. */
+function makeTx(overrides: Record<string, any> = {}) {
+  const calls: Array<{ op: string; args: unknown }> = []
+  const record = (op: string) => (args: unknown) => {
+    calls.push({ op, args })
+    return overrides[op] ?? {}
+  }
+  const tx = {
+    project: {
+      findUnique: vi.fn(record('project.findUnique')),
+      update: vi.fn(record('project.update')),
+    },
+    capacityProfile: {
+      findMany: vi.fn(record('capacityProfile.findMany')),
+      deleteMany: vi.fn(record('capacityProfile.deleteMany')),
+    },
+    capacityPlan: { deleteMany: vi.fn(record('capacityPlan.deleteMany')) },
+    timelineEntry: { deleteMany: vi.fn(record('timelineEntry.deleteMany')) },
+    storyTimelineEntry: { deleteMany: vi.fn(record('storyTimelineEntry.deleteMany')) },
+    namedResource: { deleteMany: vi.fn(record('namedResource.deleteMany')) },
+  }
+  return { tx, calls }
+}
+
+function makeDb(tx: ReturnType<typeof makeTx>['tx']) {
+  return {
+    $transaction: vi.fn(async (fn: (t: typeof tx) => Promise<unknown>) => fn(tx)),
+  } as unknown as Parameters<typeof resetProjectPlanning>[0]
+}
+
+const CURRENT_PROJECT = { id: 'proj-1', planningState: 'CURRENT' }
+
+beforeEach(() => vi.clearAllMocks())
+
+describe('resetProjectPlanning', () => {
+  it('clears the full planning allow-list and marks the project NEEDS_REPLAN', async () => {
+    const { tx, calls } = makeTx()
+    tx.project.findUnique.mockResolvedValue(CURRENT_PROJECT)
+    tx.capacityProfile.findMany.mockResolvedValue([])
+
+    const result = await resetProjectPlanning(makeDb(tx), 'proj-1')
+
+    expect(result).toEqual({ projectId: 'proj-1', planningState: 'NEEDS_REPLAN' })
+    expect(tx.capacityProfile.deleteMany).toHaveBeenCalledWith({ where: { projectId: 'proj-1' } })
+    expect(tx.capacityPlan.deleteMany).toHaveBeenCalledWith({ where: { projectId: 'proj-1' } })
+    expect(tx.timelineEntry.deleteMany).toHaveBeenCalledWith({ where: { projectId: 'proj-1' } })
+    expect(tx.storyTimelineEntry.deleteMany).toHaveBeenCalledWith({ where: { projectId: 'proj-1' } })
+    expect(tx.project.update).toHaveBeenCalledWith({
+      where: { id: 'proj-1' },
+      data: { weeklyDemandCache: Prisma.DbNull, planningState: 'NEEDS_REPLAN' },
+    })
+    // No named resources matched → nothing deleted.
+    expect(tx.namedResource.deleteMany).not.toHaveBeenCalled()
+    // No business-owned writes occurred.
+    expect(calls.some(c => c.op === 'epic.deleteMany')).toBe(false)
+  })
+
+  it('deletes only NamedResources whose provenance is a PLANNED_RESOURCE profile', async () => {
+    const { tx } = makeTx()
+    tx.project.findUnique.mockResolvedValue(CURRENT_PROJECT)
+    tx.capacityProfile.findMany.mockResolvedValue([
+      { namedResourceId: 'nr-planned-1' },
+      { namedResourceId: 'nr-planned-2' },
+      { namedResourceId: 'nr-planned-2' }, // duplicate → deduped
+      { namedResourceId: null },
+    ])
+
+    await resetProjectPlanning(makeDb(tx), 'proj-1')
+
+    expect(tx.capacityProfile.findMany).toHaveBeenCalledWith({
+      where: { projectId: 'proj-1', ownerKind: 'PLANNED_RESOURCE' },
+      select: { namedResourceId: true },
+    })
+    expect(tx.namedResource.deleteMany).toHaveBeenCalledWith({
+      where: {
+        id: { in: ['nr-planned-1', 'nr-planned-2'] },
+        resourceType: { projectId: 'proj-1' },
+      },
+    })
+  })
+
+  it('preserves user-authored (NAMED_PERSON) named resources', async () => {
+    const { tx } = makeTx()
+    tx.project.findUnique.mockResolvedValue(CURRENT_PROJECT)
+    tx.capacityProfile.findMany.mockResolvedValue([])
+
+    await resetProjectPlanning(makeDb(tx), 'proj-1')
+
+    expect(tx.namedResource.deleteMany).not.toHaveBeenCalled()
+  })
+
+  it('throws 404 when the project does not exist', async () => {
+    const { tx } = makeTx()
+    tx.project.findUnique.mockResolvedValue(null)
+
+    await expect(resetProjectPlanning(makeDb(tx), 'missing')).rejects.toThrow(ResetPlanningError)
+    await expect(resetProjectPlanning(makeDb(tx), 'missing')).rejects.toMatchObject({ status: 404 })
+    expect(tx.capacityProfile.deleteMany).not.toHaveBeenCalled()
+  })
+
+  it('is safe when the project is already NEEDS_REPLAN (idempotent quarantine)', async () => {
+    const { tx } = makeTx()
+    tx.project.findUnique.mockResolvedValue({ id: 'proj-1', planningState: 'NEEDS_REPLAN' })
+    tx.capacityProfile.findMany.mockResolvedValue([])
+
+    const result = await resetProjectPlanning(makeDb(tx), 'proj-1')
+    expect(result.planningState).toBe('NEEDS_REPLAN')
+    expect(tx.project.update).toHaveBeenCalled()
+  })
+
+  it('rolls the entire reset back when an injected failure occurs after writes', async () => {
+    const { tx } = makeTx()
+    tx.project.findUnique.mockResolvedValue(CURRENT_PROJECT)
+    tx.capacityProfile.findMany.mockResolvedValue([])
+
+    const db = {
+      $transaction: vi.fn(async (fn: (t: typeof tx) => Promise<unknown>) => {
+        await fn(tx)
+        // Simulate commit-time failure: the transaction aborts, so every
+        // write inside it is rolled back by PostgreSQL.
+        throw new Error('simulated commit failure')
+      }),
+    } as unknown as Parameters<typeof resetProjectPlanning>[0]
+
+    await expect(
+      resetProjectPlanning(db, 'proj-1', {
+        afterWrites: async () => { throw new Error('injected mid-transaction failure') },
+      }),
+    ).rejects.toThrow('injected mid-transaction failure')
+
+    // The service performed every write through the one transaction, which
+    // rejected — no partial state can have been committed. The update that
+    // flips planning state happened inside that transaction only.
+    expect(tx.project.update).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({ planningState: 'NEEDS_REPLAN' }),
+    }))
+    expect(db.$transaction).toHaveBeenCalledTimes(1)
+  })
+
+  it('executes the injected failure hook inside the transaction before commit', async () => {
+    const { tx } = makeTx()
+    tx.project.findUnique.mockResolvedValue(CURRENT_PROJECT)
+    tx.capacityProfile.findMany.mockResolvedValue([])
+    const hook = vi.fn(async () => {})
+
+    await resetProjectPlanning(makeDb(tx), 'proj-1', { afterWrites: hook })
+
+    expect(hook).toHaveBeenCalledTimes(1)
+    // Hook ran after the state flip, still inside the transaction.
+    const updateOrder = tx.project.update.mock.invocationCallOrder[0]
+    const hookOrder = hook.mock.invocationCallOrder[0]
+    expect(updateOrder).toBeLessThan(hookOrder)
+  })
+})

--- a/server/src/test/resetProjectPlanning.test.ts
+++ b/server/src/test/resetProjectPlanning.test.ts
@@ -70,25 +70,61 @@ describe('resetProjectPlanning', () => {
     expect(calls.some(c => c.op === 'epic.deleteMany')).toBe(false)
   })
 
-  it('deletes only NamedResources whose provenance is a PLANNED_RESOURCE profile', async () => {
+  it('deletes NamedResources with PLANNED_RESOURCE or proven legacy planner provenance', async () => {
     const { tx } = makeTx()
     tx.project.findUnique.mockResolvedValue(CURRENT_PROJECT)
     tx.capacityProfile.findMany.mockResolvedValue([
-      { namedResourceId: 'nr-planned-1' },
-      { namedResourceId: 'nr-planned-2' },
-      { namedResourceId: 'nr-planned-2' }, // duplicate → deduped
+      // PLANNED_RESOURCE provenance (Squad Planner apply writes these).
+      { namedResourceId: 'nr-planned-1', ownerKind: 'PLANNED_RESOURCE', source: 'SQUAD_PLANNER', planningBasis: 'CAPACITY_PROFILE' },
+      { namedResourceId: 'nr-planned-2', ownerKind: 'PLANNED_RESOURCE', source: 'MANUAL', planningBasis: 'DEMAND_FOLLOWING' },
+      // Legacy proven placeholder form: NAMED_PERSON + SQUAD_PLANNER +
+      // CAPACITY_PROFILE (isLegacyPlannerProfile).
+      { namedResourceId: 'nr-legacy-1', ownerKind: 'NAMED_PERSON', source: 'SQUAD_PLANNER', planningBasis: 'CAPACITY_PROFILE' },
+      { namedResourceId: 'nr-legacy-2', ownerKind: 'NAMED_PERSON', source: 'SQUAD_PLANNER', planningBasis: 'CAPACITY_PROFILE' },
+      // Ambiguous / real user rows: do NOT match either provenance rule.
+      { namedResourceId: 'nr-user-1', ownerKind: 'NAMED_PERSON', source: 'MANUAL', planningBasis: 'WHOLE_PROJECT_ALLOCATION' },
+      { namedResourceId: 'nr-user-2', ownerKind: 'NAMED_PERSON', source: 'SQUAD_PLANNER', planningBasis: 'DEMAND_FOLLOWING' },
       { namedResourceId: null },
     ])
 
     await resetProjectPlanning(makeDb(tx), 'proj-1')
 
     expect(tx.capacityProfile.findMany).toHaveBeenCalledWith({
-      where: { projectId: 'proj-1', ownerKind: 'PLANNED_RESOURCE' },
-      select: { namedResourceId: true },
+      where: {
+        projectId: 'proj-1',
+        OR: [
+          { ownerKind: 'PLANNED_RESOURCE' },
+          {
+            ownerKind: 'NAMED_PERSON',
+            source: 'SQUAD_PLANNER',
+            planningBasis: 'CAPACITY_PROFILE',
+          },
+        ],
+      },
+      select: { namedResourceId: true, ownerKind: true, source: true, planningBasis: true },
     })
     expect(tx.namedResource.deleteMany).toHaveBeenCalledWith({
       where: {
-        id: { in: ['nr-planned-1', 'nr-planned-2'] },
+        id: { in: ['nr-planned-1', 'nr-planned-2', 'nr-legacy-1', 'nr-legacy-2'] },
+        resourceType: { projectId: 'proj-1' },
+      },
+    })
+  })
+
+  it('removes a legacy planner placeholder while preserving an ambiguous SQUAD_PLANNER row', async () => {
+    const { tx } = makeTx()
+    tx.project.findUnique.mockResolvedValue(CURRENT_PROJECT)
+    tx.capacityProfile.findMany.mockResolvedValue([
+      { namedResourceId: 'nr-legacy', ownerKind: 'NAMED_PERSON', source: 'SQUAD_PLANNER', planningBasis: 'CAPACITY_PROFILE' },
+      // SQUAD_PLANNER source alone is NOT the proven legacy form — preserved.
+      { namedResourceId: 'nr-squad-demand', ownerKind: 'NAMED_PERSON', source: 'SQUAD_PLANNER', planningBasis: 'DEMAND_FOLLOWING' },
+    ])
+
+    await resetProjectPlanning(makeDb(tx), 'proj-1')
+
+    expect(tx.namedResource.deleteMany).toHaveBeenCalledWith({
+      where: {
+        id: { in: ['nr-legacy'] },
         resourceType: { projectId: 'proj-1' },
       },
     })


### PR DESCRIPTION
Closes #449

## Starting main SHA
`6bd23c2bf8b66676f8ffbdbd8bd7b34fb2ccb7fa` (verified against `origin/main` before work).

## Implementation summary
Adds the Reset Planning / Replan project workflow: an explicit persisted project planning state (`CURRENT` / `NEEDS_REPLAN`), one atomic reset operation (single Prisma transaction), a clear UI recovery path, narrow guards on planning-dependent operations, a canonical-validation-gated replanning completion, and a reviewed production maintenance command for the #404 classification step.

## Reset preserve / clear boundary
**Cleared (planning-owned):** `CapacityProfile`/`CapacitySegment`, `CapacityPlan`/`CapacityPlanPeriod`/`CapacityPlanEntry`, `TimelineEntry`/`StoryTimelineEntry` (generated schedule + manual overrides), `Project.weeklyDemandCache`, NamedResource rows proven to be planner-generated placeholders — matched ONLY by exact provenance markers: (a) a `PLANNED_RESOURCE` profile (what Squad Planner's `findOrCreatePlannedResources` writes), or (b) the established legacy planner form `NAMED_PERSON` + `SQUAD_PLANNER` + `CAPACITY_PROFILE` (`isLegacyPlannerProfile`, the same safe rule the Squad Planner adoption path uses); user-authored rows always carry `NAMED_PERSON` profiles outside those exact markers, and `planningState → NEEDS_REPLAN`.

**Preserved:** project identity/metadata (incl. `hoursPerDay`, onboarding/buffer weeks, `startDate`, tax), backlog hierarchy, effort/duration/resource-type assignment, dependencies, ResourceType identity/count/rates, user-authored NamedResources + `pricingModel`, discounts, overheads, snapshots. The candidate legacy capacity columns are not touched (#418 PR 2 owns them); runtime readers are NEEDS_REPLAN-aware so stale values are never projected as capacity. Ambiguous rows are preserved.

## CURRENT / NEEDS_REPLAN semantics
`CURRENT` keeps the existing fail-closed integrity rules untouched. `NEEDS_REPLAN` is only ever set by the atomic reset (or the reviewed maintenance command) — never inferred from malformed data.

## Planning-dependent guards
While NEEDS_REPLAN, these return `409 { code: "REPLAN_REQUIRED", ... }` (actionable; no legacy fallback, no invented capacity): `POST /timeline/schedule`, `POST /timeline/level`, `GET /timeline/export/csv`, manual timeline override routes, `POST /optimise`, `POST /optimise/apply`. `GET /timeline` returns an explicit neutral empty payload. Replanning surfaces stay accessible: `GET /resource-profile` serves effort/inputs with no planning-derived values; `GET /capacity-profiles` allows expected missing coverage but still fails closed on malformed rows; profile writes and Squad Planner apply (a supported replanning path that constructs canonical state from explicit inputs) remain available. Backlog/project editing is unaffected.

## Replanning completion rule
`POST /planning/complete` validates the persisted set with the existing canonical validation (`validatePersistedCapacityProfiles` + `checkPersistedCompleteness` — the same rules readiness and `GET /capacity-profiles` use) inside the same transaction that flips the state. Incomplete plans return `422 REPLAN_INCOMPLETE` with actionable findings; nothing is fabricated and the flag is never cleared by a button click alone.

## Migration / readiness interaction
New migration `20260808221539_add_project_planning_state` (enum + `Project.planningState` default `CURRENT`). The staged legacy-column migration `20260721000001_enforce_capacity_profile_ownership_invariants` was NOT modified (its SQL is untouched; a regression test asserts its ordering and invariant content). Readiness per-project completeness skips NEEDS_REPLAN projects (expected quarantine) while the global ownership audit still fails on cross-project ownership, impossible FK/owner relationships and duplicates. Snapshots capture/restore `planningState` when present (pre-feature payloads leave it untouched).

## Remediation (review round 1) — migration sequencing + fingerprint/atomic batch
- **Migration sequencing prerequisite.** Production evidence (#404) records `20260721000001_enforce_capacity_profile_ownership_invariants` as the single pending migration. It precedes the new planning-state migration in Prisma order, so the #450 release must NOT be installed while it is pending: #404 executes it as its own controlled production step (reviewed commit, maintenance window, clean preflight, backup, `migrate deploy`, verify-only-that-migration, rerun audit, stop on failure); only then does the #450 release install and deploy `20260808221539_add_project_planning_state`. Protected by `migrationSequencing.test.ts`.
- **Fingerprint contract.** Dry-run emits `stateFingerprint` (deterministic SHA-256 over exactly the reset-relevant manifest state); apply requires `--expected-fingerprint` and verifies it inside the apply transaction before any write; drift aborts with zero writes.
- **Atomic batch.** The whole manifest applies in one Prisma transaction via the shared `resetProjectPlanningWithinTransaction` body; a failure on any project rolls the whole batch back.

## Remediation (review round 2) — Serializable isolation for classification apply
- **Serializable isolation.** The destructive classification transaction now runs with `isolationLevel: Prisma.TransactionIsolationLevel.Serializable`. The fingerprint is still computed inside that transaction, so a concurrent commit that changes reset-relevant state between the fingerprint reads and the destructive writes forces a serialization conflict at the transaction boundary — the whole batch rolls back and the unreviewed change is never silently destroyed. No row locks, advisory locks or retry machinery were added.
- **Serialization conflicts fail closed.** A serialization conflict (Prisma P2034 or driver `originalCode 40001`, same detection as the Squad Planner apply path) is mapped to an actionable error: "Classification aborted because project planning state changed concurrently. Rerun the dry-run and review the new fingerprint before retrying. Nothing was changed." There is **NO automatic retry** — automatic retry could reuse the stale reviewed fingerprint after the database changed; the apply attempt is invalidated.
- **Two distinct fail-closed paths, never collapsed:** fingerprint drift (state differs before destructive work; zero writes) and serialization conflict (state changed while the reviewed transaction executed; rollback, zero committed writes). Normal fingerprint-mismatch behaviour is unchanged; dry-run remains zero-write and is generated inside ONE repeatable-read snapshot transaction (round 3).

## Remediation (review round 3) — four review findings
1. **Dry-run snapshot consistency.** The classification entries/counts AND the fingerprint are generated inside ONE Prisma transaction at repeatable-read isolation, so the report and the reviewed fingerprint always describe the same database snapshot. Zero writes (Prisma has no read-only transaction option, so the transaction is nominally read-write but performs no writes). Real-PostgreSQL concurrency test: a second connection commits a flip of reset-relevant state between the classification read and the fingerprint read; the report still reflects the pre-flip snapshot, and its fingerprint matches a fingerprint computed over the snapshot state — not the post-commit state. The existing apply drift/Serializable tests are unchanged and still pass.
2. **Legacy planner placeholders.** Reset also removes proven legacy Squad Planner placeholders — `NAMED_PERSON` + `SQUAD_PLANNER` + `CAPACITY_PROFILE` — by reusing the existing `isLegacyPlannerProfile` helper (no second provenance definition). Ambiguous, unprofiled and user-authored NamedResources (with `pricingModel` identity) are preserved. Unit tests cover every provenance case; a real-PostgreSQL reset-boundary test proves removal + preservation.
3. **Zero-demand roles exposed for replanning.** While `NEEDS_REPLAN`, `GET /resource-profile` additionally emits every preserved role with zero task demand: real identity (name/count/hours-per-day/dayRate), zero effort/allocation, no fabricated capacity, editor-usable shape. The client's normal zero-demand row filter is suspended only while `NEEDS_REPLAN` (CURRENT behaviour unchanged). The E2E no longer deletes unused roles via API: it creates explicit capacity profiles for EVERY preserved role (demand-bearing AND zero-demand) purely through the UI, completes replanning to CURRENT, and Update Timeline succeeds.
4. **Exports quarantined while NEEDS_REPLAN.** Export Resource Profile and Export Full Project are disabled with "Replan the project before exporting planning data." (inline notice + tooltip); the timeline CSV endpoint inside the full export is additionally protected by the existing server-side `REPLAN_REQUIRED` guard. `CURRENT` export is unchanged; no export format changes.

## Tests run
- **Server unit: 1721 passed / 0 failed** — incl. classification suite (37 tests: fingerprint stability/ordering/sensitivity, drift refusal, Serializable isolation requested, P2034 + 40001 conflict mapping, no automatic retry, unrelated failures unmodified, dry-run opens exactly one repeatable-read transaction), migration sequencing suite, reset suite (8 tests incl. legacy-planner provenance cases), guards suite (10 tests incl. zero-demand role exposure).
- **Client unit: 356 passed / 0 failed** — incl. new `useCommercialData.needsReplan` filter tests (zero-demand rows visible while NEEDS_REPLAN, hidden for CURRENT) and export-quarantine page tests (buttons disabled + guidance while NEEDS_REPLAN, enabled for CURRENT).
- **PostgreSQL integration: full `npm run test:integration:local` — all 14 suites passed** — incl. `planningReset.integration.test.ts` (17 tests). New real-concurrency test: two manifest projects, dry-run fingerprint, apply held at a narrow test seam after the fingerprint reads and the first project's uncommitted reset, a second real Prisma/PostgreSQL connection commits a change to the second project's segment, the apply then fails with the serialization-conflict mapping, and the assertions prove the whole batch rolled back (neither project NEEDS_REPLAN, no partial deletion, the concurrently committed mutation survived). Run repeatedly (25+ isolated runs) with no flake.
- **Playwright: `npm run test:e2e:local -- --grep "Planning reset"` — 1 passed** (full UI-only flow: no role deletion; every preserved role incl. zero-demand ones profiled through the capacity editor; completion → CURRENT; Update Timeline works).
- **`npm run validate` — EXIT 0** (lint, typecheck, builds, all tests).
- **`git diff --check` — clean.** No disposable containers left behind.

## CI status
Run #31286912137 (round-1 head): all green. Pending re-run for the round-2 head (see checks below).

## Explicit confirmations
- #421 remediation path is NOT used; superseded by this workflow.
- Legacy capacity columns are NOT removed; #418 PR 2 was not started and remains blocked behind the #449/#404 sequence.
- No production access occurred (development machine + disposable Docker PostgreSQL only; the maintenance command exists but was not executed).
- Migration sequencing and the ownership-invariants migration SQL remain unchanged from round 1.
- No optional UX work included; the Replan banner action is untouched.
- Local dev note: the configured dev DB did not exist on this machine; role `lokhor` + database `monrad_estimator` were created inside the running local `postgres:15` container so the documented `db:backup`/`db:setup`/`prisma migrate dev` flow could run. Verified backup: `backups/backup-20260809-081528-*.dump`.

Do not merge — wait for review.

