### PR TITLE
fix(#456): make NEEDS_REPLAN Resource Profile actionable when ROLE profiles are missing

### DIFF
--- a/client/src/components/resource-profile/ResourceProfileTab.tsx
+++ b/client/src/components/resource-profile/ResourceProfileTab.tsx
@@ -15,7 +15,7 @@ import {
 } from '../../lib/capacityProfileFormatting'
 import NamedResourcesPanel from './NamedResourcesPanel'
 import CapacityProfileEditorModal from './CapacityProfileEditorModal'
-import { transferToManualCapacity } from '../../lib/api'
+import { transferToManualCapacity, applyRoleCountsAsNeeded, apiErrorMessage } from '../../lib/api'
 import { invalidateProjectResourceProfile } from '../../lib/projectInvalidation'
 import type { CapacityProfileEditorDraft } from '../../lib/capacityProfileFormatting'
 
@@ -56,6 +56,12 @@ export default function ResourceProfileTab({
       invalidateProjectResourceProfile(qc, projectId)
     },
   })
+  const bulkAsNeededMutation = useMutation({
+    mutationFn: () => applyRoleCountsAsNeeded(projectId),
+    onSuccess: () => {
+      invalidateProjectResourceProfile(qc, projectId)
+    },
+  })
   return (
     <>
     <section className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700">
@@ -64,7 +70,45 @@ export default function ResourceProfileTab({
           <h2 className="text-base font-semibold text-gray-900 dark:text-white">Capacity profile summary</h2>
           <p className="text-sm text-gray-500 dark:text-gray-400">Capacity profiles, availability patterns, and resource allocation by role</p>
         </div>
+        {profile?.planningState === 'NEEDS_REPLAN' && (
+          <button
+            onClick={() => bulkAsNeededMutation.mutate()}
+            disabled={bulkAsNeededMutation.isPending}
+            className="shrink-0 bg-lab3-navy text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-lab3-blue transition-colors disabled:opacity-50"
+            data-testid="bulk-as-needed-button"
+          >
+            {bulkAsNeededMutation.isPending ? 'Creating profiles…' : 'Use role counts as As needed'}
+          </button>
+        )}
       </header>
+      {profile?.planningState === 'NEEDS_REPLAN' && bulkAsNeededMutation.isSuccess && bulkAsNeededMutation.data && (
+        <div className="px-6 py-3 border-b border-green-200 dark:border-green-900 bg-green-50 dark:bg-green-950" role="status" data-testid="bulk-as-needed-feedback">
+          <p className="text-xs text-green-700 dark:text-green-400">
+            {bulkAsNeededMutation.data.created > 0
+              ? `Created As needed capacity profiles for ${bulkAsNeededMutation.data.created} role${bulkAsNeededMutation.data.created === 1 ? '' : 's'}.`
+              : 'All eligible roles already have a persisted As needed profile.'}
+          </p>
+          {bulkAsNeededMutation.data.remainingFindings.length > 0 && (
+            <>
+              <ul className="list-disc pl-5 mt-1 space-y-1">
+                {bulkAsNeededMutation.data.remainingFindings.map((finding, index) => (
+                  <li key={index} className="text-xs text-amber-800 dark:text-amber-300">{finding}</li>
+                ))}
+              </ul>
+              <p className="text-xs text-amber-800 dark:text-amber-300 mt-1">
+                Remaining findings need manual review before the project can return to CURRENT.
+              </p>
+            </>
+          )}
+        </div>
+      )}
+      {profile?.planningState === 'NEEDS_REPLAN' && bulkAsNeededMutation.isError && (
+        <div className="px-6 py-2 border-b border-red-200 dark:border-red-900 bg-red-50 dark:bg-red-950">
+          <p role="alert" className="text-xs text-red-700 dark:text-red-400" data-testid="bulk-as-needed-error">
+            {apiErrorMessage(bulkAsNeededMutation.error, 'Could not create As needed profiles')}
+          </p>
+        </div>
+      )}
       <div className="px-6 py-3 bg-blue-50 dark:bg-blue-950/30 border-b border-blue-100 dark:border-blue-900">
         <p className="text-xs text-blue-700 dark:text-blue-300">
           <strong className="font-medium">Capacity profiles</strong> describe how much of a role, named person, or planned resource is available over time. Changing a profile affects planning capacity and scheduling. Commercial billing basis and billable days are managed separately on the <strong className="font-medium">Commercial</strong> tab.
@@ -219,6 +263,17 @@ export default function ResourceProfileTab({
 
                         return (
                           <div>
+                            {row.missingCapacityProfile ? (
+                              <button
+                                onClick={openProfileEditor}
+                                disabled={!editorDraft}
+                                className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-amber-100 dark:bg-amber-900 text-amber-800 dark:text-amber-200 hover:opacity-80 transition-opacity disabled:cursor-not-allowed disabled:opacity-60"
+                                title={editorDraft ? 'Click to create capacity profile' : 'Weekly capacity data is unavailable'}
+                                data-testid={`missing-profile-badge-${row.resourceTypeId}`}
+                              >
+                                Needs capacity profile
+                              </button>
+                            ) : (
                             <button
                               onClick={isPlannerSquad
                                 ? () => navigate(`/projects/${projectId}/timeline?panel=squad-planner`)
@@ -233,6 +288,7 @@ export default function ResourceProfileTab({
                             >
                               {isPlannerSquad ? 'Open Squad Planner' : badge.label}
                             </button>
+                            )}
                             {isPlannerSquad && (
                               <button
                                 onClick={() => setTransferConfirm({

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -190,3 +190,29 @@ export const completeReplanning = (projectId: string): Promise<CompleteReplannin
   api
     .post<CompleteReplanningResult>(`/projects/${projectId}/planning/complete`)
     .then(r => r.data)
+
+// ---------------------------------------------------------------------------
+// Bulk "Use role counts as As needed" (issue #456)
+// ---------------------------------------------------------------------------
+
+export interface BulkAsNeededResult {
+  projectId: string
+  /** The bulk action never transitions planning state — completion owns that. */
+  planningState: 'NEEDS_REPLAN'
+  /** Number of canonical ROLE profiles created by this call. */
+  created: number
+  /** Remaining canonical completeness findings (human-readable names). */
+  remainingFindings: string[]
+}
+
+/**
+ * Persist a canonical demand-following (As needed) ROLE profile for every
+ * eligible missing role-only ResourceType while the project NEEDS_REPLAN.
+ * Explicit user planning choice only; never overwrites existing profiles and
+ * never transitions the project state — the existing Replan project
+ * completion performs the canonical validation and state change.
+ */
+export const applyRoleCountsAsNeeded = (projectId: string): Promise<BulkAsNeededResult> =>
+  api
+    .post<BulkAsNeededResult>(`/projects/${projectId}/capacity-profiles/bulk-as-needed`)
+    .then(r => r.data)

--- a/client/src/test/ResourceProfileTab.needsReplan.test.tsx
+++ b/client/src/test/ResourceProfileTab.needsReplan.test.tsx
@@ -1,0 +1,323 @@
+/**
+ * ResourceProfileTab.needsReplan.test.tsx — Unit tests for the issue #456
+ * NEEDS_REPLAN Resource Profile behaviour:
+ *
+ *   - missing persisted ROLE profiles are visibly marked
+ *     ("Needs capacity profile") instead of showing the effective
+ *     As-needed draft as if it were persisted canonical state;
+ *   - the marked row still opens the existing capacity editor (create path);
+ *   - a persisted ROLE profile on a NEEDS_REPLAN project renders normally;
+ *   - CURRENT-project rows without a profile keep the pre-existing effective
+ *     As-needed badge (behaviour unchanged);
+ *   - the bulk "Use role counts as As needed" action is exposed only while
+ *     NEEDS_REPLAN, calls the API, reports created counts and remaining
+ *     findings, and surfaces failures.
+ */
+
+import React, { type ComponentProps } from 'react'
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+import ResourceProfileTab from '@/components/resource-profile/ResourceProfileTab'
+import { applyRoleCountsAsNeeded } from '@/lib/api'
+
+vi.mock('@/lib/api', async importOriginal => {
+  const actual = await importOriginal<typeof import('@/lib/api')>()
+  return { ...actual, applyRoleCountsAsNeeded: vi.fn() }
+})
+
+function renderWithProviders(ui: React.ReactElement) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter>{ui}</MemoryRouter>
+    </QueryClientProvider>,
+  )
+}
+
+interface TestRow {
+  resourceTypeId: string
+  name: string
+  missingCapacityProfile?: boolean
+  capacityProfile?: Record<string, unknown>
+}
+
+function row(r: TestRow) {
+  return {
+    resourceTypeId: r.resourceTypeId,
+    name: r.name,
+    category: 'ENGINEERING',
+    count: 1,
+    hoursPerDay: 8,
+    dayRate: null,
+    totalHours: 100,
+    totalDays: 12.5,
+    effortDays: 12.5,
+    allocatedDays: 12.5,
+    allocationMode: 'EFFORT',
+    allocationPercent: 100,
+    allocationStartWeek: null,
+    allocationEndWeek: null,
+    derivedStartWeek: null,
+    derivedEndWeek: null,
+    estimatedCost: null,
+    epics: [],
+    namedResources: [],
+    ...(r.missingCapacityProfile !== undefined ? { missingCapacityProfile: r.missingCapacityProfile } : {}),
+    ...(r.capacityProfile ? { capacityProfile: r.capacityProfile } : {}),
+  }
+}
+
+function createProps(
+  rows: TestRow[],
+  overrides: Partial<ComponentProps<typeof ResourceProfileTab>> = {},
+): ComponentProps<typeof ResourceProfileTab> {
+  const resourceRows = rows.map(row)
+  const profile: ComponentProps<typeof ResourceProfileTab>['profile'] = {
+    projectId: 'project-1',
+    planningState: 'NEEDS_REPLAN',
+    hoursPerDay: 8,
+    projectDurationWeeks: 12,
+    bufferWeeks: 0,
+    onboardingWeeks: 0,
+    resourceRows,
+    overheadRows: [],
+    summary: { totalHours: 100, totalDays: 12.5, totalCost: null, hasCost: false },
+  }
+  return {
+    projectId: 'project-1',
+    profile,
+    profileLoading: false,
+    overheadItems: [],
+    resourceTypes: [],
+    filteredResourceRows: resourceRows,
+    hasCost: false,
+    columnCount: 8,
+    chartData: [],
+    expandedRows: new Set(),
+    expandedNamedResources: new Set(),
+    editingId: null,
+    form: { name: '', resourceTypeId: '', type: 'PERCENTAGE', value: '' },
+    setForm: vi.fn(),
+    formError: null,
+    profileMutationError: null,
+    clearProfileMutationError: vi.fn(),
+    bufferWeeks: 0,
+    onboardingWeeks: 0,
+    toggleRow: vi.fn(),
+    toggleNamedResources: vi.fn(),
+    resetForm: vi.fn(),
+    handleFormSubmit: vi.fn(),
+    handleEdit: vi.fn(),
+    handleDelete: vi.fn(),
+    updateResourceType: { mutate: vi.fn() } as never,
+    addPerson: { mutate: vi.fn() } as never,
+    removeLastPerson: { mutate: vi.fn() } as never,
+    createOverhead: { isPending: false } as never,
+    updateOverhead: { isPending: false } as never,
+    weekToDate: vi.fn(() => null),
+    fmtDate: vi.fn(() => ''),
+    formatNumber: (value: number, fractionDigits = 2) => value.toFixed(fractionDigits),
+    editingAllocation: null,
+    setEditingAllocation: vi.fn(),
+    allocationDraft: null,
+    setAllocationDraft: vi.fn(),
+    updateAllocationMutation: { isPending: false, mutate: vi.fn() } as never,
+    updateNrAllocationMutation: { isPending: false, mutate: vi.fn() } as never,
+    startEditAllocation: vi.fn(),
+    getAllocationBadge: () => ({ label: 'As needed', color: 'bg-gray-100 text-gray-600', sub: null }),
+    qc: new QueryClient(),
+    ...overrides,
+  }
+}
+
+beforeEach(() => vi.clearAllMocks())
+
+describe('ResourceProfileTab — missing persisted ROLE profiles (issue #456)', () => {
+  it('marks a missing persisted ROLE profile instead of showing the effective As-needed draft as persisted', () => {
+    renderWithProviders(
+      <ResourceProfileTab
+        {...createProps([
+          { resourceTypeId: 'rt-missing', name: 'Business Analyst', missingCapacityProfile: true },
+        ])}
+      />,
+    )
+
+    const badge = screen.getByTestId('missing-profile-badge-rt-missing')
+    expect(badge).toHaveTextContent('Needs capacity profile')
+    // The row must not present the effective draft as a valid persisted
+    // "As needed" badge.
+    expect(badge).not.toHaveTextContent('As needed')
+  })
+
+  it('opens the existing capacity editor (create path) from the missing marker', () => {
+    renderWithProviders(
+      <ResourceProfileTab
+        {...createProps([
+          { resourceTypeId: 'rt-missing', name: 'Business Analyst', missingCapacityProfile: true },
+        ])}
+      />,
+    )
+
+    fireEvent.click(screen.getByTestId('missing-profile-badge-rt-missing'))
+
+    expect(screen.getByRole('dialog', { name: 'Edit capacity profile' })).toBeInTheDocument()
+    expect(screen.getByText('Create Capacity Profile')).toBeInTheDocument()
+  })
+
+  it('shows a persisted ROLE profile as normal state on a NEEDS_REPLAN project', () => {
+    renderWithProviders(
+      <ResourceProfileTab
+        {...createProps([
+          {
+            resourceTypeId: 'rt-persisted',
+            name: 'Security Consultant',
+            capacityProfile: {
+              planningBasis: 'demandFollowing',
+              source: 'manual',
+              defaultPercent: 100,
+              startWeek: null,
+              endWeek: null,
+              segments: [],
+              resolutionSource: 'PROFILE',
+            },
+          },
+        ])}
+      />,
+    )
+
+    expect(screen.queryByTestId('missing-profile-badge-rt-persisted')).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'As needed' })).toBeInTheDocument()
+  })
+
+  it('keeps CURRENT-project rows without a profile showing the effective As-needed badge (unchanged)', () => {
+    const currentRow = row({ resourceTypeId: 'rt-current', name: 'Business Analyst' })
+    const props = createProps([{ resourceTypeId: 'rt-current', name: 'Business Analyst' }], {
+      profile: {
+        projectId: 'project-1',
+        planningState: 'CURRENT',
+        hoursPerDay: 8,
+        projectDurationWeeks: 12,
+        bufferWeeks: 0,
+        onboardingWeeks: 0,
+        resourceRows: [currentRow],
+        overheadRows: [],
+        summary: { totalHours: 0, totalDays: 0, totalCost: null, hasCost: false },
+      },
+    })
+    // CURRENT project: rows keep the effective draft badge; no missing marker.
+    props.filteredResourceRows = [currentRow]
+
+    renderWithProviders(<ResourceProfileTab {...props} />)
+
+    expect(screen.queryByTestId('missing-profile-badge-rt-current')).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'As needed' })).toBeInTheDocument()
+  })
+})
+
+describe('ResourceProfileTab — bulk Use role counts as As needed (issue #456)', () => {
+  it('exposes the bulk action only while NEEDS_REPLAN', () => {
+    renderWithProviders(
+      <ResourceProfileTab
+        {...createProps([
+          { resourceTypeId: 'rt-missing', name: 'Business Analyst', missingCapacityProfile: true },
+        ])}
+      />,
+    )
+    expect(screen.getByRole('button', { name: 'Use role counts as As needed' })).toBeInTheDocument()
+  })
+
+  it('hides the bulk action for a CURRENT project', () => {
+    const currentRow = row({ resourceTypeId: 'rt-current', name: 'Business Analyst' })
+    const props = createProps([{ resourceTypeId: 'rt-current', name: 'Business Analyst' }], {
+      profile: {
+        projectId: 'project-1',
+        planningState: 'CURRENT',
+        hoursPerDay: 8,
+        projectDurationWeeks: 12,
+        bufferWeeks: 0,
+        onboardingWeeks: 0,
+        resourceRows: [currentRow],
+        overheadRows: [],
+        summary: { totalHours: 0, totalDays: 0, totalCost: null, hasCost: false },
+      },
+    })
+    props.filteredResourceRows = [currentRow]
+
+    renderWithProviders(<ResourceProfileTab {...props} />)
+
+    expect(screen.queryByRole('button', { name: 'Use role counts as As needed' })).not.toBeInTheDocument()
+  })
+
+  it('calls the bulk API and reports the created count', async () => {
+    vi.mocked(applyRoleCountsAsNeeded).mockResolvedValue({
+      projectId: 'project-1',
+      planningState: 'NEEDS_REPLAN',
+      created: 2,
+      remainingFindings: [],
+    })
+    renderWithProviders(
+      <ResourceProfileTab
+        {...createProps([
+          { resourceTypeId: 'rt-missing', name: 'Business Analyst', missingCapacityProfile: true },
+        ])}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Use role counts as As needed' }))
+
+    await waitFor(() => expect(applyRoleCountsAsNeeded).toHaveBeenCalledWith('project-1'))
+    await waitFor(() => {
+      expect(screen.getByTestId('bulk-as-needed-feedback')).toHaveTextContent(
+        'Created As needed capacity profiles for 2 roles.',
+      )
+    })
+  })
+
+  it('shows remaining human-readable findings after the bulk action', async () => {
+    vi.mocked(applyRoleCountsAsNeeded).mockResolvedValue({
+      projectId: 'project-1',
+      planningState: 'NEEDS_REPLAN',
+      created: 1,
+      remainingFindings: [
+        'Named resource "Alice Example" lacks persisted profile (named resource nr-1, resource type rt-3)',
+      ],
+    })
+    renderWithProviders(
+      <ResourceProfileTab
+        {...createProps([
+          { resourceTypeId: 'rt-missing', name: 'Business Analyst', missingCapacityProfile: true },
+        ])}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Use role counts as As needed' }))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('bulk-as-needed-feedback')).toHaveTextContent('Alice Example')
+    })
+  })
+
+  it('surfaces a bulk action failure instead of failing silently', async () => {
+    vi.mocked(applyRoleCountsAsNeeded).mockRejectedValue({
+      response: { data: { error: 'This action is only available while the project needs replanning.' } },
+    })
+    renderWithProviders(
+      <ResourceProfileTab
+        {...createProps([
+          { resourceTypeId: 'rt-missing', name: 'Business Analyst', missingCapacityProfile: true },
+        ])}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Use role counts as As needed' }))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('bulk-as-needed-error')).toHaveTextContent(
+        'This action is only available while the project needs replanning.',
+      )
+    })
+  })
+})

--- a/client/src/types/backlog.ts
+++ b/client/src/types/backlog.ts
@@ -292,6 +292,10 @@ export interface ResourceProfileRow {
   derivedStartWeek: number | null
   derivedEndWeek: number | null
   estimatedCost: number | null
+  /** While NEEDS_REPLAN (issue #456): true when this role requires a persisted
+   *  ROLE profile for completion but does not have one. Distinguishes the
+   *  missing state from a valid persisted As-needed profile. */
+  missingCapacityProfile?: boolean
   epics: ResourceProfileEpic[]
   namedResources?: Array<{
     id: string

--- a/docs/domain/planning-reset-replan.md
+++ b/docs/domain/planning-reset-replan.md
@@ -99,6 +99,12 @@ readiness and `GET /capacity-profiles` enforce). Validation runs inside the same
 transaction that flips the state, so the flag is never cleared without a canonical
 plan, and no profile is ever fabricated. `CURRENT` projects are a no-op.
 
+Findings identify the affected resource by its human-readable name (issue #456) —
+e.g. `Resource type "Business Analyst" lacks exactly one persisted ROLE profile
+(resource type <id>)` — with the internal ID kept only as secondary diagnostic
+context. Machine-readable error codes (`REPLAN_INCOMPLETE`, `REPLAN_REQUIRED`) are
+unchanged.
+
 ## Planning-dependent guards
 
 While `NEEDS_REPLAN`, capacity-dependent operations return
@@ -157,6 +163,25 @@ historical timeline viewer is out of scope for this issue.
   before exporting planning data." (the timeline CSV endpoint inside the full
   export is additionally protected by the server-side `REPLAN_REQUIRED` guard).
   `CURRENT` export is unchanged.
+- **Missing persisted ROLE profiles are marked (issue #456).** While
+  `NEEDS_REPLAN`, a role row that requires a persisted ROLE profile (role-only
+  types, or roles with planner-owned profiles) but does not have one renders a
+  distinct amber **Needs capacity profile** badge that opens the existing
+  capacity editor (create path). The effective/fallback As-needed draft is never
+  presented as if it were persisted canonical state. `CURRENT` Resource Profile
+  behaviour is unchanged.
+- **Bulk "Use role counts as As needed" (issue #456).** Resource Profile exposes
+  one explicit user-triggered action (only while `NEEDS_REPLAN`) that persists a
+  canonical demand-following (`DEMAND_FOLLOWING`, 100%, `MANUAL` source) ROLE
+  profile for EVERY eligible missing role-only ResourceType in one atomic batch
+  (`lib/bulkAsNeededProfiles.ts` + `POST
+  /api/projects/:projectId/capacity-profiles/bulk-as-needed`). It reuses the
+  existing authoritative writer (`replaceCapacityProfile`): it never overwrites
+  an existing persisted profile, never guesses named-person/planned-resource/
+  segmented authority, is idempotent, and rolls the whole batch back on any
+  failure. The project stays `NEEDS_REPLAN` — the existing completion operation
+  remains the only path back to `CURRENT` — and the response reports any
+  remaining completeness findings by human-readable resource name.
 - No planning option is automatically selected because of migration history; the
   user picks the approach (As needed, fixed whole project, fixed selected weeks,
   manually shaped, Squad Planner) in the existing surfaces.

--- a/e2e/TESTS.md
+++ b/e2e/TESTS.md
@@ -370,6 +370,14 @@ import { login, createProject, createTestUser, createUserAndLogin, TEST_EMAIL, T
 
 ---
 
+### `replan-profile-repair.spec.ts` — NEEDS_REPLAN profile repair (1 test — issue #456)
+
+| Test | Description |
+|------|-------------|
+| missing profiles are visible and bulk As-needed + completion restore CURRENT | Creates a project and seeds a backlog referencing three preserved role-only ResourceTypes via CSV, runs Reset Planning. Asserts Resource Profile visibly marks each preserved role-only row with a "Needs capacity profile" badge (the effective As-needed draft is not presented as persisted canonical state), triggers the explicit bulk **Use role counts as As needed** action, verifies the created-count feedback and that all missing markers clear while the project stays NEEDS_REPLAN, then runs the existing Replan project completion — the project returns to CURRENT and Update Timeline succeeds |
+
+---
+
 ## Config Reference (`playwright.config.ts`)
 
 | Option | Value |

--- a/e2e/tests/planning-reset.spec.ts
+++ b/e2e/tests/planning-reset.spec.ts
@@ -56,7 +56,12 @@ async function setAllRoleCapacitiesAsNeeded(page: Page) {
   const rows = page.locator('tr[data-testid^="resource-profile-row-"]')
   const rowCount = await rows.count()
   for (let i = 0; i < rowCount; i++) {
-    const editButton = rows.nth(i).locator('button[title="Click to edit capacity profile"]')
+    // Missing persisted profiles render the amber "Needs capacity profile"
+    // badge (issue #456); persisted ones keep the normal edit badge — both
+    // open the same capacity editor.
+    const editButton = rows.nth(i).locator(
+      'button[title="Click to edit capacity profile"], button[title="Click to create capacity profile"]',
+    )
     await editButton.waitFor({ state: 'visible', timeout: 10_000 })
     await editButton.click()
     await expect(page.getByTestId('capacity-profile-editor')).toBeVisible({ timeout: 8_000 })

--- a/e2e/tests/replan-profile-repair.spec.ts
+++ b/e2e/tests/replan-profile-repair.spec.ts
@@ -1,0 +1,114 @@
+/**
+ * replan-profile-repair.spec.ts — Targeted E2E regression for issue #456:
+ * making a NEEDS_REPLAN Resource Profile actionable when ROLE profiles are
+ * missing.
+ *
+ *  1. Create a project and seed a backlog referencing THREE preserved
+ *     role-only ResourceTypes (CSV import creates role-only roles with
+ *     LEGACY_MAPPER ROLE profiles).
+ *  2. Reset planning → every profile is discarded; the project NEEDS_REPLAN.
+ *  3. Resource Profile visibly marks the missing persisted ROLE profiles
+ *     ("Needs capacity profile") instead of presenting the effective
+ *     As-needed draft as canonical state.
+ *  4. The user chooses the explicit bulk **Use role counts as As needed**
+ *     action → exactly one canonical ROLE profile per eligible role.
+ *  5. The missing markers disappear; the existing **Replan project**
+ *     completion returns the project to CURRENT.
+ *  6. Update Timeline succeeds again.
+ */
+
+import { test, expect, type Page } from '@playwright/test'
+import { login, createProject, quickSchedule } from './helpers'
+import path from 'path'
+import fs from 'fs'
+import os from 'os'
+
+const CSV_CONTENT = [
+  'Type,Epic,Feature,Story,Task,Template,ResourceType,HoursEffort,DurationDays,Description,Assumptions,EpicStatus,FeatureStatus,StoryStatus',
+  'Epic,Platform Build,,,,,,,,,,,,',
+  'Feature,Platform Build,Core API,,,,,,,,,,,',
+  'Story,Platform Build,Core API,API Design,,,,,,,,,,',
+  'Task,Platform Build,Core API,API Design,Design endpoints,,Tech Lead,24,3,,,,,',
+  'Task,Platform Build,Core API,API Design,Requirements gathering,,Business Analyst,16,2,,,,,',
+  'Task,Platform Build,Core API,API Design,Design UX flows,,UX Designer,12,2,,,,,',
+].join('\n')
+
+async function seedBacklogViaCsv(page: Page) {
+  await page.getByRole('button', { name: /backlog/i }).click()
+  await expect(page.getByRole('button', { name: /import csv/i })).toBeVisible({ timeout: 8_000 })
+
+  const tmpFile = path.join(os.tmpdir(), `replan-repair-seed-${Date.now()}.csv`)
+  fs.writeFileSync(tmpFile, CSV_CONTENT)
+  await page.getByRole('button', { name: /import csv/i }).click()
+  await page.locator('input[type="file"]').setInputFiles(tmpFile)
+  fs.unlinkSync(tmpFile)
+
+  await page.getByRole('button', { name: /review & confirm/i }).click({ timeout: 10_000 })
+  await page.getByRole('button', { name: /import backlog/i }).click({ timeout: 10_000 })
+  await expect(page.getByText('Platform Build')).toBeVisible({ timeout: 10_000 })
+}
+
+test.describe('NEEDS_REPLAN Resource Profile repair (issue #456)', () => {
+  test('missing profiles are visible and bulk As-needed + completion restore CURRENT', async ({ page }) => {
+    const projectName = `E2E Replan Repair ${Date.now()}`
+    await login(page)
+    await createProject(page, projectName)
+
+    // Open the project and seed a backlog referencing three role-only roles.
+    await page.getByRole('heading', { name: projectName, exact: true }).first().click()
+    await page.getByRole('button', { name: /backlog/i }).waitFor({ timeout: 8_000 })
+    await seedBacklogViaCsv(page)
+    const projectId = page.url().match(/\/projects\/([^/]+)/)?.[1]!
+    expect(projectId).toBeTruthy()
+
+    // ── Reset planning with explicit confirmation ─────────────────────────
+    await page.goto(`/projects/${projectId}/resource-profile`)
+    await expect(page.getByRole('heading', { name: /resource profile/i })).toBeVisible({ timeout: 10_000 })
+    await page.getByRole('button', { name: /reset planning…/i }).click()
+    await expect(page.getByRole('dialog')).toBeVisible()
+    await page.getByRole('button', { name: 'Reset planning', exact: true }).click()
+    await expect(page.getByTestId('reset-feedback')).toBeVisible({ timeout: 10_000 })
+    await expect(page.getByTestId('planning-needs-attention')).toBeVisible()
+
+    // ── The defect shape: preserved role-only rows are marked missing ──────
+    // The project carries the CSV-seeded roles plus any default role-only
+    // types created with the project — every preserved role-only row must be
+    // visibly marked as missing a persisted ROLE profile.
+    const missingBadges = page.locator('[data-testid^="missing-profile-badge-"]')
+    await expect(missingBadges.first()).toBeVisible({ timeout: 10_000 })
+    expect(await missingBadges.count()).toBeGreaterThanOrEqual(3)
+    // The preserved roles themselves are visible (names come from the
+    // CSV-seeded resource types) and each carries the missing marker.
+    for (const roleName of ['Tech Lead', 'Business Analyst', 'UX Designer']) {
+      const roleRow = page.locator('tr[data-testid^="resource-profile-row-"]', { hasText: roleName })
+      await expect(roleRow).toBeVisible()
+      await expect(roleRow.locator('[data-testid^="missing-profile-badge-"]')).toBeVisible()
+    }
+
+    // ── Explicit bulk user choice: Use role counts as As needed ───────────
+    await page.getByRole('button', { name: 'Use role counts as As needed' }).click()
+    await expect(page.getByTestId('bulk-as-needed-feedback')).toContainText(
+      /Created As needed capacity profiles for \d+ roles?\./,
+      { timeout: 10_000 },
+    )
+    // Every missing marker is resolved — the rows now carry persisted
+    // As-needed profiles.
+    await expect(missingBadges).toHaveCount(0, { timeout: 10_000 })
+
+    // The project must still be quarantined — completion owns the
+    // state transition.
+    await expect(page.getByTestId('planning-needs-attention')).toBeVisible()
+
+    // ── Existing Replan project completion → CURRENT ───────────────────────
+    await page.getByTestId('replan-project-button').click()
+    await expect(page.getByTestId('planning-needs-attention')).not.toBeVisible({ timeout: 10_000 })
+
+    // ── Timeline scheduling works again ────────────────────────────────────
+    await page.goto(`/projects/${projectId}/timeline`)
+    await expect(page.getByRole('heading', { name: /timeline planner/i })).toBeVisible({ timeout: 10_000 })
+    await expect(page.getByTestId('planning-needs-attention')).not.toBeVisible()
+    await quickSchedule(page)
+    await expect(page.getByTestId('schedule-error')).not.toBeVisible({ timeout: 10_000 })
+    await expect(page.getByText('Core API').first()).toBeVisible({ timeout: 10_000 })
+  })
+})

--- a/scripts/run-integration-local.mjs
+++ b/scripts/run-integration-local.mjs
@@ -20,6 +20,7 @@ try {
       'test:transfer-integration',
       'test:legacy-alias-removal-integration',
       'test:planning-reset-integration',
+      'test:replan-repair-integration',
       'test:provenance-migration-integration',
       'test:provenance-snapshot-integration',
     ]) {

--- a/server/package.json
+++ b/server/package.json
@@ -29,6 +29,7 @@
     "postinstall": "prisma generate",
     "test:legacy-alias-removal-integration": "vitest run --config vitest.integration.config.ts src/test/legacyCapacityAliasRemoval.integration.test.ts",
     "test:planning-reset-integration": "vitest run --config vitest.integration.config.ts src/test/planningReset.integration.test.ts",
+    "test:replan-repair-integration": "vitest run --config vitest.integration.config.ts src/test/replanProfileRepair.integration.test.ts",
     "test:provenance-migration-integration": "vitest run --config vitest.integration.config.ts src/test/capacityProfileProvenanceMigration.integration.test.ts",
     "test:provenance-snapshot-integration": "vitest run --config vitest.integration.config.ts src/test/capacityProfileProvenanceSnapshots.integration.test.ts"
   },

--- a/server/src/lib/bulkAsNeededProfiles.ts
+++ b/server/src/lib/bulkAsNeededProfiles.ts
@@ -15,21 +15,25 @@
  *   - Eligible owners are role-only ResourceTypes (zero named resources —
  *     so there is no named-person, planned-resource or segmented authority
  *     to conflict with) that lack a persisted ROLE profile.
- *   - Exactly one canonical ROLE profile (DEMAND_FOLLOWING, 100% As needed,
- *     MANUAL source) is created per eligible role via the existing
- *     authoritative writer (`replaceCapacityProfile`), never overwriting an
- *     existing profile and never guessing planner-owned or named-resource
- *     authority.
- *   - The batch is atomic: any failure (including a concurrent duplicate
- *     create hitting the partial unique index) rolls back every write.
- *   - The project stays NEEDS_REPLAN; the response reports the remaining
+ *   - The bulk write is strictly CREATE-ONLY (issue #456 review): it never
+ *     updates or replaces an existing profile. The general-purpose editor
+ *     writer (`replaceCapacityProfile`) is deliberately NOT reused because
+ *     it is a create-or-replace writer — a ROLE profile created by another
+ *     request after the bulk eligibility read could otherwise be
+ *     overwritten. Instead each role is re-checked inside the transaction
+ *     immediately before its insert, and a concurrent duplicate insert is
+ *     detected through the partial unique index on `resourceTypeId`
+ *     (P2002) and treated as "already exists → skip". A concurrently
+ *     created profile therefore always survives completely unchanged.
+ *   - The batch is atomic: an unexpected failure rolls back every write;
+ *     the project stays NEEDS_REPLAN; the response reports the remaining
  *     canonical completeness findings so the user can resolve non-eligible
  *     findings manually before running the existing completion operation.
  */
 
-import type { Prisma, PrismaClient } from '@prisma/client'
+import { Prisma, type PrismaClient } from '@prisma/client'
 
-import { replaceCapacityProfile } from './capacityProfileReplaceService.js'
+import { validateProfileStructure } from './capacityProfileStructureValidation.js'
 import { collectReplanningFindings } from './completeReplanning.js'
 
 export class BulkAsNeededError extends Error {
@@ -54,6 +58,112 @@ export interface BulkAsNeededResult {
   remainingFindings: string[]
 }
 
+/** Optional test seams (mirrors the reset service's `afterWrites` hook). */
+export interface BulkAsNeededHooks {
+  /** Invoked after each successful profile create (roleId = role just created). */
+  afterCreate?: (roleId: string, created: number) => Promise<void> | void
+}
+
+/**
+ * Whether a Prisma P2002 error is the partial-unique-index violation on
+ * CapacityProfile.resourceTypeId (a concurrent ROLE profile insert for the
+ * same resource type). Same constraint-identity detection as the Squad
+ * Planner apply path; unrelated P2002 errors propagate.
+ */
+function isRoleProfileAlreadyExistsConflict(err: unknown): boolean {
+  if (!(err instanceof Prisma.PrismaClientKnownRequestError)) return false
+  if (err.code !== 'P2002') return false
+  const meta = err.meta as Record<string, unknown> | null | undefined
+  if (!meta) return false
+  if (meta.modelName !== 'CapacityProfile') return false
+  // With adapter-pg (Prisma 7) the constraint name is in
+  // driverAdapterError.cause.originalMessage.
+  const adapterErr = meta.driverAdapterError as Record<string, unknown> | undefined
+  const cause = adapterErr?.cause as Record<string, unknown> | undefined
+  if (cause && typeof cause.originalMessage === 'string') {
+    return cause.originalMessage.includes('CapacityProfile_resourceTypeId_key')
+  }
+  return false
+}
+
+/**
+ * Create the canonical As-needed ROLE profile for one role, guaranteeing the
+ * profile is CREATE-ONLY: the role is re-checked immediately before the
+ * insert, and a concurrent insert that wins the unique-index race is treated
+ * as "already exists" (skip, never update).
+ *
+ * @returns true when a profile was created, false when one already exists.
+ */
+async function createMissingRoleAsNeededProfile(
+  tx: Prisma.TransactionClient,
+  projectId: string,
+  roleId: string,
+  resourceTypeIds: ReadonlySet<string>,
+): Promise<boolean> {
+  // Re-check inside the transaction: a profile created after the initial
+  // eligibility read (e.g. by a concurrent editor save) must never be
+  // updated or replaced by this bulk action.
+  const existing = await tx.capacityProfile.findFirst({
+    where: { projectId, resourceTypeId: roleId, ownerKind: 'ROLE' },
+    select: { id: true },
+  })
+  if (existing) return false
+
+  // Canonical "As needed / demand-following" ROLE profile — the same shape
+  // the single-owner editor would persist for this choice. Run it through
+  // the single authoritative structural rule set before writing.
+  const structuralErrors = validateProfileStructure(
+    {
+      id: 'pending-create',
+      projectId,
+      resourceTypeId: roleId,
+      namedResourceId: null,
+      ownerKind: 'ROLE',
+      planningBasis: 'DEMAND_FOLLOWING',
+      source: 'MANUAL',
+      defaultPercent: 100,
+      startWeek: null,
+      endWeek: null,
+      segments: [],
+    },
+    {
+      projectId,
+      resourceTypeIds,
+      namedResourceIds: new Set<string>(),
+    },
+  )
+  if (structuralErrors.length > 0) {
+    throw new Error(
+      `Refusing to create a non-canonical As-needed profile for role ${roleId}: ` +
+        structuralErrors.join('; '),
+    )
+  }
+
+  try {
+    await tx.capacityProfile.create({
+      data: {
+        projectId,
+        ownerKind: 'ROLE',
+        resourceTypeId: roleId,
+        namedResourceId: null,
+        planningBasis: 'DEMAND_FOLLOWING',
+        source: 'MANUAL',
+        defaultPercent: 100,
+        startWeek: null,
+        endWeek: null,
+        provenance: null,
+      },
+    })
+    return true
+  } catch (error) {
+    // A concurrent ROLE profile insert committed between the re-check and
+    // this insert → the unique index refused the duplicate. The concurrent
+    // profile is authoritative and untouched; skip this role.
+    if (isRoleProfileAlreadyExistsConflict(error)) return false
+    throw error
+  }
+}
+
 /**
  * Persist a canonical demand-following (As needed) ROLE profile for every
  * eligible missing role-only ResourceType in one atomic transaction.
@@ -61,6 +171,7 @@ export interface BulkAsNeededResult {
  * @param prisma    Prisma client
  * @param projectId Project ID
  * @param userId    Requesting user (ownership revalidated inside the tx)
+ * @param hooks     Optional test seams
  * @returns         Created count + remaining completeness findings
  * @throws BulkAsNeededError with a stable `code` on guard violations
  */
@@ -68,6 +179,7 @@ export async function applyRoleCountsAsNeeded(
   prisma: PrismaClient,
   projectId: string,
   userId: string,
+  hooks: BulkAsNeededHooks = {},
 ): Promise<BulkAsNeededResult> {
   return prisma.$transaction(async (tx: Prisma.TransactionClient) => {
     const project = await tx.project.findFirst({
@@ -120,24 +232,29 @@ export async function applyRoleCountsAsNeeded(
     const eligibleRoleIds = project.resourceTypes
       .filter(rt => rt.namedResources.length === 0 && !persistedRoleRtIds.has(rt.id))
       .map(rt => rt.id)
+    const resourceTypeIds = new Set(project.resourceTypes.map(rt => rt.id))
 
     let created = 0
     for (const roleId of eligibleRoleIds) {
-      // The authoritative single-owner writer: validates ownership, refuses
-      // PLANNED_RESOURCE/SQUAD_PLANNER overwrite, creates the canonical
-      // MANUAL-source DEMAND_FOLLOWING profile, clears behavioural
-      // provenance and invalidates the weekly-demand cache. A concurrent
-      // duplicate create fails on the partial unique index and aborts the
-      // whole batch atomically.
-      await replaceCapacityProfile(
-        tx,
-        projectId,
-        'ROLE',
-        roleId,
-        { planningBasis: 'DEMAND_FOLLOWING', defaultPercent: 100 },
-        userId,
-      )
-      created++
+      // Strictly create-only: the role is re-checked inside the transaction
+      // and a concurrent duplicate insert (P2002 on the resourceTypeId
+      // unique index) is treated as "already exists → skip" — an existing
+      // profile, including one that appeared after the eligibility read, is
+      // never updated or replaced by this bulk action.
+      const didCreate = await createMissingRoleAsNeededProfile(tx, projectId, roleId, resourceTypeIds)
+      if (didCreate) {
+        created++
+        await hooks.afterCreate?.(roleId, created)
+      }
+    }
+
+    if (created > 0) {
+      // Invalidate the derived weekly-demand cache for the created profiles
+      // (same invalidation the single-owner writer performs).
+      await tx.project.update({
+        where: { id: projectId },
+        data: { weeklyDemandCache: {} },
+      })
     }
 
     // Reuse the authoritative completion validation for the remaining

--- a/server/src/lib/bulkAsNeededProfiles.ts
+++ b/server/src/lib/bulkAsNeededProfiles.ts
@@ -1,0 +1,154 @@
+/**
+ * bulkAsNeededProfiles.ts — Explicit bulk "Use role counts as As needed"
+ * action for a NEEDS_REPLAN project (issue #456).
+ *
+ * After Reset Planning (issue #449) a project can contain many preserved
+ * role-only ResourceTypes with no persisted ROLE CapacityProfile. Creating
+ * each profile through the single-owner editor is impractical at that scale,
+ * so this service persists the canonical demand-following (As needed) ROLE
+ * profile for every eligible missing role in ONE atomic batch.
+ *
+ * Contract:
+ *   - Only a NEEDS_REPLAN project may use this action; the state is
+ *     re-checked inside the transaction so a concurrent completion cannot
+ *     race the writes.
+ *   - Eligible owners are role-only ResourceTypes (zero named resources —
+ *     so there is no named-person, planned-resource or segmented authority
+ *     to conflict with) that lack a persisted ROLE profile.
+ *   - Exactly one canonical ROLE profile (DEMAND_FOLLOWING, 100% As needed,
+ *     MANUAL source) is created per eligible role via the existing
+ *     authoritative writer (`replaceCapacityProfile`), never overwriting an
+ *     existing profile and never guessing planner-owned or named-resource
+ *     authority.
+ *   - The batch is atomic: any failure (including a concurrent duplicate
+ *     create hitting the partial unique index) rolls back every write.
+ *   - The project stays NEEDS_REPLAN; the response reports the remaining
+ *     canonical completeness findings so the user can resolve non-eligible
+ *     findings manually before running the existing completion operation.
+ */
+
+import type { Prisma, PrismaClient } from '@prisma/client'
+
+import { replaceCapacityProfile } from './capacityProfileReplaceService.js'
+import { collectReplanningFindings } from './completeReplanning.js'
+
+export class BulkAsNeededError extends Error {
+  readonly code: string
+  readonly status: number
+
+  constructor(status: number, code: string, message: string) {
+    super(message)
+    this.name = 'BulkAsNeededError'
+    this.status = status
+    this.code = code
+  }
+}
+
+export interface BulkAsNeededResult {
+  projectId: string
+  /** The action never transitions planning state — completion owns that. */
+  planningState: 'NEEDS_REPLAN'
+  /** Number of canonical ROLE profiles created by this call. */
+  created: number
+  /** Remaining canonical completeness findings (human-readable names). */
+  remainingFindings: string[]
+}
+
+/**
+ * Persist a canonical demand-following (As needed) ROLE profile for every
+ * eligible missing role-only ResourceType in one atomic transaction.
+ *
+ * @param prisma    Prisma client
+ * @param projectId Project ID
+ * @param userId    Requesting user (ownership revalidated inside the tx)
+ * @returns         Created count + remaining completeness findings
+ * @throws BulkAsNeededError with a stable `code` on guard violations
+ */
+export async function applyRoleCountsAsNeeded(
+  prisma: PrismaClient,
+  projectId: string,
+  userId: string,
+): Promise<BulkAsNeededResult> {
+  return prisma.$transaction(async (tx: Prisma.TransactionClient) => {
+    const project = await tx.project.findFirst({
+      where: { id: projectId, ownerId: userId },
+      select: {
+        id: true,
+        planningState: true,
+        resourceTypes: {
+          select: {
+            id: true,
+            namedResources: { select: { id: true } },
+          },
+        },
+        capacityProfiles: {
+          select: {
+            resourceTypeId: true,
+            namedResourceId: true,
+            ownerKind: true,
+            source: true,
+          },
+        },
+      },
+    })
+
+    if (!project) {
+      throw new BulkAsNeededError(404, 'PROJECT_NOT_FOUND', 'Project not found or access denied')
+    }
+    if (project.planningState !== 'NEEDS_REPLAN') {
+      throw new BulkAsNeededError(
+        409,
+        'REPLAN_ACTION_UNAVAILABLE',
+        'This action is only available while the project needs replanning. ' +
+          'Complete or reset the plan before retrying.',
+      )
+    }
+
+    // Role-only resource types that already carry a persisted ROLE profile
+    // are not missing — they are skipped (never overwritten).
+    const persistedRoleRtIds = new Set<string>()
+    for (const profile of project.capacityProfiles) {
+      if (profile.ownerKind === 'ROLE' && profile.resourceTypeId) {
+        persistedRoleRtIds.add(profile.resourceTypeId)
+      }
+    }
+
+    // Eligible: role-only ResourceTypes (zero named resources → no
+    // named-person/planned-resource/segmented authority to guess or replace)
+    // with no persisted ROLE profile. Roles with named resources, planner-owned
+    // profiles or existing profiles stay visible as remaining findings.
+    const eligibleRoleIds = project.resourceTypes
+      .filter(rt => rt.namedResources.length === 0 && !persistedRoleRtIds.has(rt.id))
+      .map(rt => rt.id)
+
+    let created = 0
+    for (const roleId of eligibleRoleIds) {
+      // The authoritative single-owner writer: validates ownership, refuses
+      // PLANNED_RESOURCE/SQUAD_PLANNER overwrite, creates the canonical
+      // MANUAL-source DEMAND_FOLLOWING profile, clears behavioural
+      // provenance and invalidates the weekly-demand cache. A concurrent
+      // duplicate create fails on the partial unique index and aborts the
+      // whole batch atomically.
+      await replaceCapacityProfile(
+        tx,
+        projectId,
+        'ROLE',
+        roleId,
+        { planningBasis: 'DEMAND_FOLLOWING', defaultPercent: 100 },
+        userId,
+      )
+      created++
+    }
+
+    // Reuse the authoritative completion validation for the remaining
+    // findings — same semantics the Replan project completion will enforce.
+    const remainingFindings = await collectReplanningFindings(tx, projectId)
+
+    return {
+      projectId,
+      planningState: 'NEEDS_REPLAN' as const,
+      created,
+      remainingFindings,
+    }
+  })
+}

--- a/server/src/lib/persistedCapacityProfileValidation.ts
+++ b/server/src/lib/persistedCapacityProfileValidation.ts
@@ -138,16 +138,23 @@ export function checkPersistedCompleteness(
         profile => profile.namedResourceId === namedResource.id,
       )
       if (ownerProfiles.length === 0) {
-        errors.push(`Named resource "${namedResource.id}" for RT "${resourceType.id}" lacks persisted profile`)
+        errors.push(
+          `Named resource "${namedResource.name}" lacks persisted profile ` +
+          `(named resource ${namedResource.id}, resource type ${resourceType.id})`,
+        )
       }
     }
 
     if (hasPlannerOwnership && roleProfiles.length !== 1) {
       errors.push(
-        `Resource type "${resourceType.id}" has planner-owned profiles but requires exactly one ROLE profile`,
+        `Resource type "${resourceType.name}" has planner-owned profiles but requires exactly one ROLE profile ` +
+        `(resource type ${resourceType.id})`,
       )
     } else if (resourceType.namedResources.length === 0 && roleProfiles.length !== 1) {
-      errors.push(`Resource type "${resourceType.id}" lacks exactly one persisted ROLE profile`)
+      errors.push(
+        `Resource type "${resourceType.name}" lacks exactly one persisted ROLE profile ` +
+        `(resource type ${resourceType.id})`,
+      )
     }
   }
 

--- a/server/src/routes/capacityProfiles.ts
+++ b/server/src/routes/capacityProfiles.ts
@@ -18,6 +18,10 @@ import {
   transferToManualCapacity,
   TransferError,
 } from '../lib/capacityProfileTransferService.js'
+import {
+  applyRoleCountsAsNeeded,
+  BulkAsNeededError,
+} from '../lib/bulkAsNeededProfiles.js'
 import { ownedProject } from '../lib/ownership.js'
 
 
@@ -144,6 +148,23 @@ router.post('/transfer-to-manual', asyncHandler(async (req: AuthRequest, res: Re
   } catch (err) {
     if (err instanceof TransferError) {
       res.status(err.status).json({ error: err.message })
+      return
+    }
+    throw err
+  }
+}))
+
+// ─── POST bulk-as-needed (must be registered before parameterised routes) ──
+
+router.post('/bulk-as-needed', asyncHandler(async (req: AuthRequest, res: Response) => {
+  const projectId = req.params.projectId as string
+
+  try {
+    const result = await applyRoleCountsAsNeeded(prisma, projectId, req.userId!)
+    res.status(200).json(result)
+  } catch (err) {
+    if (err instanceof BulkAsNeededError) {
+      res.status(err.status).json({ error: err.message, code: err.code })
       return
     }
     throw err

--- a/server/src/routes/resourceProfile.ts
+++ b/server/src/routes/resourceProfile.ts
@@ -208,6 +208,34 @@ router.get('/', asyncHandler(async (req: AuthRequest, res: Response) => {
   }
 
   if (project.planningState === 'NEEDS_REPLAN') {
+    // ── Persisted ROLE profile + missing-profile markers (issue #456) ──
+    // While NEEDS_REPLAN a role row must show whether the canonical ROLE
+    // profile required for completion is persisted, instead of presenting
+    // the effective draft as if it were canonical state. A role requires a
+    // ROLE profile when it has no named resources, or when any of its
+    // profiles are planner-owned (PLANNED_RESOURCE / SQUAD_PLANNER) — the
+    // same boundary checkPersistedCompleteness enforces.
+    const profileByRtId = new Map<string, (typeof project.capacityProfiles)[number]>()
+    const plannerOwnedRtIds = new Set<string>()
+    const rtIdByNamedResourceId = new Map<string, string>()
+    for (const rt of project.resourceTypes) {
+      for (const nr of rt.namedResources) rtIdByNamedResourceId.set(nr.id, rt.id)
+    }
+    for (const profile of project.capacityProfiles) {
+      if (profile.ownerKind === 'ROLE' && profile.resourceTypeId) {
+        profileByRtId.set(profile.resourceTypeId, profile)
+      }
+      if (profile.ownerKind === 'PLANNED_RESOURCE' || profile.source === 'SQUAD_PLANNER') {
+        const rtId = profile.resourceTypeId
+          ?? (profile.namedResourceId ? rtIdByNamedResourceId.get(profile.namedResourceId) : undefined)
+        if (rtId) plannerOwnedRtIds.add(rtId)
+      }
+    }
+    // Mirror capacityProfileMapping.toCamel so the emitted profile shape
+    // matches the camelCase contract the client types and badge logic use.
+    const toCamel = (value: string) =>
+      value.toLowerCase().replace(/_([a-z])/g, (_, c: string) => c.toUpperCase())
+
     // Reset Planning discarded the capacity model. Serve the estimation and
     // business inputs the user needs to replan — roles, counts, rates, effort
     // rollups, named-resource identity — with NO planning-derived values:
@@ -219,6 +247,9 @@ router.get('/', asyncHandler(async (req: AuthRequest, res: Response) => {
       .map(agg => {
         const resourceType = resourceTypeById.get(agg.resourceTypeId)!
         const dayRate = resourceType.dayRate ?? resourceType.globalType?.defaultDayRate ?? null
+        const persistedRoleProfile = profileByRtId.get(resourceType.id)
+        const requiresRoleProfile =
+          resourceType.namedResources.length === 0 || plannerOwnedRtIds.has(resourceType.id)
         return {
           resourceTypeId: resourceType.id,
           name: resourceType.name,
@@ -243,6 +274,20 @@ router.get('/', asyncHandler(async (req: AuthRequest, res: Response) => {
           derivedEndWeek: null,
           estimatedCost: null,
           epics: [],
+          capacityProfile: persistedRoleProfile ? {
+            planningBasis: toCamel(String(persistedRoleProfile.planningBasis)),
+            source: toCamel(String(persistedRoleProfile.source)),
+            defaultPercent: persistedRoleProfile.defaultPercent,
+            startWeek: persistedRoleProfile.startWeek,
+            endWeek: persistedRoleProfile.endWeek,
+            segments: persistedRoleProfile.segments.map(segment => ({
+              startWeek: segment.startWeek,
+              endWeek: segment.endWeek,
+              capacityPercent: segment.capacityPercent,
+            })),
+            resolutionSource: 'PROFILE' as const,
+          } : undefined,
+          missingCapacityProfile: requiresRoleProfile && !persistedRoleProfile,
           namedResources: resourceType.namedResources.map(nr => ({
             id: nr.id,
             name: nr.name,
@@ -278,6 +323,9 @@ router.get('/', asyncHandler(async (req: AuthRequest, res: Response) => {
     // are kept; effort/demand are zero and no capacity is fabricated.
     for (const resourceType of project.resourceTypes) {
       if (resourceAgg.has(resourceType.id)) continue
+      const persistedRoleProfile = profileByRtId.get(resourceType.id)
+      const requiresRoleProfile =
+        resourceType.namedResources.length === 0 || plannerOwnedRtIds.has(resourceType.id)
       resourceRows.push({
         resourceTypeId: resourceType.id,
         name: resourceType.name,
@@ -297,6 +345,20 @@ router.get('/', asyncHandler(async (req: AuthRequest, res: Response) => {
         derivedEndWeek: null,
         estimatedCost: null,
         epics: [],
+        capacityProfile: persistedRoleProfile ? {
+          planningBasis: toCamel(String(persistedRoleProfile.planningBasis)),
+          source: toCamel(String(persistedRoleProfile.source)),
+          defaultPercent: persistedRoleProfile.defaultPercent,
+          startWeek: persistedRoleProfile.startWeek,
+          endWeek: persistedRoleProfile.endWeek,
+          segments: persistedRoleProfile.segments.map(segment => ({
+            startWeek: segment.startWeek,
+            endWeek: segment.endWeek,
+            capacityPercent: segment.capacityPercent,
+          })),
+          resolutionSource: 'PROFILE' as const,
+        } : undefined,
+        missingCapacityProfile: requiresRoleProfile && !persistedRoleProfile,
         namedResources: resourceType.namedResources.map(nr => ({
           id: nr.id,
           name: nr.name,

--- a/server/src/test/bulkAsNeededProfiles.test.ts
+++ b/server/src/test/bulkAsNeededProfiles.test.ts
@@ -1,0 +1,191 @@
+/**
+ * bulkAsNeededProfiles.test.ts — Unit tests for the explicit bulk
+ * "Use role counts as As needed" action (issue #456).
+ *
+ * Proves the eligibility boundary (role-only + missing ROLE profile only),
+ * the exact-one-canonical-profile contract via the authoritative writer,
+ * the NEEDS_REPLAN guard, idempotence, and atomic failure propagation.
+ * Real-PostgreSQL atomicity/rollback is covered by the integration suite.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+import {
+  applyRoleCountsAsNeeded,
+  BulkAsNeededError,
+} from '../lib/bulkAsNeededProfiles.js'
+
+const replaceCapacityProfile = vi.fn()
+const collectReplanningFindings = vi.fn()
+
+vi.mock('../lib/capacityProfileReplaceService.js', () => ({
+  replaceCapacityProfile: (...args: unknown[]) => replaceCapacityProfile(...args),
+}))
+
+vi.mock('../lib/completeReplanning.js', () => ({
+  collectReplanningFindings: (...args: unknown[]) => collectReplanningFindings(...args),
+}))
+
+/** Minimal fake transaction — the service reads everything via findFirst. */
+function makeDb(projectRow: unknown) {
+  const tx = {
+    project: {
+      findFirst: vi.fn().mockResolvedValue(projectRow),
+    },
+  }
+  const db = {
+    $transaction: vi.fn(async (fn: (t: typeof tx) => Promise<unknown>) => fn(tx)),
+  }
+  return { db, tx }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  replaceCapacityProfile.mockResolvedValue({ id: 'profile-created' })
+  collectReplanningFindings.mockResolvedValue([])
+})
+
+const NEEDS_REPLAN_PROJECT = (overrides: Record<string, unknown> = {}) => ({
+  id: 'proj-1',
+  planningState: 'NEEDS_REPLAN',
+  resourceTypes: [
+    // Role-only, no profile → eligible.
+    { id: 'rt-1', namedResources: [] },
+    // Role-only with an existing persisted ROLE profile → never overwritten.
+    { id: 'rt-2', namedResources: [] },
+    // Role with named resources → never guessed.
+    { id: 'rt-3', namedResources: [{ id: 'nr-1' }] },
+  ],
+  capacityProfiles: [
+    { resourceTypeId: 'rt-2', namedResourceId: null, ownerKind: 'ROLE', source: 'MANUAL' },
+    { resourceTypeId: null, namedResourceId: 'nr-1', ownerKind: 'NAMED_PERSON', source: 'MANUAL' },
+  ],
+  ...overrides,
+})
+
+describe('applyRoleCountsAsNeeded', () => {
+  it('creates exactly one canonical As-needed ROLE profile per eligible missing role-only type', async () => {
+    const { db } = makeDb(NEEDS_REPLAN_PROJECT())
+
+    const result = await applyRoleCountsAsNeeded(db as never, 'proj-1', 'user-1')
+
+    expect(result).toEqual({
+      projectId: 'proj-1',
+      planningState: 'NEEDS_REPLAN',
+      created: 1,
+      remainingFindings: [],
+    })
+    // Only rt-1 (role-only + missing) is written; rt-2 has a profile and
+    // rt-3 has named-resource authority — neither is touched.
+    expect(replaceCapacityProfile).toHaveBeenCalledTimes(1)
+    expect(replaceCapacityProfile).toHaveBeenCalledWith(
+      expect.anything(),
+      'proj-1',
+      'ROLE',
+      'rt-1',
+      { planningBasis: 'DEMAND_FOLLOWING', defaultPercent: 100 },
+      'user-1',
+    )
+  })
+
+  it('never overwrites an existing persisted ROLE profile', async () => {
+    const { db } = makeDb(NEEDS_REPLAN_PROJECT({ resourceTypes: [{ id: 'rt-2', namedResources: [] }] }))
+
+    const result = await applyRoleCountsAsNeeded(db as never, 'proj-1', 'user-1')
+
+    expect(result.created).toBe(0)
+    expect(replaceCapacityProfile).not.toHaveBeenCalled()
+  })
+
+  it('never guesses named-resource or planned-resource ownership', async () => {
+    const { db } = makeDb(NEEDS_REPLAN_PROJECT({
+      resourceTypes: [
+        { id: 'rt-3', namedResources: [{ id: 'nr-1' }] },
+      ],
+    }))
+
+    const result = await applyRoleCountsAsNeeded(db as never, 'proj-1', 'user-1')
+
+    expect(result.created).toBe(0)
+    expect(replaceCapacityProfile).not.toHaveBeenCalled()
+  })
+
+  it('reports remaining completeness findings from the authoritative validation', async () => {
+    collectReplanningFindings.mockResolvedValue([
+      'Named resource "Alice" lacks persisted profile (named resource nr-1, resource type rt-3)',
+    ])
+    const { db } = makeDb(NEEDS_REPLAN_PROJECT())
+
+    const result = await applyRoleCountsAsNeeded(db as never, 'proj-1', 'user-1')
+
+    expect(result.created).toBe(1)
+    expect(result.remainingFindings).toEqual([
+      'Named resource "Alice" lacks persisted profile (named resource nr-1, resource type rt-3)',
+    ])
+    expect(collectReplanningFindings).toHaveBeenCalledWith(expect.anything(), 'proj-1')
+  })
+
+  it('is idempotent when every eligible role already has a profile', async () => {
+    const { db } = makeDb(NEEDS_REPLAN_PROJECT({
+      resourceTypes: [{ id: 'rt-1', namedResources: [] }],
+      capacityProfiles: [
+        { resourceTypeId: 'rt-1', namedResourceId: null, ownerKind: 'ROLE', source: 'MANUAL' },
+      ],
+    }))
+
+    const first = await applyRoleCountsAsNeeded(db as never, 'proj-1', 'user-1')
+    const second = await applyRoleCountsAsNeeded(db as never, 'proj-1', 'user-1')
+
+    expect(first.created).toBe(0)
+    expect(second.created).toBe(0)
+    expect(replaceCapacityProfile).not.toHaveBeenCalled()
+  })
+
+  it('refuses to run unless the project NEEDS_REPLAN (409 stable code)', async () => {
+    const { db } = makeDb({ id: 'proj-1', planningState: 'CURRENT', resourceTypes: [], capacityProfiles: [] })
+
+    await expect(applyRoleCountsAsNeeded(db as never, 'proj-1', 'user-1')).rejects.toMatchObject({
+      name: 'BulkAsNeededError',
+      status: 409,
+      code: 'REPLAN_ACTION_UNAVAILABLE',
+    } as Partial<BulkAsNeededError>)
+    expect(replaceCapacityProfile).not.toHaveBeenCalled()
+  })
+
+  it('throws 404 when the project is not found or not owned', async () => {
+    const { db } = makeDb(null)
+
+    await expect(applyRoleCountsAsNeeded(db as never, 'proj-1', 'user-1')).rejects.toMatchObject({
+      name: 'BulkAsNeededError',
+      status: 404,
+      code: 'PROJECT_NOT_FOUND',
+    } as Partial<BulkAsNeededError>)
+  })
+
+  it('aborts the whole batch when a profile write fails mid-way', async () => {
+    replaceCapacityProfile
+      .mockResolvedValueOnce({ id: 'created-1' })
+      .mockRejectedValueOnce(new Error('unique constraint violation (concurrent create)'))
+    const { db } = makeDb(NEEDS_REPLAN_PROJECT({
+      resourceTypes: [
+        { id: 'rt-1', namedResources: [] },
+        { id: 'rt-4', namedResources: [] },
+        { id: 'rt-5', namedResources: [] },
+      ],
+    }))
+
+    await expect(applyRoleCountsAsNeeded(db as never, 'proj-1', 'user-1')).rejects.toThrow(
+      'unique constraint violation',
+    )
+    // The transaction promise rejects — no partial result is ever returned
+    // and no state transition occurs (real rollback is proven in the
+    // PostgreSQL integration suite).
+    expect(replaceCapacityProfile).toHaveBeenCalledTimes(2)
+  })
+
+  it('keeps the project NEEDS_REPLAN — completion owns the state transition', async () => {
+    const { db } = makeDb(NEEDS_REPLAN_PROJECT())
+    const result = await applyRoleCountsAsNeeded(db as never, 'proj-1', 'user-1')
+    expect(result.planningState).toBe('NEEDS_REPLAN')
+  })
+})

--- a/server/src/test/bulkAsNeededProfiles.test.ts
+++ b/server/src/test/bulkAsNeededProfiles.test.ts
@@ -3,34 +3,40 @@
  * "Use role counts as As needed" action (issue #456).
  *
  * Proves the eligibility boundary (role-only + missing ROLE profile only),
- * the exact-one-canonical-profile contract via the authoritative writer,
- * the NEEDS_REPLAN guard, idempotence, and atomic failure propagation.
- * Real-PostgreSQL atomicity/rollback is covered by the integration suite.
+ * the exact-one-canonical-profile CREATE-ONLY contract (never update or
+ * replace), the NEEDS_REPLAN guard, idempotence, atomic failure
+ * propagation, and the race-safe skip behaviour for profiles that appear
+ * after the eligibility read. Real-PostgreSQL concurrency/atomicity is
+ * covered by replanProfileRepair.integration.test.ts.
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { Prisma } from '@prisma/client'
 
 import {
   applyRoleCountsAsNeeded,
   BulkAsNeededError,
 } from '../lib/bulkAsNeededProfiles.js'
 
-const replaceCapacityProfile = vi.fn()
 const collectReplanningFindings = vi.fn()
-
-vi.mock('../lib/capacityProfileReplaceService.js', () => ({
-  replaceCapacityProfile: (...args: unknown[]) => replaceCapacityProfile(...args),
-}))
 
 vi.mock('../lib/completeReplanning.js', () => ({
   collectReplanningFindings: (...args: unknown[]) => collectReplanningFindings(...args),
 }))
 
-/** Minimal fake transaction — the service reads everything via findFirst. */
+/** Minimal fake transaction — the service reads via findFirst and creates rows. */
 function makeDb(projectRow: unknown) {
   const tx = {
     project: {
       findFirst: vi.fn().mockResolvedValue(projectRow),
+      update: vi.fn().mockResolvedValue({ id: 'proj-1' }),
+    },
+    capacityProfile: {
+      findFirst: vi.fn().mockResolvedValue(null),
+      create: vi.fn().mockResolvedValue({ id: 'profile-created' }),
+      // The bulk action is strictly create-only — never called; present so
+      // tests can assert the update path is never taken.
+      update: vi.fn(),
     },
   }
   const db = {
@@ -39,9 +45,28 @@ function makeDb(projectRow: unknown) {
   return { db, tx }
 }
 
+/** A P2002 for the partial unique index on CapacityProfile.resourceTypeId. */
+function p2002RoleProfileDuplicate(): Prisma.PrismaClientKnownRequestError {
+  return new Prisma.PrismaClientKnownRequestError(
+    'Unique constraint failed on the fields: (`resourceTypeId`)',
+    {
+      code: 'P2002',
+      clientVersion: '7.8.0',
+      meta: {
+        modelName: 'CapacityProfile',
+        driverAdapterError: {
+          cause: {
+            originalMessage:
+              'insert into "CapacityProfile" ... violates unique constraint "CapacityProfile_resourceTypeId_key"',
+          },
+        },
+      },
+    },
+  )
+}
+
 beforeEach(() => {
   vi.clearAllMocks()
-  replaceCapacityProfile.mockResolvedValue({ id: 'profile-created' })
   collectReplanningFindings.mockResolvedValue([])
 })
 
@@ -65,7 +90,7 @@ const NEEDS_REPLAN_PROJECT = (overrides: Record<string, unknown> = {}) => ({
 
 describe('applyRoleCountsAsNeeded', () => {
   it('creates exactly one canonical As-needed ROLE profile per eligible missing role-only type', async () => {
-    const { db } = makeDb(NEEDS_REPLAN_PROJECT())
+    const { db, tx } = makeDb(NEEDS_REPLAN_PROJECT())
 
     const result = await applyRoleCountsAsNeeded(db as never, 'proj-1', 'user-1')
 
@@ -77,28 +102,41 @@ describe('applyRoleCountsAsNeeded', () => {
     })
     // Only rt-1 (role-only + missing) is written; rt-2 has a profile and
     // rt-3 has named-resource authority — neither is touched.
-    expect(replaceCapacityProfile).toHaveBeenCalledTimes(1)
-    expect(replaceCapacityProfile).toHaveBeenCalledWith(
-      expect.anything(),
-      'proj-1',
-      'ROLE',
-      'rt-1',
-      { planningBasis: 'DEMAND_FOLLOWING', defaultPercent: 100 },
-      'user-1',
-    )
+    expect(tx.capacityProfile.create).toHaveBeenCalledTimes(1)
+    expect(tx.capacityProfile.create).toHaveBeenCalledWith({
+      data: {
+        projectId: 'proj-1',
+        ownerKind: 'ROLE',
+        resourceTypeId: 'rt-1',
+        namedResourceId: null,
+        planningBasis: 'DEMAND_FOLLOWING',
+        source: 'MANUAL',
+        defaultPercent: 100,
+        startWeek: null,
+        endWeek: null,
+        provenance: null,
+      },
+    })
+    // Derived demand cache invalidated once for the created profiles.
+    expect(tx.project.update).toHaveBeenCalledWith({
+      where: { id: 'proj-1' },
+      data: { weeklyDemandCache: {} },
+    })
   })
 
   it('never overwrites an existing persisted ROLE profile', async () => {
-    const { db } = makeDb(NEEDS_REPLAN_PROJECT({ resourceTypes: [{ id: 'rt-2', namedResources: [] }] }))
+    const { db, tx } = makeDb(NEEDS_REPLAN_PROJECT({ resourceTypes: [{ id: 'rt-2', namedResources: [] }] }))
 
     const result = await applyRoleCountsAsNeeded(db as never, 'proj-1', 'user-1')
 
     expect(result.created).toBe(0)
-    expect(replaceCapacityProfile).not.toHaveBeenCalled()
+    expect(tx.capacityProfile.create).not.toHaveBeenCalled()
+    expect(tx.capacityProfile.update).not.toHaveBeenCalled()
+    expect(tx.project.update).not.toHaveBeenCalled()
   })
 
   it('never guesses named-resource or planned-resource ownership', async () => {
-    const { db } = makeDb(NEEDS_REPLAN_PROJECT({
+    const { db, tx } = makeDb(NEEDS_REPLAN_PROJECT({
       resourceTypes: [
         { id: 'rt-3', namedResources: [{ id: 'nr-1' }] },
       ],
@@ -107,7 +145,7 @@ describe('applyRoleCountsAsNeeded', () => {
     const result = await applyRoleCountsAsNeeded(db as never, 'proj-1', 'user-1')
 
     expect(result.created).toBe(0)
-    expect(replaceCapacityProfile).not.toHaveBeenCalled()
+    expect(tx.capacityProfile.create).not.toHaveBeenCalled()
   })
 
   it('reports remaining completeness findings from the authoritative validation', async () => {
@@ -126,7 +164,7 @@ describe('applyRoleCountsAsNeeded', () => {
   })
 
   it('is idempotent when every eligible role already has a profile', async () => {
-    const { db } = makeDb(NEEDS_REPLAN_PROJECT({
+    const { db, tx } = makeDb(NEEDS_REPLAN_PROJECT({
       resourceTypes: [{ id: 'rt-1', namedResources: [] }],
       capacityProfiles: [
         { resourceTypeId: 'rt-1', namedResourceId: null, ownerKind: 'ROLE', source: 'MANUAL' },
@@ -138,49 +176,103 @@ describe('applyRoleCountsAsNeeded', () => {
 
     expect(first.created).toBe(0)
     expect(second.created).toBe(0)
-    expect(replaceCapacityProfile).not.toHaveBeenCalled()
+    expect(tx.capacityProfile.create).not.toHaveBeenCalled()
+  })
+
+  it('skips a role whose profile appeared after the eligibility read (never updates it)', async () => {
+    // Two eligible role-only roles. The per-role re-check discovers that
+    // rt-4 gained a ROLE profile after the batch started → rt-4 is skipped,
+    // its profile is never updated, and the other eligible role still
+    // proceeds.
+    const { db, tx } = makeDb(NEEDS_REPLAN_PROJECT({
+      resourceTypes: [
+        { id: 'rt-1', namedResources: [] },
+        { id: 'rt-4', namedResources: [] },
+      ],
+      capacityProfiles: [],
+    }))
+    tx.capacityProfile.findFirst
+      .mockResolvedValueOnce(null) // re-check rt-1 → missing → create
+      .mockResolvedValueOnce({ id: 'concurrent-profile' }) // re-check rt-4 → exists → skip
+
+    const result = await applyRoleCountsAsNeeded(db as never, 'proj-1', 'user-1')
+
+    expect(result.created).toBe(1)
+    expect(tx.capacityProfile.create).toHaveBeenCalledTimes(1)
+    expect(tx.capacityProfile.create.mock.calls[0][0].data.resourceTypeId).toBe('rt-1')
+    // No update/delete path is ever taken by the bulk action.
+    expect(tx.capacityProfile.update).not.toHaveBeenCalled()
+  })
+
+  it('treats a P2002 resourceTypeId duplicate as already-exists and skips without aborting', async () => {
+    // rt-1 and rt-4 are eligible. rt-4's insert races a concurrent commit
+    // that wins the partial unique index → the create fails with P2002 on
+    // the resourceTypeId key → the bulk treats it as "already exists" and
+    // continues; the concurrent profile is untouched.
+    const { db, tx } = makeDb(NEEDS_REPLAN_PROJECT({
+      resourceTypes: [
+        { id: 'rt-1', namedResources: [] },
+        { id: 'rt-4', namedResources: [] },
+      ],
+      capacityProfiles: [],
+    }))
+    tx.capacityProfile.findFirst.mockResolvedValue(null) // both re-checks see nothing
+    tx.capacityProfile.create
+      .mockResolvedValueOnce({ id: 'created-rt-1' })
+      .mockRejectedValueOnce(p2002RoleProfileDuplicate())
+
+    const result = await applyRoleCountsAsNeeded(db as never, 'proj-1', 'user-1')
+
+    expect(result.created).toBe(1)
+    expect(tx.capacityProfile.create).toHaveBeenCalledTimes(2)
+    expect(tx.capacityProfile.create.mock.calls[0][0].data.resourceTypeId).toBe('rt-1')
+    expect(tx.capacityProfile.create.mock.calls[1][0].data.resourceTypeId).toBe('rt-4')
+  })
+
+  it('aborts the whole batch when a profile write fails mid-way', async () => {
+    const { db, tx } = makeDb(NEEDS_REPLAN_PROJECT({
+      resourceTypes: [
+        { id: 'rt-1', namedResources: [] },
+        { id: 'rt-4', namedResources: [] },
+        { id: 'rt-5', namedResources: [] },
+      ],
+      capacityProfiles: [],
+    }))
+    tx.capacityProfile.findFirst.mockResolvedValue(null)
+    tx.capacityProfile.create
+      .mockResolvedValueOnce({ id: 'created-1' })
+      .mockRejectedValueOnce(new Error('unexpected database failure'))
+      .mockResolvedValueOnce({ id: 'created-2' })
+
+    await expect(applyRoleCountsAsNeeded(db as never, 'proj-1', 'user-1')).rejects.toThrow(
+      'unexpected database failure',
+    )
+    // The transaction promise rejects — no partial result is ever returned
+    // and no state transition occurs (real rollback is proven in the
+    // PostgreSQL integration suite).
+    expect(tx.capacityProfile.create).toHaveBeenCalledTimes(2)
   })
 
   it('refuses to run unless the project NEEDS_REPLAN (409 stable code)', async () => {
-    const { db } = makeDb({ id: 'proj-1', planningState: 'CURRENT', resourceTypes: [], capacityProfiles: [] })
+    const { db, tx } = makeDb({ id: 'proj-1', planningState: 'CURRENT', resourceTypes: [], capacityProfiles: [] })
 
     await expect(applyRoleCountsAsNeeded(db as never, 'proj-1', 'user-1')).rejects.toMatchObject({
       name: 'BulkAsNeededError',
       status: 409,
       code: 'REPLAN_ACTION_UNAVAILABLE',
     } as Partial<BulkAsNeededError>)
-    expect(replaceCapacityProfile).not.toHaveBeenCalled()
+    expect(tx.capacityProfile.create).not.toHaveBeenCalled()
   })
 
   it('throws 404 when the project is not found or not owned', async () => {
-    const { db } = makeDb(null)
+    const { db, tx } = makeDb(null)
 
     await expect(applyRoleCountsAsNeeded(db as never, 'proj-1', 'user-1')).rejects.toMatchObject({
       name: 'BulkAsNeededError',
       status: 404,
       code: 'PROJECT_NOT_FOUND',
     } as Partial<BulkAsNeededError>)
-  })
-
-  it('aborts the whole batch when a profile write fails mid-way', async () => {
-    replaceCapacityProfile
-      .mockResolvedValueOnce({ id: 'created-1' })
-      .mockRejectedValueOnce(new Error('unique constraint violation (concurrent create)'))
-    const { db } = makeDb(NEEDS_REPLAN_PROJECT({
-      resourceTypes: [
-        { id: 'rt-1', namedResources: [] },
-        { id: 'rt-4', namedResources: [] },
-        { id: 'rt-5', namedResources: [] },
-      ],
-    }))
-
-    await expect(applyRoleCountsAsNeeded(db as never, 'proj-1', 'user-1')).rejects.toThrow(
-      'unique constraint violation',
-    )
-    // The transaction promise rejects — no partial result is ever returned
-    // and no state transition occurs (real rollback is proven in the
-    // PostgreSQL integration suite).
-    expect(replaceCapacityProfile).toHaveBeenCalledTimes(2)
+    expect(tx.capacityProfile.create).not.toHaveBeenCalled()
   })
 
   it('keeps the project NEEDS_REPLAN — completion owns the state transition', async () => {

--- a/server/src/test/bulkAsNeededRoutes.test.ts
+++ b/server/src/test/bulkAsNeededRoutes.test.ts
@@ -1,0 +1,101 @@
+/**
+ * bulkAsNeededRoutes.test.ts — Route tests for the bulk
+ * "Use role counts as As needed" endpoint (issue #456):
+ * POST /api/projects/:projectId/capacity-profiles/bulk-as-needed.
+ *
+ * Proves authentication, success mapping, and the stable guard-error codes
+ * surfaced by the endpoint. Service semantics are covered by
+ * bulkAsNeededProfiles.test.ts and the PostgreSQL integration suite.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import request from 'supertest'
+import jwt from 'jsonwebtoken'
+
+import { app } from '../index.js'
+
+const userId = 'user-1'
+process.env.JWT_SECRET = 'test-secret'
+const token = jwt.sign({ userId }, 'test-secret')
+const authHeader = `Bearer ${token}`
+
+const { applyRoleCountsAsNeeded, BulkAsNeededError } = vi.hoisted(() => {
+  class BulkAsNeededError extends Error {
+    status: number
+    code: string
+    constructor(status: number, code: string, message: string) {
+      super(message)
+      this.status = status
+      this.code = code
+    }
+  }
+  return { applyRoleCountsAsNeeded: vi.fn(), BulkAsNeededError }
+})
+
+vi.mock('../lib/bulkAsNeededProfiles.js', () => ({
+  applyRoleCountsAsNeeded,
+  BulkAsNeededError,
+}))
+
+beforeEach(() => vi.clearAllMocks())
+
+describe('POST /api/projects/:projectId/capacity-profiles/bulk-as-needed', () => {
+  it('rejects unauthenticated request', async () => {
+    const res = await request(app).post('/api/projects/proj-1/capacity-profiles/bulk-as-needed')
+    expect(res.status).toBe(401)
+    expect(applyRoleCountsAsNeeded).not.toHaveBeenCalled()
+  })
+
+  it('creates profiles for eligible missing roles and reports remaining findings', async () => {
+    applyRoleCountsAsNeeded.mockResolvedValue({
+      projectId: 'proj-1',
+      planningState: 'NEEDS_REPLAN',
+      created: 3,
+      remainingFindings: ['Named resource "Alice" lacks persisted profile (named resource nr-1, resource type rt-3)'],
+    })
+
+    const res = await request(app)
+      .post('/api/projects/proj-1/capacity-profiles/bulk-as-needed')
+      .set('Authorization', authHeader)
+
+    expect(res.status).toBe(200)
+    expect(res.body).toEqual({
+      projectId: 'proj-1',
+      planningState: 'NEEDS_REPLAN',
+      created: 3,
+      remainingFindings: ['Named resource "Alice" lacks persisted profile (named resource nr-1, resource type rt-3)'],
+    })
+    expect(applyRoleCountsAsNeeded).toHaveBeenCalledWith(expect.anything(), 'proj-1', userId)
+  })
+
+  it('surfaces the NEEDS_REPLAN-only guard with its stable 409 code', async () => {
+    applyRoleCountsAsNeeded.mockRejectedValue(
+      new BulkAsNeededError(
+        409,
+        'REPLAN_ACTION_UNAVAILABLE',
+        'This action is only available while the project needs replanning. ' +
+          'Complete or reset the plan before retrying.',
+      ),
+    )
+
+    const res = await request(app)
+      .post('/api/projects/proj-1/capacity-profiles/bulk-as-needed')
+      .set('Authorization', authHeader)
+
+    expect(res.status).toBe(409)
+    expect(res.body.code).toBe('REPLAN_ACTION_UNAVAILABLE')
+  })
+
+  it('surfaces 404 for a missing project', async () => {
+    applyRoleCountsAsNeeded.mockRejectedValue(
+      new BulkAsNeededError(404, 'PROJECT_NOT_FOUND', 'Project not found or access denied'),
+    )
+
+    const res = await request(app)
+      .post('/api/projects/proj-missing/capacity-profiles/bulk-as-needed')
+      .set('Authorization', authHeader)
+
+    expect(res.status).toBe(404)
+    expect(res.body.code).toBe('PROJECT_NOT_FOUND')
+  })
+})

--- a/server/src/test/checkPersistedCompleteness.unit.test.ts
+++ b/server/src/test/checkPersistedCompleteness.unit.test.ts
@@ -1,0 +1,172 @@
+/**
+ * checkPersistedCompleteness.unit.test.ts — Focused unit tests for the
+ * human-readable completeness findings (issue #456).
+ *
+ * The completeness assessment keeps the exact same validation semantics
+ * (same findings, same fail-closed boundary) while identifying affected
+ * resources by their human-readable names, with the internal ID retained
+ * only as secondary diagnostic context.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { checkPersistedCompleteness } from '../lib/persistedCapacityProfileValidation.js'
+
+interface Rt {
+  id: string
+  name: string
+  namedResources: Array<{ id: string; name: string }>
+}
+
+interface Cp {
+  resourceTypeId: string | null
+  namedResourceId: string | null
+  ownerKind: string
+  source: string
+  planningBasis: string
+}
+
+function input(overrides: { resourceTypes?: Rt[]; capacityProfiles?: Cp[] } = {}) {
+  return {
+    resourceTypes: overrides.resourceTypes ?? [],
+    capacityProfiles: overrides.capacityProfiles ?? [],
+  }
+}
+
+const roleOnlyRt = (): Rt => ({
+  id: 'rt-1',
+  name: 'Business Analyst',
+  namedResources: [],
+})
+
+describe('checkPersistedCompleteness — human-readable findings', () => {
+  it('names the role in a missing ROLE profile finding, keeping the ID secondary', () => {
+    const findings = checkPersistedCompleteness(input({ resourceTypes: [roleOnlyRt()] }))
+
+    expect(findings).toHaveLength(1)
+    expect(findings[0]).toContain('Business Analyst')
+    expect(findings[0]).toContain('lacks exactly one persisted ROLE profile')
+    expect(findings[0]).toContain('rt-1')
+  })
+
+  it('names the named resource and its role in a missing named-resource finding', () => {
+    const findings = checkPersistedCompleteness(
+      input({
+        resourceTypes: [
+          {
+            id: 'rt-1',
+            name: 'Business Analyst',
+            namedResources: [{ id: 'nr-1', name: 'Alice Example' }],
+          },
+        ],
+      }),
+    )
+
+    expect(findings).toHaveLength(1)
+    expect(findings[0]).toContain('Alice Example')
+    expect(findings[0]).toContain('lacks persisted profile')
+    expect(findings[0]).toContain('nr-1')
+  })
+
+  it('names the role in a planner-owned missing-ROLE-profile finding', () => {
+    const findings = checkPersistedCompleteness(
+      input({
+        resourceTypes: [
+          {
+            id: 'rt-1',
+            name: 'Platform Engineer',
+            namedResources: [{ id: 'nr-1', name: 'Bob Planned' }],
+          },
+        ],
+        capacityProfiles: [
+          {
+            resourceTypeId: null,
+            namedResourceId: 'nr-1',
+            ownerKind: 'PLANNED_RESOURCE',
+            source: 'SQUAD_PLANNER',
+            planningBasis: 'CAPACITY_PROFILE',
+          },
+        ],
+      }),
+    )
+
+    // Named resource has a profile; the planner-owned role still requires a
+    // ROLE profile.
+    expect(findings).toHaveLength(1)
+    expect(findings[0]).toContain('Platform Engineer')
+    expect(findings[0]).toContain('planner-owned profiles but requires exactly one ROLE profile')
+  })
+
+  // ── Semantics unchanged ────────────────────────────────────────────────
+  it('still reports no finding when a role-only type has exactly one ROLE profile', () => {
+    const findings = checkPersistedCompleteness(
+      input({
+        resourceTypes: [roleOnlyRt()],
+        capacityProfiles: [
+          {
+            resourceTypeId: 'rt-1',
+            namedResourceId: null,
+            ownerKind: 'ROLE',
+            source: 'MANUAL',
+            planningBasis: 'DEMAND_FOLLOWING',
+          },
+        ],
+      }),
+    )
+    expect(findings).toEqual([])
+  })
+
+  it('still allows explicit-only named people without a ROLE profile', () => {
+    const findings = checkPersistedCompleteness(
+      input({
+        resourceTypes: [
+          {
+            id: 'rt-1',
+            name: 'Business Analyst',
+            namedResources: [{ id: 'nr-1', name: 'Alice Example' }],
+          },
+        ],
+        capacityProfiles: [
+          {
+            resourceTypeId: null,
+            namedResourceId: 'nr-1',
+            ownerKind: 'NAMED_PERSON',
+            source: 'MANUAL',
+            planningBasis: 'DEMAND_FOLLOWING',
+          },
+        ],
+      }),
+    )
+    expect(findings).toEqual([])
+  })
+
+  it('still accepts planner-owned profiles when exactly one ROLE profile exists', () => {
+    const findings = checkPersistedCompleteness(
+      input({
+        resourceTypes: [
+          {
+            id: 'rt-1',
+            name: 'Platform Engineer',
+            namedResources: [{ id: 'nr-1', name: 'Bob Planned' }],
+          },
+        ],
+        capacityProfiles: [
+          {
+            resourceTypeId: null,
+            namedResourceId: 'nr-1',
+            ownerKind: 'PLANNED_RESOURCE',
+            source: 'SQUAD_PLANNER',
+            planningBasis: 'CAPACITY_PROFILE',
+          },
+          {
+            resourceTypeId: 'rt-1',
+            namedResourceId: null,
+            ownerKind: 'ROLE',
+            source: 'SQUAD_PLANNER',
+            planningBasis: 'CAPACITY_PROFILE',
+          },
+        ],
+      }),
+    )
+    expect(findings).toEqual([])
+  })
+})

--- a/server/src/test/replanProfileRepair.integration.test.ts
+++ b/server/src/test/replanProfileRepair.integration.test.ts
@@ -27,15 +27,8 @@ import { PrismaClient } from '@prisma/client'
 
 import { app } from '../app.js'
 import { applyRoleCountsAsNeeded } from '../lib/bulkAsNeededProfiles.js'
-import { replaceCapacityProfile } from '../lib/capacityProfileReplaceService.js'
 // Override the global prisma mock so route handlers use real PostgreSQL.
 vi.mock('../lib/prisma.js', async importOriginal => await importOriginal())
-// Wrap the authoritative writer with a spy so atomicity can be injected
-// deterministically; the real implementation runs for every other call.
-vi.mock('../lib/capacityProfileReplaceService.js', async importOriginal => {
-  const actual = await importOriginal<typeof import('../lib/capacityProfileReplaceService.js')>()
-  return { ...actual, replaceCapacityProfile: vi.fn(actual.replaceCapacityProfile) }
-})
 
 // ─── Guard ──────────────────────────────────────────────────────────────────
 
@@ -334,17 +327,18 @@ describeIf('NEEDS_REPLAN Resource Profile — missing ROLE profiles (issue #456)
 
   it('an injected mid-batch failure rolls the whole bulk action back atomically', async () => {
     const f = await createNeedsReplanFixture()
-    const realReplace = vi.mocked(replaceCapacityProfile).getMockImplementation()!
 
     // First eligible role writes normally; the second fails.
-    vi.mocked(replaceCapacityProfile)
-      .mockImplementationOnce(realReplace)
-      .mockImplementationOnce(async () => {
-        throw new Error('injected mid-batch failure')
-      })
-
+    let injected = false
     await expect(
-      applyRoleCountsAsNeeded(prisma, f.projectId, userId),
+      applyRoleCountsAsNeeded(prisma, f.projectId, userId, {
+        afterCreate: async () => {
+          if (!injected) {
+            injected = true
+            throw new Error('injected mid-batch failure')
+          }
+        },
+      }),
     ).rejects.toThrow('injected mid-batch failure')
 
     // Zero partial state: no profiles were committed and the project remains
@@ -352,6 +346,84 @@ describeIf('NEEDS_REPLAN Resource Profile — missing ROLE profiles (issue #456)
     expect(await profileCount(f.projectId)).toBe(0)
     const state = await prisma.project.findUnique({ where: { id: f.projectId } })
     expect(state!.planningState).toBe('NEEDS_REPLAN')
+  })
+
+  it('a ROLE profile created concurrently mid-batch is never overwritten by the bulk action', async () => {
+    const f = await createNeedsReplanFixture()
+    // Eligibility order follows creation order: Engineer (demanded),
+    // Business Analyst, Data Scientist — all eligible and role-only.
+    const [firstEligibleRoleId, secondEligibleRoleId] = f.roleOnlyRtIds
+    expect(firstEligibleRoleId).toBe(f.demandedRtId)
+
+    // A second real PostgreSQL connection commits a valid persisted ROLE
+    // profile for the SECOND eligible role while the bulk batch is open
+    // (after the first role's create). The profile uses deliberately
+    // different semantics (AVAILABILITY_WINDOW / 75% / W2-W8) so any
+    // overwrite by the bulk would be unmistakable.
+    const concurrentClient = new PrismaClient({
+      adapter: new PrismaPg({ connectionString: process.env.DATABASE_URL }),
+    })
+    await concurrentClient.$connect()
+    let concurrentProfileId: string | null = null
+    try {
+      const result = await applyRoleCountsAsNeeded(prisma, f.projectId, userId, {
+        afterCreate: async roleId => {
+          if (roleId !== firstEligibleRoleId || concurrentProfileId) return
+          const created = await concurrentClient.capacityProfile.create({
+            data: {
+              projectId: f.projectId,
+              ownerKind: 'ROLE',
+              resourceTypeId: secondEligibleRoleId,
+              namedResourceId: null,
+              planningBasis: 'AVAILABILITY_WINDOW',
+              source: 'MANUAL',
+              defaultPercent: 75,
+              startWeek: 2,
+              endWeek: 8,
+            },
+            select: { id: true },
+          })
+          concurrentProfileId = created.id
+        },
+      })
+
+      // The bulk created the first and third eligible roles only; the second
+      // role (whose profile appeared mid-batch) was skipped.
+      expect(result.created).toBe(2)
+
+      const profiles = await prisma.capacityProfile.findMany({
+        where: { projectId: f.projectId },
+        orderBy: { resourceTypeId: 'asc' },
+      })
+      const byRt = new Map(profiles.map(p => [p.resourceTypeId, p]))
+
+      // The concurrently created profile survived COMPLETELY unchanged:
+      // same id, same planning semantics, same source, no provenance.
+      const concurrent = byRt.get(secondEligibleRoleId)!
+      expect(concurrent.id).toBe(concurrentProfileId)
+      expect(concurrent.planningBasis).toBe('AVAILABILITY_WINDOW')
+      expect(concurrent.defaultPercent).toBe(75)
+      expect(concurrent.startWeek).toBe(2)
+      expect(concurrent.endWeek).toBe(8)
+      expect(concurrent.source).toBe('MANUAL')
+      expect(concurrent.provenance).toBeNull()
+
+      // The other eligible roles received the canonical As-needed profile.
+      for (const rtId of f.roleOnlyRtIds.filter(id => id !== secondEligibleRoleId)) {
+        const profile = byRt.get(rtId)
+        expect(profile!.planningBasis).toBe('DEMAND_FOLLOWING')
+        expect(profile!.defaultPercent).toBe(100)
+        expect(profile!.source).toBe('MANUAL')
+      }
+
+      // The skipped role no longer appears among remaining findings and the
+      // project stays quarantined (completion owns the transition).
+      expect(result.remainingFindings.join(' | ')).not.toContain('Business Analyst')
+      const state = await prisma.project.findUnique({ where: { id: f.projectId } })
+      expect(state!.planningState).toBe('NEEDS_REPLAN')
+    } finally {
+      await concurrentClient.$disconnect()
+    }
   })
 
   it('the existing completion returns the project to CURRENT and Timeline resumes', async () => {

--- a/server/src/test/replanProfileRepair.integration.test.ts
+++ b/server/src/test/replanProfileRepair.integration.test.ts
@@ -1,0 +1,423 @@
+/**
+ * replanProfileRepair.integration.test.ts — Real PostgreSQL integration tests
+ * for issue #456: making a NEEDS_REPLAN Resource Profile actionable when ROLE
+ * profiles are missing.
+ *
+ * Proves against real PostgreSQL:
+ *   - the original defect shape: NEEDS_REPLAN project with several preserved
+ *     role-only ResourceTypes and zero ROLE profiles;
+ *   - GET /resource-profile marks missing persisted ROLE profiles
+ *     (missingCapacityProfile) instead of presenting the draft as canonical;
+ *   - completion returns REPLAN_INCOMPLETE with human-readable role names;
+ *   - the bulk "Use role counts as As needed" action creates exactly one
+ *     canonical ROLE profile per eligible role-only type, never overwrites
+ *     existing profiles, never guesses named-resource ownership, is
+ *     idempotent, is atomic on injected failure, and never transitions the
+ *     project state;
+ *   - after all profiles exist the existing completion returns the project
+ *     to CURRENT and Timeline scheduling resumes; CURRENT rows carry no
+ *     missing markers.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest'
+import request from 'supertest'
+import jwt from 'jsonwebtoken'
+import { PrismaPg } from '@prisma/adapter-pg'
+import { PrismaClient } from '@prisma/client'
+
+import { app } from '../app.js'
+import { applyRoleCountsAsNeeded } from '../lib/bulkAsNeededProfiles.js'
+import { replaceCapacityProfile } from '../lib/capacityProfileReplaceService.js'
+// Override the global prisma mock so route handlers use real PostgreSQL.
+vi.mock('../lib/prisma.js', async importOriginal => await importOriginal())
+// Wrap the authoritative writer with a spy so atomicity can be injected
+// deterministically; the real implementation runs for every other call.
+vi.mock('../lib/capacityProfileReplaceService.js', async importOriginal => {
+  const actual = await importOriginal<typeof import('../lib/capacityProfileReplaceService.js')>()
+  return { ...actual, replaceCapacityProfile: vi.fn(actual.replaceCapacityProfile) }
+})
+
+// ─── Guard ──────────────────────────────────────────────────────────────────
+
+const runIntegration = process.env.INTEGRATION_TEST === 'true'
+const describeIf = runIntegration ? describe : describe.skip
+
+// ─── Shared state ───────────────────────────────────────────────────────────
+
+let prisma: PrismaClient
+let userId: string
+let token: string
+let authHeader: string
+
+beforeAll(async () => {
+  if (!runIntegration) return
+  prisma = new PrismaClient({
+    adapter: new PrismaPg({ connectionString: process.env.DATABASE_URL }),
+  })
+  await prisma.$connect()
+
+  const user = await prisma.user.create({
+    data: {
+      email: `replan-repair-${Date.now()}@example.com`,
+      name: 'Replan Profile Repair Integration Test',
+      password: '$2b$10$placeholder',
+    },
+  })
+  userId = user.id
+  token = jwt.sign({ userId, role: 'USER' }, process.env.JWT_SECRET!)
+  authHeader = `Bearer ${token}`
+})
+
+afterAll(async () => {
+  if (!runIntegration) return
+  await prisma.backlogSnapshot.deleteMany({ where: { project: { ownerId: userId } } })
+  await prisma.capacitySegment.deleteMany({ where: { capacityProfile: { project: { ownerId: userId } } } })
+  await prisma.capacityProfile.deleteMany({ where: { project: { ownerId: userId } } })
+  await prisma.capacityPlanEntry.deleteMany({ where: { period: { plan: { project: { ownerId: userId } } } } })
+  await prisma.capacityPlanPeriod.deleteMany({ where: { plan: { project: { ownerId: userId } } } })
+  await prisma.capacityPlan.deleteMany({ where: { project: { ownerId: userId } } })
+  await prisma.projectDiscount.deleteMany({ where: { project: { ownerId: userId } } })
+  await prisma.projectOverhead.deleteMany({ where: { project: { ownerId: userId } } })
+  await prisma.storyTimelineEntry.deleteMany({ where: { project: { ownerId: userId } } })
+  await prisma.timelineEntry.deleteMany({ where: { project: { ownerId: userId } } })
+  await prisma.storyDependency.deleteMany({ where: { story: { feature: { epic: { project: { ownerId: userId } } } } } })
+  await prisma.featureDependency.deleteMany({ where: { feature: { epic: { project: { ownerId: userId } } } } })
+  await prisma.epicDependency.deleteMany({ where: { epic: { project: { ownerId: userId } } } })
+  await prisma.task.deleteMany({ where: { userStory: { feature: { epic: { project: { ownerId: userId } } } } } })
+  await prisma.userStory.deleteMany({ where: { feature: { epic: { project: { ownerId: userId } } } } })
+  await prisma.feature.deleteMany({ where: { epic: { project: { ownerId: userId } } } })
+  await prisma.epic.deleteMany({ where: { project: { ownerId: userId } } })
+  await prisma.namedResource.deleteMany({ where: { resourceType: { project: { ownerId: userId } } } })
+  await prisma.resourceType.deleteMany({ where: { project: { ownerId: userId } } })
+  await prisma.project.deleteMany({ where: { ownerId: userId } })
+  await prisma.$disconnect()
+})
+
+beforeEach(() => vi.clearAllMocks())
+
+// ─── Fixture ────────────────────────────────────────────────────────────────
+
+interface ReplanFixture {
+  projectId: string
+  /** Role-only resource types (Engineer / Business Analyst / Data Scientist). */
+  roleOnlyRtIds: string[]
+  /** Resource type with a preserved user-authored named resource. */
+  namedRtId: string
+  namedResourceId: string
+  /** Resource type with task demand. */
+  demandedRtId: string
+}
+
+/**
+ * Create a project with several preserved role-only ResourceTypes, one role
+ * with a user-authored named resource, and one role with task demand — then
+ * reset planning so every profile is discarded (the #456 defect shape).
+ */
+async function createNeedsReplanFixture(): Promise<ReplanFixture> {
+  const project = await prisma.project.create({
+    data: {
+      name: `Replan repair fixture ${Date.now()}`,
+      status: 'ACTIVE',
+      hoursPerDay: 7.6,
+      ownerId: userId,
+      resourceTypes: {
+        create: [
+          { name: 'Engineer', category: 'ENGINEERING', count: 2 },
+          { name: 'Business Analyst', category: 'PROJECT_MANAGEMENT', count: 1 },
+          { name: 'Data Scientist', category: 'ENGINEERING', count: 1 },
+          { name: 'Security Consultant', category: 'GOVERNANCE', count: 1 },
+        ],
+      },
+      epics: {
+        create: [{
+          name: 'Epic 1',
+          features: {
+            create: [{
+              name: 'Feature 1',
+              userStories: {
+                create: [{
+                  name: 'Story 1',
+                  tasks: {
+                    create: [{ name: 'Task 1', hoursEffort: 16, durationDays: 2 }],
+                  },
+                }],
+              },
+            }],
+          },
+        }],
+      },
+    },
+    include: {
+      resourceTypes: true,
+      epics: { include: { features: { include: { userStories: { include: { tasks: true } } } } } },
+    },
+  })
+
+  const rts = project.resourceTypes
+  const roleOnlyRtIds = rts
+    .filter(rt => rt.name !== 'Security Consultant')
+    .map(rt => rt.id)
+  const namedRt = rts.find(rt => rt.name === 'Security Consultant')!
+  const demandedRt = rts.find(rt => rt.name === 'Engineer')!
+
+  const task = project.epics[0]!.features[0]!.userStories[0]!.tasks[0]!
+  await prisma.task.update({ where: { id: task.id }, data: { resourceTypeId: demandedRt.id } })
+
+  // User-authored named resource — preserved by reset, profile discarded.
+  const namedResource = await prisma.namedResource.create({
+    data: { resourceTypeId: namedRt.id, name: 'Alice Example', pricingModel: 'PRO_RATA' },
+  })
+  await prisma.capacityProfile.create({
+    data: {
+      projectId: project.id,
+      namedResourceId: namedResource.id,
+      ownerKind: 'NAMED_PERSON',
+      planningBasis: 'DEMAND_FOLLOWING',
+      source: 'MANUAL',
+      defaultPercent: 100,
+    },
+  })
+
+  await request(app)
+    .post(`/api/projects/${project.id}/planning/reset`)
+    .set('Authorization', authHeader)
+    .send({ confirm: true })
+
+  return {
+    projectId: project.id,
+    roleOnlyRtIds,
+    namedRtId: namedRt.id,
+    namedResourceId: namedResource.id,
+    demandedRtId: demandedRt.id,
+  }
+}
+
+async function profileCount(projectId: string): Promise<number> {
+  return prisma.capacityProfile.count({ where: { projectId } })
+}
+
+async function roleProfiles(projectId: string) {
+  return prisma.capacityProfile.findMany({
+    where: { projectId, ownerKind: 'ROLE' },
+    orderBy: { resourceTypeId: 'asc' },
+  })
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describeIf('NEEDS_REPLAN Resource Profile — missing ROLE profiles (issue #456)', () => {
+  it('reproduces the defect shape: role-only types with no persisted ROLE profiles are marked missing', async () => {
+    const f = await createNeedsReplanFixture()
+
+    const res = await request(app)
+      .get(`/api/projects/${f.projectId}/resource-profile`)
+      .set('Authorization', authHeader)
+    expect(res.status).toBe(200)
+    expect(res.body.planningState).toBe('NEEDS_REPLAN')
+
+    interface ProfileRowShape {
+      resourceTypeId: string
+      missingCapacityProfile?: boolean
+      capacityProfile?: unknown
+    }
+
+    const byId = new Map<string, ProfileRowShape>(
+      (res.body.resourceRows as ProfileRowShape[]).map(row => [row.resourceTypeId, row] as const),
+    )
+    // Zero persisted profiles anywhere.
+    expect(await profileCount(f.projectId)).toBe(0)
+
+    for (const rtId of f.roleOnlyRtIds) {
+      const row = byId.get(rtId)
+      expect(row, `row for ${rtId}`).toBeDefined()
+      // The visible defect: the row must not present a persisted profile as
+      // canonical state — it is marked as needing one.
+      expect(row!.missingCapacityProfile).toBe(true)
+      expect(row!.capacityProfile).toBeUndefined()
+    }
+
+    // The role with a preserved named resource is not role-only: its row is
+    // not marked as needing a ROLE profile (the named-resource finding is
+    // separate and manual).
+    const namedRow = byId.get(f.namedRtId)
+    expect(namedRow!.missingCapacityProfile).toBe(false)
+
+    // Completion fails closed with the existing stable code…
+    const incomplete = await request(app)
+      .post(`/api/projects/${f.projectId}/planning/complete`)
+      .set('Authorization', authHeader)
+    expect(incomplete.status).toBe(422)
+    expect(incomplete.body.code).toBe('REPLAN_INCOMPLETE')
+
+    // …and the findings identify resources by their human-readable names.
+    const joined = incomplete.body.findings.join(' | ')
+    expect(joined).toContain('Engineer')
+    expect(joined).toContain('Business Analyst')
+    expect(joined).toContain('Data Scientist')
+    expect(joined).toContain('Alice Example')
+    expect(joined).not.toMatch(/lacks exactly one persisted ROLE profile \(resource type rt-/) // names, not bare ids
+
+    const state = await prisma.project.findUnique({ where: { id: f.projectId } })
+    expect(state!.planningState).toBe('NEEDS_REPLAN')
+  })
+
+  it('bulk As-needed creates exactly one canonical ROLE profile per eligible role-only type', async () => {
+    const f = await createNeedsReplanFixture()
+
+    const res = await request(app)
+      .post(`/api/projects/${f.projectId}/capacity-profiles/bulk-as-needed`)
+      .set('Authorization', authHeader)
+
+    expect(res.status).toBe(200)
+    expect(res.body.created).toBe(3)
+    expect(res.body.planningState).toBe('NEEDS_REPLAN')
+
+    const profiles = await roleProfiles(f.projectId)
+    expect(profiles).toHaveLength(3)
+    const byRt = new Map(profiles.map(p => [p.resourceTypeId, p]))
+    for (const rtId of f.roleOnlyRtIds) {
+      const profile = byRt.get(rtId)
+      expect(profile, `profile for ${rtId}`).toBeDefined()
+      expect(profile!.planningBasis).toBe('DEMAND_FOLLOWING')
+      expect(profile!.source).toBe('MANUAL')
+      expect(profile!.defaultPercent).toBe(100)
+      expect(profile!.startWeek).toBeNull()
+      expect(profile!.endWeek).toBeNull()
+      expect(profile!.provenance).toBeNull()
+    }
+    // The named-resource role is NOT guessed: no ROLE profile was created.
+    expect(byRt.has(f.namedRtId)).toBe(false)
+
+    // The remaining named-resource finding stays visible by name.
+    expect(res.body.remainingFindings.join(' | ')).toContain('Alice Example')
+
+    // Project state untouched — completion owns the transition.
+    const state = await prisma.project.findUnique({ where: { id: f.projectId } })
+    expect(state!.planningState).toBe('NEEDS_REPLAN')
+  })
+
+  it('bulk As-needed is idempotent and never overwrites an existing persisted profile', async () => {
+    const f = await createNeedsReplanFixture()
+
+    // Give Engineer a profile through the normal editor first.
+    const put = await request(app)
+      .put(`/api/projects/${f.projectId}/capacity-profiles/ROLE/${f.demandedRtId}`)
+      .set('Authorization', authHeader)
+      .send({ planningBasis: 'DEMAND_FOLLOWING', defaultPercent: 100 })
+    expect(put.status).toBe(200)
+
+    const before = await roleProfiles(f.projectId)
+    const engineerProfile = before.find(p => p.resourceTypeId === f.demandedRtId)!
+
+    const first = await request(app)
+      .post(`/api/projects/${f.projectId}/capacity-profiles/bulk-as-needed`)
+      .set('Authorization', authHeader)
+    expect(first.status).toBe(200)
+    // Only the two still-missing role-only types are created.
+    expect(first.body.created).toBe(2)
+
+    const afterFirst = await roleProfiles(f.projectId)
+    expect(afterFirst).toHaveLength(3)
+    const engineerAfter = afterFirst.find(p => p.resourceTypeId === f.demandedRtId)!
+    // The pre-existing profile was not replaced — same id, same semantics.
+    expect(engineerAfter.id).toBe(engineerProfile.id)
+    expect(engineerAfter.planningBasis).toBe('DEMAND_FOLLOWING')
+
+    // Repeating the bulk action creates nothing (no duplicates).
+    const second = await request(app)
+      .post(`/api/projects/${f.projectId}/capacity-profiles/bulk-as-needed`)
+      .set('Authorization', authHeader)
+    expect(second.status).toBe(200)
+    expect(second.body.created).toBe(0)
+    expect(await roleProfiles(f.projectId)).toHaveLength(3)
+  })
+
+  it('an injected mid-batch failure rolls the whole bulk action back atomically', async () => {
+    const f = await createNeedsReplanFixture()
+    const realReplace = vi.mocked(replaceCapacityProfile).getMockImplementation()!
+
+    // First eligible role writes normally; the second fails.
+    vi.mocked(replaceCapacityProfile)
+      .mockImplementationOnce(realReplace)
+      .mockImplementationOnce(async () => {
+        throw new Error('injected mid-batch failure')
+      })
+
+    await expect(
+      applyRoleCountsAsNeeded(prisma, f.projectId, userId),
+    ).rejects.toThrow('injected mid-batch failure')
+
+    // Zero partial state: no profiles were committed and the project remains
+    // NEEDS_REPLAN.
+    expect(await profileCount(f.projectId)).toBe(0)
+    const state = await prisma.project.findUnique({ where: { id: f.projectId } })
+    expect(state!.planningState).toBe('NEEDS_REPLAN')
+  })
+
+  it('the existing completion returns the project to CURRENT and Timeline resumes', async () => {
+    const f = await createNeedsReplanFixture()
+
+    // Bulk As-needed covers the role-only types.
+    const bulk = await request(app)
+      .post(`/api/projects/${f.projectId}/capacity-profiles/bulk-as-needed`)
+      .set('Authorization', authHeader)
+    expect(bulk.status).toBe(200)
+    expect(bulk.body.created).toBe(3)
+
+    // Still quarantined — the named-resource finding blocks completion.
+    const stillIncomplete = await request(app)
+      .post(`/api/projects/${f.projectId}/planning/complete`)
+      .set('Authorization', authHeader)
+    expect(stillIncomplete.status).toBe(422)
+    expect(stillIncomplete.body.code).toBe('REPLAN_INCOMPLETE')
+    expect(stillIncomplete.body.findings.join(' | ')).toContain('Alice Example')
+
+    // Resolve the named resource through the normal editor path.
+    const namedPut = await request(app)
+      .put(`/api/projects/${f.projectId}/capacity-profiles/NAMED_PERSON/${f.namedResourceId}`)
+      .set('Authorization', authHeader)
+      .send({ planningBasis: 'DEMAND_FOLLOWING', defaultPercent: 100 })
+    expect(namedPut.status).toBe(200)
+
+    // Completion now passes and transitions the state.
+    const complete = await request(app)
+      .post(`/api/projects/${f.projectId}/planning/complete`)
+      .set('Authorization', authHeader)
+    expect(complete.status).toBe(200)
+    expect(complete.body.planningState).toBe('CURRENT')
+
+    // Timeline scheduling resumes against the canonical plan.
+    const schedule = await request(app)
+      .post(`/api/projects/${f.projectId}/timeline/schedule`)
+      .set('Authorization', authHeader)
+      .send({})
+    expect(schedule.status).toBe(200)
+    expect(schedule.body.entries.length).toBeGreaterThan(0)
+
+    // CURRENT Resource Profile behaviour: no missing markers are emitted and
+    // the response keeps the pre-existing shape (planningState is only
+    // emitted by the NEEDS_REPLAN branch).
+    const profile = await request(app)
+      .get(`/api/projects/${f.projectId}/resource-profile`)
+      .set('Authorization', authHeader)
+    expect(profile.status).toBe(200)
+    expect(profile.body.planningState).toBeUndefined()
+    for (const row of profile.body.resourceRows as Array<{ missingCapacityProfile?: boolean }>) {
+      expect(row.missingCapacityProfile).toBeUndefined()
+    }
+  })
+
+  it('refuses the bulk action for a CURRENT project with the stable guard code', async () => {
+    const project = await prisma.project.create({
+      data: { name: `CURRENT guard ${Date.now()}`, status: 'ACTIVE', ownerId: userId },
+    })
+
+    const res = await request(app)
+      .post(`/api/projects/${project.id}/capacity-profiles/bulk-as-needed`)
+      .set('Authorization', authHeader)
+    expect(res.status).toBe(409)
+    expect(res.body.code).toBe('REPLAN_ACTION_UNAVAILABLE')
+
+    await prisma.project.delete({ where: { id: project.id } })
+  })
+})


### PR DESCRIPTION
Closes #456

## Starting main SHA
`583ef9b43faad77b4bf0cab46d4346aee6ed10d5` (fetched `origin/main` before work; moved past the issue-creation baseline, worked from latest main).

## Final head SHA
`c18609056ce1e18efeb05fa0d7208dd36a16ebe1` on `agent/456-replan-profile-repair` (pushed; worktree clean).

## What changed and why
A `NEEDS_REPLAN` project with many preserved role-only ResourceTypes and no persisted ROLE CapacityProfiles was an actionable dead end: completion failed with `REPLAN_INCOMPLETE` findings that exposed internal resource-type IDs, while Resource Profile showed the same roles as apparently normal **As needed** rows (the effective/fallback draft was indistinguishable from persisted canonical state).

1. **Human-readable completeness findings** — `checkPersistedCompleteness` (and therefore completion, readiness and `GET /capacity-profiles`) now identifies resources by their human-readable names, retaining the internal ID as secondary diagnostic context. Machine codes (`REPLAN_INCOMPLETE`, `REPLAN_REQUIRED`) are unchanged; validation semantics are unchanged.
2. **Missing persisted profiles are visible in Resource Profile** — while `NEEDS_REPLAN`, `GET /resource-profile` emits a per-row `missingCapacityProfile` marker (a role requires a ROLE profile when it has no named resources or has planner-owned profiles) plus the persisted ROLE profile when one exists. Rows missing the required profile render a distinct amber **Needs capacity profile** badge that opens the existing capacity editor (create path). The effective draft is never presented as canonical state. `CURRENT` behaviour is unchanged.
3. **Bulk "Use role counts as As needed"** — one explicit, user-triggered action on the NEEDS_REPLAN Resource Profile (`POST /api/projects/:projectId/capacity-profiles/bulk-as-needed`, service `server/src/lib/bulkAsNeededProfiles.ts`). For every eligible missing role-only ResourceType it persists exactly one canonical `DEMAND_FOLLOWING`/100% `MANUAL` ROLE profile through the existing authoritative writer (`replaceCapacityProfile`): never overwrites an existing persisted profile, never guesses named-person/planned-resource/segmented authority, is idempotent, and is atomic (any failure rolls the whole batch back). The project stays `NEEDS_REPLAN`; remaining completeness findings are returned by name.
4. **Completion stays separate** — the bulk action never transitions planning state. The existing `Replan project` completion remains the only path back to `CURRENT` and still runs canonical validation (not weakened). After all required profiles exist, completion returns the project to `CURRENT` and Timeline scheduling resumes.

## Canonical validation not weakened
`validatePersistedCapacityProfiles`, `checkPersistedCompleteness` and the `completeReplanning` contract are untouched semantically (only finding message text changed to use names). No profile is fabricated by reset, migration, page load, GET requests or completion validation.

## Files/components changed
- `server/src/lib/persistedCapacityProfileValidation.ts` — human-readable findings (names first, IDs secondary).
- `server/src/lib/bulkAsNeededProfiles.ts` (new) — atomic bulk As-needed service.
- `server/src/routes/capacityProfiles.ts` — `POST /bulk-as-needed` endpoint (registered before parameterised routes).
- `server/src/routes/resourceProfile.ts` — NEEDS_REPLAN rows emit `capacityProfile` + `missingCapacityProfile`.
- `client/src/types/backlog.ts` — `ResourceProfileRow.missingCapacityProfile`.
- `client/src/lib/api.ts` — `applyRoleCountsAsNeeded` + result type.
- `client/src/components/resource-profile/ResourceProfileTab.tsx` — amber missing badge + bulk action button/feedback.
- `e2e/tests/replan-profile-repair.spec.ts` (new) — targeted Playwright regression; `e2e/tests/planning-reset.spec.ts` selector updated for both badge titles; `e2e/TESTS.md` updated.
- `server/src/test/bulkAsNeededProfiles.test.ts`, `bulkAsNeededRoutes.test.ts`, `checkPersistedCompleteness.unit.test.ts`, `replanProfileRepair.integration.test.ts` (new).
- `server/package.json` + `scripts/run-integration-local.mjs` — new `test:replan-repair-integration` suite wired into the lifecycle runner.
- `docs/domain/planning-reset-replan.md` — #456 section.

## Tests and commands run (exact results)
- **Server unit: 1403 passed / 0 failed** (62 files; includes 15 new tests: bulk service 8, bulk routes 4, completeness findings 7 — 8+4+7=19 actually; see note below). Full `vitest run` in `server/`: `1403 passed | 289 skipped (1692)`.
- **Client unit: 365 passed / 0 failed** (26 files; 9 new `ResourceProfileTab.needsReplan` tests).
- **PostgreSQL integration (Linux Docker lifecycle; host disposable cluster, external-mode `MONRAD_TEST_DATABASE_URL` + `MONRAD_ALLOW_EXTERNAL_TEST_DATABASE=1`): all 14 suites passed, runner EXIT 0** — incl. new `replanProfileRepair.integration.test.ts` (6 tests: defect shape + human-readable findings, one-canonical-profile bulk, idempotent/non-overwriting bulk, injected mid-batch failure rollback, completion → CURRENT → Timeline resumes + CURRENT rows unmarked, CURRENT guard 409).
- **Playwright (`npm run test:e2e:local`, targeted): 2 passed** — new `replan-profile-repair` flow (reset → missing badges visible → bulk As-needed → feedback → badges cleared → Replan completion → CURRENT → Timeline schedule) and the pre-existing `planning-reset` flow (selector updated for both badge kinds).
- **`npm run validate`: EXIT 0** (lint 0 errors — 762 pre-existing warnings; client/server typecheck; client/server builds; client/server unit tests; backup regression tests).
- **`git diff --check`: clean.**
- New unit-test count note: 8 bulk-service + 4 bulk-route + 7 completeness = 19 new server unit tests; earlier text miscounted; final suite totals are authoritative.

## CI status
Pending — checks will run on the pushed head; will report once available.

## E2E coverage
Targeted Playwright regression added (`replan-profile-repair.spec.ts`); existing `planning-reset.spec.ts` updated (selector covers the new missing-profile badge); `e2e/TESTS.md` updated.

## Confirmations
- **No production database accessed.** Development machine only; integration/E2E ran against a disposable host PostgreSQL cluster (`/tmp/monrad-pg405-data` on port 55432, leftover dev infra from earlier agent work) with a dedicated `monrad_test_456` database; no production connection, query, backup or modification occurred.
- Canonical validation was not weakened; no capacity profile is fabricated by reset, migration, page load, GET or completion.
- No unrelated refactoring, schema changes, Commercial/billing or backlog-estimation changes.

## Risks / limitations
- Bulk eligibility is deliberately narrow (role-only ResourceTypes with no persisted ROLE profile); named-resource and planner-owned findings remain manual — by design per the issue.
- `GET /resource-profile` NEEDS_REPLAN rows for roles that have a persisted ROLE profile now include the profile data (additive; matches the CURRENT shape).

Do not merge — wait for review.