### PR TITLE
fix(#463): refresh feature names in generated documents

### DIFF
--- a/client/src/components/backlog/FeatureList.tsx
+++ b/client/src/components/backlog/FeatureList.tsx
@@ -6,7 +6,7 @@ import { CSS } from '@dnd-kit/utilities'
 import { api, apiErrorMessage, duplicateBacklogItem } from '../../lib/api'
 import type { Feature, ResourceType } from '../../types/backlog'
 import type { EpicColour } from '../../lib/epicColours'
-import { invalidateProjectAll } from '../../lib/projectInvalidation'
+import { invalidateProjectAll, invalidateProjectDocumentData } from '../../lib/projectInvalidation'
 import StoryList from './StoryList'
 import ApplyTemplateModal from './ApplyTemplateModal'
 import RichTextEditor from '../shared/RichTextEditor'
@@ -163,10 +163,13 @@ export default function FeatureList({ epicId, features, resourceTypes, projectId
 
   const { setNodeRef } = useDroppable({ id: 'epic-container-' + epicId })
 
-  const invalidate = () => qc.invalidateQueries({ queryKey: ['backlog', projectId] })
+  const invalidate = () => {
+    qc.invalidateQueries({ queryKey: ['backlog', projectId] })
+    invalidateProjectDocumentData(qc, projectId)
+  }
   const invalidateDuplicate = () => {
     invalidateProjectAll(qc, projectId)
-    qc.invalidateQueries({ queryKey: ['backlog', projectId] })
+    invalidate()
   }
   const [duplicateError, setDuplicateError] = useState<string | null>(null)
 

--- a/client/src/lib/projectInvalidation.ts
+++ b/client/src/lib/projectInvalidation.ts
@@ -18,6 +18,22 @@ export function invalidateProjectPlanning(
   queryClient.invalidateQueries({ queryKey: ['timeline', projectId] })
   queryClient.invalidateQueries({ queryKey: ['resource-profile', projectId] })
 }
+/**
+ * Invalidate every query used to assemble a newly generated document.
+ *
+ * These payload inputs include feature names, so metadata changes must not
+ * leave a document page with a still-fresh cached representation.
+ */
+export function invalidateProjectDocumentData(
+  queryClient: QueryInvalidator,
+  projectId: string | undefined,
+) {
+  if (!projectId) return
+  queryClient.invalidateQueries({ queryKey: ['effort', projectId] })
+  queryClient.invalidateQueries({ queryKey: ['timeline', projectId] })
+  queryClient.invalidateQueries({ queryKey: ['resource-profile', projectId] })
+  queryClient.invalidateQueries({ queryKey: ['epics', projectId] })
+}
 
 /**
  * Invalidate query keys consumed by the Resource Profile domain.

--- a/client/src/pages/BacklogPage.tsx
+++ b/client/src/pages/BacklogPage.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from 'react'
 import DOMPurify from 'dompurify'
 import { useParams, useNavigate } from 'react-router-dom'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { invalidateProjectAll } from '../lib/projectInvalidation'
+import { invalidateProjectAll, invalidateProjectDocumentData } from '../lib/projectInvalidation'
 import {
   DndContext, DragOverlay, closestCorners, PointerSensor, useSensor, useSensors,
   type DragStartEvent, type DragOverEvent, type DragEndEvent,
@@ -70,15 +70,17 @@ export default function BacklogPage() {
   // Full invalidation: for mutations that affect effort/hours/active-status
   const invalidate = () => {
     invalidateProjectAll(qc, projectId)
+    invalidateProjectDocumentData(qc, projectId)
     qc.invalidateQueries({ queryKey: ['backlog', projectId] })
     qc.invalidateQueries({ queryKey: ['epicDeps', projectId] })
     qc.invalidateQueries({ queryKey: ['feature-deps', projectId] })
   }
 
-  // Backlog-only invalidation: for metadata-only mutations (name, description, assumptions)
-  // that cannot affect timeline scheduling or resource demand
+  // Metadata-only mutations do not affect planning, but document payloads
+  // include hierarchy names and assumptions from these queries.
   const invalidateBacklog = () => {
     qc.invalidateQueries({ queryKey: ['backlog', projectId] })
+    invalidateProjectDocumentData(qc, projectId)
   }
 
   const createEpic = useMutation({

--- a/client/src/test/projectInvalidation.test.ts
+++ b/client/src/test/projectInvalidation.test.ts
@@ -4,6 +4,7 @@ import {
   invalidateProjectResourceProfile,
   invalidateProjectCommercial,
   invalidateProjectAll,
+  invalidateProjectDocumentData,
 } from '@/lib/projectInvalidation'
 
 describe('projectInvalidation', () => {
@@ -23,6 +24,28 @@ describe('projectInvalidation', () => {
       const invalidateQueries = vi.fn()
 
       invalidateProjectPlanning({ invalidateQueries } as never, undefined)
+
+      expect(invalidateQueries).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('invalidateProjectDocumentData', () => {
+    it('invalidates every query used by document generation', () => {
+      const invalidateQueries = vi.fn()
+
+      invalidateProjectDocumentData({ invalidateQueries } as never, 'project-1')
+
+      expect(invalidateQueries).toHaveBeenCalledTimes(4)
+      expect(invalidateQueries).toHaveBeenNthCalledWith(1, { queryKey: ['effort', 'project-1'] })
+      expect(invalidateQueries).toHaveBeenNthCalledWith(2, { queryKey: ['timeline', 'project-1'] })
+      expect(invalidateQueries).toHaveBeenNthCalledWith(3, { queryKey: ['resource-profile', 'project-1'] })
+      expect(invalidateQueries).toHaveBeenNthCalledWith(4, { queryKey: ['epics', 'project-1'] })
+    })
+
+    it('does nothing when projectId is undefined', () => {
+      const invalidateQueries = vi.fn()
+
+      invalidateProjectDocumentData({ invalidateQueries } as never, undefined)
 
       expect(invalidateQueries).not.toHaveBeenCalled()
     })

--- a/server/src/routes/documents.ts
+++ b/server/src/routes/documents.ts
@@ -52,8 +52,21 @@ router.post('/generate', asyncHandler(async (req: AuthRequest, res: Response) =>
     res.status(400).json({ error: 'Invalid format' }); return
   }
 
+  // Resolve hierarchy names from persistence at generation time rather than
+  // trusting a potentially stale Documents-page query cache.
+  const currentEpics = await prisma.epic.findMany({
+    where: { projectId },
+    orderBy: { order: 'asc' },
+    include: {
+      features: {
+        orderBy: { order: 'asc' },
+        include: { userStories: { orderBy: { order: 'asc' } } },
+      },
+    },
+  })
+
   // Render HTML and generate PDF
-  const html = renderScopeDocumentHtml({ ...documentData, tz })
+  const html = renderScopeDocumentHtml({ ...documentData, epics: currentEpics, tz })
   const buffer = await generatePdfFromHtml(html)
 
   // Ensure output directory exists

--- a/server/src/routes/documents.ts
+++ b/server/src/routes/documents.ts
@@ -33,6 +33,57 @@ function formatExportTimestamp(tz?: string): string {
   }
 }
 
+type CurrentEpic = {
+  id: string
+  name: string
+  features: Array<{ id: string; name: string }>
+}
+
+type DocumentEntry = Record<string, unknown> & {
+  epicId?: string
+  epicName?: string
+  featureId?: string
+  featureName?: string
+  features?: DocumentEntry[]
+}
+
+type DocumentData = Record<string, unknown> & {
+  timelineData?: Record<string, unknown> & { entries?: DocumentEntry[] }
+  resourceProfileData?: Record<string, unknown> & {
+    resourceRows?: Array<Record<string, unknown> & { epics?: DocumentEntry[] }>
+  }
+}
+
+function canonicalizeDocumentHierarchyNames(documentData: DocumentData, currentEpics: CurrentEpic[]): DocumentData {
+  const epicNames = new Map(currentEpics.map(epic => [epic.id, epic.name]))
+  const featureNames = new Map(currentEpics.flatMap(epic => epic.features.map(feature => [feature.id, feature.name] as const)))
+
+  const withCurrentNames = (entry: DocumentEntry): DocumentEntry => {
+    const canonicalEntry = { ...entry }
+    if (entry.epicId && epicNames.has(entry.epicId)) canonicalEntry.epicName = epicNames.get(entry.epicId)
+    if (entry.featureId && featureNames.has(entry.featureId)) canonicalEntry.featureName = featureNames.get(entry.featureId)
+    return canonicalEntry
+  }
+
+  const timelineData = documentData.timelineData?.entries
+    ? { ...documentData.timelineData, entries: documentData.timelineData.entries.map(withCurrentNames) }
+    : documentData.timelineData
+  const resourceProfileData = documentData.resourceProfileData?.resourceRows
+    ? {
+        ...documentData.resourceProfileData,
+        resourceRows: documentData.resourceProfileData.resourceRows.map(row => ({
+          ...row,
+          epics: row.epics?.map(epic => ({
+            ...withCurrentNames(epic),
+            features: epic.features?.map(withCurrentNames),
+          })),
+        })),
+      }
+    : documentData.resourceProfileData
+
+  return { ...documentData, timelineData, resourceProfileData }
+}
+
 // POST /api/projects/:projectId/documents/generate
 // Body: { type: string, format: string, label: string, tz?: string, documentData: ScopeDocumentProps }
 // Server renders HTML via React renderToStaticMarkup, then generates PDF via Puppeteer.
@@ -66,7 +117,8 @@ router.post('/generate', asyncHandler(async (req: AuthRequest, res: Response) =>
   })
 
   // Render HTML and generate PDF
-  const html = renderScopeDocumentHtml({ ...documentData, epics: currentEpics, tz })
+  const canonicalDocumentData = canonicalizeDocumentHierarchyNames(documentData, currentEpics)
+  const html = renderScopeDocumentHtml({ ...canonicalDocumentData, epics: currentEpics, tz } as unknown as Parameters<typeof renderScopeDocumentHtml>[0])
   const buffer = await generatePdfFromHtml(html)
 
   // Ensure output directory exists

--- a/server/src/test/documents.test.ts
+++ b/server/src/test/documents.test.ts
@@ -93,6 +93,100 @@ describe('POST /api/projects/:projectId/documents/generate', () => {
     expect(rendered.epics[0].isActive).toBe(isActive)
     expect(rendered.epics[0].features[0].name).toBe('Renamed Feature')
   })
+  it('canonicalizes stale hierarchy names in derived document data without changing values', async () => {
+    const currentEpics = [{
+      id: 'epic-1',
+      name: 'Renamed Epic',
+      isActive: true,
+      features: [{ id: 'feature-1', name: 'Renamed Feature', isActive: true, userStories: [] }],
+    }]
+    const timelineEntry = {
+      featureId: 'feature-1',
+      featureName: 'Old Feature',
+      epicId: 'epic-1',
+      epicName: 'Old Epic',
+      epicOrder: 0,
+      featureOrder: 0,
+      startWeek: 2,
+      durationWeeks: 3,
+      startDate: '2025-01-15T00:00:00.000Z',
+      endDate: '2025-02-05T00:00:00.000Z',
+      timelineColour: '#3b82f6',
+    }
+    const resourceFeature = {
+      featureId: 'feature-1',
+      featureName: 'Old Feature',
+      hours: 8,
+      days: 1,
+      stories: [{ storyId: 'story-1', storyName: 'Story', hours: 8, days: 1 }],
+    }
+    const resourceEpic = {
+      epicId: 'epic-1',
+      epicName: 'Old Epic',
+      hours: 8,
+      days: 1,
+      features: [resourceFeature],
+    }
+    const resourceRow = {
+      resourceTypeId: 'rt-1',
+      name: 'Developer',
+      category: 'Engineering',
+      totalHours: 8,
+      totalDays: 1,
+      epics: [resourceEpic],
+      namedResources: [],
+    }
+
+    vi.mocked(prisma.project.findFirst).mockResolvedValue(mockProject as unknown as Awaited<ReturnType<typeof prisma.project.findFirst>>)
+    vi.mocked(prisma.epic.findMany).mockResolvedValue(currentEpics as unknown as Awaited<ReturnType<typeof prisma.epic.findMany>>)
+    vi.mocked(prisma.generatedDocument.create).mockResolvedValue(mockDoc as unknown as Awaited<ReturnType<typeof prisma.generatedDocument.create>>)
+    vi.spyOn(fs, 'mkdirSync').mockImplementation(() => undefined)
+    vi.spyOn(fs, 'writeFileSync').mockReturnValue(undefined)
+    vi.spyOn(fs, 'existsSync').mockReturnValue(false)
+
+    const res = await request(app)
+      .post('/api/projects/proj-1/documents/generate')
+      .set('Authorization', authHeader)
+      .send({
+        ...generateBody,
+        documentData: {
+          ...generateBody.documentData,
+          epics: [{ id: 'epic-1', name: 'Old Epic', isActive: true, features: [{ id: 'feature-1', name: 'Old Feature', isActive: true, userStories: [] }] }],
+          timelineData: {
+            startDate: '2025-01-01',
+            projectedEndDate: '2025-02-05',
+            entries: [timelineEntry],
+            bufferWeeks: 1,
+            onboardingWeeks: 2,
+          },
+          resourceProfileData: {
+            resourceRows: [resourceRow],
+            overheadRows: [],
+            summary: { totalHours: 8, totalDays: 1, hasCost: false },
+          },
+        },
+      })
+
+    expect(res.status).toBe(201)
+    const rendered = vi.mocked(renderScopeDocumentHtml).mock.calls[0][0]
+    expect(rendered.epics[0].name).toBe('Renamed Epic')
+    expect(rendered.epics[0].features[0].name).toBe('Renamed Feature')
+    expect(rendered.timelineData.entries).toEqual([{
+      ...timelineEntry,
+      epicName: 'Renamed Epic',
+      featureName: 'Renamed Feature',
+    }])
+    expect(rendered.resourceProfileData.resourceRows).toEqual([{
+      ...resourceRow,
+      epics: [{
+        ...resourceEpic,
+        epicName: 'Renamed Epic',
+        features: [{ ...resourceFeature, featureName: 'Renamed Feature' }],
+      }],
+    }])
+    expect(JSON.stringify(rendered.timelineData)).not.toContain('Old Feature')
+    expect(JSON.stringify(rendered.resourceProfileData)).not.toContain('Old Feature')
+  })
 
   it('creates a new document without mutating historical generated documents', async () => {
     vi.mocked(prisma.project.findFirst).mockResolvedValue(mockProject as unknown as Awaited<ReturnType<typeof prisma.project.findFirst>>)

--- a/server/src/test/documents.test.ts
+++ b/server/src/test/documents.test.ts
@@ -4,6 +4,7 @@ import jwt from 'jsonwebtoken'
 import fs from 'fs'
 import { app } from '../index.js'
 import { prisma } from '../lib/prisma.js'
+import { renderScopeDocumentHtml } from '../lib/scopeDocumentRenderer.js'
 
 process.env.JWT_SECRET = 'test-secret'
 
@@ -32,7 +33,10 @@ const mockDoc = {
   createdAt: new Date().toISOString(),
 }
 
-beforeEach(() => vi.clearAllMocks())
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.mocked(prisma.epic.findMany).mockResolvedValue([])
+})
 
 describe('POST /api/projects/:projectId/documents/generate', () => {
   it('returns 201 with the created document record on success', async () => {
@@ -52,6 +56,60 @@ describe('POST /api/projects/:projectId/documents/generate', () => {
     expect(res.status).toBe(201)
     expect(res.body.id).toBe('doc-1')
     expect(res.body.label).toBe('Scope Document v1')
+  })
+
+  it.each([true, false])('renders persisted feature names when the parent epic is %s', async (isActive) => {
+    const currentEpics = [{
+      id: 'epic-1',
+      name: 'Epic 1',
+      isActive,
+      features: [{
+        id: 'feature-1',
+        name: 'Renamed Feature',
+        isActive: true,
+        userStories: [],
+      }],
+    }]
+    vi.mocked(prisma.project.findFirst).mockResolvedValue(mockProject as unknown as Awaited<ReturnType<typeof prisma.project.findFirst>>)
+    vi.mocked(prisma.epic.findMany).mockResolvedValue(currentEpics as unknown as Awaited<ReturnType<typeof prisma.epic.findMany>>)
+    vi.mocked(prisma.generatedDocument.create).mockResolvedValue(mockDoc as unknown as Awaited<ReturnType<typeof prisma.generatedDocument.create>>)
+    vi.spyOn(fs, 'mkdirSync').mockImplementation(() => undefined)
+    vi.spyOn(fs, 'writeFileSync').mockReturnValue(undefined)
+    vi.spyOn(fs, 'existsSync').mockReturnValue(false)
+
+    const res = await request(app)
+      .post('/api/projects/proj-1/documents/generate')
+      .set('Authorization', authHeader)
+      .send({
+        ...generateBody,
+        documentData: {
+          ...generateBody.documentData,
+          epics: [{ id: 'epic-1', name: 'Epic 1', isActive, features: [{ id: 'feature-1', name: 'Old Feature', isActive: true, userStories: [] }] }],
+        },
+      })
+
+    expect(res.status).toBe(201)
+    const rendered = vi.mocked(renderScopeDocumentHtml).mock.calls[0][0]
+    expect(rendered.epics[0].isActive).toBe(isActive)
+    expect(rendered.epics[0].features[0].name).toBe('Renamed Feature')
+  })
+
+  it('creates a new document without mutating historical generated documents', async () => {
+    vi.mocked(prisma.project.findFirst).mockResolvedValue(mockProject as unknown as Awaited<ReturnType<typeof prisma.project.findFirst>>)
+    vi.mocked(prisma.generatedDocument.create).mockResolvedValue(mockDoc as unknown as Awaited<ReturnType<typeof prisma.generatedDocument.create>>)
+    vi.spyOn(fs, 'mkdirSync').mockImplementation(() => undefined)
+    vi.spyOn(fs, 'writeFileSync').mockReturnValue(undefined)
+    vi.spyOn(fs, 'existsSync').mockReturnValue(false)
+
+    const res = await request(app)
+      .post('/api/projects/proj-1/documents/generate')
+      .set('Authorization', authHeader)
+      .send(generateBody)
+
+    expect(res.status).toBe(201)
+    expect(prisma.generatedDocument.create).toHaveBeenCalledOnce()
+    expect(prisma.generatedDocument.update).not.toHaveBeenCalled()
+    expect(prisma.generatedDocument.delete).not.toHaveBeenCalled()
   })
 
   it('returns 404 when the project does not exist or is not owned', async () => {

--- a/server/src/test/scopeDocumentRenderer.test.ts
+++ b/server/src/test/scopeDocumentRenderer.test.ts
@@ -128,3 +128,32 @@ describe('renderScopeDocumentHtml — Gantt chart pagination', () => {
     expect(html).not.toContain(PAGE_DIV)
   })
 })
+
+describe('renderScopeDocumentHtml — scope hierarchy freshness', () => {
+  it('keeps both scope branches and renders their current feature names', () => {
+    const props = buildProps([])
+    const html = renderScopeDocumentHtml({
+      ...props,
+      sections: { ...props.sections, scope: true, ganttChart: false },
+      epics: [
+        {
+          id: 'in-scope-epic',
+          name: 'In Scope Epic',
+          isActive: true,
+          features: [{ id: 'in-scope-feature', name: 'Renamed In-Scope Feature', isActive: true, userStories: [] }],
+        },
+        {
+          id: 'out-of-scope-epic',
+          name: 'Out of Scope Epic',
+          isActive: false,
+          features: [{ id: 'out-of-scope-feature', name: 'Renamed Out-of-Scope Feature', isActive: true, userStories: [] }],
+        },
+      ],
+    })
+
+    expect(html).toContain('Renamed In-Scope Feature')
+    expect(html).toContain('Renamed Out-of-Scope Feature')
+    expect(html).not.toContain('Old In-Scope Feature')
+    expect(html).not.toContain('Old Out-of-Scope Feature')
+  })
+})


### PR DESCRIPTION
Closes #463

## Root cause
The Documents page could send stale cached hierarchy and derived data after a Feature rename. The generation route refreshed `documentData.epics`, but Timeline/Gantt and Effort data consumed names independently from `timelineData.entries` and `resourceProfileData.resourceRows`.

## Fix
- Re-read current Epics, Features, and Stories from persistence at generation time.
- Canonicalize only Epic/Feature names in timeline entries and resource-profile hierarchy entries by stable IDs.
- Preserve all scheduling, resource, numerical, ordering, scope, and historical-document data.
- Retain client invalidation for preview/UI freshness; correctness no longer depends on refetch timing.

## Tests
- Added route regression coverage with deliberately stale `epics`, timeline, and resource-profile names; assertions cover current names and unchanged derived values.
- Existing in-scope/out-of-scope, renderer scope, and historical-document coverage remains in place.
- Focused document route tests passed.
- `npm run validate` passed.
- `git diff --check` passed.

## Manual validation
Against local PostgreSQL, renamed Features and then Epics under both in-scope and out-of-scope parents. Generated new PDFs with stale client-derived payloads and confirmed current names throughout Scope, Effort, Timeline Summary, Gantt, and Resource Profile data; stale names were absent from matched entries. Confirmed a document generated before the later Epic rename remained unchanged. Cleaned up manual projects and PDF artifacts.

CI run [#32094119588](https://github.com/NickMonrad/monrad-estimator/actions/runs/32094119588) passed all jobs.

No #464 work, calculation changes, scope-semantics changes, historical rewrites, or unrelated refactoring are included.