### PR TITLE
fix(#462): separate task effort from duration in scheduling demand

### DIFF
--- a/docs/FUNCTIONAL_SPEC.md
+++ b/docs/FUNCTIONAL_SPEC.md
@@ -551,9 +551,9 @@ The scheduler does **not** use a simple uniform spread. Instead, active-story ta
 
 1. Active stories only are considered
 2. Tasks are grouped by `resourceTypeId`
-3. Each task's effective days are calculated from `durationDays` when present, otherwise from `hoursEffort / effectiveHoursPerDay`
-4. For each resource type, person-days are divided by the configured resource type `count`
-5. The largest resource-type duration becomes the feature duration floor, with a minimum of `0.2` weeks
+3. Resource demand person-days are calculated from `hoursEffort / effectiveHoursPerDay`
+4. Elapsed task days use positive `durationDays` when supplied, otherwise `hoursEffort / effectiveHoursPerDay`
+5. The bottleneck elapsed duration is divided by the configured resource type `count`, with a minimum of `0.2` weeks
 6. For parallel epics, a shared-resource minimum-span floor is applied so parallel features cannot complete faster than total demand divided by available weekly capacity
 
 See the [architecture guide](architecture/scheduling-and-resource-model.md) for the full Mermaid flowchart of this calculation.

--- a/docs/FUNCTIONAL_SPEC.md
+++ b/docs/FUNCTIONAL_SPEC.md
@@ -552,8 +552,8 @@ The scheduler does **not** use a simple uniform spread. Instead, active-story ta
 1. Active stories only are considered
 2. Tasks are grouped by `resourceTypeId`
 3. Resource demand person-days are calculated from `hoursEffort / effectiveHoursPerDay`
-4. Elapsed task days use positive `durationDays` when supplied, otherwise `hoursEffort / effectiveHoursPerDay`
-5. The bottleneck elapsed duration is divided by the configured resource type `count`, with a minimum of `0.2` weeks
+4. Elapsed task days use positive `durationDays` when supplied, otherwise `hoursEffort / effectiveHoursPerDay`; only effort-derived days respond to `ResourceType.count`, while explicit duration overrides remain undivided
+5. The largest resource-type elapsed duration becomes the feature duration floor, with a minimum of `0.2` weeks
 6. For parallel epics, a shared-resource minimum-span floor is applied so parallel features cannot complete faster than total demand divided by available weekly capacity
 
 See the [architecture guide](architecture/scheduling-and-resource-model.md) for the full Mermaid flowchart of this calculation.

--- a/docs/architecture/scheduling-and-resource-model.md
+++ b/docs/architecture/scheduling-and-resource-model.md
@@ -409,8 +409,8 @@ Current feature duration is driven by the bottleneck resource type:
 1. Active stories only are considered.
 2. Tasks are grouped by `resourceTypeId`.
 3. Resource demand person-days are calculated from `hoursEffort / effectiveHoursPerDay`.
-4. Elapsed task days use positive `durationDays` when supplied, otherwise `hoursEffort / effectiveHoursPerDay`; the bottleneck elapsed duration is divided by `ResourceType.count`.
-5. The largest resource-type duration becomes the feature duration floor, with a minimum of `0.2` weeks.
+4. Elapsed task days use positive `durationDays` when supplied, otherwise `hoursEffort / effectiveHoursPerDay`; only effort-derived days are divided by `ResourceType.count`, so explicit overrides remain unchanged.
+5. The largest resource-type elapsed duration becomes the feature duration floor, with a minimum of `0.2` weeks.
 6. For parallel epics, a shared-resource minimum-span floor is applied so parallel features cannot complete faster than total demand divided by available weekly capacity.
 
 ```mermaid
@@ -418,8 +418,8 @@ flowchart TD
   Tasks[Active tasks in feature]
   Group[Group tasks by resourceTypeId]
   EffortDays[Calculate effort days<br/>hoursEffort / hoursPerDay]
-  ScheduleDays[Calculate elapsed days<br/>durationDays override or effort days]
-  Divide[Divide elapsed RT duration by ResourceType.count]
+  ExplicitDuration[Use positive durationDays<br/>unchanged]
+  EffortDuration[Use effort days<br/>divided by ResourceType.count]
   Bottleneck[Take max RT days]
   Weeks[Convert days to weeks<br/>max 0.2 minimum]
   Parallel{Parent epic featureMode = parallel?}
@@ -428,7 +428,8 @@ flowchart TD
 
   Tasks --> Group
   Group --> EffortDays
-  Group --> ScheduleDays --> Divide --> Bottleneck --> Weeks --> Parallel
+  Group --> ExplicitDuration --> Bottleneck
+  Group --> EffortDays --> EffortDuration --> Bottleneck
   EffortDays --> Parallel
   Parallel -- yes --> Floor --> Duration
   Parallel -- no --> Duration

--- a/docs/architecture/scheduling-and-resource-model.md
+++ b/docs/architecture/scheduling-and-resource-model.md
@@ -25,8 +25,8 @@ The app deliberately separates four related but different concepts:
 
 | Concept | Primary source | Owned by | Notes |
 |---|---|---|---|
-| Delivery effort | `Task.hoursEffort`, `Task.durationDays`, task `resourceTypeId` | Backlog / Effort Review | This is the estimated work required to deliver the scoped backlog. |
-| Scheduling reality | `TimelineEntry`, `StoryTimelineEntry`, `Project.weeklyDemandCache` | Timeline Planner | This is where work lands over time after dependencies, manual overrides, and optional resource levelling. |
+| Delivery effort | `Task.hoursEffort`, task `resourceTypeId` | Backlog / Effort Review | This is the estimated work required to deliver the scoped backlog. A positive `durationDays` is an elapsed scheduling override, not additional effort. |
+| Scheduling reality | `TimelineEntry`, `StoryTimelineEntry`, `Task.durationDays`, `Project.weeklyDemandCache` | Timeline Planner | This is where work lands over time after dependencies, manual overrides, and optional resource levelling. |
 | Resource capacity / staffing shape | `ResourceType`, `NamedResource` | Resource Profile / planning controls | This describes which role/person/slot capacity is available by week. `CapacityPlan` is turned into week-by-week staffing numbers and named-resource windows for the response/shared planning read model, but is **not** passed directly into `runScheduler`. The scheduler currently receives raw `ResourceType.count` values. |
 | Commercial pricing | `ResourceType.dayRate`, `NamedResource.pricingModel`, `ProjectOverhead`, `ProjectDiscount`, tax fields | Commercial / Resource Profile presentation | Pricing may use scheduled actual days, pro-rata allocation, full-project allocation, discounts, or overheads. It should not be treated as identical to effort or capacity. |
 
@@ -36,7 +36,7 @@ flowchart LR
     Epic[Epic]
     Feature[Feature]
     Story[UserStory]
-    Task[Task effort<br/>hoursEffort + durationDays + resourceType]
+    Task[Task effort<br/>hoursEffort + resourceType<br/>durationDays = elapsed override]
     Epic --> Feature --> Story --> Task
   end
 
@@ -408,8 +408,8 @@ Current feature duration is driven by the bottleneck resource type:
 
 1. Active stories only are considered.
 2. Tasks are grouped by `resourceTypeId`.
-3. Each task's effective days are calculated from `durationDays` when present, otherwise from `hoursEffort / effectiveHoursPerDay`.
-4. For each resource type, person-days are divided by the configured resource type `count`.
+3. Resource demand person-days are calculated from `hoursEffort / effectiveHoursPerDay`.
+4. Elapsed task days use positive `durationDays` when supplied, otherwise `hoursEffort / effectiveHoursPerDay`; the bottleneck elapsed duration is divided by `ResourceType.count`.
 5. The largest resource-type duration becomes the feature duration floor, with a minimum of `0.2` weeks.
 6. For parallel epics, a shared-resource minimum-span floor is applied so parallel features cannot complete faster than total demand divided by available weekly capacity.
 
@@ -417,15 +417,19 @@ Current feature duration is driven by the bottleneck resource type:
 flowchart TD
   Tasks[Active tasks in feature]
   Group[Group tasks by resourceTypeId]
-  EffectiveDays[Calculate effective days<br/>durationDays override or hoursEffort / hoursPerDay]
-  Divide[Divide each RT demand by ResourceType.count]
+  EffortDays[Calculate effort days<br/>hoursEffort / hoursPerDay]
+  ScheduleDays[Calculate elapsed days<br/>durationDays override or effort days]
+  Divide[Divide elapsed RT duration by ResourceType.count]
   Bottleneck[Take max RT days]
   Weeks[Convert days to weeks<br/>max 0.2 minimum]
   Parallel{Parent epic featureMode = parallel?}
   Floor[Apply parallel epic shared-resource min span]
   Duration[Feature durationWeeks]
 
-  Tasks --> Group --> EffectiveDays --> Divide --> Bottleneck --> Weeks --> Parallel
+  Tasks --> Group
+  Group --> EffortDays
+  Group --> ScheduleDays --> Divide --> Bottleneck --> Weeks --> Parallel
+  EffortDays --> Parallel
   Parallel -- yes --> Floor --> Duration
   Parallel -- no --> Duration
 ```

--- a/server/src/lib/leveller.ts
+++ b/server/src/lib/leveller.ts
@@ -15,7 +15,7 @@ import {
   type SchedulerInput,
   type SchedulerResourceType,
 } from './scheduler.js'
-import { effectiveDays } from '../utils/round.js'
+import { effortDays, scheduleDurationDays } from '../utils/round.js'
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Types
@@ -89,7 +89,7 @@ export function levelEpicStarts(input: SchedulerInput): LevellingResult {
       for (const [rtId, tasks] of byRt) {
         const personDays = tasks.reduce((sum, t) => {
           const rtHpd = t.resourceType?.hoursPerDay ?? hpd
-          return sum + effectiveDays(t.durationDays, t.hoursEffort, rtHpd)
+          return sum + scheduleDurationDays(t.durationDays, t.hoursEffort, rtHpd)
         }, 0)
         const rawCount = rtId ? (rtCountMap.get(rtId) ?? 1) : 1
         const count = input.maxParallelismPerFeature
@@ -115,7 +115,7 @@ export function levelEpicStarts(input: SchedulerInput): LevellingResult {
         for (const task of story.tasks) {
           if (!task.resourceTypeId) continue
           const rtHpd = task.resourceType?.hoursPerDay ?? hpd
-          const demandDays = effectiveDays(task.durationDays, task.hoursEffort, rtHpd)
+          const demandDays = effortDays(task.hoursEffort, rtHpd)
           demandByRt.set(
             task.resourceTypeId,
             (demandByRt.get(task.resourceTypeId) ?? 0) + demandDays,
@@ -253,7 +253,7 @@ export function levelEpicStarts(input: SchedulerInput): LevellingResult {
         for (const task of story.tasks) {
           if (!task.resourceTypeId) continue
           const rtHpd = task.resourceType?.hoursPerDay ?? hpd
-          const demandDays = effectiveDays(task.durationDays, task.hoursEffort, rtHpd)
+          const demandDays = effortDays(task.hoursEffort, rtHpd)
           demandByRt.set(task.resourceTypeId, (demandByRt.get(task.resourceTypeId) ?? 0) + demandDays)
         }
       }

--- a/server/src/lib/leveller.ts
+++ b/server/src/lib/leveller.ts
@@ -91,11 +91,8 @@ export function levelEpicStarts(input: SchedulerInput): LevellingResult {
         const count = input.maxParallelismPerFeature
           ? Math.min(rawCount, input.maxParallelismPerFeature)
           : rawCount
-        const personDays = tasks.reduce((sum, task) => {
-          const rtHpd = task.resourceType?.hoursPerDay ?? hpd
-          return sum + scheduleDurationDaysAtCount(task.durationDays, task.hoursEffort, rtHpd, count)
-        }, 0)
-        if (personDays > maxDays) maxDays = personDays
+        const days = scheduleDurationDaysAtCount(tasks, hpd, count)
+        if (days > maxDays) maxDays = days
       }
       featureDurations.set(feature.id, Math.max(0.2, maxDays / 5))
     }

--- a/server/src/lib/leveller.ts
+++ b/server/src/lib/leveller.ts
@@ -15,7 +15,7 @@ import {
   type SchedulerInput,
   type SchedulerResourceType,
 } from './scheduler.js'
-import { effortDays, scheduleDurationDays } from '../utils/round.js'
+import { effortDays, scheduleDurationDaysAtCount } from '../utils/round.js'
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Types
@@ -87,16 +87,15 @@ export function levelEpicStarts(input: SchedulerInput): LevellingResult {
       }
       let maxDays = 0
       for (const [rtId, tasks] of byRt) {
-        const personDays = tasks.reduce((sum, t) => {
-          const rtHpd = t.resourceType?.hoursPerDay ?? hpd
-          return sum + scheduleDurationDays(t.durationDays, t.hoursEffort, rtHpd)
-        }, 0)
         const rawCount = rtId ? (rtCountMap.get(rtId) ?? 1) : 1
         const count = input.maxParallelismPerFeature
           ? Math.min(rawCount, input.maxParallelismPerFeature)
           : rawCount
-        const days = personDays / count
-        if (days > maxDays) maxDays = days
+        const personDays = tasks.reduce((sum, task) => {
+          const rtHpd = task.resourceType?.hoursPerDay ?? hpd
+          return sum + scheduleDurationDaysAtCount(task.durationDays, task.hoursEffort, rtHpd, count)
+        }, 0)
+        if (personDays > maxDays) maxDays = personDays
       }
       featureDurations.set(feature.id, Math.max(0.2, maxDays / 5))
     }

--- a/server/src/lib/projectPlanningModel.ts
+++ b/server/src/lib/projectPlanningModel.ts
@@ -29,7 +29,7 @@ import {
   type MaterializedCapacityPlanResource,
 } from './capacityPlanMaterialisation.js'
 import { deriveNamedResourceAssignments } from './namedResourceAssignments.js'
-import { effectiveDays } from '../utils/round.js'
+import { effortDays } from '../utils/round.js'
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Cache key resolution (backward-compatible: tries ID then legacy name)
@@ -397,7 +397,7 @@ export function computeResourceBreakdown(
       const key = task.resourceTypeId ?? '_unassigned'
       const name = task.resourceType?.name ?? 'Unassigned'
       const hpd = task.resourceType?.hoursPerDay ?? fallbackHpd
-      const days = effectiveDays(task.durationDays, task.hoursEffort, hpd)
+      const days = effortDays(task.hoursEffort, hpd)
       const existing = byRt.get(key) ?? { name, days: 0 }
       byRt.set(key, { name, days: existing.days + days })
     }

--- a/server/src/lib/sa-planner.ts
+++ b/server/src/lib/sa-planner.ts
@@ -13,7 +13,7 @@ import {
   type SchedulerInput,
   type SchedulerResourceType,
 } from './scheduler.js'
-import { effectiveDays } from '../utils/round.js'
+import { effortDays } from '../utils/round.js'
 
 // ─── Config ──────────────────────────────────────────────────────────────────
 
@@ -112,7 +112,7 @@ export function runSAPlanner(
         for (const task of story.tasks) {
           if (!task.resourceTypeId) continue
           const rtHpd = task.resourceType?.hoursPerDay ?? hpd
-          const days = effectiveDays(task.durationDays, task.hoursEffort, rtHpd)
+          const days = effortDays(task.hoursEffort, rtHpd)
           totalDaysByRt.set(task.resourceTypeId, (totalDaysByRt.get(task.resourceTypeId) ?? 0) + days)
         }
       }

--- a/server/src/lib/scheduler.ts
+++ b/server/src/lib/scheduler.ts
@@ -9,7 +9,7 @@
  * Phase 2 extraction: issue #233
  */
 
-import { effortDays, scheduleDurationDays } from '../utils/round.js'
+import { effortDays, scheduleDurationDays, scheduleDurationDaysAtCount } from '../utils/round.js'
 // ─────────────────────────────────────────────────────────────────────────────
 // Input / Output types
 // ─────────────────────────────────────────────────────────────────────────────
@@ -496,12 +496,11 @@ export function runScheduler(input: SchedulerInput): SchedulerOutput {
 
     let maxDays = 0
     for (const [rtId, rtTasks] of byRt) {
-      const personDays = rtTasks.reduce((sum, t) => {
-        const hpd = t.resourceType?.hoursPerDay ?? fallbackHoursPerDay
-        return sum + scheduleDurationDays(t.durationDays, t.hoursEffort, hpd)
-      }, 0)
       const count = rtId ? (rtCountMap.get(rtId) ?? 1) : 1
-      const days = personDays / count
+      const days = rtTasks.reduce((sum, task) => {
+        const hpd = task.resourceType?.hoursPerDay ?? fallbackHoursPerDay
+        return sum + scheduleDurationDaysAtCount(task.durationDays, task.hoursEffort, hpd, count)
+      }, 0)
       if (days > maxDays) maxDays = days
     }
     return Math.max(0.2, maxDays / 5)

--- a/server/src/lib/scheduler.ts
+++ b/server/src/lib/scheduler.ts
@@ -497,10 +497,7 @@ export function runScheduler(input: SchedulerInput): SchedulerOutput {
     let maxDays = 0
     for (const [rtId, rtTasks] of byRt) {
       const count = rtId ? (rtCountMap.get(rtId) ?? 1) : 1
-      const days = rtTasks.reduce((sum, task) => {
-        const hpd = task.resourceType?.hoursPerDay ?? fallbackHoursPerDay
-        return sum + scheduleDurationDaysAtCount(task.durationDays, task.hoursEffort, hpd, count)
-      }, 0)
+      const days = scheduleDurationDaysAtCount(rtTasks, fallbackHoursPerDay, count)
       if (days > maxDays) maxDays = days
     }
     return Math.max(0.2, maxDays / 5)

--- a/server/src/lib/scheduler.ts
+++ b/server/src/lib/scheduler.ts
@@ -9,7 +9,7 @@
  * Phase 2 extraction: issue #233
  */
 
-import { effectiveDays } from '../utils/round.js'
+import { effortDays, scheduleDurationDays } from '../utils/round.js'
 // ─────────────────────────────────────────────────────────────────────────────
 // Input / Output types
 // ─────────────────────────────────────────────────────────────────────────────
@@ -362,7 +362,7 @@ export function computeParallelWarnings(
         for (const task of story.tasks) {
           const rtId = task.resourceTypeId ?? '_unassigned'
           const hpd = task.resourceType?.hoursPerDay ?? fallbackHoursPerDay
-          const days = effectiveDays(task.durationDays, task.hoursEffort, hpd)
+          const days = effortDays(task.hoursEffort, hpd)
           if (!demandMap.has(rtId)) {
             demandMap.set(rtId, {
               name: task.resourceType?.name ?? 'Unassigned',
@@ -459,7 +459,7 @@ export function runScheduler(input: SchedulerInput): SchedulerOutput {
       for (const task of tasks) {
         if (!task.resourceTypeId) continue
         const hpd = task.resourceType?.hoursPerDay ?? fallbackHoursPerDay
-        const demand = effectiveDays(task.durationDays, task.hoursEffort, hpd)
+        const demand = effortDays(task.hoursEffort, hpd)
         totalDemandByRt.set(
           task.resourceTypeId,
           (totalDemandByRt.get(task.resourceTypeId) ?? 0) + demand,
@@ -498,13 +498,19 @@ export function runScheduler(input: SchedulerInput): SchedulerOutput {
     for (const [rtId, rtTasks] of byRt) {
       const personDays = rtTasks.reduce((sum, t) => {
         const hpd = t.resourceType?.hoursPerDay ?? fallbackHoursPerDay
-        return sum + effectiveDays(t.durationDays, t.hoursEffort, hpd)
+        return sum + scheduleDurationDays(t.durationDays, t.hoursEffort, hpd)
       }, 0)
       const count = rtId ? (rtCountMap.get(rtId) ?? 1) : 1
       const days = personDays / count
       if (days > maxDays) maxDays = days
     }
     return Math.max(0.2, maxDays / 5)
+  }
+  function storyScheduleHours(story: SchedulerStory): number {
+    return story.tasks.reduce((sum, task) => {
+      const hpd = task.resourceType?.hoursPerDay ?? fallbackHoursPerDay
+      return sum + scheduleDurationDays(task.durationDays, task.hoursEffort, hpd) * hpd
+    }, 0)
   }
 
   function storyPhaseSchedule(feature: typeof allFeatures[0]): Array<{ storyId: string; weeks: number }> {
@@ -699,17 +705,13 @@ export function runScheduler(input: SchedulerInput): SchedulerOutput {
       if (!manualStoryWeeks.has(story.id)) continue
       if (story.isActive === false) continue
       const sw = manualStoryWeeks.get(story.id)!
-      const totalHours = story.tasks.reduce((sum, t) => {
-        const hpd = t.resourceType?.hoursPerDay ?? fallbackHoursPerDay
-        return sum + effectiveDays(t.durationDays, t.hoursEffort, hpd) * hpd
-      }, 0)
-      const dur = Math.max(0.2, totalHours / fallbackHoursPerDay / 5)
+      const dur = Math.max(0.2, storyScheduleHours(story) / fallbackHoursPerDay / 5)
       const endWeek = sw + dur
 
       for (const task of story.tasks) {
         const rtId = task.resourceTypeId ?? '_unassigned'
         const hpd = task.resourceType?.hoursPerDay ?? fallbackHoursPerDay
-        const hours = effectiveDays(task.durationDays, task.hoursEffort, hpd) * hpd
+        const hours = effortDays(task.hoursEffort, hpd) * hpd
         pinnedIntervals.push({ rtId, hpd, totalHours: hours, dur, startWeek: sw, endWeek })
         // Weekly totals for output accounting
         const startW = Math.floor(sw)
@@ -736,7 +738,7 @@ export function runScheduler(input: SchedulerInput): SchedulerOutput {
         for (const task of story.tasks) {
           const rtId = task.resourceTypeId ?? '_unassigned'
           const hpd = task.resourceType?.hoursPerDay ?? fallbackHoursPerDay
-          const hours = effectiveDays(task.durationDays, task.hoursEffort, hpd) * hpd
+          const hours = effortDays(task.hoursEffort, hpd) * hpd
           result.set(rtId, (result.get(rtId) ?? 0) + hours)
         }
       }
@@ -754,7 +756,7 @@ export function runScheduler(input: SchedulerInput): SchedulerOutput {
     // each feature.  Only the current story's resource demand is eligible
     // for capacity allocation; when all demand for the current story is
     // consumed, the next story phase begins.
-    const storyPhases = new Map<string, Array<{ storyId: string; byRt: Map<string, number> }>>()
+    const storyPhases = new Map<string, Array<{ storyId: string; byRt: Map<string, number>; weeks: number }>>()
     const currentStoryIdx = new Map<string, number>()
 
     function advanceToNextStory(fId: string): boolean {
@@ -777,10 +779,10 @@ export function runScheduler(input: SchedulerInput): SchedulerOutput {
         for (const task of s.tasks) {
           const rtId = task.resourceTypeId ?? '_unassigned'
           const hpd = task.resourceType?.hoursPerDay ?? fallbackHoursPerDay
-          const hours = effectiveDays(task.durationDays, task.hoursEffort, hpd) * hpd
+          const hours = effortDays(task.hoursEffort, hpd) * hpd
           byRt.set(rtId, (byRt.get(rtId) ?? 0) + hours)
         }
-        return { storyId: s.id, byRt }
+        return { storyId: s.id, byRt, weeks: storyBottleneckWeeks(s) }
       })
       storyPhases.set(fId, phases)
       advanceToNextStory(fId)
@@ -879,11 +881,13 @@ export function runScheduler(input: SchedulerInput): SchedulerOutput {
         let remainingStepCapacity = capPerStep
         for (const fId of sorted) {
           const rem = remainingHours.get(fId)!.get(rtId)!
-          // Greedy within remaining capacity: take what you need, up to
-          // what's left in the step.  Small features will claim their full
-          // remaining work and finish; large features get whatever capacity
-          // remains after smaller competing work has been satisfied.
-          const actualAllocated = Math.min(rem, remainingStepCapacity)
+          const phase = storyPhases.get(fId)?.[currentStoryIdx.get(fId) ?? 0]
+          const pacedStepCapacity = phase && phase.weeks > 0
+            ? ((phase.byRt.get(rtId) ?? 0) / phase.weeks) * STEP
+            : Infinity
+          // Pace effort across an elapsed duration override; capacity can still
+          // reduce the allocation and extend the realised schedule.
+          const actualAllocated = Math.min(rem, remainingStepCapacity, pacedStepCapacity)
           remainingStepCapacity -= actualAllocated
 
           const consumptionKey = `${rtId}|${currentWeek}`
@@ -1011,29 +1015,13 @@ export function runScheduler(input: SchedulerInput): SchedulerOutput {
     )
   )
 
-  function storyResourceHours(story: typeof allStories[0]): Map<string, number> {
-    const result = new Map<string, number>()
-    for (const task of story.tasks) {
-      const rtId = task.resourceTypeId ?? '_unassigned'
-      const hpd = task.resourceType?.hoursPerDay ?? fallbackHoursPerDay
-      const hours = effectiveDays(task.durationDays, task.hoursEffort, hpd) * hpd
-      result.set(rtId, (result.get(rtId) ?? 0) + hours)
-    }
-    return result
-  }
-
-  function storyTotalHours(story: typeof allStories[0]): number {
-    return [...storyResourceHours(story).values()].reduce((a, b) => a + b, 0)
-  }
-
   const storyScheduled = new Map<string, { startWeek: number; durationWeeks: number; isManual: boolean }>()
 
   // Pass 1: manual-pinned stories
   for (const story of allStories) {
     if (manualStoryWeeks.has(story.id)) {
       const sw = manualStoryWeeks.get(story.id)!
-      const totalHours = storyTotalHours(story)
-      const dur = Math.max(0.2, totalHours / fallbackHoursPerDay / 5)
+      const dur = Math.max(0.2, storyScheduleHours(story) / fallbackHoursPerDay / 5)
       storyScheduled.set(story.id, { startWeek: sw, durationWeeks: dur, isManual: true })
     }
   }

--- a/server/src/routes/resourceProfile.ts
+++ b/server/src/routes/resourceProfile.ts
@@ -3,7 +3,7 @@ import { ResourceCategory } from '@prisma/client'
 import { prisma } from '../lib/prisma.js'
 import { asyncHandler } from '../lib/asyncHandler.js'
 import { authenticate, AuthRequest } from '../middleware/auth.js'
-import { effectiveDays } from '../utils/round.js'
+import { effortDays } from '../utils/round.js'
 import { buildResourceCapacityProfileMap } from '../lib/capacityProfileResourceAdapter.js'
 import { resolveSchedulerCapacity } from '../lib/schedulerCapacityResolver.js'
 import { deriveProjectPlanningModel } from '../lib/projectPlanningModel.js'
@@ -141,7 +141,7 @@ router.get('/', asyncHandler(async (req: AuthRequest, res: Response) => {
           if (!effectiveHoursPerDay) continue
 
           const hours = task.hoursEffort ?? 0
-          const days = effectiveDays(task.durationDays, hours, effectiveHoursPerDay)
+          const days = effortDays(hours, effectiveHoursPerDay)
           if (!resourceAgg.has(resourceType.id)) {
             resourceAgg.set(resourceType.id, {
               resourceTypeId: resourceType.id,

--- a/server/src/routes/squadPlan.ts
+++ b/server/src/routes/squadPlan.ts
@@ -14,7 +14,7 @@ import { Prisma } from '@prisma/client'
 import { prisma } from '../lib/prisma.js'
 import { asyncHandler } from '../lib/asyncHandler.js'
 import { authenticate, AuthRequest } from '../middleware/auth.js'
-import { effectiveDays } from '../utils/round.js'
+import { effortDays } from '../utils/round.js'
 import { ownedProject } from '../lib/ownership.js'
 import { buildSnapshot } from './snapshots.js'
 import { pruneSnapshots } from '../lib/snapshotUtils.js'
@@ -676,7 +676,7 @@ router.post('/apply', asyncHandler(async (req: AuthRequest, res: Response) => {
             for (const task of story.tasks) {
               if (!task.resourceTypeId) continue
               const rtHpd = task.resourceType?.hoursPerDay ?? hpd
-              const days = effectiveDays(task.durationDays, task.hoursEffort, rtHpd)
+              const days = effortDays(task.hoursEffort, rtHpd)
               demandByRt.set(task.resourceTypeId, (demandByRt.get(task.resourceTypeId) ?? 0) + days)
             }
           }
@@ -695,7 +695,7 @@ router.post('/apply', asyncHandler(async (req: AuthRequest, res: Response) => {
             for (const task of story.tasks) {
               if (!task.resourceTypeId) continue
               const rtHpd = task.resourceType?.hoursPerDay ?? hpd
-              storyDays += effectiveDays(task.durationDays, task.hoursEffort, rtHpd)
+              storyDays += effortDays(task.hoursEffort, rtHpd)
             }
             const proportion = totalFeatureDays > 0 ? storyDays / totalFeatureDays : 0
             const storyDuration = Math.max(1, Math.ceil(span.durationWeeks * proportion))

--- a/server/src/routes/squadPlan.ts
+++ b/server/src/routes/squadPlan.ts
@@ -14,7 +14,7 @@ import { Prisma } from '@prisma/client'
 import { prisma } from '../lib/prisma.js'
 import { asyncHandler } from '../lib/asyncHandler.js'
 import { authenticate, AuthRequest } from '../middleware/auth.js'
-import { effortDays } from '../utils/round.js'
+import { scheduleDurationDays } from '../utils/round.js'
 import { ownedProject } from '../lib/ownership.js'
 import { buildSnapshot } from './snapshots.js'
 import { pruneSnapshots } from '../lib/snapshotUtils.js'
@@ -670,17 +670,7 @@ router.post('/apply', asyncHandler(async (req: AuthRequest, res: Response) => {
             fallbackStartWeek,
           )
 
-          const demandByRt = new Map<string, number>()
           const activeStories = feature.userStories.filter(s => s.isActive !== false)
-          for (const story of activeStories) {
-            for (const task of story.tasks) {
-              if (!task.resourceTypeId) continue
-              const rtHpd = task.resourceType?.hoursPerDay ?? hpd
-              const days = effortDays(task.hoursEffort, rtHpd)
-              demandByRt.set(task.resourceTypeId, (demandByRt.get(task.resourceTypeId) ?? 0) + days)
-            }
-          }
-
           pfFeatureRows.push({
             projectId,
             featureId: feature.id,
@@ -689,15 +679,20 @@ router.post('/apply', asyncHandler(async (req: AuthRequest, res: Response) => {
             isManual: false as const,
           })
 
-          const totalFeatureDays = Array.from(demandByRt.values()).reduce((sum, d) => sum + d, 0)
+          const storyScheduleDays = new Map<string, number>()
           for (const story of activeStories) {
-            let storyDays = 0
+            let days = 0
             for (const task of story.tasks) {
               if (!task.resourceTypeId) continue
               const rtHpd = task.resourceType?.hoursPerDay ?? hpd
-              storyDays += effortDays(task.hoursEffort, rtHpd)
+              days += scheduleDurationDays(task.durationDays, task.hoursEffort, rtHpd)
             }
-            const proportion = totalFeatureDays > 0 ? storyDays / totalFeatureDays : 0
+            storyScheduleDays.set(story.id, days)
+          }
+          const totalStoryScheduleDays = Array.from(storyScheduleDays.values()).reduce((sum, d) => sum + d, 0)
+          for (const story of activeStories) {
+            const storyDays = storyScheduleDays.get(story.id) ?? 0
+            const proportion = totalStoryScheduleDays > 0 ? storyDays / totalStoryScheduleDays : 0
             const storyDuration = Math.max(1, Math.ceil(span.durationWeeks * proportion))
             pfStoryRows.push({
               projectId,

--- a/server/src/test/leveller.test.ts
+++ b/server/src/test/leveller.test.ts
@@ -131,6 +131,23 @@ describe('levelEpicStarts', () => {
     expect(result.totalDeliveryWeeks).toBeCloseTo(1, 8)
     expect(result.featureStartWeeks.get('f1')).toBe(0)
   })
+  it('keeps three explicit same-resource tasks at the longest override', () => {
+    const rt = makeRt('rt1', 'Dev', 2, 7.6)
+    const result = levelEpicStarts(baseInput({
+      project: { hoursPerDay: 7.6 },
+      epics: [makeEpic('e1', [
+        makeFeature('f1', [makeStory('s1', [
+          makeTask(7.6, 'rt1', 'Dev', 7.6, 5),
+          makeTask(7.6, 'rt1', 'Dev', 7.6, 5),
+          makeTask(7.6, 'rt1', 'Dev', 7.6, 5),
+        ])]),
+      ], { featureMode: 'parallel' })],
+      resourceTypes: [rt],
+    }))
+
+    expect(result.totalDeliveryWeeks).toBeCloseTo(1, 8)
+    expect(result.featureStartWeeks.get('f1')).toBe(0)
+  })
 
   it('3 competing epics all needing same RT (count=1) are staggered sequentially', () => {
     // RT count=1: only 5 days/week capacity (1 person × 8hpd × 5days = 40h/wk = 5 days/wk)

--- a/server/src/test/leveller.test.ts
+++ b/server/src/test/leveller.test.ts
@@ -20,11 +20,17 @@ import type {
 // Builder helpers (mirrors scheduler.test.ts pattern)
 // ─────────────────────────────────────────────────────────────────────────────
 
-function makeTask(hoursEffort: number, rtId: string | null = null, rtName = 'Dev', hpd = 8) {
+function makeTask(
+  hoursEffort: number,
+  rtId: string | null = null,
+  rtName = 'Dev',
+  hpd = 8,
+  durationDays: number | null = null,
+) {
   return {
     resourceTypeId: rtId,
     hoursEffort,
-    durationDays: null as null,
+    durationDays,
     resourceType: rtId ? { id: rtId, name: rtName, hoursPerDay: hpd } : null,
   }
 }
@@ -96,6 +102,18 @@ describe('levelEpicStarts', () => {
     expect(result.epicStartWeeks.get('e1')).toBe(0)
     expect(result.featureStartWeeks.get('f1')).toBe(0)
     expect(result.totalDeliveryWeeks).toBeGreaterThan(0)
+  })
+  it('does not divide an explicit duration override by resource headcount', () => {
+    const rt = makeRt('rt1', 'Dev', 2, 7.6)
+    const result = levelEpicStarts(baseInput({
+      project: { hoursPerDay: 7.6 },
+      epics: [makeEpic('e1', [
+        makeFeature('f1', [makeStory('s1', [makeTask(7.6, 'rt1', 'Dev', 7.6, 5)])]),
+      ], { featureMode: 'parallel' })],
+      resourceTypes: [rt],
+    }))
+
+    expect(result.totalDeliveryWeeks).toBeCloseTo(1, 8)
   })
 
   it('3 competing epics all needing same RT (count=1) are staggered sequentially', () => {

--- a/server/src/test/leveller.test.ts
+++ b/server/src/test/leveller.test.ts
@@ -115,6 +115,22 @@ describe('levelEpicStarts', () => {
 
     expect(result.totalDeliveryWeeks).toBeCloseTo(1, 8)
   })
+  it('shares explicit same-resource task durations across available headcount', () => {
+    const rt = makeRt('rt1', 'Dev', 2, 7.6)
+    const result = levelEpicStarts(baseInput({
+      project: { hoursPerDay: 7.6 },
+      epics: [makeEpic('e1', [
+        makeFeature('f1', [makeStory('s1', [
+          makeTask(7.6, 'rt1', 'Dev', 7.6, 5),
+          makeTask(7.6, 'rt1', 'Dev', 7.6, 5),
+        ])]),
+      ], { featureMode: 'parallel' })],
+      resourceTypes: [rt],
+    }))
+
+    expect(result.totalDeliveryWeeks).toBeCloseTo(1, 8)
+    expect(result.featureStartWeeks.get('f1')).toBe(0)
+  })
 
   it('3 competing epics all needing same RT (count=1) are staggered sequentially', () => {
     // RT count=1: only 5 days/week capacity (1 person × 8hpd × 5days = 40h/wk = 5 days/wk)

--- a/server/src/test/projectPlanningModel.test.ts
+++ b/server/src/test/projectPlanningModel.test.ts
@@ -16,6 +16,7 @@ import {
   convertWeeklyDemandCache,
   deriveProjectPlanningModel,
 } from '../lib/projectPlanningModel.js'
+import { deriveNamedResourceAssignments } from '../lib/namedResourceAssignments.js'
 import type { MaterializedCapacityPlanResource } from '../lib/capacityPlanMaterialisation.js'
 import type { SchedulerNamedResource } from '../lib/scheduler.js'
 
@@ -118,7 +119,7 @@ describe('computeResourceBreakdown', () => {
     expect(result).toHaveLength(0)
   })
 
-  it('uses durationDays when provided', () => {
+  it('uses hoursEffort for demand when durationDays is provided', () => {
     const feature = {
       userStories: [
         {
@@ -135,8 +136,60 @@ describe('computeResourceBreakdown', () => {
       ],
     }
     const result = computeResourceBreakdown(feature, 8)
-    // effectiveDays(3, 8, 8) = max(3, 8/8) = 3
-    expect(result[0].days).toBe(3)
+    expect(result[0].days).toBe(1)
+  })
+
+  it('keeps 38 effort hours at five effort-days despite a shorter duration override', () => {
+    const feature = {
+      userStories: [{
+        isActive: true,
+        tasks: [{
+          resourceTypeId: 'rt-dev',
+          hoursEffort: 38,
+          durationDays: 3,
+          resourceType: { name: 'Developer', hoursPerDay: 7.6 },
+        }],
+      }],
+    }
+    expect(computeResourceBreakdown(feature, 7.6)[0].days).toBe(5)
+  })
+
+  it('reconciles fallback weekly demand and named assignments to effort', () => {
+    const feature = {
+      userStories: [{
+        isActive: true,
+        tasks: [{
+          resourceTypeId: 'rt-dev',
+          hoursEffort: 7.6,
+          durationDays: 5,
+          resourceType: { name: 'Developer', hoursPerDay: 7.6 },
+        }],
+      }],
+    }
+    const entries = [{ startWeek: 0, durationWeeks: 1, feature }]
+    const resourceTypes = [{
+      name: 'Developer',
+      id: 'rt-dev',
+      hoursPerDay: 7.6,
+      allocationMode: 'EFFORT',
+      count: 1,
+      namedResources: [{
+        id: 'nr-dev',
+        name: 'Alice',
+        startWeek: null,
+        endWeek: null,
+        allocationPct: 100,
+        allocationMode: 'EFFORT',
+        allocationPercent: 100,
+        allocationStartWeek: null,
+        allocationEndWeek: null,
+      }],
+    }]
+    const weeklyDemand = buildFallbackWeeklyDemand(entries, resourceTypes, new Map(), 7.6)
+    expect(weeklyDemand.reduce((sum, row) => sum + row.demandDays, 0)).toBe(1)
+
+    const assignment = deriveNamedResourceAssignments({ resourceTypes, weeklyDemand }).get('rt-dev')
+    expect(assignment?.actualAllocatedDays).toBe(1)
   })
 
   it('uses fallback hoursPerDay when task resourceType lacks it', () => {

--- a/server/src/test/resourceProfile.test.ts
+++ b/server/src/test/resourceProfile.test.ts
@@ -149,7 +149,7 @@ beforeEach(() => {
 })
 
 describe('GET /api/projects/:projectId/resource-profile', () => {
-  it('uses task.durationDays when provided', async () => {
+  it('uses task.hoursEffort for effort totals when durationDays is provided', async () => {
     vi.mocked(prisma.project.findFirst).mockResolvedValue({
       id: 'proj-1',
       ownerId: userId,
@@ -218,8 +218,8 @@ describe('GET /api/projects/:projectId/resource-profile', () => {
     expect(res.status).toBe(200)
     const devRow = res.body.resourceRows.find((row: any) => row.resourceTypeId === 'rt-dev')
     expect(devRow).toBeTruthy()
-    expect(devRow.effortDays).toBe(3)
-    expect(devRow.totalDays).toBe(3)
+    expect(devRow.effortDays).toBe(1)
+    expect(devRow.totalDays).toBe(1)
   })
 
   it('falls back to active CAPACITY_PLAN periods when persisted named-resource windows are stale', async () => {
@@ -1316,7 +1316,7 @@ describe('GET /api/projects/:projectId/resource-profile', () => {
     // Only active epic's effort should appear
     const devRow = res.body.resourceRows.find((row: any) => row.resourceTypeId === 'rt-dev')
     expect(devRow).toBeTruthy()
-    expect(devRow.effortDays).toBe(5) // effectiveDays(5, 80, 8) = 5 — positive durationDays used directly
+    expect(devRow.effortDays).toBe(10) // 80h / 8hpd; durationDays is elapsed scheduling data only
     expect(devRow.epics).toHaveLength(1)
     expect(devRow.epics[0].epicId).toBe('epic-active')
   })
@@ -3483,7 +3483,7 @@ describe('GET /resource-profile — restored Class A n=0 display (issue #438)', 
     // Demand window W0..W3 (4 weeks): the aggregate 300% ROLE is 3 FTE, so the
     // display shows 4 × 5 × 3 = 60 days — NOT count-scaled (4 × 5 × 3 × 3 = 180).
     expect(devRow.allocatedDays).toBe(60)
-    expect(devRow.effortDays).toBe(3)
+    expect(devRow.effortDays).toBe(1) // 8h / 8hpd; durationDays does not change effort
     // The projected legacy shape is the availability-window (TIMELINE) mode
     // with the aggregate percent; the restored profile is surfaced faithfully.
     expect(devRow.allocationMode).toBe('TIMELINE')

--- a/server/src/test/scheduler.test.ts
+++ b/server/src/test/scheduler.test.ts
@@ -872,7 +872,7 @@ describe('runScheduler', () => {
     const totalDays = [...result.weeklyConsumptionMap.values()].reduce((sum, days) => sum + days, 0)
     const featureEntry = result.featureSchedule.find(entry => entry.featureId === 'f1')!
     expect(totalDays).toBeCloseTo(5, 8)
-    expect(featureEntry.durationWeeks).toBeGreaterThanOrEqual(1)
+    expect(featureEntry.durationWeeks).toBeCloseTo(1, 8)
   })
 
   it('does not inflate pinned story or manual feature demand from duration overrides', () => {

--- a/server/src/test/scheduler.test.ts
+++ b/server/src/test/scheduler.test.ts
@@ -844,6 +844,20 @@ describe('runScheduler', () => {
     expect(totalDays).toBeCloseTo(1, 8)
     expect(result.featureSchedule.find(entry => entry.featureId === 'f1')?.durationWeeks).toBeCloseTo(1, 8)
   })
+  it('does not divide an explicit duration override by resource headcount', () => {
+    const rt = makeRt('rt1', 'Dev', 2, 7.6)
+    const feature = makeFeature('f1', [makeStory('s1', [makeTask(7.6, 'rt1', 'Dev', 7.6, 5)])])
+    const result = runScheduler(baseInput({
+      project: { hoursPerDay: 7.6 },
+      epics: [makeEpic('e1', [feature])],
+      resourceTypes: [rt],
+      resourceLevel: true,
+    }))
+
+    const totalDays = [...result.weeklyConsumptionMap.values()].reduce((sum, days) => sum + days, 0)
+    expect(totalDays).toBeCloseTo(1, 8)
+    expect(result.featureSchedule.find(entry => entry.featureId === 'f1')?.durationWeeks).toBeCloseTo(1, 8)
+  })
 
   it('resource levelling consumes 38 effort hours despite a three-day override', () => {
     const rt = makeRt('rt1', 'Dev', 1, 7.6)

--- a/server/src/test/scheduler.test.ts
+++ b/server/src/test/scheduler.test.ts
@@ -25,11 +25,17 @@ import { deriveSlotSegments } from '../routes/squadPlan.js'
 // Helpers to build minimal input objects
 // ─────────────────────────────────────────────────────────────────────────────
 
-function makeTask(hoursEffort: number, rtId: string | null = null, rtName = 'Dev', hpd = 8) {
+function makeTask(
+  hoursEffort: number,
+  rtId: string | null = null,
+  rtName = 'Dev',
+  hpd = 8,
+  durationDays: number | null = null,
+) {
   return {
     resourceTypeId: rtId,
     hoursEffort,
-    durationDays: null as null,
+    durationDays,
     resourceType: rtId ? { id: rtId, name: rtName, hoursPerDay: hpd } : null,
   }
 }
@@ -823,6 +829,62 @@ describe('runScheduler', () => {
     expect(result.weeklyConsumptionMap.size).toBeGreaterThan(0)
     const totalDays = [...result.weeklyConsumptionMap.values()].reduce((a, b) => a + b, 0)
     expect(totalDays).toBeCloseTo(5, 0)  // 40h / 8hpd = 5 days
+  })
+  it('paces a longer duration without inflating levelled effort demand', () => {
+    const rt = makeRt('rt1', 'Dev', 1, 7.6)
+    const feature = makeFeature('f1', [makeStory('s1', [makeTask(7.6, 'rt1', 'Dev', 7.6, 5)])])
+    const result = runScheduler(baseInput({
+      project: { hoursPerDay: 7.6 },
+      epics: [makeEpic('e1', [feature])],
+      resourceTypes: [rt],
+      resourceLevel: true,
+    }))
+
+    const totalDays = [...result.weeklyConsumptionMap.values()].reduce((sum, days) => sum + days, 0)
+    expect(totalDays).toBeCloseTo(1, 8)
+    expect(result.featureSchedule.find(entry => entry.featureId === 'f1')?.durationWeeks).toBeCloseTo(1, 8)
+  })
+
+  it('resource levelling consumes 38 effort hours despite a three-day override', () => {
+    const rt = makeRt('rt1', 'Dev', 1, 7.6)
+    const feature = makeFeature('f1', [makeStory('s1', [makeTask(38, 'rt1', 'Dev', 7.6, 3)])])
+    const result = runScheduler(baseInput({
+      project: { hoursPerDay: 7.6 },
+      epics: [makeEpic('e1', [feature])],
+      resourceTypes: [rt],
+      resourceLevel: true,
+    }))
+
+    const totalDays = [...result.weeklyConsumptionMap.values()].reduce((sum, days) => sum + days, 0)
+    const featureEntry = result.featureSchedule.find(entry => entry.featureId === 'f1')!
+    expect(totalDays).toBeCloseTo(5, 8)
+    expect(featureEntry.durationWeeks).toBeGreaterThanOrEqual(1)
+  })
+
+  it('does not inflate pinned story or manual feature demand from duration overrides', () => {
+    const rt = makeRt('rt1', 'Dev', 1, 7.6)
+    const pinnedStory = makeStory('s-pinned', [makeTask(7.6, 'rt1', 'Dev', 7.6, 5)])
+    const pinnedResult = runScheduler(baseInput({
+      project: { hoursPerDay: 7.6 },
+      epics: [makeEpic('e-pinned', [makeFeature('f-pinned', [pinnedStory])])],
+      resourceTypes: [rt],
+      manualStoryEntries: [{ storyId: 's-pinned', startWeek: 0 }],
+      resourceLevel: true,
+    }))
+    const pinnedDays = [...pinnedResult.weeklyConsumptionMap.values()].reduce((sum, days) => sum + days, 0)
+    expect(pinnedDays).toBeCloseTo(1, 8)
+    expect(pinnedResult.storySchedule.find(entry => entry.storyId === 's-pinned')?.durationWeeks).toBeCloseTo(1, 8)
+
+    const manualResult = runScheduler(baseInput({
+      project: { hoursPerDay: 7.6 },
+      epics: [makeEpic('e-manual', [makeFeature('f-manual', [makeStory('s-manual', [makeTask(7.6, 'rt1', 'Dev', 7.6, 5)])])])],
+      resourceTypes: [rt],
+      manualFeatureEntries: [{ featureId: 'f-manual', startWeek: 0, durationWeeks: 4 }],
+      resourceLevel: true,
+    }))
+    const manualDays = [...manualResult.weeklyConsumptionMap.values()].reduce((sum, days) => sum + days, 0)
+    expect(manualDays).toBeCloseTo(1, 8)
+    expect(manualResult.featureSchedule.find(entry => entry.featureId === 'f-manual')?.durationWeeks).toBe(4)
   })
 
   it('resourceLevel=true: small feature finishes promptly regardless of feature iteration order', () => {

--- a/server/src/test/scheduler.test.ts
+++ b/server/src/test/scheduler.test.ts
@@ -877,6 +877,46 @@ describe('runScheduler', () => {
     expect(totalDays * 7.6).toBeCloseTo(15.2, 8)
     expect(featureEntry.durationWeeks).toBeCloseTo(1, 8)
   })
+  it('keeps three explicit same-resource tasks within the longest override', () => {
+    const rt = makeRt('rt1', 'Dev', 2, 7.6)
+    const feature = makeFeature('f1', [makeStory('s1', [
+      makeTask(7.6, 'rt1', 'Dev', 7.6, 5),
+      makeTask(7.6, 'rt1', 'Dev', 7.6, 5),
+      makeTask(7.6, 'rt1', 'Dev', 7.6, 5),
+    ])])
+    const result = runScheduler(baseInput({
+      project: { hoursPerDay: 7.6 },
+      epics: [makeEpic('e1', [feature])],
+      resourceTypes: [rt],
+      resourceLevel: true,
+    }))
+
+    const totalDays = [...result.weeklyConsumptionMap.values()].reduce((sum, days) => sum + days, 0)
+    const featureEntry = result.featureSchedule.find(entry => entry.featureId === 'f1')!
+    expect(totalDays).toBeCloseTo(3, 8)
+    expect(totalDays * 7.6).toBeCloseTo(22.8, 8)
+    expect(featureEntry.durationWeeks).toBeCloseTo(1, 8)
+  })
+
+  it('keeps three explicit tasks within five days at single-resource capacity', () => {
+    const rt = makeRt('rt1', 'Dev', 1, 7.6)
+    const feature = makeFeature('f1', [makeStory('s1', [
+      makeTask(7.6, 'rt1', 'Dev', 7.6, 5),
+      makeTask(7.6, 'rt1', 'Dev', 7.6, 5),
+      makeTask(7.6, 'rt1', 'Dev', 7.6, 5),
+    ])])
+    const result = runScheduler(baseInput({
+      project: { hoursPerDay: 7.6 },
+      epics: [makeEpic('e1', [feature])],
+      resourceTypes: [rt],
+      resourceLevel: true,
+    }))
+
+    const totalDays = [...result.weeklyConsumptionMap.values()].reduce((sum, days) => sum + days, 0)
+    const featureEntry = result.featureSchedule.find(entry => entry.featureId === 'f1')!
+    expect(totalDays).toBeCloseTo(3, 8)
+    expect(featureEntry.durationWeeks).toBeCloseTo(1, 8)
+  })
 
   it('resource levelling consumes 38 effort hours despite a three-day override', () => {
     const rt = makeRt('rt1', 'Dev', 1, 7.6)

--- a/server/src/test/scheduler.test.ts
+++ b/server/src/test/scheduler.test.ts
@@ -858,6 +858,25 @@ describe('runScheduler', () => {
     expect(totalDays).toBeCloseTo(1, 8)
     expect(result.featureSchedule.find(entry => entry.featureId === 'f1')?.durationWeeks).toBeCloseTo(1, 8)
   })
+  it('shares explicit same-resource task durations across available headcount', () => {
+    const rt = makeRt('rt1', 'Dev', 2, 7.6)
+    const feature = makeFeature('f1', [makeStory('s1', [
+      makeTask(7.6, 'rt1', 'Dev', 7.6, 5),
+      makeTask(7.6, 'rt1', 'Dev', 7.6, 5),
+    ])])
+    const result = runScheduler(baseInput({
+      project: { hoursPerDay: 7.6 },
+      epics: [makeEpic('e1', [feature])],
+      resourceTypes: [rt],
+      resourceLevel: true,
+    }))
+
+    const totalDays = [...result.weeklyConsumptionMap.values()].reduce((sum, days) => sum + days, 0)
+    const featureEntry = result.featureSchedule.find(entry => entry.featureId === 'f1')!
+    expect(totalDays).toBeCloseTo(2, 8)
+    expect(totalDays * 7.6).toBeCloseTo(15.2, 8)
+    expect(featureEntry.durationWeeks).toBeCloseTo(1, 8)
+  })
 
   it('resource levelling consumes 38 effort hours despite a three-day override', () => {
     const rt = makeRt('rt1', 'Dev', 1, 7.6)

--- a/server/src/test/squadPlan.test.ts
+++ b/server/src/test/squadPlan.test.ts
@@ -337,7 +337,7 @@ function mockCapacityProfilesForApply(rtId = 'rt-dev', namedResourceIds: string[
   }) as any)
 }
 
-  it('refreshes weeklyDemandCache from the applied planner output', async () => {
+  it('refreshes demand from effort and preserves duration-weighted story spans', async () => {
     vi.mocked(prisma.project.findFirst).mockResolvedValue(mockProject as never)
     mockCapacityProfilesForApply()
     vi.mocked(prisma.capacityPlan.findFirst).mockResolvedValue(null as never)
@@ -390,7 +390,22 @@ function mockCapacityProfilesForApply(rtId = 'rt-dev', namedResourceIds: string[
                   {
                     id: 'task-1',
                     resourceTypeId: 'rt-dev',
-                    hoursEffort: 16,
+                    hoursEffort: 80,
+                    durationDays: 20,
+                    resourceType: { id: 'rt-dev', name: 'Developer', hoursPerDay: 8 },
+                  },
+                ],
+                dependencies: [],
+              },
+              {
+                id: 'story-2',
+                order: 1,
+                isActive: true,
+                tasks: [
+                  {
+                    id: 'task-2',
+                    resourceTypeId: 'rt-dev',
+                    hoursEffort: 80,
                     durationDays: null,
                     resourceType: { id: 'rt-dev', name: 'Developer', hoursPerDay: 8 },
                   },
@@ -479,10 +494,16 @@ function mockCapacityProfilesForApply(rtId = 'rt-dev', namedResourceIds: string[
       })
 
     expect(res.status).toBe(201)
-    expect(capturedTx.project.update).toHaveBeenCalledWith({
-      where: { id: 'proj-1' },
-      data: { weeklyDemandCache: { 'rt-dev|0': 2 } },
-    })
+    const projectUpdateArg = capturedTx.project.update.mock.calls.at(-1)?.[0]
+    const weeklyDemandCache = projectUpdateArg?.data?.weeklyDemandCache as Record<string, number>
+    expect(Object.values(weeklyDemandCache).reduce((sum, days) => sum + days, 0)).toBeCloseTo(20, 6)
+    expect(weeklyDemandCache['rt-dev|0']).toBeCloseTo(5, 6)
+
+    const storyRows = capturedTx.storyTimelineEntry.createMany.mock.calls.at(-1)?.[0]?.data
+    expect(storyRows).toEqual(expect.arrayContaining([
+      expect.objectContaining({ storyId: 'story-1', durationWeeks: 3 }),
+      expect.objectContaining({ storyId: 'story-2', durationWeeks: 2 }),
+    ]))
   })
 
   it('replays applied reduced-period capacity into weeklyDemandCache', async () => {

--- a/server/src/utils/round.ts
+++ b/server/src/utils/round.ts
@@ -17,15 +17,33 @@ export const scheduleDurationDays = (
 ): number =>
   durationDays && durationDays > 0 ? durationDays : effortDays(hoursEffort, hoursPerDay)
 
-/** Calculate elapsed task days, preserving overrides while meeting effort capacity. */
+/** Calculate elapsed days for tasks sharing one resource type. */
 export const scheduleDurationDaysAtCount = (
-  durationDays: number | null | undefined,
-  hoursEffort: number,
-  hoursPerDay: number,
+  tasks: ReadonlyArray<{
+    durationDays: number | null | undefined
+    hoursEffort: number
+    resourceType?: { hoursPerDay?: number | null } | null
+  }>,
+  fallbackHoursPerDay: number,
   resourceCount: number,
 ): number => {
-  const effortDurationDays = effortDays(hoursEffort, hoursPerDay) / Math.max(1, resourceCount)
-  return durationDays && durationDays > 0
-    ? Math.max(durationDays, effortDurationDays)
-    : effortDurationDays
+  const count = Math.max(1, resourceCount)
+  let totalEffortDays = 0
+  let totalScheduleDays = 0
+  let explicitDurationFloor = 0
+
+  for (const task of tasks) {
+    const hoursPerDay = task.resourceType?.hoursPerDay ?? fallbackHoursPerDay
+    totalEffortDays += effortDays(task.hoursEffort, hoursPerDay)
+    totalScheduleDays += scheduleDurationDays(task.durationDays, task.hoursEffort, hoursPerDay)
+    if (task.durationDays && task.durationDays > explicitDurationFloor) {
+      explicitDurationFloor = task.durationDays
+    }
+  }
+
+  return Math.max(
+    totalEffortDays / count,
+    totalScheduleDays / count,
+    explicitDurationFloor,
+  )
 }

--- a/server/src/utils/round.ts
+++ b/server/src/utils/round.ts
@@ -16,3 +16,14 @@ export const scheduleDurationDays = (
   hoursPerDay: number,
 ): number =>
   durationDays && durationDays > 0 ? durationDays : effortDays(hoursEffort, hoursPerDay)
+
+/** Calculate elapsed task days without dividing an explicit duration override by headcount. */
+export const scheduleDurationDaysAtCount = (
+  durationDays: number | null | undefined,
+  hoursEffort: number,
+  hoursPerDay: number,
+  resourceCount: number,
+): number =>
+  durationDays && durationDays > 0
+    ? durationDays
+    : effortDays(hoursEffort, hoursPerDay) / Math.max(1, resourceCount)

--- a/server/src/utils/round.ts
+++ b/server/src/utils/round.ts
@@ -17,13 +17,15 @@ export const scheduleDurationDays = (
 ): number =>
   durationDays && durationDays > 0 ? durationDays : effortDays(hoursEffort, hoursPerDay)
 
-/** Calculate elapsed task days without dividing an explicit duration override by headcount. */
+/** Calculate elapsed task days, preserving overrides while meeting effort capacity. */
 export const scheduleDurationDaysAtCount = (
   durationDays: number | null | undefined,
   hoursEffort: number,
   hoursPerDay: number,
   resourceCount: number,
-): number =>
-  durationDays && durationDays > 0
-    ? durationDays
-    : effortDays(hoursEffort, hoursPerDay) / Math.max(1, resourceCount)
+): number => {
+  const effortDurationDays = effortDays(hoursEffort, hoursPerDay) / Math.max(1, resourceCount)
+  return durationDays && durationDays > 0
+    ? Math.max(durationDays, effortDurationDays)
+    : effortDurationDays
+}

--- a/server/src/utils/round.ts
+++ b/server/src/utils/round.ts
@@ -29,21 +29,15 @@ export const scheduleDurationDaysAtCount = (
 ): number => {
   const count = Math.max(1, resourceCount)
   let totalEffortDays = 0
-  let totalScheduleDays = 0
   let explicitDurationFloor = 0
 
   for (const task of tasks) {
     const hoursPerDay = task.resourceType?.hoursPerDay ?? fallbackHoursPerDay
     totalEffortDays += effortDays(task.hoursEffort, hoursPerDay)
-    totalScheduleDays += scheduleDurationDays(task.durationDays, task.hoursEffort, hoursPerDay)
     if (task.durationDays && task.durationDays > explicitDurationFloor) {
       explicitDurationFloor = task.durationDays
     }
   }
 
-  return Math.max(
-    totalEffortDays / count,
-    totalScheduleDays / count,
-    explicitDurationFloor,
-  )
+  return Math.max(totalEffortDays / count, explicitDurationFloor)
 }

--- a/server/src/utils/round.ts
+++ b/server/src/utils/round.ts
@@ -5,14 +5,14 @@ export const round2 = (n: number): number => Math.round(n * 100) / 100
 export const calcDurationDays = (hoursEffort: number, hoursPerDay: number): number =>
   round2(hoursEffort / hoursPerDay)
 
-/**
- * Get effective days for demand calculation.
- * Falls through to hours/hpd when durationDays is null, undefined, 0, negative, or NaN.
- * This provides defensive hardening against invalid persisted data.
- */
-export const effectiveDays = (
+/** Calculate authoritative delivery effort in person-days. */
+export const effortDays = (hoursEffort: number, hoursPerDay: number): number =>
+  hoursEffort / hoursPerDay
+
+/** Calculate elapsed scheduling duration, honouring a positive task override. */
+export const scheduleDurationDays = (
   durationDays: number | null | undefined,
   hoursEffort: number,
   hoursPerDay: number,
 ): number =>
-  durationDays && durationDays > 0 ? durationDays : (hoursEffort / hoursPerDay)
+  durationDays && durationDays > 0 ? durationDays : effortDays(hoursEffort, hoursPerDay)


### PR DESCRIPTION
## Summary

Fix #462 by separating authoritative task effort from elapsed task duration. This remediation removes the remaining grouped-duration defect from the current head `4d981dded02eb16da750e16f277fed48e3097c4b`.

## Related issue

Closes #462

## Root cause

`scheduleDurationDaysAtCount()` summed each task's explicit elapsed duration before dividing by headcount. Three one-effort-day tasks with five-day overrides and count 2 therefore produced 7.5 elapsed days, incorrectly treating elapsed overrides as capacity demand.

## Implementation

- Kept `effortDays(hoursEffort, hoursPerDay)` as the authoritative demand calculation.
- Changed grouped elapsed duration to `max(sum(effortDays) / usableCount, max(positive durationDays))`.
- Removed the explicit-duration sum from the capacity floor.
- Applied the group-level helper in both scheduler and leveller raw-duration paths.
- Added scheduler and leveller three-task regressions.
- Preserved pinned/manual demand, resource levelling, planning-model, Resource Profile, SA planner, parallel warning, Squad Planner span, and existing sequential scheduling behavior.
- No schema or migration changes.

## Exact grouped-duration semantics

For each resource-type group:

```text
groupEffortCapacityDays = sum(effortDays(task)) / max(1, resourceCount)
explicitDurationFloor = max(positive task.durationDays)
groupElapsedDays = max(groupEffortCapacityDays, explicitDurationFloor)
```

Thus three one-effort-day tasks with five-day overrides and count 2 occupy five elapsed days while consuming three effort-days; explicit durations are never summed into person-capacity demand. A 20-effort-day group with count 2 and a three-day override still requires at least 10 elapsed days.

## Tests and validation

- Focused command `npm exec --workspace=server vitest run src/test/scheduler.test.ts src/test/leveller.test.ts src/test/squadPlan.test.ts`: 3 files passed; 120 tests passed.
- Affected server suites: 6 files passed; 209 tests passed.
- `npm run validate`: passed; server 62 files passed / 18 skipped, 1,427 tests passed / 293 skipped; client 26 files passed, 365 tests passed. Lint emitted existing warnings and no errors.
- CI for `84e361be2726b74294f659fca67387b48a344531`: all six jobs passed, including Playwright E2E, Docker-first integration, backup regression, and Ubuntu/macOS/Windows lifecycle.

## Production-project validation

The exact project `CUT LAB3-COL-6641-Coles - Automation - Security Alerts` remains unavailable. The isolated worktree has no `server/.env` and no `DATABASE_URL`; no unverified database was accessed or modified. Equivalent fixtures verify the required demand totals, grouped elapsed spans, levelling, pinned/manual paths, planning reconciliation, and named-resource assignments. The real-data Update timeline check remains outstanding outside this environment; expected totals are Coles Staff Member 19.0d, Principal Consultant - Security 8.25d, Principal Engineer - Cloud & DevOps 18.95d, Senior Engineer - Security 9.0d, total 55.2d.

## Files changed by this remediation

- `server/src/utils/round.ts`
- `server/src/test/scheduler.test.ts`
- `server/src/test/leveller.test.ts`

The complete PR also contains the previously accepted #462 changes in the existing 14-file diff.

## Final commit

`84e361be2726b74294f659fca67387b48a344531` (`fix(#462): ignore explicit durations in capacity floor`)

## Review control

- Draft PR; auto-merge is not enabled.
- Do not merge — wait for review.