### PR TITLE
fix(#464): restore document generation settings

### DIFF
--- a/client/src/pages/DocumentsPage.tsx
+++ b/client/src/pages/DocumentsPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect } from 'react'
+import { useState, useCallback, useEffect, useRef } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { api } from '../lib/api'
@@ -17,6 +17,42 @@ interface GeneratedDoc {
   generatedBy: { email: string }
 }
 
+type DocumentSections = {
+  cover: boolean
+  scope: boolean
+  effort: boolean
+  timeline: boolean
+  resourceProfile: boolean
+  assumptions: boolean
+  ganttChart: boolean
+}
+
+const DEFAULT_SECTIONS: DocumentSections = {
+  cover: true,
+  scope: true,
+  effort: true,
+  timeline: true,
+  resourceProfile: true,
+  assumptions: true,
+  ganttChart: true,
+}
+
+function restoreDocumentSections(sections: GeneratedDoc['sections']): DocumentSections {
+  if (!sections || typeof sections !== 'object' || Array.isArray(sections)) {
+    return { ...DEFAULT_SECTIONS }
+  }
+
+  const restored = { ...DEFAULT_SECTIONS }
+  let hasRecognizedSection = false
+  for (const key of Object.keys(DEFAULT_SECTIONS) as Array<keyof DocumentSections>) {
+    if (typeof sections[key] === 'boolean') {
+      restored[key] = sections[key]
+      hasRecognizedSection = true
+    }
+  }
+  return hasRecognizedSection ? restored : { ...DEFAULT_SECTIONS }
+}
+
 function defaultLabel(projectName?: string): string {
   const now = new Date()
   const tz = Intl.DateTimeFormat().resolvedOptions().timeZone
@@ -32,15 +68,9 @@ export default function DocumentsPage() {
   const { user } = useAuth()
   const queryClient = useQueryClient()
 
-  const [sections, setSections] = useState({
-    cover: true,
-    scope: true,
-    effort: true,
-    timeline: true,
-    resourceProfile: true,
-    assumptions: true,
-    ganttChart: true,
-  })
+  const [sections, setSections] = useState<DocumentSections>(() => ({ ...DEFAULT_SECTIONS }))
+  const sectionsProjectIdRef = useRef<string | null>(null)
+  const hydratedSectionsProjectIdRef = useRef<string | null>(null)
   const [label, setLabel] = useState(defaultLabel)
   const [generating, setGenerating] = useState(false)
   const [generateError, setGenerateError] = useState<string | null>(null)
@@ -81,11 +111,26 @@ export default function DocumentsPage() {
     enabled: !!projectId,
   })
 
-  const { data: generatedDocs = [], isLoading: docsLoading } = useQuery<GeneratedDoc[]>({
+  const { data: generatedDocs = [], isLoading: docsLoading, isFetching: docsFetching, isSuccess: docsLoaded } = useQuery<GeneratedDoc[]>({
     queryKey: ['generated-docs', projectId],
     queryFn: () => api.get(`/projects/${projectId}/documents`).then(r => r.data),
     enabled: !!projectId,
   })
+
+  useEffect(() => {
+    if (!projectId) return
+
+    if (sectionsProjectIdRef.current !== projectId) {
+      sectionsProjectIdRef.current = projectId
+      hydratedSectionsProjectIdRef.current = null
+      setSections({ ...DEFAULT_SECTIONS })
+    }
+
+    if (!docsLoaded || docsLoading || docsFetching || hydratedSectionsProjectIdRef.current === projectId) return
+
+    hydratedSectionsProjectIdRef.current = projectId
+    setSections(restoreDocumentSections(generatedDocs[0]?.sections))
+  }, [projectId, generatedDocs, docsLoaded, docsLoading, docsFetching])
 
   // ── Derived "all data loaded" flag ────────────────────────────
   const allLoaded = !!(project && effortData && timelineData && resourceProfileData)

--- a/client/src/test/DocumentsPage.test.tsx
+++ b/client/src/test/DocumentsPage.test.tsx
@@ -1,0 +1,219 @@
+import React from 'react'
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter, Route, Routes, useNavigate } from 'react-router-dom'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import DocumentsPage from '@/pages/DocumentsPage'
+
+const mockGet = vi.hoisted(() => vi.fn())
+const mockPost = vi.hoisted(() => vi.fn())
+
+vi.mock('@/lib/api', () => ({
+  api: {
+    get: mockGet,
+    post: mockPost,
+    delete: vi.fn(),
+  },
+}))
+
+vi.mock('@/hooks/useAuth', () => ({
+  useAuth: () => ({ user: { name: 'Test User', email: 'test@example.com' }, logout: vi.fn() }),
+}))
+
+vi.mock('@/components/layout/AppLayout', () => ({
+  default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}))
+
+type SectionKey = 'cover' | 'scope' | 'effort' | 'timeline' | 'resourceProfile' | 'assumptions' | 'ganttChart'
+
+type StoredDocument = {
+  id: string
+  label: string
+  format: string
+  type: string
+  createdAt: string
+  sections: Record<string, boolean> | null
+  generatedBy: { email: string }
+}
+
+const sectionLabels: Record<SectionKey, string> = {
+  cover: 'Cover Page',
+  scope: 'Scope Summary',
+  effort: 'Effort Breakdown',
+  timeline: 'Timeline Summary',
+  resourceProfile: 'Resource Profile',
+  assumptions: 'Assumptions',
+  ganttChart: 'Gantt Chart',
+}
+
+const defaultSections: Record<SectionKey, boolean> = {
+  cover: true,
+  scope: true,
+  effort: true,
+  timeline: true,
+  resourceProfile: true,
+  assumptions: true,
+  ganttChart: true,
+}
+
+let documentsByProject: Record<string, StoredDocument[]> = {}
+
+function documentRecord(id: string, sections: Record<string, boolean> | null): StoredDocument {
+  return {
+    id,
+    label: id,
+    format: 'pdf',
+    type: 'SCOPE_DOC',
+    createdAt: '2026-08-18T01:00:00.000Z',
+    sections,
+    generatedBy: { email: 'test@example.com' },
+  }
+}
+
+function projectIdFromUrl(url: string): string {
+  return url.match(/^\/projects\/([^/]+)/)?.[1] ?? ''
+}
+
+function createQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  })
+}
+
+function ProjectSwitcher({ targetProjectId }: { targetProjectId: string }) {
+  const navigate = useNavigate()
+  return <button onClick={() => navigate(`/projects/${targetProjectId}/documents`)}>Switch project</button>
+}
+
+function renderPage(projectId = 'project-a', targetProjectId?: string) {
+  const queryClient = createQueryClient()
+  const view = render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={[`/projects/${projectId}/documents`]}>
+        <Routes>
+          <Route
+            path="/projects/:id/documents"
+            element={
+              <>
+                <DocumentsPage />
+                {targetProjectId && <ProjectSwitcher targetProjectId={targetProjectId} />}
+              </>
+            }
+          />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  )
+  return { ...view, queryClient }
+}
+
+async function expectSections(expected: Record<SectionKey, boolean>) {
+  await waitFor(() => {
+    for (const key of Object.keys(expected) as SectionKey[]) {
+      const checkbox = screen.getByRole('checkbox', { name: sectionLabels[key] })
+      if (expected[key]) expect(checkbox).toBeChecked()
+      else expect(checkbox).not.toBeChecked()
+    }
+  })
+}
+
+beforeEach(() => {
+  documentsByProject = {}
+  vi.clearAllMocks()
+  mockPost.mockResolvedValue({ data: {} })
+  mockGet.mockImplementation((url: string) => {
+    const projectId = projectIdFromUrl(url)
+    if (url.endsWith('/documents')) return Promise.resolve({ data: documentsByProject[projectId] ?? [] })
+    if (url.includes('/effort')) return Promise.resolve({ data: {} })
+    if (url.includes('/timeline')) return Promise.resolve({ data: { projectedEndDate: null } })
+    if (url.includes('/resource-profile')) return Promise.resolve({ data: {} })
+    if (url.includes('/epics')) return Promise.resolve({ data: [] })
+    return Promise.resolve({ data: { id: projectId, name: `Project ${projectId}` } })
+  })
+})
+
+describe('DocumentsPage section settings restoration', () => {
+  it('uses the existing defaults when there are no previous generated documents', async () => {
+    renderPage()
+
+    await expectSections(defaultSections)
+  })
+
+  it('restores section selections from the newest generated document', async () => {
+    const restoredSections = { ...defaultSections, scope: false, effort: false, ganttChart: false }
+    documentsByProject['project-a'] = [documentRecord('newest', restoredSections)]
+    renderPage()
+
+    await expectSections(restoredSections)
+  })
+
+  it('uses the newest generation when document history has different settings', async () => {
+    const olderSections = { ...defaultSections, scope: false }
+    const newestSections = { ...defaultSections, resourceProfile: false, assumptions: false }
+    documentsByProject['project-a'] = [
+      documentRecord('newest', newestSections),
+      documentRecord('older', olderSections),
+    ]
+    renderPage()
+
+    await expectSections(newestSections)
+  })
+
+  it('keeps settings isolated when switching projects', async () => {
+    documentsByProject['project-a'] = [documentRecord('project-a-doc', { ...defaultSections, scope: false })]
+    renderPage('project-a', 'project-b')
+
+    await waitFor(() => expect(screen.getByRole('checkbox', { name: sectionLabels.scope })).not.toBeChecked())
+    fireEvent.click(screen.getByRole('button', { name: 'Switch project' }))
+
+    await expectSections(defaultSections)
+  })
+
+  it('does not replace the latest successful settings after generation fails', async () => {
+    const savedSections = { ...defaultSections, timeline: false, assumptions: false }
+    documentsByProject['project-a'] = [documentRecord('saved', savedSections)]
+    const view = renderPage()
+    await expectSections(savedSections)
+
+    mockPost.mockRejectedValueOnce({ response: { data: { error: 'Generation failed' } } })
+    fireEvent.click(screen.getByRole('button', { name: 'Generate & Save' }))
+    expect(await screen.findByText('Generation failed')).toBeInTheDocument()
+    await expectSections(savedSections)
+
+    view.unmount()
+    renderPage()
+    await expectSections(savedSections)
+  })
+
+  it('falls back to defaults when the latest document has null section metadata', async () => {
+    documentsByProject['project-a'] = [documentRecord('legacy', null)]
+    renderPage()
+
+    await expectSections(defaultSections)
+  })
+
+  it('falls back to defaults for unusable legacy section metadata', async () => {
+    documentsByProject['project-a'] = [documentRecord('legacy', { oldSectionName: true })]
+    renderPage()
+
+    await expectSections(defaultSections)
+  })
+
+  it('does not overwrite user edits when document history refetches', async () => {
+    const savedSections = { ...defaultSections, scope: false }
+    documentsByProject['project-a'] = [documentRecord('saved', savedSections)]
+    const { queryClient } = renderPage()
+    await expectSections(savedSections)
+
+    fireEvent.click(screen.getByRole('checkbox', { name: sectionLabels.scope }))
+    const documentRequestCount = () => mockGet.mock.calls.filter(([url]) => (url as string).endsWith('/documents')).length
+    const previousDocumentRequestCount = documentRequestCount()
+    await queryClient.invalidateQueries({ queryKey: ['generated-docs', 'project-a'] })
+    await waitFor(() => expect(documentRequestCount()).toBeGreaterThan(previousDocumentRequestCount))
+
+    expect(screen.getByRole('checkbox', { name: sectionLabels.scope })).toBeChecked()
+  })
+})


### PR DESCRIPTION
Closes #464

## Summary
- Restore the section selections from the latest successfully generated document when opening the Documents page.
- Keep defaults for projects without generated documents or legacy documents without usable section metadata.
- Reset and rehydrate per-project state without overwriting current user edits during refetches or failed generation.

## Root cause
The Documents page always initialized the section controls from hard-coded defaults and never hydrated them from persisted `GeneratedDocument.sections` metadata.

## Tests
- `npm test --workspace=client` — passed (27 files, 377 tests)
- `npm test --workspace=server` — passed (63 files passed, 19 skipped; 1,439 passed, 296 skipped)
- `npm run test:local-db` — passed (182 tests)
- Focused `npm test --workspace=client -- src/test/DocumentsPage.test.tsx --run` — passed (8 tests)
- `npm run validate` — failed only in the pre-existing/flaky local-postgres lifecycle test `runCommand waits for termination before rejecting on abort`; the isolated `npm run test:local-db` rerun passed.
- `git diff --check` — passed

## Manual validation
Using local PostgreSQL-backed app: generated a document with non-default selections, reloaded Documents, confirmed selections restored; generated a second configuration and confirmed newest settings restored; switched projects and confirmed isolation; forced generation failure and confirmed prior settings remained.

## Scope
No schema changes, API changes, or unrelated document-generation changes.